### PR TITLE
Fix: allow emojis in safestring

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -100,7 +100,8 @@ const GameConfigSchema = z.object({
 const SafeString = z
   .string()
   // Remove common dangerous characters and patterns
-  .regex(/^[a-zA-Z0-9\s.,!?@#$%&*()-_+=\[\]{}|;:"'\/]+$/)
+  // The weird \u stuff is to allow emojis
+  .regex(/^[a-zA-Z0-9\s.,!?@#$%&*()-_+=\[\]{}|;:"'\/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]]+$/) 
   // Reasonable max length to prevent DOS
   .max(1000);
 
@@ -323,3 +324,5 @@ export const GameRecordSchema = z.object({
   turns: z.array(TurnSchema),
   winner: ID.nullable(),
 });
+
+

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -13,7 +13,7 @@ const matcher = new RegExpMatcher({
 export const MIN_USERNAME_LENGTH = 3;
 export const MAX_USERNAME_LENGTH = 27;
 
-const validPattern = /^[a-zA-Z0-9_\[\] 🐈🍀]+$/;
+const validPattern = /^[a-zA-Z0-9_\[\] 🐈🍀]+$/u;
 
 const shadowNames = [
   "NicePeopleOnly",
@@ -71,7 +71,7 @@ export function validateUsername(username: string): {
 
 export function sanitizeUsername(str: string): string {
   const sanitized = str
-    .replace(/[^a-zA-Z0-9_\[\] 🐈🍀]/g, "")
+    .replace(/[^a-zA-Z0-9_\[\] 🐈🍀]/gu, "")
     .slice(0, MAX_USERNAME_LENGTH);
   return sanitized.padEnd(MIN_USERNAME_LENGTH, "x");
 }


### PR DESCRIPTION
Some allowed characters were being rejected by the zod authentication. Added a bunch of ranges for allowed emoji unicode.