### PR TITLE
Add live update for player menu

### DIFF
--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -145,14 +145,12 @@ export class PlayerPanel extends LitElement implements Layer {
     this.eventBus.on(MouseUpEvent, (e: MouseEvent) => this.hide());
   }
 
-  tick() {
+  async tick() {
     if (this.isVisible && this.tile) {
       const myPlayer = this.g.myPlayer();
-      if (myPlayer && myPlayer.isAlive()) {
-        myPlayer.actions(this.tile).then((actions) => {
-          this.actions = actions;
-          this.requestUpdate();
-        });
+      if (myPlayer !== null && myPlayer.isAlive()) {
+        this.actions = await myPlayer.actions(this.tile);
+        this.requestUpdate();
       }
     }
   }

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -146,7 +146,15 @@ export class PlayerPanel extends LitElement implements Layer {
   }
 
   tick() {
-    this.requestUpdate();
+    if (this.isVisible && this.tile) {
+      const myPlayer = this.g.myPlayer();
+      if (myPlayer && myPlayer.isAlive()) {
+        myPlayer.actions(this.tile).then((actions) => {
+          this.actions = actions;
+          this.requestUpdate();
+        });
+      }
+    }
   }
 
   getTotalNukesSent(otherId: PlayerID): number {

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -269,32 +269,32 @@ export class RadialMenu implements Layer {
   async tick() {
     // Only update when menu is visible
     if (!this.isVisible || this.clickedCell === null) return;
-      const myPlayer = this.g
-        .playerViews()
-        .find((p) => p.clientID() == this.clientID);
-      if (myPlayer === undefined || !myPlayer.isAlive()) return;
-        const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
-        const actions = await myPlayer.actions(tile);
-          // Only update the boat option to avoid unnecessary processing
-          if (actions.canBoat) {
-            this.activateMenuElement(Slot.Boat, "#3f6ab1", boatIcon, () => {
-              if (this.clickedCell === null) return;
-              this.eventBus.emit(
-                new SendBoatAttackIntentEvent(
-                  this.g.owner(tile).id(),
-                  this.clickedCell,
-                  this.uiState.attackRatio * myPlayer.troops(),
-                ),
-              );
-            });
-          } else {
-            // Disable the boat option if no longer available
-            const menuItem = this.menuItems.get(Slot.Boat);
-            menuItem.disabled = true;
-            menuItem.color = null;
-            menuItem.icon = null;
-            this.updateMenuItemState(menuItem);
-          }
+    const myPlayer = this.g
+      .playerViews()
+      .find((p) => p.clientID() == this.clientID);
+    if (myPlayer === undefined || !myPlayer.isAlive()) return;
+    const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
+    const actions = await myPlayer.actions(tile);
+    // Only update the boat option to avoid unnecessary processing
+    if (actions.canBoat) {
+      this.activateMenuElement(Slot.Boat, "#3f6ab1", boatIcon, () => {
+        if (this.clickedCell === null) return;
+        this.eventBus.emit(
+          new SendBoatAttackIntentEvent(
+            this.g.owner(tile).id(),
+            this.clickedCell,
+            this.uiState.attackRatio * myPlayer.troops(),
+          ),
+        );
+      });
+    } else {
+      // Disable the boat option if no longer available
+      const menuItem = this.menuItems.get(Slot.Boat);
+      menuItem.disabled = true;
+      menuItem.color = null;
+      menuItem.icon = null;
+      this.updateMenuItemState(menuItem);
+    }
   }
 
   renderLayer(context: CanvasRenderingContext2D) {

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -44,7 +44,7 @@ export class RadialMenu implements Layer {
   private clickedCell: Cell | null = null;
   private lastClosed: number = 0;
 
-  private originalTileOwner: PlayerView | TerraNullius | null = null;
+  private originalTileOwner: PlayerView | TerraNullius;
   private menuElement: d3.Selection<HTMLDivElement, unknown, null, undefined>;
   private isVisible: boolean = false;
   private readonly menuItems = new Map([

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -266,8 +266,35 @@ export class RadialMenu implements Layer {
       .style("pointer-events", "none");
   }
 
-  tick() {
-    // Update logic if needed
+  async tick() {
+    // Only update when menu is visible
+    if (!this.isVisible || this.clickedCell === null) return;
+      const myPlayer = this.g
+        .playerViews()
+        .find((p) => p.clientID() == this.clientID);
+      if (myPlayer === undefined || !myPlayer.isAlive()) return;
+        const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
+        const actions = await myPlayer.actions(tile);
+          // Only update the boat option to avoid unnecessary processing
+          if (actions.canBoat) {
+            this.activateMenuElement(Slot.Boat, "#3f6ab1", boatIcon, () => {
+              if (this.clickedCell === null) return;
+              this.eventBus.emit(
+                new SendBoatAttackIntentEvent(
+                  this.g.owner(tile).id(),
+                  this.clickedCell,
+                  this.uiState.attackRatio * myPlayer.troops(),
+                ),
+              );
+            });
+          } else {
+            // Disable the boat option if no longer available
+            const menuItem = this.menuItems.get(Slot.Boat);
+            menuItem.disabled = true;
+            menuItem.color = null;
+            menuItem.icon = null;
+            this.updateMenuItemState(menuItem);
+          }
   }
 
   renderLayer(context: CanvasRenderingContext2D) {

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -327,7 +327,7 @@ export class RadialMenu implements Layer {
     }
 
     const myPlayer = this.g.myPlayer();
-    if (!myPlayer) {
+    if (myPlayer === null) {
       consolex.warn("my player not found");
       return;
     }

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -270,9 +270,7 @@ export class RadialMenu implements Layer {
   async tick() {
     // Only update when menu is visible
     if (!this.isVisible || this.clickedCell === null) return;
-    const myPlayer = this.g
-      .playerViews()
-      .find((p) => p.clientID() == this.clientID);
+    const myPlayer = this.g.myPlayer();
     if (myPlayer === undefined || !myPlayer.isAlive()) return;
     const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
     if (this.originalTileOwner.isPlayer()) {
@@ -328,9 +326,7 @@ export class RadialMenu implements Layer {
       return;
     }
 
-    const myPlayer = this.g
-      .playerViews()
-      .find((p) => p.clientID() == this.clientID);
+    const myPlayer = this.g.myPlayer();
     if (!myPlayer) {
       consolex.warn("my player not found");
       return;

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -8,7 +8,7 @@ import swordIcon from "../../../../resources/images/SwordIconWhite.svg";
 import traitorIcon from "../../../../resources/images/TraitorIconWhite.svg";
 import { consolex } from "../../../core/Consolex";
 import { EventBus } from "../../../core/EventBus";
-import { Cell, PlayerActions } from "../../../core/game/Game";
+import { Cell, PlayerActions, TerraNullius } from "../../../core/game/Game";
 import { TileRef } from "../../../core/game/GameMap";
 import { GameView, PlayerView } from "../../../core/game/GameView";
 import { ClientID } from "../../../core/Schemas";
@@ -44,6 +44,7 @@ export class RadialMenu implements Layer {
   private clickedCell: Cell | null = null;
   private lastClosed: number = 0;
 
+  private originalTileOwner: PlayerView | TerraNullius | null = null;
   private menuElement: d3.Selection<HTMLDivElement, unknown, null, undefined>;
   private isVisible: boolean = false;
   private readonly menuItems = new Map([
@@ -274,27 +275,20 @@ export class RadialMenu implements Layer {
       .find((p) => p.clientID() == this.clientID);
     if (myPlayer === undefined || !myPlayer.isAlive()) return;
     const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
-    const actions = await myPlayer.actions(tile);
-    // Only update the boat option to avoid unnecessary processing
-    if (actions.canBoat) {
-      this.activateMenuElement(Slot.Boat, "#3f6ab1", boatIcon, () => {
-        if (this.clickedCell === null) return;
-        this.eventBus.emit(
-          new SendBoatAttackIntentEvent(
-            this.g.owner(tile).id(),
-            this.clickedCell,
-            this.uiState.attackRatio * myPlayer.troops(),
-          ),
-        );
-      });
+    if (this.originalTileOwner.isPlayer()) {
+      if (this.g.owner(tile) != this.originalTileOwner) {
+        this.closeMenu();
+        return;
+      }
     } else {
-      // Disable the boat option if no longer available
-      const menuItem = this.menuItems.get(Slot.Boat);
-      menuItem.disabled = true;
-      menuItem.color = null;
-      menuItem.icon = null;
-      this.updateMenuItemState(menuItem);
+      if (this.g.owner(tile).isPlayer() || this.g.owner(tile) == myPlayer) {
+        this.closeMenu();
+        return;
+      }
     }
+    const actions = await myPlayer.actions(tile);
+    this.disableAllButtons();
+    this.handlePlayerActions(myPlayer, actions, tile);
   }
 
   renderLayer(context: CanvasRenderingContext2D) {
@@ -317,12 +311,7 @@ export class RadialMenu implements Layer {
     } else {
       this.showRadialMenu(event.x, event.y);
     }
-    this.enableCenterButton(false);
-    for (const item of this.menuItems.values()) {
-      item.disabled = true;
-      this.updateMenuItemState(item);
-    }
-
+    this.disableAllButtons();
     this.clickedCell = this.transformHandler.screenToWorldCoordinates(
       event.x,
       event.y,
@@ -331,7 +320,7 @@ export class RadialMenu implements Layer {
       return;
     }
     const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
-
+    this.originalTileOwner = this.g.owner(tile);
     if (this.g.inSpawnPhase()) {
       if (this.g.isLand(tile) && !this.g.hasOwner(tile)) {
         this.enableCenterButton(true);
@@ -454,6 +443,14 @@ export class RadialMenu implements Layer {
       }
     }
     this.hideRadialMenu();
+  }
+
+  private disableAllButtons() {
+    this.enableCenterButton(false);
+    for (const item of this.menuItems.values()) {
+      item.disabled = true;
+      this.updateMenuItemState(item);
+    }
   }
 
   private activateMenuElement(

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -271,7 +271,7 @@ export class RadialMenu implements Layer {
     // Only update when menu is visible
     if (!this.isVisible || this.clickedCell === null) return;
     const myPlayer = this.g.myPlayer();
-    if (myPlayer === undefined || !myPlayer.isAlive()) return;
+    if (myPlayer === null || !myPlayer.isAlive()) return;
     const tile = this.g.ref(this.clickedCell.x, this.clickedCell.y);
     if (this.originalTileOwner.isPlayer()) {
       if (this.g.owner(tile) != this.originalTileOwner) {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -343,6 +343,9 @@ export class PlayerImpl implements Player {
     if (this.isFriendly(other)) {
       return false;
     }
+    if (other.info().playerType == PlayerType.Bot) {
+      return false;
+    }
 
     const hasPending =
       this.incomingAllianceRequests().find((ar) => ar.requestor() == other) !=

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -343,9 +343,6 @@ export class PlayerImpl implements Player {
     if (this.isFriendly(other)) {
       return false;
     }
-    if (other.info().playerType == PlayerType.Bot) {
-      return false;
-    }
 
     const hasPending =
       this.incomingAllianceRequests().find((ar) => ar.requestor() == other) !=


### PR DESCRIPTION
## Description:

UX Improvement - Make the player menu options update live, like donations and re-offering alliance if it was rejected previously. Now player doesn't have to keep re-opening the menu to see the options updated.

Fixes #521 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

eyeseeem