### PR TITLE
Fix to getArea function within TerrainMapGenerator

### DIFF
--- a/src/scripts/TerrainMapGenerator.ts
+++ b/src/scripts/TerrainMapGenerator.ts
@@ -352,9 +352,9 @@ function getArea(
       next.push([x - 1, y]);
       next.push([x, y + 1]);
       next.push([x, y - 1]);
+      area.push([x, y]);
     }
 
-    area.push([x, y]);
     visited.add(key);
   }
 


### PR DESCRIPTION
getArea function was adding the coords to area regardless of whether the TerrainType at that coord was targetType. Result was inaccurate area lengths that were always >= the accurate area length.