### PR TITLE
Use monospace font for private lobby code input

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -194,6 +194,11 @@ label.option-card:hover {
   margin: 8px 0px 0px 0px;
 }
 
+#lobbyIdInput {
+  font-family: monospace;
+  font-weight: 600;
+}
+
 .lobby-id-button {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Description:
Changes private lobby code input font to be monospace. Parity with lobby creation screen (#438).

**Before:**
![image](https://github.com/user-attachments/assets/da25cf2c-a8df-4d62-86ae-1eb575ad7bac)

**After:**
![image](https://github.com/user-attachments/assets/a65a0ff8-d48e-4c38-a949-8cc0fc82d383)


## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

imdarktom
