### PR TITLE
cancel trade if port is captured (no trade inside same country)

### DIFF
--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -65,6 +65,14 @@ export class TradeShipExecution implements Execution {
       this.wasCaptured = true;
     }
 
+    // If a player captures an other player's port while trading we should delete
+    // the ship.
+    if (this._dstPort.owner().id() == this.srcPort.owner().id()) {
+      this.tradeShip.delete(false);
+      this.active = false;
+      return;
+    }
+
     if (
       !this.wasCaptured &&
       (!this._dstPort.isActive() ||

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -539,7 +539,9 @@ export class PlayerImpl implements Player {
   }
 
   canTrade(other: Player): boolean {
-    return !other.hasEmbargoAgainst(this) && !this.hasEmbargoAgainst(other);
+    const embargo =
+      other.hasEmbargoAgainst(this) || this.hasEmbargoAgainst(other);
+    return !embargo && other.id() != this.id();
   }
 
   addEmbargo(other: PlayerID): void {


### PR DESCRIPTION
If the port of destination and of source have same owner it means a
player captures port of another player, we cease all trade that happens
inside same country.
Also added a check in the canTrade code to be more reliable and correct
even outside of the specific case of capturing a port.
