### PR TITLE
Improve private lobby code readability

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -214,6 +214,8 @@ label.option-card:hover {
   font-size: 14px;
   color: #fff;
   text-align: center;
+  font-family: monospace;
+  font-weight: 600;
 }
 
 .players-list {


### PR DESCRIPTION
## Description:
Use mono font for code generated for private lobbies, making it easier to distinguish some letters (lowercase L's vs. capital I's).
Fixes #391.
Fixes #462 

Before:
![image](https://github.com/user-attachments/assets/0b6f6f15-5e7c-4c31-abed-3301a3f508e9)

After:
![image](https://github.com/user-attachments/assets/abd7b6f7-75e6-4461-85fa-528ebf92cc14)


## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

imdarktom
