### PR TITLE
Donate the attackratio instead of 1/3

### DIFF
--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -145,6 +145,7 @@ export function createRenderer(
   playerPanel.g = game;
   playerPanel.eventBus = eventBus;
   playerPanel.emojiTable = emojiTable;
+  playerPanel.uiState = uiState;
 
   const chatModal = document.querySelector("chat-modal") as ChatModal;
   if (!(chatModal instanceof ChatModal)) {

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -30,6 +30,7 @@ import {
 } from "../../Transport";
 import { renderNumber, renderTroops } from "../../Utils";
 import { ChatModal } from "./ChatModal";
+import { UIState } from "../UIState";
 import { EmojiTable } from "./EmojiTable";
 import { Layer } from "./Layer";
 
@@ -38,6 +39,7 @@ export class PlayerPanel extends LitElement implements Layer {
   public g: GameView;
   public eventBus: EventBus;
   public emojiTable: EmojiTable;
+  public uiState: UIState;
 
   private actions: PlayerActions | null = null;
   private tile: TileRef | null = null;
@@ -91,7 +93,13 @@ export class PlayerPanel extends LitElement implements Layer {
     other: PlayerView,
   ) {
     e.stopPropagation();
-    this.eventBus.emit(new SendDonateTroopsIntentEvent(myPlayer, other, null));
+    this.eventBus.emit(
+      new SendDonateTroopsIntentEvent(
+        myPlayer,
+        other,
+        myPlayer.troops() * this.uiState.attackRatio,
+      ),
+    );
     this.hide();
   }
 

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -29,8 +29,8 @@ import {
   SendTargetPlayerIntentEvent,
 } from "../../Transport";
 import { renderNumber, renderTroops } from "../../Utils";
-import { ChatModal } from "./ChatModal";
 import { UIState } from "../UIState";
+import { ChatModal } from "./ChatModal";
 import { EmojiTable } from "./EmojiTable";
 import { Layer } from "./Layer";
 


### PR DESCRIPTION
## Description:

The changes introduce a new public uiState property to the PlayerPanel class and ensure it is assigned from the shared UI state in the createRenderer function. The troop donation logic in PlayerPanel is updated to use the attackRatio from uiState to determine the number of troops to donate, replacing the previous static or null value.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

PilkeySEK