### PR TITLE
Hide wrongly displayed "Hide" button on main page

### DIFF
--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -58,6 +58,7 @@ export class EventsDisplay extends LitElement implements Layer {
   public game: GameView;
   public clientID: ClientID;
 
+  private active: boolean = false;
   private events: Event[] = [];
   @state() private incomingAttacks: AttackUpdate[] = [];
   @state() private outgoingAttacks: AttackUpdate[] = [];
@@ -97,6 +98,7 @@ export class EventsDisplay extends LitElement implements Layer {
   init() {}
 
   tick() {
+    this.active = true;
     const updates = this.game.updatesSinceLastTick();
     for (const [ut, fn] of this.updateMap) {
       updates[ut]?.forEach((u) => fn(u));
@@ -531,6 +533,10 @@ export class EventsDisplay extends LitElement implements Layer {
   }
 
   render() {
+    if (!this.active) {
+      return html``;
+    }
+
     this.events.sort((a, b) => {
       const aPrior = a.priority ?? 100000;
       const bPrior = b.priority ?? 100000;


### PR DESCRIPTION
## Description:
A previous commit made the "Hide" button of the event log visible on the main page. This hides it again, as before.
![image](https://github.com/user-attachments/assets/83e7dbe8-9af7-4719-8c74-f89076345a4a)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
jacks0n