### PR TITLE
fix radial menu image dimensions

### DIFF
--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -9,6 +9,11 @@ export class HelpModal extends LitElement {
 
   // Added #helpModal infront of everything to prevent leaks of css in other elements outside this one
   private styles = css`
+    .radial-menu-image {
+      width: 211px;
+      height: 200px;
+    }
+    
     #helpModal.modal-overlay {
       display: none;
       position: fixed;
@@ -293,7 +298,7 @@ export class HelpModal extends LitElement {
           <div class="text-2xl font-bold text-center">Radial menu</div>
 
           <div class="flex flex-col md:flex-row gap-4">
-            <img src="/images/helpModal/radialMenu.png" alt="Radial menu" title="Radial menu" />
+            <img src="/images/helpModal/radialMenu.png" alt="Radial menu" title="Radial menu", class="radial-menu-image" />
             <div>
               <p class="mb-4">Right clicking (or touch on mobile) opens the radial menu. From there you can:</p>
               <ul>


### PR DESCRIPTION
Here's a before vs. after:
![grafik](https://github.com/user-attachments/assets/9a977663-9414-41af-9a7b-9bdf66f9a95c)
![grafik](https://github.com/user-attachments/assets/2ce2eae4-a811-4e09-a02f-2f5b79d1d9d8)
I fixed this through some forbidden thing called _creating a class just for the image and applying the exact image dimensions as the width & height_
If anyone has a better fix, please :pray: