### PR TITLE
Update deploy script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,20 +11,6 @@ RUN apt-get update && apt-get install -y nginx supervisor git && \
 # Set the working directory in the container
 WORKDIR /usr/src/app
 
-# Copy package.json and package-lock.json
-COPY package*.json ./
-
-# Install dependencies while bypassing Husky hooks
-ENV HUSKY=0 
-ENV NPM_CONFIG_IGNORE_SCRIPTS=1
-RUN mkdir -p .git && npm install
-
-# Copy the rest of the application code
-COPY . .
-
-# Build the client-side application
-RUN npm run build-prod
-
 # Copy Nginx configuration and ensure it's used instead of the default
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 RUN rm -f /etc/nginx/sites-enabled/default
@@ -38,3 +24,17 @@ EXPOSE 80 443
 
 # Start Supervisor to manage both Node.js and Nginx
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+
+# Copy package.json and package-lock.json
+COPY package*.json ./
+
+# Install dependencies while bypassing Husky hooks
+ENV HUSKY=0
+ENV NPM_CONFIG_IGNORE_SCRIPTS=1
+RUN mkdir -p .git && npm ci
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the client-side application
+RUN npm run build-prod

--- a/deploy.sh
+++ b/deploy.sh
@@ -54,6 +54,10 @@ else
     ENV="prod"
 fi
 
+if [ -z "$SSH_KEY" ]; then
+  SSH_KEY="~/.ssh/id_rsa"
+fi
+
 # Check required environment variables
 if [ -z "$SERVER_HOST" ]; then
     echo "Error: SERVER_HOST_${REGION^^} not defined in .env file or environment"


### PR DESCRIPTION
1. Update the deploy script to fall back to ~/.ssh/id_rsa if no key path is set.
2. Reorder the dockerfile build steps to reduce the number of layers that need to be rebuilt.