### PR TITLE
Area based Cities

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -259,6 +259,7 @@ export class ClientGameRunner {
       return;
     }
     consolex.log(`clicked cell ${cell}`);
+    // console.log("tile. "+cell.y * 2000 + cell.x)
     const tile = this.gameView.ref(cell.x, cell.y);
     if (
       this.gameView.isLand(tile) &&

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -71,6 +71,12 @@ const buildTable: BuildItemDisplay[][] = [
       icon: cityIcon,
       description: "Increase max population",
     },
+    // needs new icon
+    {
+      unitType: UnitType.CityUpgrade,
+      icon: cityIcon,
+      description: "Upgrades an existing City",
+    },
   ],
 ];
 

--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -38,6 +38,12 @@ export class StructureLayer implements Layer {
       borderRadius: 8.525,
       territoryRadius: 6.525,
     },
+    // for construction
+    [UnitType.CityUpgrade]: {
+      icon: cityIcon,
+      borderRadius: 8.525,
+      territoryRadius: 6.525,
+    },
     [UnitType.MissileSilo]: {
       icon: missileSiloIcon,
       borderRadius: 8,

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -94,9 +94,7 @@ export class TerritoryLayer implements Layer {
           const radiusSquared = radius * radius;
 
           if (distanceSquared <= radiusSquared) {
-            // if (this.game.ownerID(targetTile) == update.ownerID) {
             this.enqueueTile(targetTile);
-            // }
             return true;
           }
           return false;

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -169,6 +169,7 @@ export interface Theme {
   defendedBorderColor(playerInfo: PlayerInfo): Colord;
   cityColor(playerInfo: PlayerInfo): Colord;
   defendedCityColor(playerInfo: PlayerInfo): Colord;
+  defenseRingColor(playerInfo: PlayerInfo): Colord;
   terrainColor(gm: GameMap, tile: TileRef): Colord;
   backgroundColor(): Colord;
   falloutColor(): Colord;

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -168,6 +168,7 @@ export interface Theme {
   borderColor(playerInfo: PlayerInfo): Colord;
   defendedBorderColor(playerInfo: PlayerInfo): Colord;
   cityColor(playerInfo: PlayerInfo): Colord;
+  defendedCityColor(playerInfo: PlayerInfo): Colord;
   terrainColor(gm: GameMap, tile: TileRef): Colord;
   backgroundColor(): Colord;
   falloutColor(): Colord;

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -158,7 +158,7 @@ export interface Config {
   defensePostDefenseBonus(): number;
   falloutDefenseModifier(): number;
   difficultyModifier(difficulty: Difficulty): number;
-  cityRange(): number;
+  cityMaxSize(): number;
   // 0-1
   traitorDefenseDebuff(): number;
 }

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -158,6 +158,7 @@ export interface Config {
   defensePostDefenseBonus(): number;
   falloutDefenseModifier(): number;
   difficultyModifier(difficulty: Difficulty): number;
+  cityRange(): number;
   // 0-1
   traitorDefenseDebuff(): number;
 }
@@ -166,6 +167,7 @@ export interface Theme {
   territoryColor(playerInfo: PlayerInfo): Colord;
   borderColor(playerInfo: PlayerInfo): Colord;
   defendedBorderColor(playerInfo: PlayerInfo): Colord;
+  cityColor(playerInfo: PlayerInfo): Colord;
   terrainColor(gm: GameMap, tile: TileRef): Colord;
   backgroundColor(): Colord;
   falloutColor(): Colord;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -452,12 +452,12 @@ export class DefaultConfig implements Config {
         ? 1_000_000_000
         : 2 * (Math.pow(player.numTilesOwned(), 0.6) * 1000 + 50000) +
           player.units(UnitType.City).reduce((sum, city) => {
-            const citySize = city.size();
+            const citySize = Math.floor(city.size() * city.ownerRatio());
             let populationIncrease = this.cityPopulationIncrease();
             let multiplier = 1.0;
 
-            // increase the pop that city gives by the size of the city and multiplier that is used
-            // example city of size 20 gets this.cityPopulationIncrease() * this.cityUpgradePopulationIncrease()^3 added to the max population
+            // increase the pop that city gives by the size of the city its ratio of tiles occupied and multiplier that is used
+            // example city of size 20 with 0.75 ratio (15) gets this.cityPopulationIncrease() * this.cityUpgradePopulationIncrease()^2 added to the max population
             if (citySize > 5) {
               const extraSize = citySize - 5;
               const multiplierCount = Math.floor(extraSize / 5);

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -111,6 +111,10 @@ export class DefaultConfig implements Config {
   defensePostDefenseBonus(): number {
     return 5;
   }
+
+  cityRange(): number {
+    return 10;
+  }
   spawnNPCs(): boolean {
     return !this._gameConfig.disableNPCs;
   }

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -347,7 +347,7 @@ export class DefaultConfig implements Config {
         speed *= this.cityDefenseDebuff();
       }
       for (const dp of gm.nearbyDefensePosts(tileToConquer)) {
-        if (dp.owner() == defender) {
+        if (dp.unit.owner() == defender) {
           // make it harder to conquer city tiles in the range of an defense post
           if (gm.nearbyCity(tileToConquer)?.insideCity) {
             mag *= this.cityDefensePostDefenseBonus();

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -115,6 +115,12 @@ export class DefaultConfig implements Config {
   defensePostDefenseBonus(): number {
     return 5;
   }
+  cityDefensePostDefenseBonus(): number {
+    return 8;
+  }
+  cityDefenseDebuff(): number {
+    return 0.8;
+  }
 
   cityMaxSize(): number {
     return 50;
@@ -335,11 +341,23 @@ export class DefaultConfig implements Config {
         throw new Error(`terrain type ${type} not supported`);
     }
     if (defender.isPlayer()) {
+      //make it easier to conquer city tiles
+      if (gm.nearbyCity(tileToConquer)?.insideCity) {
+        mag *= this.cityDefenseDebuff();
+        speed *= this.cityDefenseDebuff();
+      }
       for (const dp of gm.nearbyDefensePosts(tileToConquer)) {
         if (dp.owner() == defender) {
-          mag *= this.defensePostDefenseBonus();
-          speed *= this.defensePostDefenseBonus();
-          break;
+          // make it harder to conquer city tiles in the range of an defense post
+          if (gm.nearbyCity(tileToConquer)?.insideCity) {
+            mag *= this.cityDefensePostDefenseBonus();
+            speed *= this.cityDefensePostDefenseBonus();
+            break;
+          } else {
+            mag *= this.defensePostDefenseBonus();
+            speed *= this.defensePostDefenseBonus();
+            break;
+          }
         }
       }
     }

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -294,6 +294,16 @@ export const pastelTheme = new (class implements Theme {
     });
   }
 
+  defenseRingColor(playerInfo: PlayerInfo): Colord {
+    const tc = this.territoryColor(playerInfo).rgba;
+
+    return colord({
+      r: Math.max(tc.r - 15, 0),
+      g: Math.max(tc.g - 15, 0),
+      b: Math.max(tc.b - 15, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -284,6 +284,16 @@ export const pastelTheme = new (class implements Theme {
     });
   }
 
+  defendedCityColor(playerInfo: PlayerInfo): Colord {
+    const tc = this.territoryColor(playerInfo).rgba;
+
+    return colord({
+      r: Math.max(tc.r - 20, 0),
+      g: Math.max(tc.g - 20, 0),
+      b: Math.max(tc.b - 20, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -273,6 +273,16 @@ export const pastelTheme = new (class implements Theme {
     });
   }
 
+  cityColor(playerInfo: PlayerInfo): Colord {
+    const bc = this.cityColor(playerInfo).rgba;
+
+    return colord({
+      r: Math.min(bc.r - 10, 0),
+      g: Math.min(bc.g - 10, 0),
+      b: Math.min(bc.b - 10, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -273,13 +273,14 @@ export const pastelTheme = new (class implements Theme {
     });
   }
 
+  // color of the circle around cities
   cityColor(playerInfo: PlayerInfo): Colord {
-    const bc = this.cityColor(playerInfo).rgba;
+    const tc = this.territoryColor(playerInfo).rgba;
 
     return colord({
-      r: Math.min(bc.r - 10, 0),
-      g: Math.min(bc.g - 10, 0),
-      b: Math.min(bc.b - 10, 0),
+      r: Math.max(tc.r - 10, 0),
+      g: Math.max(tc.g - 10, 0),
+      b: Math.max(tc.b - 10, 0),
     });
   }
 

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -294,6 +294,16 @@ export const pastelThemeDark = new (class implements Theme {
     });
   }
 
+  defenseRingColor(playerInfo: PlayerInfo): Colord {
+    const tc = this.territoryColor(playerInfo).rgba;
+
+    return colord({
+      r: Math.max(tc.r - 15, 0),
+      g: Math.max(tc.g - 15, 0),
+      b: Math.max(tc.b - 15, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -273,13 +273,14 @@ export const pastelThemeDark = new (class implements Theme {
     });
   }
 
+  // color of the circle around cities
   cityColor(playerInfo: PlayerInfo): Colord {
-    const bc = this.cityColor(playerInfo).rgba;
+    const tc = this.territoryColor(playerInfo).rgba;
 
     return colord({
-      r: Math.min(bc.r - 10, 0),
-      g: Math.min(bc.g - 10, 0),
-      b: Math.min(bc.b - 10, 0),
+      r: Math.max(tc.r - 40, 0),
+      g: Math.max(tc.g - 40, 0),
+      b: Math.max(tc.b - 40, 0),
     });
   }
 

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -284,6 +284,16 @@ export const pastelThemeDark = new (class implements Theme {
     });
   }
 
+  defendedCityColor(playerInfo: PlayerInfo): Colord {
+    const tc = this.territoryColor(playerInfo).rgba;
+
+    return colord({
+      r: Math.max(tc.r - 20, 0),
+      g: Math.max(tc.g - 20, 0),
+      b: Math.max(tc.b - 20, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -273,6 +273,16 @@ export const pastelThemeDark = new (class implements Theme {
     });
   }
 
+  cityColor(playerInfo: PlayerInfo): Colord {
+    const bc = this.cityColor(playerInfo).rgba;
+
+    return colord({
+      r: Math.min(bc.r - 10, 0),
+      g: Math.min(bc.g - 10, 0),
+      b: Math.min(bc.b - 10, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/execution/CityUpgradeExecution.ts
+++ b/src/core/execution/CityUpgradeExecution.ts
@@ -1,0 +1,64 @@
+import { consolex } from "../Consolex";
+import {
+  Execution,
+  Game,
+  Player,
+  Unit,
+  PlayerID,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+
+export class CityUpgradeExecution implements Execution {
+  private player: Player;
+  private mg: Game;
+  private cityUpgrde: Unit;
+  private active: boolean = true;
+
+  constructor(
+    private ownerId: PlayerID,
+    private tile: TileRef,
+  ) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+    if (!mg.hasPlayer(this.ownerId)) {
+      console.warn(`CityExecution: player ${this.ownerId} not found`);
+      this.active = false;
+      return;
+    }
+    this.player = mg.player(this.ownerId);
+  }
+
+  tick(ticks: number): void {
+    if (this.cityUpgrde == null) {
+      const spawnTile = this.player.canBuild(UnitType.CityUpgrade, this.tile);
+      if (spawnTile == false) {
+        consolex.warn("cannot build cityUpgrde");
+        this.active = false;
+        return;
+      }
+      this.cityUpgrde = this.player.buildUnit(
+        UnitType.CityUpgrade,
+        0,
+        spawnTile,
+      );
+    }
+    if (!this.cityUpgrde.isActive()) {
+      this.active = false;
+      return;
+    }
+  }
+
+  owner(): Player {
+    return null;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -11,6 +11,7 @@ import {
 } from "../game/Game";
 import { TileRef } from "../game/GameMap";
 import { CityExecution } from "./CityExecution";
+import { CityUpgradeExecution } from "./CityUpgradeExecution";
 import { DefensePostExecution } from "./DefensePostExecution";
 import { MirvExecution } from "./MIRVExecution";
 import { MissileSiloExecution } from "./MissileSiloExecution";
@@ -51,6 +52,13 @@ export class ConstructionExecution implements Execution {
         this.completeConstruction();
         this.active = false;
         return;
+      }
+      // if an upgrade is done make the construction over the existing city
+      if (
+        this.mg.nearbyCity(this.tile).insideCity &&
+        this.constructionType == UnitType.CityUpgrade
+      ) {
+        this.tile = this.mg.nearbyCity(this.tile).city.tile();
       }
       const spawnTile = this.player.canBuild(this.constructionType, this.tile);
       if (spawnTile == false) {
@@ -113,6 +121,9 @@ export class ConstructionExecution implements Execution {
         break;
       case UnitType.City:
         this.mg.addExecution(new CityExecution(player.id(), this.tile));
+        break;
+      case UnitType.CityUpgrade:
+        this.mg.addExecution(new CityUpgradeExecution(player.id(), this.tile));
         break;
       default:
         throw Error(`unit type ${this.constructionType} not supported`);

--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -311,6 +311,12 @@ export class FakeHumanExecution implements Execution {
       2,
       (t) => new ConstructionExecution(this.player.id(), t, UnitType.City),
     );
+    this.maybeSpawnStructure(
+      UnitType.CityUpgrade,
+      1,
+      (t) =>
+        new ConstructionExecution(this.player.id(), t, UnitType.CityUpgrade),
+    );
     if (this.maybeSpawnWarship()) {
       return;
     }
@@ -336,7 +342,26 @@ export class FakeHumanExecution implements Execution {
     ) {
       return;
     }
-    const tile = this.randTerritoryTile(this.player);
+
+    let tile: TileRef | null = null;
+
+    //get a random city and upgrade it
+    if (type === UnitType.CityUpgrade) {
+      const cities = this.player
+        .units(UnitType.City)
+        .filter((city) => city.size() < 50);
+
+      if (cities.length > 0) {
+        const randomCity =
+          cities[Math.floor(this.random.next() * cities.length)];
+        tile = randomCity.tile();
+      } else {
+        return;
+      }
+    } else {
+      tile = this.randTerritoryTile(this.player);
+    }
+
     if (tile == null) {
       return;
     }

--- a/src/core/game/CityGrid.ts
+++ b/src/core/game/CityGrid.ts
@@ -88,7 +88,13 @@ export class CityGrid {
           const dy = tileY - y;
           const distSquared = dx * dx + dy * dy;
 
-          const cityRadiusSquared = citySize * citySize;
+          const cityRadiusSquared = this.gm.getCityRadius(
+            unit.id(),
+            dx,
+            dy,
+            citySize,
+            this.searchRange,
+          );
 
           if (distSquared <= rangeSquared) {
             const isInside = distSquared <= cityRadiusSquared;

--- a/src/core/game/CityGrid.ts
+++ b/src/core/game/CityGrid.ts
@@ -1,0 +1,85 @@
+import { Unit } from "./Game";
+import { GameMap, TileRef } from "./GameMap";
+import { UnitView } from "./GameView";
+
+export class CityGrid {
+  private grid: Set<Unit | UnitView>[][];
+  private readonly cellSize = 100;
+
+  constructor(
+    private gm: GameMap,
+    private searchRange: number,
+  ) {
+    this.grid = Array(Math.ceil(gm.height() / this.cellSize))
+      .fill(null)
+      .map(() =>
+        Array(Math.ceil(gm.width() / this.cellSize))
+          .fill(null)
+          .map(() => new Set<Unit | UnitView>()),
+      );
+  }
+
+  private getGridCoords(x: number, y: number): [number, number] {
+    return [Math.floor(x / this.cellSize), Math.floor(y / this.cellSize)];
+  }
+
+  addCity(unit: Unit | UnitView) {
+    const tile = unit.tile();
+    const [gridX, gridY] = this.getGridCoords(this.gm.x(tile), this.gm.y(tile));
+
+    if (this.isValidCell(gridX, gridY)) {
+      this.grid[gridY][gridX].add(unit);
+    }
+  }
+
+  removeCity(unit: Unit | UnitView) {
+    const tile = unit.tile();
+    const [gridX, gridY] = this.getGridCoords(this.gm.x(tile), this.gm.y(tile));
+
+    if (this.isValidCell(gridX, gridY)) {
+      this.grid[gridY][gridX].delete(unit);
+    }
+  }
+
+  private isValidCell(gridX: number, gridY: number): boolean {
+    return (
+      gridX >= 0 &&
+      gridX < this.grid[0].length &&
+      gridY >= 0 &&
+      gridY < this.grid.length
+    );
+  }
+
+  nearbyCities(tile: TileRef): Array<Unit | UnitView> {
+    const x = this.gm.x(tile);
+    const y = this.gm.y(tile);
+    const [gridX, gridY] = this.getGridCoords(x, y);
+    const cellsToCheck = Math.ceil(this.searchRange / this.cellSize);
+    const nearby: Array<Unit | UnitView> = [];
+
+    const startGridX = Math.max(0, gridX - cellsToCheck);
+    const endGridX = Math.min(this.grid[0].length - 1, gridX + cellsToCheck);
+    const startGridY = Math.max(0, gridY - cellsToCheck);
+    const endGridY = Math.min(this.grid.length - 1, gridY + cellsToCheck);
+
+    const rangeSquared = this.searchRange * this.searchRange;
+
+    for (let cy = startGridY; cy <= endGridY; cy++) {
+      for (let cx = startGridX; cx <= endGridX; cx++) {
+        for (const unit of this.grid[cy][cx]) {
+          const tileX = this.gm.x(unit.tile());
+          const tileY = this.gm.y(unit.tile());
+          const dx = tileX - x;
+          const dy = tileY - y;
+          const distSquared = dx * dx + dy * dy;
+
+          if (distSquared <= rangeSquared) {
+            nearby.push(unit);
+          }
+        }
+      }
+    }
+
+    return nearby;
+  }
+}

--- a/src/core/game/DefensePostGrid.ts
+++ b/src/core/game/DefensePostGrid.ts
@@ -55,12 +55,14 @@ export class DefenseGrid {
 
   // Get all defense units within range of a point
   // Returns [unit, distanceSquared] pairs for efficient filtering
-  nearbyDefenses(tile: TileRef): Array<Unit | UnitView> {
+  nearbyDefenses(
+    tile: TileRef,
+  ): Array<{ unit: Unit | UnitView; distSquared: number }> {
     const x = this.gm.x(tile);
     const y = this.gm.y(tile);
     const [gridX, gridY] = this.getGridCoords(x, y);
     const cellsToCheck = Math.ceil(this.searchRange / this.cellSize);
-    const nearby: Array<Unit | UnitView> = [];
+    const nearby: Array<{ unit: Unit | UnitView; distSquared: number }> = [];
 
     // Pre-calculate range bounds for efficiency
     const startGridX = Math.max(0, gridX - cellsToCheck);
@@ -81,7 +83,7 @@ export class DefenseGrid {
           const distSquared = dx * dx + dy * dy;
 
           if (distSquared <= rangeSquared) {
-            nearby.push(unit);
+            nearby.push({ unit, distSquared });
           }
         }
       }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -391,7 +391,7 @@ export interface Game extends GameMap {
   // Units
   units(...types: UnitType[]): Unit[];
   unitInfo(type: UnitType): UnitInfo;
-  nearbyDefensePosts(tile: TileRef): Unit[];
+  nearbyDefensePosts(tile: TileRef): Array<{ unit: Unit; distSquared: number }>;
   nearbyCity(tile: TileRef): { city: Unit | null; insideCity: boolean };
 
   addExecution(...exec: Execution[]): void;

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -237,6 +237,9 @@ export interface Unit {
 
   increaseSize(amount: number): void;
   size(): number;
+
+  ownerRatio(): number;
+  calcOwnerRatio(gm: GameMap): void;
 }
 
 export interface TerraNullius {

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -76,6 +76,7 @@ export enum UnitType {
   MissileSilo = "Missile Silo",
   DefensePost = "Defense Post",
   City = "City",
+  CityUpgrade = "CityUpgrade",
   MIRV = "MIRV",
   MIRVWarhead = "MIRV Warhead",
   Construction = "Construction",
@@ -233,6 +234,9 @@ export interface Unit {
 
   // Only for some types, otherwise return null
   dstPort(): Unit;
+
+  increaseSize(amount: number): void;
+  size(): number;
 }
 
 export interface TerraNullius {
@@ -385,6 +389,7 @@ export interface Game extends GameMap {
   units(...types: UnitType[]): Unit[];
   unitInfo(type: UnitType): UnitInfo;
   nearbyDefensePosts(tile: TileRef): Unit[];
+  nearbyCity(tile: TileRef): { city: Unit | null; insideCity: boolean };
 
   addExecution(...exec: Execution[]): void;
   displayMessage(

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -558,8 +558,13 @@ export class GameImpl implements Game {
     this.defenseGrid.removeDefense(dp);
   }
 
-  nearbyDefensePosts(tile: TileRef): Unit[] {
-    return this.defenseGrid.nearbyDefenses(tile) as Unit[];
+  nearbyDefensePosts(
+    tile: TileRef,
+  ): Array<{ unit: Unit; distSquared: number }> {
+    return this.defenseGrid.nearbyDefenses(tile) as Array<{
+      unit: Unit;
+      distSquared: number;
+    }>;
   }
 
   addCity(dp: Unit) {

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -30,6 +30,7 @@ import { UnitImpl } from "./UnitImpl";
 import { consolex } from "../Consolex";
 import { GameMap, GameMapImpl, TileRef, TileUpdate } from "./GameMap";
 import { DefenseGrid } from "./DefensePostGrid";
+import { CityGrid } from "./CityGrid";
 import { StatsImpl } from "./StatsImpl";
 import { Stats } from "./Stats";
 
@@ -67,6 +68,7 @@ export class GameImpl implements Game {
 
   private updates: GameUpdates = createGameUpdatesMap();
   private defenseGrid: DefenseGrid;
+  private cityGrid: CityGrid;
 
   private _stats: StatsImpl = new StatsImpl();
 
@@ -92,6 +94,7 @@ export class GameImpl implements Game {
       this._map,
       this._config.defensePostRange(),
     );
+    this.cityGrid = new CityGrid(this._map, this._config.cityRange());
   }
   isOnEdgeOfMap(ref: TileRef): boolean {
     return this._map.isOnEdgeOfMap(ref);
@@ -549,6 +552,17 @@ export class GameImpl implements Game {
 
   nearbyDefensePosts(tile: TileRef): Unit[] {
     return this.defenseGrid.nearbyDefenses(tile) as Unit[];
+  }
+
+  addCity(dp: Unit) {
+    this.cityGrid.addCity(dp);
+  }
+  removeCity(dp: Unit) {
+    this.cityGrid.removeCity(dp);
+  }
+
+  nearbyCities(tile: TileRef): Unit[] {
+    return this.cityGrid.nearbyCities(tile) as Unit[];
   }
 
   ref(x: number, y: number): TileRef {

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -94,7 +94,7 @@ export class GameImpl implements Game {
       this._map,
       this._config.defensePostRange(),
     );
-    this.cityGrid = new CityGrid(this._map, this._config.cityRange());
+    this.cityGrid = new CityGrid(this._map, this._config.cityMaxSize());
   }
   isOnEdgeOfMap(ref: TileRef): boolean {
     return this._map.isOnEdgeOfMap(ref);
@@ -561,8 +561,12 @@ export class GameImpl implements Game {
     this.cityGrid.removeCity(dp);
   }
 
-  nearbyCities(tile: TileRef): Unit[] {
-    return this.cityGrid.nearbyCities(tile) as Unit[];
+  nearbyCity(tile: TileRef): { city: Unit | null; insideCity: boolean } {
+    const result = this.cityGrid.nearbyCity(tile);
+    return {
+      city: result.city as Unit | null,
+      insideCity: result.insideCity,
+    };
   }
 
   ref(x: number, y: number): TileRef {

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -664,6 +664,18 @@ export class GameImpl implements Game {
   ): Set<TileRef> {
     return this._map.bfs(tile, filter);
   }
+  getCityRadius(
+    cityID: number,
+    dx: number,
+    dy: number,
+    citySize: number,
+    maxRange: number,
+  ): number {
+    return this._map.getCityRadius(cityID, dx, dy, citySize, maxRange);
+  }
+  circularNoise(seed: number, x: number, y: number): number {
+    return this._map.circularNoise(seed, x, y);
+  }
   toTileUpdate(tile: TileRef): bigint {
     return this._map.toTileUpdate(tile);
   }

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -401,6 +401,14 @@ export class GameImpl implements Game {
       type: GameUpdateType.Tile,
       update: this.toTileUpdate(tile),
     });
+
+    const result = this.nearbyCity(tile);
+
+    const closestCity = result?.city;
+    const insideCity = result?.insideCity;
+    if (closestCity && insideCity) {
+      closestCity.calcOwnerRatio(this._map);
+    }
   }
 
   relinquish(tile: TileRef) {

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -312,6 +312,8 @@ export class GameMapImpl implements GameMap {
 
     const adjustedRadius = baseRadius * (0.9 + noiseFactor * 0.2);
 
+    maxRange = maxRange - 10;
+
     const cityMaxRangeSquared = maxRange * maxRange;
     const finalRadiusSquared = Math.min(
       adjustedRadius * adjustedRadius,

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -74,6 +74,7 @@ export interface UnitUpdate {
   constructionType?: UnitType;
   targetId?: number;
   size?: number;
+  ownerRatio?: number;
 }
 
 export interface AttackUpdate {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -73,6 +73,7 @@ export interface UnitUpdate {
   health?: number;
   constructionType?: UnitType;
   targetId?: number;
+  size?: number;
 }
 
 export interface AttackUpdate {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -333,8 +333,13 @@ export class GameView implements GameMap {
     return this.updatedTiles;
   }
 
-  nearbyDefenses(tile: TileRef): UnitView[] {
-    return this.defensePostGrid.nearbyDefenses(tile) as UnitView[];
+  nearbyDefenses(
+    tile: TileRef,
+  ): Array<{ unit: UnitView; distSquared: number }> {
+    return this.defensePostGrid.nearbyDefenses(tile) as Array<{
+      unit: UnitView;
+      distSquared: number;
+    }>;
   }
 
   nearbyCity(tile: TileRef): { city: UnitView | null; insideCity: boolean } {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -31,6 +31,7 @@ import { GameMap, GameMapImpl, TileRef, TileUpdate } from "./GameMap";
 import { GameUpdateViewData } from "./GameUpdates";
 import { DefenseGrid } from "./DefensePostGrid";
 import { PlayerStats } from "./Stats";
+import { CityGrid } from "./CityGrid";
 
 export class UnitView {
   public _wasUpdated = true;
@@ -236,6 +237,7 @@ export class GameView implements GameMap {
   private _myPlayer: PlayerView | null = null;
 
   private defensePostGrid: DefenseGrid;
+  private cityGrid: CityGrid;
 
   private toDelete = new Set<number>();
 
@@ -254,6 +256,7 @@ export class GameView implements GameMap {
       playerNameViewData: {},
     };
     this.defensePostGrid = new DefenseGrid(_map, _config.defensePostRange());
+    this.cityGrid = new CityGrid(_map, _config.defensePostRange());
   }
   isOnEdgeOfMap(ref: TileRef): boolean {
     return this._map.isOnEdgeOfMap(ref);
@@ -306,6 +309,13 @@ export class GameView implements GameMap {
           this.defensePostGrid.removeDefense(unit);
         }
       }
+      if (update.unitType == UnitType.City) {
+        if (update.isActive) {
+          this.cityGrid.addCity(unit);
+        } else {
+          this.cityGrid.removeCity(unit);
+        }
+      }
       if (!unit.isActive()) {
         // Wait until next tick to delete the unit.
         this.toDelete.add(unit.id());
@@ -319,6 +329,10 @@ export class GameView implements GameMap {
 
   nearbyDefenses(tile: TileRef): UnitView[] {
     return this.defensePostGrid.nearbyDefenses(tile) as UnitView[];
+  }
+
+  nearbyCities(tile: TileRef): UnitView[] {
+    return this.cityGrid.nearbyCities(tile) as UnitView[];
   }
 
   myClientID(): ClientID {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -96,6 +96,9 @@ export class UnitView {
   targetId() {
     return this.data.targetId;
   }
+  size() {
+    return this.data.size;
+  }
 }
 
 export class PlayerView {
@@ -256,7 +259,7 @@ export class GameView implements GameMap {
       playerNameViewData: {},
     };
     this.defensePostGrid = new DefenseGrid(_map, _config.defensePostRange());
-    this.cityGrid = new CityGrid(_map, _config.defensePostRange());
+    this.cityGrid = new CityGrid(_map, _config.cityMaxSize());
   }
   isOnEdgeOfMap(ref: TileRef): boolean {
     return this._map.isOnEdgeOfMap(ref);
@@ -331,8 +334,12 @@ export class GameView implements GameMap {
     return this.defensePostGrid.nearbyDefenses(tile) as UnitView[];
   }
 
-  nearbyCities(tile: TileRef): UnitView[] {
-    return this.cityGrid.nearbyCities(tile) as UnitView[];
+  nearbyCity(tile: TileRef): { city: UnitView | null; insideCity: boolean } {
+    const result = this.cityGrid.nearbyCity(tile);
+    return {
+      city: result.city as UnitView | null,
+      insideCity: result.insideCity,
+    };
   }
 
   myClientID(): ClientID {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -99,6 +99,9 @@ export class UnitView {
   size() {
     return this.data.size;
   }
+  ownerRatio() {
+    return this.data.ownerRatio;
+  }
 }
 
 export class PlayerView {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -507,6 +507,18 @@ export class GameView implements GameMap {
   ): Set<TileRef> {
     return this._map.bfs(tile, filter);
   }
+  getCityRadius(
+    cityID: number,
+    dx: number,
+    dy: number,
+    citySize: number,
+    maxRange: number,
+  ): number {
+    return this._map.getCityRadius(cityID, dx, dy, citySize, maxRange);
+  }
+  circularNoise(seed: number, x: number, y: number): number {
+    return this._map.circularNoise(seed, x, y);
+  }
   toTileUpdate(tile: TileRef): bigint {
     return this._map.toTileUpdate(tile);
   }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -664,6 +664,7 @@ export class PlayerImpl implements Player {
         this.removeGold(cost);
         this.removeTroops(troops);
         this.mg.addUpdate(existingCity.toUpdate());
+        existingCity.calcOwnerRatio(this.mg);
         return existingCity;
       }
     }
@@ -675,6 +676,7 @@ export class PlayerImpl implements Player {
       this.mg.nextUnitID(),
       this,
       10,
+      1,
       dstPort,
     );
     this._units.push(b);
@@ -686,6 +688,7 @@ export class PlayerImpl implements Player {
     }
     if (type == UnitType.City) {
       this.mg.addCity(b);
+      b.calcOwnerRatio(this.mg);
     }
     return b;
   }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -665,6 +665,9 @@ export class PlayerImpl implements Player {
     if (type == UnitType.DefensePost) {
       this.mg.addDefensePost(b);
     }
+    if (type == UnitType.City) {
+      this.mg.addCity(b);
+    }
     return b;
   }
 

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -660,7 +660,7 @@ export class PlayerImpl implements Player {
       if (nearbyCity && insideCity) {
         const existingCity = nearbyCity;
 
-        existingCity.increaseSize(5);
+        existingCity.increaseSize(10);
         this.removeGold(cost);
         this.removeTroops(troops);
         this.mg.addUpdate(existingCity.toUpdate());
@@ -707,39 +707,10 @@ export class PlayerImpl implements Player {
     }
 
     if (unitType == UnitType.CityUpgrade) {
-      const city = this.mg.nearbyCity(targetTile)?.city;
-      let isValid = true;
-
-      // if there is a city check the tiles in a radius + 5 around them so the city actually has the space to expand outward
-      if (city) {
-        const cityTile = city.tile();
-        const citySize = city.size();
-        const radius = citySize + 5;
-
-        // only in 8 directions because of performance
-        const angleStep = Math.PI / 4;
-        for (let angle = 0; angle < 2 * Math.PI; angle += angleStep) {
-          const checkX =
-            this.mg.x(cityTile) + Math.round(Math.cos(angle) * radius);
-          const checkY =
-            this.mg.y(cityTile) + Math.round(Math.sin(angle) * radius);
-          const checkTile = checkY * this.mg.width() + checkX;
-
-          if (checkTile) {
-            const tileOwner = this.mg.ownerID(checkTile);
-            if (tileOwner !== this.mg.ownerID(cityTile)) {
-              isValid = false;
-              break;
-            }
-          }
-        }
-      }
-
       if (
         !this.mg.nearbyCity(targetTile).insideCity ||
         this.mg.nearbyCity(targetTile).city.size() ==
-          this.mg.config().cityMaxSize() ||
-        !isValid
+          this.mg.config().cityMaxSize()
       ) {
         return false;
       }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -710,7 +710,13 @@ export class PlayerImpl implements Player {
       if (
         !this.mg.nearbyCity(targetTile).insideCity ||
         this.mg.nearbyCity(targetTile).city.size() ==
-          this.mg.config().cityMaxSize()
+          this.mg.config().cityMaxSize() ||
+        this.mg
+          .units(UnitType.Construction)
+          .some(
+            (unit) =>
+              unit.tile() === this.mg.nearbyCity(targetTile).city.tile(),
+          )
       ) {
         return false;
       }

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -205,8 +205,6 @@ export class UnitImpl implements Unit {
 
     const ownershipRatio = totalTiles > 0 ? ownedTiles / totalTiles : 0;
 
-    console.log(ownershipRatio);
-
     this._ownerRatio = ownershipRatio;
   }
 

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -185,7 +185,13 @@ export class UnitImpl implements Unit {
       const dy = gm.y(targetTile) - gm.y(cityTile);
 
       const distanceSquared = dx * dx + dy * dy;
-      const radiusSquared = radius * radius;
+      const radiusSquared = gm.getCityRadius(
+        this.id(),
+        dx,
+        dy,
+        radius,
+        this.mg.config().cityMaxSize(),
+      );
 
       if (distanceSquared > radiusSquared) return false;
 
@@ -200,6 +206,7 @@ export class UnitImpl implements Unit {
     const ownershipRatio = totalTiles > 0 ? ownedTiles / totalTiles : 0;
 
     console.log(ownershipRatio);
+
     this._ownerRatio = ownershipRatio;
   }
 

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -119,6 +119,9 @@ export class UnitImpl implements Unit {
     if (this.type() == UnitType.DefensePost) {
       this.mg.removeDefensePost(this);
     }
+    if (this.type() == UnitType.City) {
+      this.mg.removeCity(this);
+    }
     if (displayMessage) {
       this.mg.displayMessage(
         `Your ${this.type()} was destroyed`,

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -23,6 +23,7 @@ export class UnitImpl implements Unit {
     private _troops: number,
     private _id: number,
     public _owner: PlayerImpl,
+    private _size: number,
     private _dstPort?: Unit,
   ) {
     // default to 60% health (or 1.2 is no health specified)
@@ -47,6 +48,7 @@ export class UnitImpl implements Unit {
       health: this.hasHealth() ? Number(this._health) : undefined,
       constructionType: this._constructionType,
       targetId: this.target() ? this.target().id() : null,
+      size: this.size(),
     };
   }
 
@@ -159,6 +161,14 @@ export class UnitImpl implements Unit {
 
   dstPort(): Unit {
     return this._dstPort;
+  }
+
+  size(): number {
+    return this._size;
+  }
+
+  increaseSize(amount: number): void {
+    this._size += amount;
   }
 
   setTarget(target: Unit) {


### PR DESCRIPTION
Alright this is a big one and probably needs a ton of testing

The basic idea is Cities create an area around them when being build this area can be upgraded using cityUpgrades this increases their size and the population they give.

currently its a start size if 10 (5 for normal pop the other 5 give +20%) after that each upgrade gives +10 size so 2x +20% until a max of size 50. The actual pop they give is depended on the ratio of tiles they city could have and actually has. 
Example: a city of size 20 has 5 for normal pop and 15 giving the 20% extra if that city only has 75% of the tiles it could have those 15 are reduced to 10 so the city only gives 2x 20% pop instead of 3x.

additionally city tiles are easier to claim (20% easier) but if there is a defense post nearby the 8 times harder to claim (even stronger then normal defense post tiles).

I also added a ring around defense posts showing the area they actually protect.

This PR is based on the suggestion of "Unbuilt" on the openfront discord server