### PR TITLE
small sam buff

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -255,16 +255,18 @@ export class DefaultConfig implements Config {
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 5 * 10,
         };
+      // the starting cost should allways be 1mil because the way to defeat a sam launcher is to send 2 nukes at once and it should then give a positive gold trade because 2 nukes are 1.5mil and the first sam is 1mil
+      // when there are multiple sam launchers at the same both try to intercept the same nuke so sending 2 at once also works in that case and prevents building unnukable areas
       case UnitType.SAMLauncher:
         return {
           cost: (p: Player) =>
             p.type() == PlayerType.Human && this.infiniteGold()
               ? 0
               : Math.min(
-                  1_500_000 * 3,
+                  3_000_000 * 3,
                   (p.unitsIncludingConstruction(UnitType.SAMLauncher).length +
                     1) *
-                    1_500_000,
+                    1_000_000,
                 ),
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 30 * 10,

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -22,7 +22,8 @@ export class SAMLauncherExecution implements Execution {
 
   private searchRange = 100;
 
-  private missileAttackRate = 100; // 10 seconds
+  // the attack rate of the missile should ensure that 2 nukes coming at once can not be defended so the value should never be below 5sec (in a searchrange of 100) anything above just gives a bit of extra time for the second nuke
+  private missileAttackRate = 75; // 7.5 seconds
   private lastMissileAttack = 0;
 
   private pseudoRandom: PseudoRandom;
@@ -61,6 +62,8 @@ export class SAMLauncherExecution implements Execution {
       this.pseudoRandom = new PseudoRandom(this.post.id());
     }
 
+    // only attack atom or hydrogen bombs
+    // mirvs and mirvwarheads should never be attacked by an sam to keep them as the "game ender"
     const nukes = this.mg
       .units(UnitType.AtomBomb, UnitType.HydrogenBomb)
       .filter(

--- a/src/core/execution/SAMMissileExecution.ts
+++ b/src/core/execution/SAMMissileExecution.ts
@@ -23,10 +23,11 @@ export class SAMMissileExecution implements Execution {
     private target: Unit,
     private mg: Game,
     private pseudoRandom: number,
-    private speed: number = 6,
-    // Regular atom bomb or warhead of MIRV
+    // make it able to catch up to nukes
+    private speed: number = 10,
+    // the hitting chance should never be below 50% because then it will feel useless because more then half of the time it doesnt actually intercept the nuke
     private hittingChance: number = 0.75,
-    private hittingChanceHydrogen: number = 0.1,
+    private hittingChanceHydrogen: number = 0.5,
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -65,15 +66,10 @@ export class SAMMissileExecution implements Execution {
           this.active = false;
           let hit = false;
           if (
-            this.target.type() == UnitType.HydrogenBomb &&
-            this.pseudoRandom < this.hittingChanceHydrogen
-          ) {
-            hit = true;
-          } else if (
-            [UnitType.MIRVWarhead, UnitType.AtomBomb].includes(
-              this.target.type(),
-            ) &&
-            this.pseudoRandom < this.hittingChance
+            (this.target.type() == UnitType.AtomBomb &&
+              this.pseudoRandom < this.hittingChance) ||
+            (this.target.type() == UnitType.HydrogenBomb &&
+              this.pseudoRandom < this.hittingChanceHydrogen)
           ) {
             hit = true;
           }


### PR DESCRIPTION
this reverts some of the changes @ilan-schemoul did to not make the sam completly useless. I added some comments explaining why i chose these specfific values.

and i also removed the mirvwarhead stuff because it wasnt in the sam execution and the missile cant catch up to the warhead anyway