### PR TITLE
Update BotNames.ts to include Queendom

### DIFF
--- a/src/core/execution/utils/BotNames.ts
+++ b/src/core/execution/utils/BotNames.ts
@@ -176,6 +176,7 @@ export const BOT_NAME_SUFFIXES = [
   "Empire",
   "Dynasty",
   "Kingdom",
+  "Queendom",
   "Sultanate",
   "Confederation",
   "Union",


### PR DESCRIPTION
A Queendom is a kingdom ruled by a Queen and I feel like both kingdom and Queendom should be included.