### PR TITLE
fix: warship icon

### DIFF
--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -136,7 +136,7 @@ export class StructureLayer implements Layer {
     // Clear previous rendering
     for (const tile of this.game.bfs(
       unit.tile(),
-      euclDistFN(unit.tile(), config.borderRadius),
+      euclDistFN(unit.tile(), config.borderRadius, true),
     )) {
       this.clearCell(new Cell(this.game.x(tile), this.game.y(tile)));
     }
@@ -148,7 +148,7 @@ export class StructureLayer implements Layer {
     // Draw border and territory
     for (const tile of this.game.bfs(
       unit.tile(),
-      euclDistFN(unit.tile(), config.borderRadius),
+      euclDistFN(unit.tile(), config.borderRadius, true),
     )) {
       this.paintCell(
         new Cell(this.game.x(tile), this.game.y(tile)),
@@ -161,7 +161,7 @@ export class StructureLayer implements Layer {
 
     for (const tile of this.game.bfs(
       unit.tile(),
-      euclDistFN(unit.tile(), config.territoryRadius),
+      euclDistFN(unit.tile(), config.territoryRadius, true),
     )) {
       this.paintCell(
         new Cell(this.game.x(tile), this.game.y(tile)),

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -109,7 +109,10 @@ export class TerritoryLayer implements Layer {
       if (!centerTile) {
         continue;
       }
-      for (const tile of this.game.bfs(centerTile, euclDistFN(centerTile, 9))) {
+      for (const tile of this.game.bfs(
+        centerTile,
+        euclDistFN(centerTile, 9, false),
+      )) {
         if (!this.game.hasOwner(tile)) {
           this.paintHighlightCell(
             new Cell(this.game.x(tile), this.game.y(tile)),

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -235,7 +235,7 @@ export class UnitLayer implements Layer {
     // Clear previous area
     for (const t of this.game.bfs(
       unit.lastTile(),
-      euclDistFN(unit.lastTile(), 6),
+      euclDistFN(unit.lastTile(), 6, false),
     )) {
       this.clearCell(this.game.x(t), this.game.y(t));
     }
@@ -256,7 +256,10 @@ export class UnitLayer implements Layer {
     }
 
     // Paint outer territory
-    for (const t of this.game.bfs(unit.tile(), euclDistFN(unit.tile(), 5))) {
+    for (const t of this.game.bfs(
+      unit.tile(),
+      euclDistFN(unit.tile(), 5, false),
+    )) {
       this.paintCell(this.game.x(t), this.game.y(t), rel, outerColor, 255);
     }
 
@@ -275,7 +278,10 @@ export class UnitLayer implements Layer {
     }
 
     // Paint inner territory
-    for (const t of this.game.bfs(unit.tile(), euclDistFN(unit.tile(), 1))) {
+    for (const t of this.game.bfs(
+      unit.tile(),
+      euclDistFN(unit.tile(), 1, false),
+    )) {
       this.paintCell(
         this.game.x(t),
         this.game.y(t),
@@ -336,7 +342,7 @@ export class UnitLayer implements Layer {
     // Clear previous area
     for (const t of this.game.bfs(
       unit.lastTile(),
-      euclDistFN(unit.lastTile(), range),
+      euclDistFN(unit.lastTile(), range, false),
     )) {
       this.clearCell(this.game.x(t), this.game.y(t));
     }
@@ -344,7 +350,7 @@ export class UnitLayer implements Layer {
     if (unit.isActive()) {
       for (const t of this.game.bfs(
         unit.tile(),
-        euclDistFN(unit.tile(), range),
+        euclDistFN(unit.tile(), range, false),
       )) {
         this.paintCell(
           this.game.x(t),
@@ -354,7 +360,10 @@ export class UnitLayer implements Layer {
           255,
         );
       }
-      for (const t of this.game.bfs(unit.tile(), euclDistFN(unit.tile(), 2))) {
+      for (const t of this.game.bfs(
+        unit.tile(),
+        euclDistFN(unit.tile(), 2, false),
+      )) {
         this.paintCell(
           this.game.x(t),
           this.game.y(t),
@@ -389,7 +398,7 @@ export class UnitLayer implements Layer {
     // Clear previous area
     for (const t of this.game.bfs(
       unit.lastTile(),
-      euclDistFN(unit.lastTile(), 3),
+      euclDistFN(unit.lastTile(), 3, false),
     )) {
       this.clearCell(this.game.x(t), this.game.y(t));
     }

--- a/src/core/execution/Util.ts
+++ b/src/core/execution/Util.ts
@@ -1,7 +1,7 @@
 import { euclDistFN, GameMap, TileRef } from "../game/GameMap";
 
 export function getSpawnTiles(gm: GameMap, tile: TileRef): TileRef[] {
-  return Array.from(gm.bfs(tile, euclDistFN(tile, 4))).filter(
+  return Array.from(gm.bfs(tile, euclDistFN(tile, 4, false))).filter(
     (t) => !gm.hasOwner(t) && gm.isLand(t),
   );
 }

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -320,17 +320,22 @@ export class GameMapImpl implements GameMap {
 export function euclDistFN(
   root: TileRef,
   dist: number,
+  center: boolean,
 ): (gm: GameMap, tile: TileRef) => boolean {
-  return (gm: GameMap, n: TileRef) => {
-    // shifts the root tile’s coordinates by -0.5 so that its “center”
-    // center becomes the corner of four pixels rather than the middle of one pixel.
-    // just makes things based off even pixels instead of odd. Used to use 9x9 icons now 10x10 icons etc...
-    const rootX = gm.x(root) - 0.5;
-    const rootY = gm.y(root) - 0.5;
-    const dx = gm.x(n) - rootX;
-    const dy = gm.y(n) - rootY;
-    return Math.sqrt(dx * dx + dy * dy) <= dist;
-  };
+  if (!center) {
+    return (gm: GameMap, n: TileRef) => gm.euclideanDist(root, n) <= dist;
+  } else {
+    return (gm: GameMap, n: TileRef) => {
+      // shifts the root tile’s coordinates by -0.5 so that its “center”
+      // center becomes the corner of four pixels rather than the middle of one pixel.
+      // just makes things based off even pixels instead of odd. Used to use 9x9 icons now 10x10 icons etc...
+      const rootX = gm.x(root) - 0.5;
+      const rootY = gm.y(root) - 0.5;
+      const dx = gm.x(n) - rootX;
+      const dy = gm.y(n) - rootY;
+      return Math.sqrt(dx * dx + dy * dy) <= dist;
+    };
+  }
 }
 
 export function manhattanDistFN(


### PR DESCRIPTION
A previous update that brought the new icon broke the warship because it
changed euclidian function.
Now if we have a unit (like warship) we use the old algorithm, for the
icon (to center them) we use the new one
