### PR TITLE
Add information about the amount of gold carried by trading ships

### DIFF
--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -251,6 +251,9 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
         </div>
         <div class="mt-1">
           <div class="text-sm opacity-80">${unit.type()}</div>
+          ${unit.hasDstPortId() && unit.hasSrcPortId()
+            ? html` <div class="text-sm opacity-80">Gold: ${unit.gold()}</div> `
+            : ""}
           ${unit.hasHealth()
             ? html`
                 <div class="text-sm opacity-80">Health: ${unit.health()}</div>

--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -47,6 +47,7 @@ export class TradeShipExecution implements Execution {
       }
       this.tradeShip = this.origOwner.buildUnit(UnitType.TradeShip, 0, spawn, {
         dstPort: this._dstPort,
+        srcPort: this.srcPort,
       });
     }
 

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -240,6 +240,7 @@ export class PlayerInfo {
 // Some units have info specific to them
 export interface UnitSpecificInfos {
   dstPort?: Unit; // Only for trade ships
+  srcPort?: Unit; // Only for trade ships
   detonationDst?: TileRef; // Only for nukes
   warshipTarget?: Unit;
   cooldownDuration?: number;

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -69,6 +69,7 @@ export interface UnitUpdate {
   lastPos: TileRef;
   isActive: boolean;
   dstPortId?: number; // Only for trade ships
+  srcPortId?: number; // Only for trade ships
   detonationDst?: TileRef; // Only for nukes
   warshipTargetId?: number;
   health?: number;

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -87,8 +87,28 @@ export class UnitView {
   isActive(): boolean {
     return this.data.isActive;
   }
+  hasDstPortId(): boolean {
+    return this.data.dstPortId != undefined;
+  }
+  hasSrcPortId(): boolean {
+    return this.data.srcPortId != undefined;
+  }
   hasHealth(): boolean {
     return this.data.health != undefined;
+  }
+  gold(): string {
+    if (this.type() != UnitType.TradeShip) {
+      throw Error("Must be a trade ship");
+    }
+    return this.gameView
+      .config()
+      .tradeShipGold(
+        this.gameView.manhattanDist(
+          this.gameView.unit(this.srcPortId()).tile(),
+          this.gameView.unit(this.dstPortId()).tile(),
+        ),
+      )
+      .toFixed(0);
   }
   health(): number {
     return this.data.health ?? 0;
@@ -101,6 +121,12 @@ export class UnitView {
       throw Error("Must be a trade ship");
     }
     return this.data.dstPortId;
+  }
+  srcPortId(): number {
+    if (this.type() != UnitType.TradeShip) {
+      throw Error("Must be a trade ship");
+    }
+    return this.data.srcPortId;
   }
   detonationDst(): TileRef {
     if (!nukeTypes.includes(this.type())) {

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -26,6 +26,7 @@ export class UnitImpl implements Unit {
 
   private _cooldownTick: Tick | null = null;
   private _dstPort: Unit | null = null; // Only for trade ships
+  private _srcPort: Unit | null = null; // Only for trade ships
   private _detonationDst: TileRef | null = null; // Only for nukes
   private _warshipTarget: Unit | null = null;
   private _cooldownDuration: number | null = null;
@@ -42,6 +43,7 @@ export class UnitImpl implements Unit {
     this._health = toInt(this.mg.unitInfo(_type).maxHealth ?? 1);
     this._lastTile = _tile;
     this._dstPort = unitsSpecificInfos.dstPort;
+    this._srcPort = unitsSpecificInfos.srcPort;
     this._detonationDst = unitsSpecificInfos.detonationDst;
     this._warshipTarget = unitsSpecificInfos.warshipTarget;
     this._cooldownDuration = unitsSpecificInfos.cooldownDuration;
@@ -54,6 +56,7 @@ export class UnitImpl implements Unit {
   toUpdate(): UnitUpdate {
     const warshipTarget = this.warshipTarget();
     const dstPort = this.dstPort();
+    const srcPort = this.srcPort();
     return {
       type: GameUpdateType.Unit,
       unitType: this._type,
@@ -66,6 +69,7 @@ export class UnitImpl implements Unit {
       health: this.hasHealth() ? Number(this._health) : undefined,
       constructionType: this._constructionType,
       dstPortId: dstPort ? dstPort.id() : null,
+      srcPortId: srcPort ? srcPort.id() : null,
       warshipTargetId: warshipTarget ? warshipTarget.id() : null,
       detonationDst: this.detonationDst(),
       ticksLeftInCooldown: this.ticksLeftInCooldown(this._cooldownDuration),
@@ -192,6 +196,10 @@ export class UnitImpl implements Unit {
     return this._dstPort;
   }
 
+  srcPort(): Unit {
+    return this._srcPort;
+  }
+
   // set the cooldown to the current tick or remove it
   setCooldown(triggerCooldown: boolean): void {
     if (triggerCooldown) {
@@ -216,6 +224,10 @@ export class UnitImpl implements Unit {
 
   setDstPort(dstPort: Unit): void {
     this._dstPort = dstPort;
+  }
+
+  setSrcPort(srcPort: Unit): void {
+    this._srcPort = srcPort;
   }
 
   setMoveTarget(moveTarget: TileRef) {


### PR DESCRIPTION
## Description:
This pull request introduces a feature that displays the gold carried by trade ships in the Trade Info section. It enhances the user experience by providing visibility into the value of goods being transported by ships, making it easier for players to track their trades.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found: 

alpgul00 (Discord is banned in Turkey. Please communicate via GitHub.)

![upgraded-parakeet-gp4qx5r94429gqj-3000 app github dev_join_TfnlHfvc](https://github.com/user-attachments/assets/fe6ba249-c488-4e9e-8a3c-c1a5267cd1d7)
