### PR TITLE
fix: touch screen should always open menu when touch screen

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -290,7 +290,9 @@ export class InputHandler {
       Math.abs(event.y - this.lastPointerDownY);
     if (dist < 10) {
       if (event.pointerType == "touch") {
+        this.eventBus.emit(new ContextMenuEvent(event.clientX, event.clientY));
         event.preventDefault();
+        return;
       }
 
       if (!this.userSettings.leftClickOpensMenu() || event.shiftKey) {


### PR DESCRIPTION
Previous patch (to choos left click actions) by mistake made touchscreen
by default attack with touch instead of open menu
