### PR TITLE
Revert "Change BorderTiles from Array to Set (#230)"

### DIFF
--- a/src/core/execution/BotExecution.ts
+++ b/src/core/execution/BotExecution.ts
@@ -73,12 +73,12 @@ export class BotExecution implements Execution {
       this.neighborsTerraNullius = false;
     }
 
-  const border = new Set(
-  this.bot.borderTiles().flatMap((t) => this.mg.neighbors(t)));
-  const enemies = Array.from(border).filter(
-  (t) => this.mg.hasOwner(t) && this.mg.owner(t) !== this.bot);
+    const border = Array.from(this.bot.borderTiles())
+      .flatMap((t) => this.mg.neighbors(t))
+      .filter((t) => this.mg.hasOwner(t) && this.mg.owner(t) != this.bot);
 
-if (enemies.length === 0) return;
+    if (border.length == 0) {
+      return;
     }
 
     const toAttack = border[this.random.nextInt(0, border.length)];


### PR DESCRIPTION
This reverts commit 812465138262747e7b7d97ac36b046bc8ef1eb85 which
breaks compilation, has wrong indentation and uses flatMap without
Array.from which is also wrong.
