### PR TITLE
Fixed mouse move bug, where if your cursor is over an UI element it doesn't fire the mouseUp event

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -85,15 +85,15 @@ export class InputHandler {
 
   initialize() {
     this.canvas.addEventListener("pointerdown", (e) => this.onPointerDown(e));
-    this.canvas.addEventListener("pointerup", (e) => this.onPointerUp(e));
+    window.addEventListener("pointerup", (e) => this.onPointerUp(e));
     this.canvas.addEventListener("wheel", (e) => this.onScroll(e), {
       passive: false,
     });
-    this.canvas.addEventListener("pointermove", this.onPointerMove.bind(this));
+    window.addEventListener("pointermove", this.onPointerMove.bind(this));
     this.canvas.addEventListener("contextmenu", (e: MouseEvent) => {
       this.onContextMenu(e);
     });
-    this.canvas.addEventListener("mousemove", (e) => {
+    window.addEventListener("mousemove", (e) => {
       if (e.movementX == 0 && e.movementY == 0) {
         return;
       }


### PR DESCRIPTION
If you are moving around with the mouse left click held down, and you release it when ontop of a UI element like the scoreboard, the mouseUp event will not fire, causing you to be stuck in the move event. You had to click somewhere to "let go" of the initial mouse down.