### PR TITLE
Reworked the pathfinding of transport ships

### DIFF
--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -130,7 +130,7 @@ export function closestShoreTN(
     gm.isShore(t),
   );
 
-  const targetIsWater = gm.isWater(target);
+  var targetIsWater = gm.isWater(target);
 
   // prevents the search from ignoring islands when the target is a water tile
   if (targetIsWater) {
@@ -149,6 +149,7 @@ export function closestShoreTN(
       );
 
     target = tn.length > 0 ? tn[0] : null;
+    targetIsWater = gm.isWater(target);
     if (!target) return [null, null];
   }
 
@@ -176,7 +177,7 @@ export function closestShoreTN(
     for (const neighbor of gm.neighbors(tile)) {
       if (
         !visited.has(neighbor) &&
-        !(gm.ownerID(tile) === attacker.smallID()) &&
+        !(gm.ownerID(neighbor) === attacker.smallID()) &&
         (targetIsWater || !gm.isWater(neighbor))
       ) {
         queue.push([neighbor, dist + 1]);

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -126,9 +126,11 @@ export function closestShoreTN(
   searchDist: number,
   defender?: Player,
 ): [TileRef | null, TileRef | null] {
-  const borderTiles = Array.from(attacker.borderTiles()).filter((t) =>
-    gm.isShore(t),
-  );
+  const borderTile = Array.from(attacker.borderTiles())
+    .filter((t) => gm.isShore(t))
+    .sort(
+      (a, b) => gm.manhattanDist(target, a) - gm.manhattanDist(target, b),
+    )[0];
 
   var targetIsWater = gm.isWater(target);
 
@@ -189,22 +191,18 @@ export function closestShoreTN(
   if (shoreTiles.length === 0) return [null, null];
 
   let bestShore: TileRef | null = null;
-  let bestBorderTile: TileRef | null = null;
   let minDist = Infinity;
 
   // based on the players border tiles get the shortest path from player to shore
   for (const shore of shoreTiles) {
-    for (const border of borderTiles) {
-      const dist = gm.manhattanDist(border, shore);
-      if (dist < minDist) {
-        minDist = dist;
-        bestShore = shore;
-        bestBorderTile = border;
-      }
+    const dist = gm.manhattanDist(borderTile, shore);
+    if (dist < minDist) {
+      minDist = dist;
+      bestShore = shore;
     }
   }
 
-  return [bestShore, bestBorderTile];
+  return [bestShore, borderTile];
 }
 
 export function simpleHash(str: string): number {

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -150,8 +150,9 @@ export function closestShoreTN(
 
     target = tn.length > 0 ? tn[0] : null;
     targetIsWater = gm.isWater(target);
-    if (!target) return [null, null];
   }
+
+  if (!target) return [null, null];
 
   const queue: [TileRef, number][] = [[target, 0]];
   const visited = new Set<TileRef>();
@@ -178,7 +179,7 @@ export function closestShoreTN(
       if (
         !visited.has(neighbor) &&
         !(gm.ownerID(neighbor) === attacker.smallID()) &&
-        (targetIsWater || !gm.isWater(neighbor))
+        !gm.isWater(neighbor)
       ) {
         queue.push([neighbor, dist + 1]);
       }

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -106,7 +106,8 @@ export class TransportShipExecution implements Execution {
 
     this.troops = Math.min(this.troops, this.attacker.troops());
 
-    this.dst = targetTransportTile(this.mg, this.ref);
+    // destination tile of the ship
+    this.dst = targetTransportTile(this.mg, this.ref, this.attacker);
     if (this.dst == null) {
       consolex.warn(
         `${this.attacker} cannot send ship to ${this.target}, cannot find attack tile`,

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -107,7 +107,10 @@ export class TransportShipExecution implements Execution {
     this.troops = Math.min(this.troops, this.attacker.troops());
 
     // destination tile of the ship
-    this.dst = targetTransportTile(this.mg, this.ref, this.attacker);
+    const start = performance.now();
+    let result = targetTransportTile(this.mg, this.ref, this.attacker);
+
+    this.dst = result[0];
     if (this.dst == null) {
       consolex.warn(
         `${this.attacker} cannot send ship to ${this.target}, cannot find attack tile`,
@@ -122,13 +125,15 @@ export class TransportShipExecution implements Execution {
       return;
     }
 
-    this.src = src;
+    this.src = result[1];
 
     this.boat = this.attacker.buildUnit(
       UnitType.TransportShip,
       this.troops,
       this.src,
     );
+    const end = performance.now();
+    console.log(start, end);
   }
 
   tick(ticks: number) {

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -107,7 +107,6 @@ export class TransportShipExecution implements Execution {
     this.troops = Math.min(this.troops, this.attacker.troops());
 
     // destination and start tile of the ship
-    const start = performance.now();
     let result = targetTransportTile(this.mg, this.ref, this.attacker);
 
     this.dst = result[0];
@@ -132,8 +131,6 @@ export class TransportShipExecution implements Execution {
       this.troops,
       this.src,
     );
-    const end = performance.now();
-    console.log(end - start);
   }
 
   tick(ticks: number) {

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -106,11 +106,12 @@ export class TransportShipExecution implements Execution {
 
     this.troops = Math.min(this.troops, this.attacker.troops());
 
-    // destination tile of the ship
+    // destination and start tile of the ship
     const start = performance.now();
     let result = targetTransportTile(this.mg, this.ref, this.attacker);
 
     this.dst = result[0];
+    this.src = result[1];
     if (this.dst == null) {
       consolex.warn(
         `${this.attacker} cannot send ship to ${this.target}, cannot find attack tile`,
@@ -118,6 +119,7 @@ export class TransportShipExecution implements Execution {
       this.active = false;
       return;
     }
+    //just gives back if the boat can be build or not
     const src = this.attacker.canBuild(UnitType.TransportShip, this.dst);
     if (src == false) {
       consolex.warn(`can't build transport ship`);
@@ -125,15 +127,13 @@ export class TransportShipExecution implements Execution {
       return;
     }
 
-    this.src = result[1];
-
     this.boat = this.attacker.buildUnit(
       UnitType.TransportShip,
       this.troops,
       this.src,
     );
     const end = performance.now();
-    console.log(start, end);
+    console.log(end - start);
   }
 
   tick(ticks: number) {

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -158,6 +158,16 @@ export class TransportShipExecution implements Execution {
           this.active = false;
           return;
         }
+
+        // if the transport ships target is not a player but the actual destination is a player make the transport ship still attack the player of the destination tile
+        if (
+          this.mg.playerBySmallID(this.mg.ownerID(this.dst)) &&
+          Object.keys(this.target).length === 0
+        ) {
+          this.target = this.mg.playerBySmallID(this.mg.ownerID(this.dst));
+          this.targetID = this.target.id();
+        }
+
         if (this.target.isPlayer() && this.attacker.isAlliedWith(this.target)) {
           this.target.addTroops(this.troops);
         } else {

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -120,8 +120,8 @@ export class TransportShipExecution implements Execution {
       return;
     }
     //just gives back if the boat can be build or not
-    const src = this.attacker.canBuild(UnitType.TransportShip, this.dst);
-    if (src == false) {
+    const buildable = this.attacker.canBuild(UnitType.TransportShip, this.dst);
+    if (!buildable) {
       consolex.warn(`can't build transport ship`);
       this.active = false;
       return;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -667,6 +667,7 @@ export class PlayerImpl implements Player {
     return b;
   }
 
+  // decides where the unit or building spawns
   canBuild(unitType: UnitType, targetTile: TileRef): TileRef | false {
     const cost = this.mg.unitInfo(unitType).cost(this);
     if (!this.isAlive() || this.gold() < cost) {
@@ -810,7 +811,8 @@ export class PlayerImpl implements Player {
       return false;
     }
 
-    const dst = targetTransportTile(this.mg, tile);
+    // destination tile of the ship
+    const dst = targetTransportTile(this.mg, tile, this);
     if (dst == null) {
       return false;
     }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -756,11 +756,12 @@ export class PlayerImpl implements Player {
     if (!this.mg.isShore(targetTile)) {
       return false;
     }
-    const spawn = closestShoreTN(this.mg, this, targetTile, 50)[1];
-    if (spawn == null) {
-      return false;
-    }
-    return spawn;
+    // const spawn = closestShoreTN(this.mg, this, targetTile, 50)[1];
+    // if (spawn == null) {
+    //   return false;
+    // }
+    // return spawn;
+    return 1;
   }
 
   tradeShipSpawn(targetTile: TileRef): TileRef | false {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -24,12 +24,12 @@ import { GameUpdateType } from "./GameUpdates";
 import { ClientID } from "../Schemas";
 import {
   assertNever,
-  closestShoreFromPlayer,
+  closestShoreTN,
   distSortUnit,
   maxInt,
   minInt,
   simpleHash,
-  sourceDstOceanShore,
+  // sourceDstOceanShore,
   targetTransportTile,
   toInt,
   within,
@@ -756,7 +756,7 @@ export class PlayerImpl implements Player {
     if (!this.mg.isShore(targetTile)) {
       return false;
     }
-    const spawn = closestShoreFromPlayer(this.mg, this, targetTile);
+    const spawn = closestShoreTN(this.mg, this, targetTile, 50)[1];
     if (spawn == null) {
       return false;
     }
@@ -812,7 +812,7 @@ export class PlayerImpl implements Player {
     }
 
     // destination tile of the ship
-    const dst = targetTransportTile(this.mg, tile, this);
+    const dst = targetTransportTile(this.mg, tile, this)[0];
     if (dst == null) {
       return false;
     }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -756,6 +756,7 @@ export class PlayerImpl implements Player {
     if (!this.mg.isShore(targetTile)) {
       return false;
     }
+    // not needed anymore because closestShoreTN gives back start and end tile
     // const spawn = closestShoreTN(this.mg, this, targetTile, 50)[1];
     // if (spawn == null) {
     //   return false;


### PR DESCRIPTION
Transport ships now search for the shortest path from the players shore to the target shore when sending out transport ships to prevent them from going longer distances then they should.