### PR TITLE
fix: nginx not caching static resources

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -43,7 +43,7 @@ server {
     error_log /var/log/nginx/error.log;
     
     # Static file handling with proper MIME types and consistent caching
-    location ~* ^/static/(.*)$ {
+    location ~* \.(jpg|jpeg|png|gif|ico|svg|webp|woff|woff2|ttf|eot)$ {
         proxy_pass http://127.0.0.1:3000;
         
         # Include MIME types


### PR DESCRIPTION
The current nginx config isn't caching any images given they're not being served under the `/static/` path. 