### PR TITLE
Improved radial menu

### DIFF
--- a/src/client/graphics/layers/OptionsMenu.ts
+++ b/src/client/graphics/layers/OptionsMenu.ts
@@ -110,6 +110,10 @@ export class OptionsMenu extends LitElement implements Layer {
     this.userSettings.toggleLeftClickOpenMenu();
   }
 
+  private onToggleRadialMenuMode() {
+    this.userSettings.toggleRadialMenuMode();
+  }
+
   init() {
     console.log("init called from OptionsMenu");
     this.showPauseButton =
@@ -199,6 +203,11 @@ export class OptionsMenu extends LitElement implements Layer {
               (this.userSettings.leftClickOpensMenu()
                 ? "Opens menu"
                 : "Attack"),
+          })}
+          ${button({
+            onClick: this.onToggleRadialMenuMode,
+            title: "Radial menu mode",
+            children: "🎛: " + this.userSettings.radialMenuMode(),
           })}
         </div>
       </div>

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -1,3 +1,16 @@
+export enum RadialMenuMode {
+  Default = "Default",
+  Classic = "Classic",
+}
+
+function isTouchDevice() {
+  return (
+    "ontouchstart" in window ||
+    navigator.maxTouchPoints > 0 ||
+    window.matchMedia("(pointer: coarse)").matches
+  );
+}
+
 export class UserSettings {
   get(key: string, defaultValue: boolean) {
     const value = localStorage.getItem(key);
@@ -8,8 +21,20 @@ export class UserSettings {
     if (value === "false") return false;
   }
 
+  getEnum<T>(key: string, defaultValue: T, validValues: T[]): T {
+    const value = localStorage.getItem(key);
+    if (!value) return defaultValue;
+    if (!validValues.includes(value as T)) return defaultValue;
+
+    return value as T;
+  }
+
   set(key: string, value: boolean) {
     localStorage.setItem(key, value ? "true" : "false");
+  }
+
+  setEnum(key: string, value: string) {
+    localStorage.setItem(key, value);
   }
 
   emojis() {
@@ -26,6 +51,23 @@ export class UserSettings {
 
   toggleLeftClickOpenMenu() {
     this.set("settings.leftClickOpensMenu", !this.leftClickOpensMenu());
+  }
+
+  radialMenuMode() {
+    return this.getEnum(
+      "settings.radialMenuMode",
+      isTouchDevice() ? RadialMenuMode.Classic : RadialMenuMode.Default,
+      [RadialMenuMode.Default, RadialMenuMode.Classic],
+    );
+  }
+
+  toggleRadialMenuMode() {
+    this.setEnum(
+      "settings.radialMenuMode",
+      this.radialMenuMode() == RadialMenuMode.Default
+        ? RadialMenuMode.Classic
+        : RadialMenuMode.Default,
+    );
   }
 
   toggleEmojis() {


### PR DESCRIPTION
This changes the radial menu to improve several points:

1. It removes the attack button from the center and replaces it with a close button
- This prevents accidental attacks by not having the default first action be a lethal one :)
- Places the close button in the most logical place
- Makes room for alliance button

2. Replaces the old close button with an alliance management button
- Allows users to quickly start and end alliances
- These are very common actions and especially ending alliances is often frustratingly slow
- The PlayerPanel sucks to navigate and this reduces its need to be opened.

![image](https://github.com/user-attachments/assets/2f0813e0-4073-4837-8d42-8ddb88390680)
