### PR TITLE
have nginx cache index for 1s.

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -158,13 +158,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
     
+    # Updated HTML file caching - 1 second cache
     location ~* \.html$ {
         proxy_pass http://127.0.0.1:3000;
         add_header Content-Type text/html;
-        add_header Cache-Control "public, max-age=86400";  # 24 hours for HTML files
+        add_header Cache-Control "public, max-age=1";  # 1 second for HTML files
         
         proxy_cache STATIC;
-        proxy_cache_valid 200 302 24h;
+        proxy_cache_valid 200 302 1s;  # Cache successful responses for 1 second
         proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
         proxy_cache_lock on;
         add_header X-Cache-Status $upstream_cache_status;
@@ -175,9 +176,17 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
     
-    # Root location - make sure index.html is the default
+    # Updated Root location - with 1 second cache
     location = / {
         proxy_pass http://127.0.0.1:3000;
+        add_header Cache-Control "public, max-age=1";  # 1 second cache
+        
+        proxy_cache STATIC;
+        proxy_cache_valid 200 302 1s;  # Cache successful responses for 1 second
+        proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+        proxy_cache_lock on;
+        add_header X-Cache-Status $upstream_cache_status;
+        
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;
@@ -187,9 +196,20 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
     
-    # Main location
+    # Main location with conditional caching for index.html
     location / {
         proxy_pass http://127.0.0.1:3000;
+        
+        # Add caching for any index.html that might be served here
+        if ($request_uri ~* "index\.html$") {
+            add_header Cache-Control "public, max-age=1";
+            proxy_cache STATIC;
+            proxy_cache_valid 200 302 1s;
+            proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+            proxy_cache_lock on;
+            add_header X-Cache-Status $upstream_cache_status;
+        }
+        
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection $connection_upgrade;

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -30,8 +30,10 @@ app.use(
     setHeaders: (res, path) => {
       // You can conditionally set different cache times based on file types
       if (path.endsWith(".html")) {
-        // HTML files get shorter cache time
-        res.setHeader("Cache-Control", "public, max-age=60");
+        // Set HTML files to no-cache to ensure Express doesn't send 304s
+        res.setHeader("Cache-Control", "no-cache, must-revalidate");
+        res.setHeader("Pragma", "no-cache");
+        res.setHeader("Expires", "0");
       } else if (path.match(/\.(js|css|svg)$/)) {
         // JS, CSS, SVG get long cache with immutable
         res.setHeader("Cache-Control", "public, max-age=31536000, immutable");


### PR DESCRIPTION
This is required for A B deployments, the browser wasn't updating due to conditional caches