### PR TITLE
Fix Workers not getting killed by bombs

### DIFF
--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -167,6 +167,7 @@ export class NukeExecution implements Execution {
         const mp = this.mg.player(owner.id());
         mp.relinquish(tile);
         mp.removeTroops((5 * mp.population()) / mp.numTilesOwned());
+        mp.removeWorkers((5 * mp.population()) / mp.numTilesOwned());
         if (!attacked.has(mp)) {
           attacked.set(mp, 0);
         }

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -166,8 +166,8 @@ export class NukeExecution implements Execution {
       if (owner.isPlayer()) {
         const mp = this.mg.player(owner.id());
         mp.relinquish(tile);
-        mp.removeTroops((5 * mp.population()) / mp.numTilesOwned());
-        mp.removeWorkers((5 * mp.population()) / mp.numTilesOwned());
+        mp.removeTroops((5 * mp.removeTroops((5 * mp.troops())) / mp.numTilesOwned());
+mp.removeWorkers((5 * mp.workers())) / mp.numTilesOwned());
         if (!attacked.has(mp)) {
           attacked.set(mp, 0);
         }


### PR DESCRIPTION
When a bomb drops on land, it doesn't kill part of the population, it kills part of the troops. This PR fixes this issue and now a bomb kills both troops and workers.