### PR TITLE
Inversion of how water color was being set as it moved away from land…

### DIFF
--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -285,14 +285,12 @@ export const pastelTheme = new (class implements Theme {
         if (gm.isShoreline(tile) && gm.isWater(tile)) {
           return this.shorelineWater;
         }
-        if (gm.magnitude(tile) < 10) {
-          return colord({
-            r: Math.max(w.r - 10 + mag, 0),
-            g: Math.max(w.g - 10 + mag, 0),
-            b: Math.max(w.b - 10 + mag, 0),
-          });
-        }
-        return this.water;
+        return colord({
+          r: Math.max(w.r - 10 + (11 - Math.min(mag, 10)), 0),
+          g: Math.max(w.g - 10 + (11 - Math.min(mag, 10)), 0),
+          b: Math.max(w.b - 10 + (11 - Math.min(mag, 10)), 0),
+        });
+
       case TerrainType.Plains:
         return colord({
           r: 190,


### PR DESCRIPTION
Inversion of the way water values on the light palette get set as the tile is further from land. Was previously resulting in the darkest water being the closest to land. 

![Before](https://github.com/user-attachments/assets/3b2d8e9a-0648-40ac-8725-c0bcbebf61ac)
![After](https://github.com/user-attachments/assets/6356758f-abbf-493b-a82b-652a9c642539)