### PR TITLE
Fixed SAM Icon in help modal

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -327,6 +327,11 @@ label.option-card:hover {
     center / cover;
 }
 
+#helpModal .sam-launcher-icon {
+  mask: url("../../resources/images/SamLauncherIconWhite.svg") no-repeat
+    center / cover;
+}
+
 #helpModal .atom-bomb-icon {
   mask: url("../../resources/images/NukeIconWhite.svg") no-repeat center / cover;
 }


### PR DESCRIPTION
## Description:
The SAM launcher icon is missing again, fixed.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
