### PR TITLE
Display Owner and Gold Amount of Trading Ships in Trade Info Overlay

### DIFF
--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -286,6 +286,14 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
         </div>
         <div class="mt-1">
           <div class="text-sm opacity-80">${unit.type()}</div>
+          ${unit.hasDstPortId() && unit.hasSrcPortId()
+            ? html` <div class="text-sm opacity-80">Gold: ${unit.gold()}</div> `
+            : ""}
+          ${unit.hasDstPortId()
+            ? html`<div class="text-sm opacity-80">
+                Destination: ${unit.destination()}
+              </div>`
+            : ""}
           ${unit.hasHealth()
             ? html`
                 <div class="text-sm opacity-80">

--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -278,6 +278,8 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
       (unit.owner() === this.myPlayer() ||
         this.myPlayer()?.isFriendly(unit.owner())) ??
       false;
+    const gold = unit.gold();
+    const destination = unit.destination();
 
     return html`
       <div class="p-2">
@@ -286,12 +288,12 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
         </div>
         <div class="mt-1">
           <div class="text-sm opacity-80">${unit.type()}</div>
-          ${unit.hasDstPortId() && unit.hasSrcPortId()
-            ? html` <div class="text-sm opacity-80">Gold: ${unit.gold()}</div> `
+          ${gold !== ""
+            ? html` <div class="text-sm opacity-80">Gold: ${gold}</div> `
             : ""}
-          ${unit.hasDstPortId()
+          ${destination !== ""
             ? html`<div class="text-sm opacity-80">
-                Destination: ${unit.destination()}
+                Destination: ${destination}
               </div>`
             : ""}
           ${unit.hasHealth()

--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -51,6 +51,7 @@ export class TradeShipExecution implements Execution {
       }
       this.tradeShip = this.origOwner.buildUnit(UnitType.TradeShip, spawn, {
         dstPort: this._dstPort,
+        srcPort: this.srcPort,
         lastSetSafeFromPirates: ticks,
       });
     }

--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -51,7 +51,7 @@ export class TradeShipExecution implements Execution {
       }
       this.tradeShip = this.origOwner.buildUnit(UnitType.TradeShip, spawn, {
         dstPort: this._dstPort,
-        srcPort: this.srcPort,
+        tilesTraveled: this.tilesTraveled,
         lastSetSafeFromPirates: ticks,
       });
     }
@@ -109,6 +109,7 @@ export class TradeShipExecution implements Execution {
       }
       this.tradeShip.move(cachedNextTile);
       this.tilesTraveled++;
+      this.tradeShip.setTilesTraveled(this.tilesTraveled);
       return;
     }
 
@@ -133,6 +134,7 @@ export class TradeShipExecution implements Execution {
         }
         this.tradeShip.move(result.tile);
         this.tilesTraveled++;
+        this.tradeShip.setTilesTraveled(this.tilesTraveled);
         break;
       case PathFindResultType.PathNotFound:
         consolex.warn("captured trade ship cannot find route");

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -168,6 +168,7 @@ export interface UnitParamsMap {
 
   [UnitType.TradeShip]: {
     dstPort: Unit;
+    srcPort: Unit;
     lastSetSafeFromPirates?: number;
   };
 
@@ -350,6 +351,7 @@ export interface Unit {
   isCooldown(): boolean;
   setDstPort(dstPort: Unit): void;
   dstPort(): Unit | null; // Only for trade ships
+  srcPort(): Unit | null; // Only for trade ships
   setSafeFromPirates(): void; // Only for trade ships
   isSafeFromPirates(): boolean; // Only for trade ships
   detonationDst(): TileRef | null; // Only for nukes

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -168,7 +168,7 @@ export interface UnitParamsMap {
 
   [UnitType.TradeShip]: {
     dstPort: Unit;
-    srcPort: Unit;
+    tilesTraveled: number;
     lastSetSafeFromPirates?: number;
   };
 
@@ -350,8 +350,8 @@ export interface Unit {
   ticksLeftInCooldown(cooldownDuration: number): Tick;
   isCooldown(): boolean;
   setDstPort(dstPort: Unit): void;
+  setTilesTraveled(tiles: number): void; // Only for trade ships
   dstPort(): Unit | null; // Only for trade ships
-  srcPort(): Unit | null; // Only for trade ships
   setSafeFromPirates(): void; // Only for trade ships
   isSafeFromPirates(): boolean; // Only for trade ships
   detonationDst(): TileRef | null; // Only for nukes

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -74,7 +74,7 @@ export interface UnitUpdate {
   lastPos: TileRef;
   isActive: boolean;
   dstPortId?: number; // Only for trade ships
-  srcPortId?: number; // Only for trade ships
+  tilesTraveled?: number; // Only for trade ships
   detonationDst?: TileRef; // Only for nukes
   warshipTargetId?: number;
   health?: number;

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -74,6 +74,7 @@ export interface UnitUpdate {
   lastPos: TileRef;
   isActive: boolean;
   dstPortId?: number; // Only for trade ships
+  srcPortId?: number; // Only for trade ships
   detonationDst?: TileRef; // Only for nukes
   warshipTargetId?: number;
   health?: number;

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -88,8 +88,32 @@ export class UnitView {
   isActive(): boolean {
     return this.data.isActive;
   }
+  hasDstPortId(): boolean {
+    return this.data.dstPortId !== undefined;
+  }
+  hasSrcPortId(): boolean {
+    return this.data.srcPortId !== undefined;
+  }
   hasHealth(): boolean {
     return this.data.health !== undefined;
+  }
+  gold(): string {
+    if (this.type() !== UnitType.TradeShip) {
+      throw Error("Must be a trade ship");
+    }
+    const srcPort = this.gameView?.unit(this.srcPortId() ?? 0);
+    const dstPort = this.gameView?.unit(this.dstPortId() ?? 0);
+    if (srcPort === undefined || dstPort === undefined) {
+      return "0";
+    }
+    return this.gameView
+      .config()
+      .tradeShipGold(
+        this.gameView.manhattanDist(srcPort.tile(), dstPort.tile()),
+      )
+      .toLocaleString("en-US", {
+        maximumFractionDigits: 0,
+      });
   }
   health(): number {
     return this.data.health ?? 0;
@@ -99,6 +123,19 @@ export class UnitView {
   }
   dstPortId(): number | undefined {
     return this.data.dstPortId;
+  }
+  destination(): string {
+    const dstPort = this.gameView.unit(this.dstPortId() ?? 0);
+    if (dstPort === undefined) {
+      return "";
+    }
+    return dstPort.owner().name();
+  }
+  srcPortId(): number | undefined {
+    if (this.type() !== UnitType.TradeShip) {
+      throw Error("Must be a trade ship");
+    }
+    return this.data.srcPortId;
   }
   detonationDst(): TileRef | undefined {
     if (!nukeTypes.includes(this.type())) {

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -88,32 +88,31 @@ export class UnitView {
   isActive(): boolean {
     return this.data.isActive;
   }
-  hasDstPortId(): boolean {
-    return this.data.dstPortId !== undefined;
-  }
-  hasSrcPortId(): boolean {
-    return this.data.srcPortId !== undefined;
-  }
   hasHealth(): boolean {
     return this.data.health !== undefined;
   }
   gold(): string {
     if (this.type() !== UnitType.TradeShip) {
-      throw Error("Must be a trade ship");
+      return "";
     }
-    const srcPort = this.gameView?.unit(this.srcPortId() ?? 0);
-    const dstPort = this.gameView?.unit(this.dstPortId() ?? 0);
-    if (srcPort === undefined || dstPort === undefined) {
-      return "0";
-    }
+    const tilesTraveled = this.data.tilesTraveled ?? 0;
     return this.gameView
       .config()
-      .tradeShipGold(
-        this.gameView.manhattanDist(srcPort.tile(), dstPort.tile()),
-      )
+      .tradeShipGold(tilesTraveled)
       .toLocaleString("en-US", {
         maximumFractionDigits: 0,
       });
+  }
+  destination(): string {
+    const dstPortId = this.dstPortId();
+    if (dstPortId === undefined) {
+      return "";
+    }
+    const dstPort = this.gameView.unit(dstPortId);
+    if (dstPort === undefined) {
+      return "";
+    }
+    return dstPort.owner().name();
   }
   health(): number {
     return this.data.health ?? 0;
@@ -123,19 +122,6 @@ export class UnitView {
   }
   dstPortId(): number | undefined {
     return this.data.dstPortId;
-  }
-  destination(): string {
-    const dstPort = this.gameView.unit(this.dstPortId() ?? 0);
-    if (dstPort === undefined) {
-      return "";
-    }
-    return dstPort.owner().name();
-  }
-  srcPortId(): number | undefined {
-    if (this.type() !== UnitType.TradeShip) {
-      throw Error("Must be a trade ship");
-    }
-    return this.data.srcPortId;
   }
   detonationDst(): TileRef | undefined {
     if (!nukeTypes.includes(this.type())) {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -25,7 +25,7 @@ export class UnitImpl implements Unit {
   private _troops: number;
   private _cooldownTick: Tick | null = null;
   private _dstPort: Unit | undefined = undefined; // Only for trade ships
-  private _srcPort: Unit | undefined = undefined; // Only for trade ships
+  private _tilesTraveled: number; // Only for trade ships
   private _detonationDst: TileRef | undefined = undefined; // Only for nukes
   private _warshipTarget: Unit | undefined = undefined;
   private _cooldownDuration: number | undefined = undefined;
@@ -47,7 +47,7 @@ export class UnitImpl implements Unit {
 
     this._troops = "troops" in params ? (params.troops ?? 0) : 0;
     this._dstPort = "dstPort" in params ? params.dstPort : undefined;
-    this._srcPort = "srcPort" in params ? params.srcPort : undefined;
+    this._tilesTraveled = "tilesTraveled" in params ? params.tilesTraveled : 0;
     this._cooldownDuration =
       "cooldownDuration" in params ? params.cooldownDuration : undefined;
     this._lastSetSafeFromPirates =
@@ -70,7 +70,6 @@ export class UnitImpl implements Unit {
   toUpdate(): UnitUpdate {
     const warshipTarget = this.warshipTarget();
     const dstPort = this.dstPort();
-    const srcPort = this.srcPort();
     if (this._lastTile === null) throw new Error("null _lastTile");
     const ticksLeftInCooldown =
       this._cooldownDuration !== undefined
@@ -89,7 +88,7 @@ export class UnitImpl implements Unit {
       health: this.hasHealth() ? Number(this._health) : undefined,
       constructionType: this._constructionType,
       dstPortId: dstPort?.id() ?? undefined,
-      srcPortId: srcPort?.id() ?? undefined,
+      tilesTraveled: this._tilesTraveled,
       warshipTargetId: warshipTarget?.id() ?? undefined,
       detonationDst: this.detonationDst() ?? undefined,
       ticksLeftInCooldown,
@@ -223,10 +222,6 @@ export class UnitImpl implements Unit {
     return this._dstPort ?? null;
   }
 
-  srcPort(): Unit | null {
-    return this._srcPort ?? null;
-  }
-
   // set the cooldown to the current tick or remove it
   setCooldown(triggerCooldown: boolean): void {
     if (triggerCooldown) {
@@ -251,8 +246,8 @@ export class UnitImpl implements Unit {
     this._dstPort = dstPort;
   }
 
-  setSrcPort(srcPort: Unit): void {
-    this._srcPort = srcPort;
+  setTilesTraveled(tilesTraveled: number): void {
+    this._tilesTraveled = tilesTraveled;
   }
 
   setMoveTarget(moveTarget: TileRef) {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -25,6 +25,7 @@ export class UnitImpl implements Unit {
   private _troops: number;
   private _cooldownTick: Tick | null = null;
   private _dstPort: Unit | undefined = undefined; // Only for trade ships
+  private _srcPort: Unit | undefined = undefined; // Only for trade ships
   private _detonationDst: TileRef | undefined = undefined; // Only for nukes
   private _warshipTarget: Unit | undefined = undefined;
   private _cooldownDuration: number | undefined = undefined;
@@ -46,6 +47,7 @@ export class UnitImpl implements Unit {
 
     this._troops = "troops" in params ? (params.troops ?? 0) : 0;
     this._dstPort = "dstPort" in params ? params.dstPort : undefined;
+    this._srcPort = "srcPort" in params ? params.srcPort : undefined;
     this._cooldownDuration =
       "cooldownDuration" in params ? params.cooldownDuration : undefined;
     this._lastSetSafeFromPirates =
@@ -68,6 +70,7 @@ export class UnitImpl implements Unit {
   toUpdate(): UnitUpdate {
     const warshipTarget = this.warshipTarget();
     const dstPort = this.dstPort();
+    const srcPort = this.srcPort();
     if (this._lastTile === null) throw new Error("null _lastTile");
     const ticksLeftInCooldown =
       this._cooldownDuration !== undefined
@@ -86,6 +89,7 @@ export class UnitImpl implements Unit {
       health: this.hasHealth() ? Number(this._health) : undefined,
       constructionType: this._constructionType,
       dstPortId: dstPort?.id() ?? undefined,
+      srcPortId: srcPort?.id() ?? undefined,
       warshipTargetId: warshipTarget?.id() ?? undefined,
       detonationDst: this.detonationDst() ?? undefined,
       ticksLeftInCooldown,
@@ -219,6 +223,10 @@ export class UnitImpl implements Unit {
     return this._dstPort ?? null;
   }
 
+  srcPort(): Unit | null {
+    return this._srcPort ?? null;
+  }
+
   // set the cooldown to the current tick or remove it
   setCooldown(triggerCooldown: boolean): void {
     if (triggerCooldown) {
@@ -241,6 +249,10 @@ export class UnitImpl implements Unit {
 
   setDstPort(dstPort: Unit): void {
     this._dstPort = dstPort;
+  }
+
+  setSrcPort(srcPort: Unit): void {
+    this._srcPort = srcPort;
   }
 
   setMoveTarget(moveTarget: TileRef) {

--- a/tests/Warship.test.ts
+++ b/tests/Warship.test.ts
@@ -105,7 +105,7 @@ describe("Warship", () => {
       game.ref(coastX + 1, 7),
       {
         dstPort,
-        srcPort: player1.units(UnitType.Port)[0],
+        tilesTraveled: 0,
       },
     );
 
@@ -132,7 +132,7 @@ describe("Warship", () => {
       game.ref(coastX + 1, 11),
       {
         dstPort,
-        srcPort: player1.units(UnitType.Port)[0],
+        tilesTraveled: 0,
       },
     );
 

--- a/tests/Warship.test.ts
+++ b/tests/Warship.test.ts
@@ -105,6 +105,7 @@ describe("Warship", () => {
       game.ref(coastX + 1, 7),
       {
         dstPort,
+        srcPort: player1.units(UnitType.Port)[0],
       },
     );
 
@@ -131,6 +132,7 @@ describe("Warship", () => {
       game.ref(coastX + 1, 11),
       {
         dstPort,
+        srcPort: player1.units(UnitType.Port)[0],
       },
     );
 


### PR DESCRIPTION
## Description:
Fixes #513, Fixes #546
It has been combined with this pull request #547
## Screenshot:
![ubiquitous-space-goggles-4rj7qgvpgr3756-3000 app github dev_join_Fd5MOEcY](https://github.com/user-attachments/assets/a15f63c1-3908-4b39-bf97-13bc9718eddf)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced unit information overlay to display gold amount and destination owner for trade ships with both source and destination ports.
  - Trade ships now track and display both source and destination ports, along with a calculated gold value based on their journey.
- **Bug Fixes**
  - Corrected display and tracking of source port information for trade ships in various interfaces.
- **Documentation**
  - Updated interfaces and class methods to reflect new properties and behaviors related to trade ship ports and gold calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->