### PR TITLE
Better Alliance expiration

### DIFF
--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -25,6 +25,7 @@ import { createGame } from "./game/GameImpl";
 import { loadTerrainMap as loadGameMap } from "./game/TerrainMapLoader";
 import { ClientID, GameConfig, Turn } from "./Schemas";
 import { GameUpdateViewData } from "./game/GameUpdates";
+import { AllianceExpireCheckExecution } from "./execution/alliance/AllianceExpireCheckExecution";
 
 export async function createGameRunner(
   gameID: string,
@@ -72,6 +73,7 @@ export class GameRunner {
       this.game.addExecution(...this.execManager.fakeHumanExecutions());
     }
     this.game.addExecution(new WinCheckExecution());
+    this.game.addExecution(new AllianceExpireCheckExecution());
   }
 
   public addTurn(turn: Turn): void {

--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -127,6 +127,16 @@ export class FakeHumanExecution implements Execution {
       return;
     }
 
+    // Renew expired alliances
+    this.player.expiredAlliances().forEach((a) => {
+      if (
+        !a.other(this.player).isTraitor() &&
+        this.player.canSendAllianceRequest(a.other(this.player))
+      ) {
+        this.player.createAllianceRequest(a.other(this.player));
+      }
+    });
+
     if (ticks % this.random.nextInt(40, 80) != 0) {
       return;
     }

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -86,16 +86,6 @@ export class PlayerExecution implements Execution {
     this.player.addTroops(adjustRate);
     this.player.removeWorkers(adjustRate);
 
-    const alliances = Array.from(this.player.alliances());
-    for (const alliance of alliances) {
-      if (
-        this.mg.ticks() - alliance.createdAt() >
-        this.mg.config().allianceDuration()
-      ) {
-        alliance.expire();
-      }
-    }
-
     if (ticks - this.lastCalc > this.ticksPerClusterCalc) {
       if (this.player.lastTileChange() > this.lastCalc) {
         this.lastCalc = ticks;

--- a/src/core/execution/alliance/AllianceExpireCheckExecution.ts
+++ b/src/core/execution/alliance/AllianceExpireCheckExecution.ts
@@ -1,0 +1,45 @@
+import { Execution, Game, Player } from "../../game/Game";
+
+/**
+ * Expiration check for alliances.
+ */
+export class AllianceExpireCheckExecution implements Execution {
+  private active = true;
+  private mg: Game = null;
+
+  constructor() {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+  }
+
+  tick(ticks: number) {
+    for (const player of this.mg.players()) {
+      player.expiredAlliances().length = 0; // clear expired alliances
+    }
+
+    for (const alliance of this.mg.alliances()) {
+      if (
+        this.mg.ticks() - alliance.createdAt() >
+        this.mg.config().allianceDuration()
+      ) {
+        alliance.expire();
+
+        alliance.requestor().expiredAlliances().push(alliance);
+        alliance.recipient().expiredAlliances().push(alliance);
+      }
+    }
+  }
+
+  owner(): Player {
+    return null;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -331,6 +331,7 @@ export interface Player {
   incomingAllianceRequests(): AllianceRequest[];
   outgoingAllianceRequests(): AllianceRequest[];
   alliances(): MutableAlliance[];
+  expiredAlliances(): Alliance[];
   allies(): Player[];
   isAlliedWith(other: Player): boolean;
   allianceWith(other: Player): MutableAlliance | null;
@@ -398,6 +399,9 @@ export interface Game extends GameMap {
   addPlayer(playerInfo: PlayerInfo, manpower: number): Player;
   terraNullius(): TerraNullius;
   owner(ref: TileRef): Player | TerraNullius;
+
+  // Alliances
+  alliances(): MutableAlliance[];
 
   // Game State
   ticks(): Tick;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -16,6 +16,7 @@ import {
   GameUpdates,
   TerrainType,
   EmojiMessage,
+  MutableAlliance,
 } from "./Game";
 import { GameUpdate } from "./GameUpdates";
 import { GameUpdateType } from "./GameUpdates";
@@ -100,6 +101,11 @@ export class GameImpl implements Game {
   owner(ref: TileRef): Player | TerraNullius {
     return this.playerBySmallID(this.ownerID(ref));
   }
+
+  alliances(): MutableAlliance[] {
+    return this.alliances_;
+  }
+
   playerBySmallID(id: number): Player | TerraNullius {
     if (id == 0) {
       return this.terraNullius();

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -83,6 +83,7 @@ export class PlayerImpl implements Player {
   private _displayName: string;
 
   public pastOutgoingAllianceRequests: AllianceRequest[] = [];
+  public _expiredAlliances: Alliance[] = [];
 
   private targets_: Target[] = [];
 
@@ -303,6 +304,10 @@ export class PlayerImpl implements Player {
     return this.mg.alliances_.filter(
       (a) => a.requestor() == this || a.recipient() == this,
     );
+  }
+
+  expiredAlliances(): Alliance[] {
+    return this._expiredAlliances;
   }
 
   allies(): Player[] {


### PR DESCRIPTION
Content of this PR:
- Moved alliance expiration to a global execution (Little perf improvement, as we avoid checking alliances from the 2 ends between 2 players)
- Added expiration message 
![Image 1](https://github.com/user-attachments/assets/80577626-c2a1-40f4-bfe4-b0cd5711f674)
- Nations will auto propose to renew (if eligible)
- Added message when you've accepted an alliance
![Image 2](https://github.com/user-attachments/assets/4ab4843f-ba25-4d4d-bac5-ef8258058569)


Tested in singleplayer with nations & bots.
Tested in multiplayer against myself (2 tabs)