### PR TITLE
fix: lobby were twice as long because of dynamic timer

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -90,7 +90,6 @@ function getServerConfig(gameEnv: string) {
 export interface ServerConfig {
   turnIntervalMs(): number;
   gameCreationRate(highTraffic: boolean): number;
-  lobbyLifetime(highTraffic: boolean): number;
   lobbyMaxPlayers(map: GameMapType): number;
   discordRedirectURI(): string;
   numWorkers(): number;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -66,9 +66,6 @@ export abstract class DefaultServerConfig implements ServerConfig {
     }
     return Math.random() < 0.3 ? 60 : 40;
   }
-  lobbyLifetime(highTraffic: boolean): number {
-    return this.gameCreationRate(highTraffic) * 2;
-  }
   workerIndex(gameID: GameID): number {
     return simpleHash(gameID) % this.numWorkers();
   }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -201,7 +201,7 @@ export class GameServer {
       return this._startTime;
     } else {
       //game hasn't started yet, only works for public games
-      return this.createdAt + this.config.lobbyLifetime(this.highTraffic);
+      return this.createdAt + this.config.gameCreationRate(this.highTraffic);
     }
   }
 
@@ -382,7 +382,7 @@ export class GameServer {
 
     const msSinceCreation = now - this.createdAt;
     const lessThanLifetime =
-      msSinceCreation < this.config.lobbyLifetime(this.highTraffic);
+      msSinceCreation < this.config.gameCreationRate(this.highTraffic);
     const notEnoughPlayers =
       this.gameConfig.gameType == GameType.Public &&
       this.gameConfig.maxPlayers &&
@@ -392,7 +392,9 @@ export class GameServer {
     }
     const warmupOver =
       now >
-      this.createdAt + this.config.lobbyLifetime(this.highTraffic) + 30 * 1000;
+      this.createdAt +
+        this.config.gameCreationRate(this.highTraffic) +
+        30 * 1000;
     if (noActive && warmupOver && noRecentPings) {
       return GamePhase.Finished;
     }
@@ -413,7 +415,7 @@ export class GameServer {
       })),
       gameConfig: this.gameConfig,
       msUntilStart: this.isPublic()
-        ? this.createdAt + this.config.lobbyLifetime(this.highTraffic)
+        ? this.createdAt + this.config.gameCreationRate(this.highTraffic)
         : undefined,
     };
   }


### PR DESCRIPTION
We previously had a system where lobbyLifetime = gameCreationRate * 2
It was to always have one lobby ready.
With dynamic timer (start if enough player or timer's over) we cannot
rely on this system (which used setInterval) so we have one lobby and
check every 100ms if we need to create another lobby.
Might add 100ms+time of creating a lobby ms latency. Which is fine I
guess.
