### PR TITLE
Add live update for naval invasion button

### DIFF
--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -266,18 +266,19 @@ export class RadialMenu implements Layer {
       .style("pointer-events", "none");
   }
 
-  tick() {
+  async tick() {
     // Only update when menu is visible
-    if (this.isVisible && this.clickedCell) {
+    if (!this.isVisible || this.clickedCell === null) return;
       const myPlayer = this.g
         .playerViews()
         .find((p) => p.clientID() == this.clientID);
-      if (myPlayer && myPlayer.isAlive()) {
+      if (myPlayer === undefined || !myPlayer.isAlive()) return;
         const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
-        myPlayer.actions(tile).then((actions) => {
+        const actions = await myPlayer.actions(tile);
           // Only update the boat option to avoid unnecessary processing
           if (actions.canBoat) {
             this.activateMenuElement(Slot.Boat, "#3f6ab1", boatIcon, () => {
+              if (this.clickedCell === null) return;
               this.eventBus.emit(
                 new SendBoatAttackIntentEvent(
                   this.g.owner(tile).id(),
@@ -294,9 +295,6 @@ export class RadialMenu implements Layer {
             menuItem.icon = null;
             this.updateMenuItemState(menuItem);
           }
-        });
-      }
-    }
   }
 
   renderLayer(context: CanvasRenderingContext2D) {

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -267,7 +267,34 @@ export class RadialMenu implements Layer {
   }
 
   tick() {
-    // Update logic if needed
+    // Only update when menu is visible
+    if (this.isVisible && this.clickedCell) {
+      const myPlayer = this.g.playerViews().find((p) => p.clientID() == this.clientID);
+      if (myPlayer && myPlayer.isAlive()) {
+        const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
+        myPlayer.actions(tile).then((actions) => {
+          // Only update the boat option to avoid unnecessary processing
+          if (actions.canBoat) {
+            this.activateMenuElement(Slot.Boat, "#3f6ab1", boatIcon, () => {
+              this.eventBus.emit(
+                new SendBoatAttackIntentEvent(
+                  this.g.owner(tile).id(),
+                  this.clickedCell,
+                  this.uiState.attackRatio * myPlayer.troops(),
+                ),
+              );
+            });
+          } else {
+            // Disable the boat option if no longer available
+            const menuItem = this.menuItems.get(Slot.Boat);
+            menuItem.disabled = true;
+            menuItem.color = null;
+            menuItem.icon = null;
+            this.updateMenuItemState(menuItem);
+          }
+        });
+      }
+    }
   }
 
   renderLayer(context: CanvasRenderingContext2D) {

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -269,7 +269,9 @@ export class RadialMenu implements Layer {
   tick() {
     // Only update when menu is visible
     if (this.isVisible && this.clickedCell) {
-      const myPlayer = this.g.playerViews().find((p) => p.clientID() == this.clientID);
+      const myPlayer = this.g
+        .playerViews()
+        .find((p) => p.clientID() == this.clientID);
       if (myPlayer && myPlayer.isAlive()) {
         const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
         myPlayer.actions(tile).then((actions) => {


### PR DESCRIPTION
## Description:

UX Improvement - Make naval invasion button on radial menu update each tick. This way, player can keep the menu open and click as soon as a naval invasion is available, and doesn't need to close and re-open the menu.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

eyeseeem