### PR TITLE
lower trade on SP than MP

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -130,7 +130,7 @@ export class DefaultConfig implements Config {
     return 10000 + 150 * Math.pow(dist, 1.1);
   }
   tradeShipSpawnRate(): number {
-    return 500;
+    return this._gameConfig.gameType == GameType.Singleplayer ? 700 : 500;
   }
 
   unitInfo(type: UnitType): UnitInfo {


### PR DESCRIPTION
SP trade is OP because unlike MP bots don't currently buy a lot of
warships
