### PR TITLE
All players must join game before spawn

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -317,6 +317,7 @@ export class HostLobbyModal extends LitElement {
           new CustomEvent("join-lobby", {
             detail: {
               gameID: this.lobbyId,
+              clientID: generateID(),
             } as JoinLobbyEvent,
             bubbles: true,
             composed: true,

--- a/src/client/JoinPrivateLobbyModal.ts
+++ b/src/client/JoinPrivateLobbyModal.ts
@@ -7,7 +7,7 @@ import { JoinLobbyEvent } from "./Main";
 import { translateText } from "../client/Utils";
 import "./components/baseComponents/Modal";
 import "./components/baseComponents/Button";
-
+import { generateID } from "../core/Util";
 @customElement("join-private-lobby-modal")
 export class JoinPrivateLobbyModal extends LitElement {
   @query("o-modal") private modalEl!: HTMLElement & {
@@ -187,7 +187,10 @@ export class JoinPrivateLobbyModal extends LitElement {
 
       this.dispatchEvent(
         new CustomEvent("join-lobby", {
-          detail: { gameID: lobbyId } as JoinLobbyEvent,
+          detail: {
+            gameID: lobbyId,
+            clientID: generateID(),
+          } as JoinLobbyEvent,
           bubbles: true,
           composed: true,
         }),
@@ -232,6 +235,7 @@ export class JoinPrivateLobbyModal extends LitElement {
           detail: {
             gameID: lobbyId,
             gameRecord: gameRecord,
+            clientID: generateID(),
           } as JoinLobbyEvent,
           bubbles: true,
           composed: true,

--- a/src/client/LocalPersistantStats.ts
+++ b/src/client/LocalPersistantStats.ts
@@ -4,7 +4,6 @@ import { GameConfig, GameID, GameRecord } from "../core/Schemas";
 
 export interface LocalStatsData {
   [key: GameID]: {
-    playerId: PlayerID;
     lobby: GameConfig;
     // Only once the game is over
     gameRecord?: GameRecord;
@@ -29,14 +28,14 @@ export namespace LocalPersistantStats {
 
   // The user can quit the game anytime so better save the lobby as soon as the
   // game starts.
-  export function startGame(id: GameID, playerId: PlayerID, lobby: GameConfig) {
+  export function startGame(id: GameID, lobby: GameConfig) {
     if (typeof localStorage === "undefined") {
       return;
     }
 
     _startTime = Date.now();
     const stats = getStats();
-    stats[id] = { playerId, lobby };
+    stats[id] = { lobby };
     save(stats);
   }
 

--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -3,18 +3,14 @@ import { consolex } from "../core/Consolex";
 import { GameEvent } from "../core/EventBus";
 import {
   AllPlayersStats,
-  ClientID,
   ClientMessage,
   ClientMessageSchema,
   ClientSendWinnerMessage,
-  GameConfig,
-  GameID,
   GameRecordSchema,
   Intent,
   PlayerRecord,
   ServerMessage,
   ServerStartGameMessageSchema,
-  ServerTurnMessageSchema,
   Turn,
 } from "../core/Schemas";
 import {
@@ -59,8 +55,17 @@ export class LocalServer {
     this.clientMessage(
       ServerStartGameMessageSchema.parse({
         type: "start",
-        config: this.lobbyConfig.gameConfig,
+        gameID: this.lobbyConfig.gameStartInfo.gameID,
+        gameStartInfo: this.lobbyConfig.gameStartInfo,
         turns: this.turns,
+        players: [
+          {
+            flag: this.lobbyConfig.flag,
+            playerID: generateID(),
+            clientID: this.lobbyConfig.clientID,
+            username: this.lobbyConfig.playerName,
+          },
+        ],
       }),
     );
   }
@@ -136,7 +141,7 @@ export class LocalServer {
     }
     const pastTurn: Turn = {
       turnNumber: this.turns.length,
-      gameID: this.lobbyConfig.gameID,
+      gameID: this.lobbyConfig.gameStartInfo.gameID,
       intents: this.intents,
     };
     this.turns.push(pastTurn);
@@ -154,13 +159,13 @@ export class LocalServer {
       {
         ip: null,
         persistentID: getPersistentIDFromCookie(),
-        username: this.lobbyConfig.playerName(),
+        username: this.lobbyConfig.playerName,
         clientID: this.lobbyConfig.clientID,
       },
     ];
     const record = createGameRecord(
-      this.lobbyConfig.gameID,
-      this.lobbyConfig.gameConfig,
+      this.lobbyConfig.gameStartInfo.gameID,
+      this.lobbyConfig.gameStartInfo,
       players,
       this.turns,
       this.startedAt,
@@ -178,7 +183,7 @@ export class LocalServer {
       type: "application/json",
     });
     const workerPath = this.lobbyConfig.serverConfig.workerPath(
-      this.lobbyConfig.gameID,
+      this.lobbyConfig.gameStartInfo.gameID,
     );
     navigator.sendBeacon(`/${workerPath}/api/archive_singleplayer_game`, blob);
   }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -25,15 +25,21 @@ import { HelpModal } from "./HelpModal";
 import { GameType } from "../core/game/Game";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import GoogleAdElement from "./GoogleAdElement";
-import { GameConfig, GameInfo, GameRecord } from "../core/Schemas";
+import {
+  GameConfig,
+  GameInfo,
+  GameRecord,
+  GameStartInfo,
+} from "../core/Schemas";
 import "./LangSelector";
 import { LangSelector } from "./LangSelector";
 
 export interface JoinLobbyEvent {
+  clientID: string;
   // Multiplayer games only have gameID, gameConfig is not known until game starts.
   gameID: string;
   // GameConfig only exists when playing a singleplayer game.
-  gameConfig?: GameConfig;
+  gameStartInfo?: GameStartInfo;
   // GameRecord exists when replaying an archived game.
   gameRecord?: GameRecord;
 }
@@ -179,17 +185,16 @@ class Client {
     const config = await getServerConfigFromClient();
     this.gameStop = joinLobby(
       {
+        gameID: lobby.gameID,
         serverConfig: config,
-        flag: (): string =>
+        flag:
           this.flagInput.getCurrentFlag() == "xx"
             ? ""
             : this.flagInput.getCurrentFlag(),
-        playerName: (): string => this.usernameInput.getCurrentUsername(),
-        gameID: lobby.gameID,
+        playerName: this.usernameInput.getCurrentUsername(),
         persistentID: getPersistentIDFromCookie(),
-        playerID: generateID(),
-        clientID: generateID(),
-        gameConfig: lobby.gameConfig ?? lobby.gameRecord?.gameConfig,
+        clientID: lobby.clientID,
+        gameStartInfo: lobby.gameStartInfo ?? lobby.gameRecord?.gameStartInfo,
         gameRecord: lobby.gameRecord,
       },
       () => {

--- a/src/client/PublicLobby.ts
+++ b/src/client/PublicLobby.ts
@@ -5,6 +5,8 @@ import { consolex } from "../core/Consolex";
 import { getMapsImage } from "./utilities/Maps";
 import { GameID, GameInfo } from "../core/Schemas";
 import { translateText } from "../client/Utils";
+import { JoinLobbyEvent } from "./Main";
+import { generateID } from "../core/Util";
 
 @customElement("public-lobby")
 export class PublicLobby extends LitElement {
@@ -166,7 +168,10 @@ export class PublicLobby extends LitElement {
       this.currLobby = lobby;
       this.dispatchEvent(
         new CustomEvent("join-lobby", {
-          detail: lobby,
+          detail: {
+            gameID: lobby.gameID,
+            clientID: generateID(),
+          } as JoinLobbyEvent,
           bubbles: true,
           composed: true,
         }),

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -324,22 +324,35 @@ export class SinglePlayerModal extends LitElement {
     consolex.log(
       `Starting single player game with map: ${GameMapType[this.selectedMap]}${this.useRandomMap ? " (Randomly selected)" : ""}`,
     );
+    const clientID = generateID();
+    const gameID = generateID();
 
     this.dispatchEvent(
       new CustomEvent("join-lobby", {
         detail: {
-          gameID: generateID(),
-          gameConfig: {
-            gameMap: this.selectedMap,
-            gameType: GameType.Singleplayer,
-            gameMode: this.gameMode,
-            difficulty: this.selectedDifficulty,
-            disableNPCs: this.disableNPCs,
-            disableNukes: this.disableNukes,
-            bots: this.bots,
-            infiniteGold: this.infiniteGold,
-            infiniteTroops: this.infiniteTroops,
-            instantBuild: this.instantBuild,
+          clientID: clientID,
+          gameID: gameID,
+          gameStartInfo: {
+            gameID: gameID,
+            players: [
+              {
+                playerID: generateID(),
+                clientID,
+                username: "PLACEHOLDER",
+              },
+            ],
+            config: {
+              gameMap: this.selectedMap,
+              gameType: GameType.Singleplayer,
+              gameMode: this.gameMode,
+              difficulty: this.selectedDifficulty,
+              disableNPCs: this.disableNPCs,
+              disableNukes: this.disableNukes,
+              bots: this.bots,
+              infiniteGold: this.infiniteGold,
+              infiniteTroops: this.infiniteTroops,
+              instantBuild: this.instantBuild,
+            },
           },
         } as JoinLobbyEvent,
         bubbles: true,

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -165,7 +165,7 @@ export class Transport {
     // For multiplayer games, GameConfig is not known until game starts.
     this.isLocal =
       lobbyConfig.gameRecord != null ||
-      lobbyConfig.gameConfig?.gameType == GameType.Singleplayer;
+      lobbyConfig.gameStartInfo?.config.gameType == GameType.Singleplayer;
 
     this.eventBus.on(SendAllianceRequestIntentEvent, (e) =>
       this.onSendAllianceRequest(e),
@@ -325,7 +325,7 @@ export class Transport {
           clientID: this.lobbyConfig.clientID,
           lastTurn: numTurns,
           persistentID: this.lobbyConfig.persistentID,
-          username: this.lobbyConfig.playerName(),
+          username: this.lobbyConfig.playerName,
         }),
       ),
     );
@@ -354,7 +354,6 @@ export class Transport {
     this.sendIntent({
       type: "allianceRequest",
       clientID: this.lobbyConfig.clientID,
-      playerID: event.requestor.id(),
       recipient: event.recipient.id(),
     });
   }
@@ -364,7 +363,6 @@ export class Transport {
       type: "allianceRequestReply",
       clientID: this.lobbyConfig.clientID,
       requestor: event.requestor.id(),
-      playerID: event.recipient.id(),
       accept: event.accepted,
     });
   }
@@ -373,7 +371,6 @@ export class Transport {
     this.sendIntent({
       type: "breakAlliance",
       clientID: this.lobbyConfig.clientID,
-      playerID: event.requestor.id(),
       recipient: event.recipient.id(),
     });
   }
@@ -382,9 +379,8 @@ export class Transport {
     this.sendIntent({
       type: "spawn",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
-      flag: this.lobbyConfig.flag(),
-      name: this.lobbyConfig.playerName(),
+      flag: this.lobbyConfig.flag,
+      name: this.lobbyConfig.playerName,
       playerType: PlayerType.Human,
       x: event.cell.x,
       y: event.cell.y,
@@ -395,7 +391,6 @@ export class Transport {
     this.sendIntent({
       type: "attack",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       targetID: event.targetID,
       troops: event.troops,
     });
@@ -405,7 +400,6 @@ export class Transport {
     this.sendIntent({
       type: "boat",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       targetID: event.targetID,
       troops: event.troops,
       x: event.cell.x,
@@ -417,7 +411,6 @@ export class Transport {
     this.sendIntent({
       type: "targetPlayer",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       target: event.targetID,
     });
   }
@@ -426,7 +419,6 @@ export class Transport {
     this.sendIntent({
       type: "emoji",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       recipient:
         event.recipient == AllPlayers ? AllPlayers : event.recipient.id(),
       emoji: event.emoji,
@@ -437,7 +429,6 @@ export class Transport {
     this.sendIntent({
       type: "donate",
       clientID: this.lobbyConfig.clientID,
-      playerID: event.sender.id(),
       recipient: event.recipient.id(),
       troops: event.troops,
     });
@@ -447,7 +438,6 @@ export class Transport {
     this.sendIntent({
       type: "embargo",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       targetID: event.target.id(),
       action: event.action,
     });
@@ -457,7 +447,6 @@ export class Transport {
     this.sendIntent({
       type: "troop_ratio",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       ratio: event.ratio,
     });
   }
@@ -466,7 +455,6 @@ export class Transport {
     this.sendIntent({
       type: "build_unit",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       unit: event.unit,
       x: event.cell.x,
       y: event.cell.y,
@@ -530,7 +518,6 @@ export class Transport {
     this.sendIntent({
       type: "cancel_attack",
       clientID: this.lobbyConfig.clientID,
-      playerID: event.playerID,
       attackID: event.attackID,
     });
   }
@@ -539,7 +526,6 @@ export class Transport {
     this.sendIntent({
       type: "move_warship",
       clientID: this.lobbyConfig.clientID,
-      playerID: this.lobbyConfig.playerID,
       unitId: event.unitId,
       tile: event.tile,
     });

--- a/src/client/graphics/layers/WinModal.ts
+++ b/src/client/graphics/layers/WinModal.ts
@@ -211,7 +211,12 @@ export class WinModal extends LitElement implements Layer {
 
   tick() {
     const myPlayer = this.game.myPlayer();
-    if (!this.hasShownDeathModal && myPlayer && !myPlayer.isAlive()) {
+    if (
+      !this.hasShownDeathModal &&
+      myPlayer &&
+      !myPlayer.isAlive() &&
+      !this.game.inSpawnPhase()
+    ) {
       this.hasShownDeathModal = true;
       this._title = "You died";
       this.won = false;

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -7,10 +7,8 @@ import { WinCheckExecution } from "./execution/WinCheckExecution";
 import {
   AllPlayers,
   BuildableUnit,
-  Cell,
   Game,
   GameUpdates,
-  MessageType,
   Player,
   PlayerActions,
   PlayerID,
@@ -18,24 +16,34 @@ import {
   PlayerBorderTiles,
   PlayerType,
   UnitType,
+  PlayerInfo,
 } from "./game/Game";
-import { DisplayMessageUpdate, ErrorUpdate } from "./game/GameUpdates";
+import { ErrorUpdate } from "./game/GameUpdates";
 import { NameViewData } from "./game/Game";
 import { GameUpdateType } from "./game/GameUpdates";
 import { createGame } from "./game/GameImpl";
 import { loadTerrainMap as loadGameMap } from "./game/TerrainMapLoader";
-import { ClientID, GameConfig, Turn } from "./Schemas";
+import { ClientID, GameStartInfo, Turn } from "./Schemas";
 import { GameUpdateViewData } from "./game/GameUpdates";
 
 export async function createGameRunner(
-  gameID: string,
-  gameConfig: GameConfig,
+  gameStart: GameStartInfo,
   clientID: ClientID,
   callBack: (gu: GameUpdateViewData) => void,
 ): Promise<GameRunner> {
-  const config = await getConfig(gameConfig, null);
-  const gameMap = await loadGameMap(gameConfig.gameMap);
+  const config = await getConfig(gameStart.config, null);
+  const gameMap = await loadGameMap(gameStart.config.gameMap);
   const game = createGame(
+    gameStart.players.map(
+      (p) =>
+        new PlayerInfo(
+          p.flag,
+          p.username,
+          PlayerType.Human,
+          p.clientID,
+          p.playerID,
+        ),
+    ),
     gameMap.gameMap,
     gameMap.miniGameMap,
     gameMap.nationMap,
@@ -43,7 +51,7 @@ export async function createGameRunner(
   );
   const gr = new GameRunner(
     game as Game,
-    new Executor(game, gameID, clientID),
+    new Executor(game, gameStart.gameID, clientID),
     callBack,
   );
   gr.init();

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -8,6 +8,7 @@ import {
   GameConfig,
   GameID,
   GameRecord,
+  GameStartInfo,
   PlayerRecord,
   PlayerStats,
   Turn,
@@ -249,7 +250,7 @@ export function onlyImages(html: string) {
 
 export function createGameRecord(
   id: GameID,
-  gameConfig: GameConfig,
+  gameStart: GameStartInfo,
   // username does not need to be set.
   players: PlayerRecord[],
   turns: Turn[],
@@ -261,7 +262,7 @@ export function createGameRecord(
 ): GameRecord {
   const record: GameRecord = {
     id: id,
-    gameConfig: gameConfig,
+    gameStartInfo: gameStart,
     startTimestampMS: start,
     endTimestampMS: end,
     date: new Date().toISOString().split("T")[0],

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -56,34 +56,24 @@ export class Executor {
   }
 
   createExec(intent: Intent): Execution {
-    let player: Player;
-    if (intent.type != "spawn") {
-      if (!this.mg.hasPlayer(intent.playerID)) {
-        console.warn(
-          `player ${intent.playerID} not found on intent ${intent.type}`,
-        );
-        return new NoOpExecution();
-      }
-      player = this.mg.player(intent.playerID);
-      if (player.clientID() != intent.clientID) {
-        console.warn(
-          `intent ${intent.type} has incorrect clientID ${intent.clientID} for player ${player.name()} with clientID ${player.clientID()}`,
-        );
-        return new NoOpExecution();
-      }
+    const player = this.mg.playerByClientID(intent.clientID);
+    if (!player) {
+      console.warn(`player with clientID ${intent.clientID} not found`);
+      return new NoOpExecution();
     }
+    const playerID = player.id();
 
     switch (intent.type) {
       case "attack": {
         return new AttackExecution(
           intent.troops,
-          intent.playerID,
+          playerID,
           intent.targetID,
           null,
         );
       }
       case "cancel_attack":
-        return new RetreatExecution(intent.playerID, intent.attackID);
+        return new RetreatExecution(playerID, intent.attackID);
       case "move_warship":
         return new MoveWarshipExecution(intent.unitId, intent.tile);
       case "spawn":
@@ -94,50 +84,42 @@ export class Executor {
             intent.clientID == this.clientID
               ? sanitize(intent.name)
               : fixProfaneUsername(sanitize(intent.name)),
-            intent.playerType,
+            PlayerType.Human,
             intent.clientID,
-            intent.playerID,
+            playerID,
           ),
           this.mg.ref(intent.x, intent.y),
         );
       case "boat":
         return new TransportShipExecution(
-          intent.playerID,
+          playerID,
           intent.targetID,
           this.mg.ref(intent.x, intent.y),
           intent.troops,
         );
       case "allianceRequest":
-        return new AllianceRequestExecution(intent.playerID, intent.recipient);
+        return new AllianceRequestExecution(playerID, intent.recipient);
       case "allianceRequestReply":
         return new AllianceRequestReplyExecution(
           intent.requestor,
-          intent.playerID,
+          playerID,
           intent.accept,
         );
       case "breakAlliance":
-        return new BreakAllianceExecution(intent.playerID, intent.recipient);
+        return new BreakAllianceExecution(playerID, intent.recipient);
       case "targetPlayer":
-        return new TargetPlayerExecution(intent.playerID, intent.target);
+        return new TargetPlayerExecution(playerID, intent.target);
       case "emoji":
-        return new EmojiExecution(
-          intent.playerID,
-          intent.recipient,
-          intent.emoji,
-        );
+        return new EmojiExecution(playerID, intent.recipient, intent.emoji);
       case "donate":
-        return new DonateExecution(
-          intent.playerID,
-          intent.recipient,
-          intent.troops,
-        );
+        return new DonateExecution(playerID, intent.recipient, intent.troops);
       case "troop_ratio":
-        return new SetTargetTroopRatioExecution(intent.playerID, intent.ratio);
+        return new SetTargetTroopRatioExecution(playerID, intent.ratio);
       case "embargo":
         return new EmbargoExecution(player, intent.targetID, intent.action);
       case "build_unit":
         return new ConstructionExecution(
-          intent.playerID,
+          playerID,
           this.mg.ref(intent.x, intent.y),
           intent.unit,
         );
@@ -147,9 +129,7 @@ export class Executor {
   }
 
   spawnBots(numBots: number): Execution[] {
-    return new BotSpawner(this.mg, this.gameID)
-      .spawnBots(numBots)
-      .map((i) => this.createExec(i));
+    return new BotSpawner(this.mg, this.gameID).spawnBots(numBots);
   }
 
   fakeHumanExecutions(): Execution[] {

--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -17,7 +17,7 @@ export class SpawnExecution implements Execution {
 
   constructor(
     private playerInfo: PlayerInfo,
-    private tile: TileRef,
+    public readonly tile: TileRef,
   ) {}
 
   init(mg: Game, ticks: number) {

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -39,12 +39,13 @@ import { Stats } from "./Stats";
 import { simpleHash } from "../Util";
 
 export function createGame(
+  humans: PlayerInfo[],
   gameMap: GameMap,
   miniGameMap: GameMap,
   nationMap: NationMap,
   config: Config,
 ): Game {
-  return new GameImpl(gameMap, miniGameMap, nationMap, config);
+  return new GameImpl(humans, gameMap, miniGameMap, nationMap, config);
 }
 
 export type CellString = string;
@@ -82,11 +83,13 @@ export class GameImpl implements Game {
   private botTeam: Team = { name: TeamName.Bot };
 
   constructor(
+    private _humans: PlayerInfo[],
     private _map: GameMap,
     private miniGameMap: GameMap,
     nationMap: NationMap,
     private _config: Config,
   ) {
+    this._humans.forEach((p) => this.addPlayer(p, 100));
     this._terraNullius = new TerraNulliusImpl();
     this._width = _map.width();
     this._height = _map.height();

--- a/src/core/worker/Worker.worker.ts
+++ b/src/core/worker/Worker.worker.ts
@@ -33,8 +33,7 @@ ctx.addEventListener("message", async (e: MessageEvent<MainThreadMessage>) => {
     case "init":
       try {
         gameRunner = createGameRunner(
-          message.gameID,
-          message.gameConfig,
+          message.gameStartInfo,
           message.clientID,
           gameUpdate,
         ).then((gr) => {

--- a/src/core/worker/WorkerClient.ts
+++ b/src/core/worker/WorkerClient.ts
@@ -1,12 +1,11 @@
 import {
   PlayerActions,
   PlayerID,
-  PlayerInfo,
   PlayerProfile,
   PlayerBorderTiles,
 } from "../game/Game";
 import { ErrorUpdate, GameUpdateViewData } from "../game/GameUpdates";
-import { ClientID, GameConfig, GameID, Turn } from "../Schemas";
+import { ClientID, GameStartInfo, Turn } from "../Schemas";
 import { generateID } from "../Util";
 import { WorkerMessage } from "./WorkerMessages";
 
@@ -19,8 +18,7 @@ export class WorkerClient {
   ) => void;
 
   constructor(
-    private gameID: GameID,
-    private gameConfig: GameConfig,
+    private gameStartInfo: GameStartInfo,
     private clientID: ClientID,
   ) {
     this.worker = new Worker(new URL("./Worker.worker.ts", import.meta.url));
@@ -68,8 +66,7 @@ export class WorkerClient {
       this.worker.postMessage({
         type: "init",
         id: messageId,
-        gameID: this.gameID,
-        gameConfig: this.gameConfig,
+        gameStartInfo: this.gameStartInfo,
         clientID: this.clientID,
       });
 

--- a/src/core/worker/WorkerMessages.ts
+++ b/src/core/worker/WorkerMessages.ts
@@ -1,5 +1,10 @@
 import { GameUpdateViewData } from "../game/GameUpdates";
-import { ClientID, GameConfig, GameID, Turn } from "../Schemas";
+import {
+  ClientID,
+  Turn,
+  ServerStartGameMessage,
+  GameStartInfo,
+} from "../Schemas";
 import {
   PlayerActions,
   PlayerID,
@@ -33,8 +38,7 @@ export interface HeartbeatMessage extends BaseWorkerMessage {
 // Messages from main thread to worker
 export interface InitMessage extends BaseWorkerMessage {
   type: "init";
-  gameID: GameID;
-  gameConfig: GameConfig;
+  gameStartInfo: GameStartInfo;
   clientID: ClientID;
 }
 

--- a/src/server/Archive.ts
+++ b/src/server/Archive.ts
@@ -54,10 +54,10 @@ async function archiveAnalyticsToR2(gameRecord: GameRecord) {
     end_time: new Date(gameRecord.endTimestampMS).toISOString(),
     duration_seconds: gameRecord.durationSeconds,
     number_turns: gameRecord.num_turns,
-    game_mode: gameRecord.gameConfig.gameType,
+    game_mode: gameRecord.gameStartInfo.config.gameType,
     winner: gameRecord.winner,
-    difficulty: gameRecord.gameConfig.difficulty,
-    mapType: gameRecord.gameConfig.gameMap,
+    difficulty: gameRecord.gameStartInfo.config.difficulty,
+    mapType: gameRecord.gameStartInfo.config.gameMap,
     players: gameRecord.players.map((p) => ({
       username: p.username,
       ip: p.ip,

--- a/src/server/Client.ts
+++ b/src/server/Client.ts
@@ -1,11 +1,14 @@
 import WebSocket from "ws";
 import { ClientID } from "../core/Schemas";
-import { Tick } from "../core/game/Game";
+import { PlayerID, Tick } from "../core/game/Game";
+import { generateID } from "../core/Util";
 
 export class Client {
   public lastPing: number;
 
   public hashes: Map<Tick, number> = new Map();
+
+  public readonly playerID: PlayerID = generateID();
 
   constructor(
     public readonly clientID: ClientID,

--- a/tests/util/Setup.ts
+++ b/tests/util/Setup.ts
@@ -36,5 +36,5 @@ export async function setup(mapName: string, _gameConfig: GameConfig = {}) {
   const config = new TestConfig(serverConfig, gameConfig, new UserSettings());
 
   // Create and return the game
-  return createGame(gameMap, miniGameMap, nationMap, config);
+  return createGame([], gameMap, miniGameMap, nationMap, config); // TODO: !!!
 }


### PR DESCRIPTION
## Description:
The server stores all players that have joined, and once the game starts it sends a list of players to all clients. Players cannot join after the game has started. Server now generated the PlayerID instead of the client.

The is necessary for team mode, we need to know how who is playing the game before it starts so we can properly assign teams based on clans.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan