### PR TITLE
[UI/Bugfix] Fixed the player info overlay displaying false when troops where equal to 0

### DIFF
--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -205,14 +205,16 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
           ${player.name()}
         </div>
         <div class="text-sm opacity-80">Type: ${playerType}</div>
-        ${player.troops() >= 1 &&
-        html`<div class="text-sm opacity-80" translate="no">
-          Defending troops: ${renderTroops(player.troops())}
-        </div>`}
-        ${attackingTroops >= 1 &&
-        html`<div class="text-sm opacity-80" translate="no">
-          Attacking troops: ${renderTroops(attackingTroops)}
-        </div>`}
+        ${player.troops() >= 1
+          ? html`<div class="text-sm opacity-80" translate="no">
+              Defending troops: ${renderTroops(player.troops())}
+            </div>`
+          : ""}
+        ${attackingTroops >= 1
+          ? html`<div class="text-sm opacity-80" translate="no">
+              Attacking troops: ${renderTroops(attackingTroops)}
+            </div>`
+          : ""}
         <div class="text-sm opacity-80" translate="no">
           Gold: ${renderNumber(player.gold())}
         </div>


### PR DESCRIPTION
The player info was: 
![Before](https://github.com/user-attachments/assets/1fc3a4f1-3052-4a0d-b310-f94de10178a0)

I fixed it to:
![After](https://github.com/user-attachments/assets/901ffc10-4d93-4418-9d56-e3b94a4fb5af)

One thing I'm not sure about, is if we want to hide the attacking troops on 0 or always show it? In this PR it's always shown.

