### PR TITLE
tweak numbers of attack

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -353,8 +353,8 @@ export class DefaultConfig implements Config {
     const type = gm.terrainType(tileToConquer);
     switch (type) {
       case TerrainType.Plains:
-        mag = 80;
-        speed = 15;
+        mag = 85;
+        speed = 16.5;
         break;
       case TerrainType.Highland:
         mag = 100;
@@ -406,14 +406,14 @@ export class DefaultConfig implements Config {
     if (defender.isPlayer()) {
       return {
         attackerTroopLoss:
-          within(defender.troops() / attackTroops, 0.5, 2) *
+          within(defender.troops() / attackTroops, 0.6, 2) *
           mag *
           0.8 *
           largeModifier *
           (defender.isTraitor() ? this.traitorDefenseDebuff() : 1),
         defenderTroopLoss: defender.troops() / defender.numTilesOwned(),
         tilesPerTickUsed:
-          within(defender.troops() / (5 * attackTroops), 0.2, 1.5) *
+          within(defender.troops() / (4 * attackTroops), 0.2, 1.5) *
           speed *
           largeModifier,
       };


### PR DESCRIPTION
Slightly decrease flat land advantage (in certain cases it feels almost
instataneous otherwise)
To calculate speed bonus use 4*attackTroops instead of 5 (people keep
complaining than small numbers of troops take crazy amount of lands
veryn quick)
Slightly increase minimum multiplier for attacker loss, to make
snowballing a little bit slower.
I only slightly modified numbers because the meta is fun it's just too
quick on certain cases.
