### PR TITLE
unitgrid instead of defensepostgrid

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -81,6 +81,31 @@ export class TerritoryLayer implements Layer {
             }
           });
       }
+      if (update.unitType == UnitType.SAMLauncher) {
+        const tile = update.pos;
+
+        this.game.bfs(tile, (gm, targetTile) => {
+          const dx = this.game.x(targetTile) - this.game.x(tile);
+          const dy = this.game.y(targetTile) - this.game.y(tile);
+
+          const distanceSquared = dx * dx + dy * dy;
+          const radiusSquared =
+            this.game.config().SAMRange() * this.game.config().SAMRange();
+          if (distanceSquared <= radiusSquared) {
+            if (
+              Math.abs(
+                Math.sqrt(distanceSquared) - this.game.config().SAMRange(),
+              ) < 1.5 &&
+              this.game.ownerID(tile) == update.ownerID
+            ) {
+              this.enqueueTile(targetTile);
+            }
+            // make the bfs search even when its not the ring yet
+            return true;
+          }
+          return false;
+        });
+      }
     });
 
     if (!this.game.inSpawnPhase()) {
@@ -240,8 +265,13 @@ export class TerritoryLayer implements Layer {
     const owner = this.game.owner(tile) as PlayerView;
     if (this.game.isBorder(tile)) {
       if (
-        this.game.nearbyDefenses(tile).filter((u) => u.owner() == owner)
-          .length > 0
+        this.game
+          .nearbyUnits(
+            tile,
+            this.game.config().defensePostRange(),
+            UnitType.DefensePost,
+          )
+          .filter((u) => u.unit.owner() == owner).length > 0
       ) {
         this.paintCell(
           this.game.x(tile),
@@ -258,12 +288,29 @@ export class TerritoryLayer implements Layer {
         );
       }
     } else {
-      this.paintCell(
-        this.game.x(tile),
-        this.game.y(tile),
-        this.theme.territoryColor(owner.info()),
-        150,
-      );
+      const isOnDefenseRing = this.game
+        .nearbyUnits(tile, this.game.config().SAMRange(), UnitType.SAMLauncher)
+        .filter((u) => u.unit.owner() == owner)
+        .some((u) => {
+          const dist = Math.sqrt(u.distSquared);
+          return Math.abs(dist - this.game.config().SAMRange()) < 1.5;
+        });
+
+      if (isOnDefenseRing) {
+        this.paintCell(
+          this.game.x(tile),
+          this.game.y(tile),
+          this.theme.SAMRingColor(owner.info()),
+          255,
+        );
+      } else {
+        this.paintCell(
+          this.game.x(tile),
+          this.game.y(tile),
+          this.theme.territoryColor(owner.info()),
+          150,
+        );
+      }
     }
   }
 

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -161,6 +161,7 @@ export interface Config {
   tradeShipGold(dist: number): Gold;
   tradeShipSpawnRate(numberOfPorts: number): number;
   defensePostRange(): number;
+  SAMRange(): number;
   defensePostDefenseBonus(): number;
   falloutDefenseModifier(percentOfFallout: number): number;
   difficultyModifier(difficulty: Difficulty): number;
@@ -172,6 +173,7 @@ export interface Theme {
   territoryColor(playerInfo: PlayerInfo): Colord;
   borderColor(playerInfo: PlayerInfo): Colord;
   defendedBorderColor(playerInfo: PlayerInfo): Colord;
+  SAMRingColor(playerInfo: PlayerInfo): Colord;
   terrainColor(gm: GameMap, tile: TileRef): Colord;
   backgroundColor(): Colord;
   falloutColor(): Colord;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -128,6 +128,9 @@ export class DefaultConfig implements Config {
   defensePostRange(): number {
     return 30;
   }
+  SAMRange(): number {
+    return 100;
+  }
   defensePostDefenseBonus(): number {
     return 5;
   }
@@ -364,8 +367,12 @@ export class DefaultConfig implements Config {
         throw new Error(`terrain type ${type} not supported`);
     }
     if (defender.isPlayer()) {
-      for (const dp of gm.nearbyDefensePosts(tileToConquer)) {
-        if (dp.owner() == defender) {
+      for (const dp of gm.nearbyUnits(
+        tileToConquer,
+        gm.config().defensePostRange(),
+        UnitType.DefensePost,
+      )) {
+        if (dp.unit.owner() == defender) {
           mag *= this.defensePostDefenseBonus();
           speed *= this.defensePostDefenseBonus();
           break;

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -273,6 +273,15 @@ export const pastelTheme = new (class implements Theme {
     });
   }
 
+  SAMRingColor(playerInfo: PlayerInfo): Colord {
+    const tc = this.territoryColor(playerInfo).rgba;
+    return colord({
+      r: Math.max(tc.r - 20, 0),
+      g: Math.max(tc.g - 20, 0),
+      b: Math.max(tc.b - 20, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -273,6 +273,15 @@ export const pastelThemeDark = new (class implements Theme {
     });
   }
 
+  SAMRingColor(playerInfo: PlayerInfo): Colord {
+    const tc = this.territoryColor(playerInfo).rgba;
+    return colord({
+      r: Math.max(tc.r - 20, 0),
+      g: Math.max(tc.g - 20, 0),
+      b: Math.max(tc.b - 20, 0),
+    });
+  }
+
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -402,7 +402,12 @@ export interface Game extends GameMap {
   // Units
   units(...types: UnitType[]): Unit[];
   unitInfo(type: UnitType): UnitInfo;
-  nearbyDefensePosts(tile: TileRef): Unit[];
+  // nearbyDefensePosts(tile: TileRef): Unit[];
+  nearbyUnits(
+    tile: TileRef,
+    searchRange: number,
+    type: UnitType,
+  ): Array<{ unit: Unit; distSquared: number }>;
 
   addExecution(...exec: Execution[]): void;
   displayMessage(

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -29,7 +29,8 @@ import { MessageType } from "./Game";
 import { UnitImpl } from "./UnitImpl";
 import { consolex } from "../Consolex";
 import { GameMap, GameMapImpl, TileRef, TileUpdate } from "./GameMap";
-import { DefenseGrid } from "./DefensePostGrid";
+// import { DefenseGrid } from "./DefensePostGrid";
+import { UnitGrid } from "./UnitGrid";
 import { StatsImpl } from "./StatsImpl";
 import { Stats } from "./Stats";
 
@@ -66,7 +67,8 @@ export class GameImpl implements Game {
   private _nextUnitID = 1;
 
   private updates: GameUpdates = createGameUpdatesMap();
-  private defenseGrid: DefenseGrid;
+  // private defenseGrid: DefenseGrid;
+  private unitGrid: UnitGrid;
 
   private _stats: StatsImpl = new StatsImpl();
 
@@ -88,10 +90,11 @@ export class GameImpl implements Game {
           n.strength,
         ),
     );
-    this.defenseGrid = new DefenseGrid(
-      this._map,
-      this._config.defensePostRange(),
-    );
+    // this.defenseGrid = new DefenseGrid(
+    //   this._map,
+    //   this._config.defensePostRange(),
+    // );
+    this.unitGrid = new UnitGrid(this._map);
   }
   isOnEdgeOfMap(ref: TileRef): boolean {
     return this._map.isOnEdgeOfMap(ref);
@@ -541,15 +544,33 @@ export class GameImpl implements Game {
     });
   }
 
-  addDefensePost(dp: Unit) {
-    this.defenseGrid.addDefense(dp);
+  // addDefensePost(dp: Unit) {
+  //   this.defenseGrid.addDefense(dp);
+  // }
+  // removeDefensePost(dp: Unit) {
+  //   this.defenseGrid.removeDefense(dp);
+  // }
+
+  addUnit(u: Unit) {
+    this.unitGrid.addUnit(u);
   }
-  removeDefensePost(dp: Unit) {
-    this.defenseGrid.removeDefense(dp);
+  removeUnit(u: Unit) {
+    this.unitGrid.removeUnit(u);
   }
 
-  nearbyDefensePosts(tile: TileRef): Unit[] {
-    return this.defenseGrid.nearbyDefenses(tile) as Unit[];
+  // nearbyDefensePosts(tile: TileRef): Unit[] {
+  //   return this.defenseGrid.nearbyDefenses(tile) as Unit[];
+  // }
+
+  nearbyUnits(
+    tile: TileRef,
+    searchRange: number,
+    type: UnitType,
+  ): Array<{ unit: Unit; distSquared: number }> {
+    return this.unitGrid.nearbyUnits(tile, searchRange, type) as Array<{
+      unit: Unit;
+      distSquared: number;
+    }>;
   }
 
   ref(x: number, y: number): TileRef {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -30,8 +30,10 @@ import { TerraNulliusImpl } from "./TerraNulliusImpl";
 import { WorkerClient } from "../worker/WorkerClient";
 import { GameMap, GameMapImpl, TileRef, TileUpdate } from "./GameMap";
 import { GameUpdateViewData } from "./GameUpdates";
-import { DefenseGrid } from "./DefensePostGrid";
+// import { DefenseGrid } from "./DefensePostGrid";
+import { UnitGrid } from "./UnitGrid";
 import { consolex } from "../Consolex";
+import { SAMLauncherExecution } from "../execution/SAMLauncherExecution";
 
 export class UnitView {
   public _wasUpdated = true;
@@ -251,7 +253,8 @@ export class GameView implements GameMap {
 
   private _myPlayer: PlayerView | null = null;
 
-  private defensePostGrid: DefenseGrid;
+  // private defensePostGrid: DefenseGrid;
+  private unitGrid: UnitGrid;
 
   private toDelete = new Set<number>();
 
@@ -269,7 +272,8 @@ export class GameView implements GameMap {
       updates: null,
       playerNameViewData: {},
     };
-    this.defensePostGrid = new DefenseGrid(_map, _config.defensePostRange());
+    // this.defensePostGrid = new DefenseGrid(_map, _config.defensePostRange());
+    this.unitGrid = new UnitGrid(_map);
   }
   isOnEdgeOfMap(ref: TileRef): boolean {
     return this._map.isOnEdgeOfMap(ref);
@@ -315,12 +319,17 @@ export class GameView implements GameMap {
         unit = new UnitView(this, update);
         this._units.set(update.id, unit);
       }
-      if (update.unitType == UnitType.DefensePost) {
-        if (update.isActive) {
-          this.defensePostGrid.addDefense(unit);
-        } else {
-          this.defensePostGrid.removeDefense(unit);
-        }
+      // if (update.unitType == UnitType.DefensePost) {
+      //   if (update.isActive) {
+      //     this.defensePostGrid.addDefense(unit);
+      //   } else {
+      //     this.defensePostGrid.removeDefense(unit);
+      //   }
+      // }
+      if (update.isActive) {
+        this.unitGrid.addUnit(unit);
+      } else {
+        this.unitGrid.removeUnit(unit);
       }
       if (!unit.isActive()) {
         // Wait until next tick to delete the unit.
@@ -333,8 +342,19 @@ export class GameView implements GameMap {
     return this.updatedTiles;
   }
 
-  nearbyDefenses(tile: TileRef): UnitView[] {
-    return this.defensePostGrid.nearbyDefenses(tile) as UnitView[];
+  // nearbyDefenses(tile: TileRef): UnitView[] {
+  //   return this.defensePostGrid.nearbyDefenses(tile) as UnitView[];
+  // }
+
+  nearbyUnits(
+    tile: TileRef,
+    searchRange: number,
+    type: UnitType,
+  ): Array<{ unit: UnitView; distSquared: number }> {
+    return this.unitGrid.nearbyUnits(tile, searchRange, type) as Array<{
+      unit: UnitView;
+      distSquared: number;
+    }>;
   }
 
   myClientID(): ClientID {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -665,9 +665,11 @@ export class PlayerImpl implements Player {
     this.removeGold(cost);
     this.removeTroops(troops);
     this.mg.addUpdate(b.toUpdate());
-    if (type == UnitType.DefensePost) {
-      this.mg.addDefensePost(b);
-    }
+    // if (type == UnitType.DefensePost) {
+    //   this.mg.addDefensePost(b);
+    // }
+    this.mg.addUnit(b);
+
     return b;
   }
 

--- a/src/core/game/UnitGrid.ts
+++ b/src/core/game/UnitGrid.ts
@@ -1,0 +1,93 @@
+import { Unit, UnitType } from "./Game";
+import { GameMap, TileRef } from "./GameMap";
+import { UnitView } from "./GameView";
+
+export class UnitGrid {
+  private grid: Set<Unit | UnitView>[][];
+  private readonly cellSize = 100;
+
+  constructor(private gm: GameMap) {
+    this.grid = Array(Math.ceil(gm.height() / this.cellSize))
+      .fill(null)
+      .map(() =>
+        Array(Math.ceil(gm.width() / this.cellSize))
+          .fill(null)
+          .map(() => new Set<Unit | UnitView>()),
+      );
+  }
+
+  // Get grid coordinates from pixel coordinates
+  private getGridCoords(x: number, y: number): [number, number] {
+    return [Math.floor(x / this.cellSize), Math.floor(y / this.cellSize)];
+  }
+
+  // Add a unit to the grid
+  addUnit(unit: Unit | UnitView) {
+    const tile = unit.tile();
+    const [gridX, gridY] = this.getGridCoords(this.gm.x(tile), this.gm.y(tile));
+
+    if (this.isValidCell(gridX, gridY)) {
+      this.grid[gridY][gridX].add(unit);
+    }
+  }
+
+  // Remove a unit from the grid
+  removeUnit(unit: Unit | UnitView) {
+    const tile = unit.tile();
+    const [gridX, gridY] = this.getGridCoords(this.gm.x(tile), this.gm.y(tile));
+
+    if (this.isValidCell(gridX, gridY)) {
+      this.grid[gridY][gridX].delete(unit);
+    }
+  }
+
+  private isValidCell(gridX: number, gridY: number): boolean {
+    return (
+      gridX >= 0 &&
+      gridX < this.grid[0].length &&
+      gridY >= 0 &&
+      gridY < this.grid.length
+    );
+  }
+
+  // Get all units within range of a point
+  // Returns [unit, distanceSquared] pairs for efficient filtering
+  nearbyUnits(
+    tile: TileRef,
+    searchRange: number,
+    type: UnitType,
+  ): Array<{ unit: Unit | UnitView; distSquared: number }> {
+    const x = this.gm.x(tile);
+    const y = this.gm.y(tile);
+    const [gridX, gridY] = this.getGridCoords(x, y);
+    const cellsToCheck = Math.ceil(searchRange / this.cellSize);
+    const nearby: Array<{ unit: Unit | UnitView; distSquared: number }> = [];
+
+    const startGridX = Math.max(0, gridX - cellsToCheck);
+    const endGridX = Math.min(this.grid[0].length - 1, gridX + cellsToCheck);
+    const startGridY = Math.max(0, gridY - cellsToCheck);
+    const endGridY = Math.min(this.grid.length - 1, gridY + cellsToCheck);
+
+    const rangeSquared = searchRange * searchRange;
+
+    for (let cy = startGridY; cy <= endGridY; cy++) {
+      for (let cx = startGridX; cx <= endGridX; cx++) {
+        for (const unit of this.grid[cy][cx]) {
+          const tileX = this.gm.x(unit.tile());
+          const tileY = this.gm.y(unit.tile());
+          const dx = tileX - x;
+          const dy = tileY - y;
+          const distSquared = dx * dx + dy * dy;
+
+          if (distSquared <= rangeSquared) {
+            if (unit.type() == type) {
+              nearby.push({ unit, distSquared });
+            }
+          }
+        }
+      }
+    }
+
+    return nearby;
+  }
+}

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -128,9 +128,10 @@ export class UnitImpl implements Unit {
     this._owner._units = this._owner._units.filter((b) => b != this);
     this._active = false;
     this.mg.addUpdate(this.toUpdate());
-    if (this.type() == UnitType.DefensePost) {
-      this.mg.removeDefensePost(this);
-    }
+    // if (this.type() == UnitType.DefensePost) {
+    //   this.mg.removeDefensePost(this);
+    // }
+    this.mg.removeUnit(this);
     if (displayMessage) {
       this.mg.displayMessage(
         `Your ${this.type()} was destroyed`,


### PR DESCRIPTION
added a unitgrid instead of a defensepostgrid for all units to be able to see if a tile is inside the range of a unit by a custom distance

this is used for the sam launcher to draw a circle around the area it protects

removed all parts that use the defensepostgrid and made it use the unitgrid instead