### PR TITLE
[Security] Added username sanitization on server

### DIFF
--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -44,6 +44,7 @@ import { andFN, manhattanDistFN, TileRef } from "./GameMap";
 import { AttackImpl } from "./AttackImpl";
 import { PseudoRandom } from "../PseudoRandom";
 import { consolex } from "../Consolex";
+import { sanitizeUsername } from "../validations/username";
 
 interface Target {
   tick: Tick;
@@ -101,7 +102,7 @@ export class PlayerImpl implements Player {
     startTroops: number,
   ) {
     this._flag = playerInfo.flag;
-    this._name = playerInfo.name;
+    this._name = sanitizeUsername(playerInfo.name);
     this._targetTroopRatio = 95n;
     this._troops = toInt(startTroops);
     this._workers = 0n;


### PR DESCRIPTION
Fixing issues #282 where players can bypass max username length by editing their storage. I added a sanitization on the server side to avoid all kind of cheat on the username as we can't trust clients