### PR TITLE
fix: Make bot team not able to win

### DIFF
--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -1,5 +1,12 @@
 import { EventBus, GameEvent } from "../EventBus";
-import { Execution, Game, GameMode, Player, Team } from "../game/Game";
+import {
+  Execution,
+  Game,
+  GameMode,
+  Player,
+  Team,
+  TeamName,
+} from "../game/Game";
 
 export class WinEvent implements GameEvent {
   constructor(public readonly winner: Player) {}
@@ -66,6 +73,7 @@ export class WinCheckExecution implements Execution {
       this.mg.numLandTiles() - this.mg.numTilesWithFallout();
     const percentage = (max[1] / numTilesWithoutFallout) * 100;
     if (percentage > this.mg.config().percentageTilesOwnedToWin()) {
+      if (max[0].name == TeamName.Bot) return;
       this.mg.setWinner(max[0].name, this.mg.stats().stats());
       console.log(`${max[0].name} has won the game`);
       this.active = false;


### PR DESCRIPTION
## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:
PilkeySEK

Bot team has over 80% of the map:
![image](https://github.com/user-attachments/assets/a3f3e18b-e23e-4645-89a6-fd876ec73ff7)
How it was before (the bug):
![image](https://github.com/user-attachments/assets/ff872d2d-a9a9-4f3f-96ff-3153d3bff333)
