### PR TITLE
Changes to the build-map script for ease of use

### DIFF
--- a/src/scripts/TerrainMapGenerator.ts
+++ b/src/scripts/TerrainMapGenerator.ts
@@ -362,6 +362,7 @@ function processOcean(map: Terrain[][]) {
       displayProgress((marked / totalWater) * 100, "[_Processing__Ocean_]");
     }
   }
+  displayProgress(100, "[_Processing__Ocean_]");
   process.stdout.write("\n");
 }
 

--- a/src/scripts/TerrainMapGenerator.ts
+++ b/src/scripts/TerrainMapGenerator.ts
@@ -35,37 +35,23 @@ class Terrain {
 
 // --- Main function to prompt user then build the map ---
 async function main() {
-  // Prompt for folder path containing the PNG and JSON files
+  // Prompt for folder path containing the PNG file
   mapFolderPath = await prompt(
     "Enter map folder path (e.g., C:\\Users\\user\\map_folder): ",
   );
 
-  // Read folder contents to locate the JSON and PNG files
+  // Read folder contents to locate the PNG file
   const files = await fs.readdir(mapFolderPath);
-  const jsonFiles = files.filter((f) => f.toLowerCase().endsWith(".json"));
   const pngFiles = files.filter((f) => f.toLowerCase().endsWith(".png"));
 
-  if (jsonFiles.length !== 1) {
-    console.error("Error: Expected exactly one JSON file in the folder.");
-    process.exit(1);
-  }
   if (pngFiles.length !== 1) {
     console.error("Error: Expected exactly one PNG file in the folder.");
     process.exit(1);
   }
 
-  // Read the JSON file to get the map name
-  const jsonPath = path.join(mapFolderPath, jsonFiles[0]);
-  const jsonContent = await fs.readFile(jsonPath, "utf8");
-  let jsonData: any;
-  try {
-    jsonData = JSON.parse(jsonContent);
-  } catch (error) {
-    console.error("Error parsing JSON file:", error);
-    process.exit(1);
-  }
-  mapName = jsonData.name;
+  // Use the PNG file name as the map name
   pngFileName = pngFiles[0];
+  mapName = path.parse(pngFileName).name; // Get file name without extension
 
   // Prompt for removing small lakes
   const removeAns = await prompt("Remove small lakes? [y/n]: ");


### PR DESCRIPTION
Added file path prompt, instead of just using a name field and assuming the png is already in '..\resources\maps'

Takes any folder if it has the correct png file and adds both bin files to that folder. Only requires the png file.
![Screenshot 2025-02-25 185244](https://github.com/user-attachments/assets/f30a5019-aff1-4c85-8d90-36550cb60e7f)
Added progress bars and more information when using the script to compile a map



![Screenshot 2025-02-25 185301](https://github.com/user-attachments/assets/ce5226a2-837c-4b1d-8207-1f0b1a4ae7a7)
![Screenshot 2025-02-25 190635](https://github.com/user-attachments/assets/330e58d4-45e6-4b8b-b30a-2de64bd39c72)
![Screenshot 2025-02-25 190034](https://github.com/user-attachments/assets/4a99e2e2-0062-4704-9f46-4b879468b11d)

These changes I think allows for easier and quicker implementation of custom maps into the game as now you just type 'npm run build-map' and follow the instructions.

![Screenshot 2025-02-25 190825](https://github.com/user-attachments/assets/8f695f2f-e046-499f-a474-78e89743fb9f)