### PR TITLE
fix typo in a House name

### DIFF
--- a/resources/maps/KnownWorld.json
+++ b/resources/maps/KnownWorld.json
@@ -85,7 +85,7 @@
     },
     {
       "coordinates": [246, 746],
-      "name": "Hous Tully",
+      "name": "House Tully",
       "strength": 3
     },
     {


### PR DESCRIPTION
## Description:

Fixes a small typo in the name of one of the Houses in the Known World map (Hous Tully -> House Tully)
Fixes #533 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

N/A
