### PR TITLE
Add Faroe Islands map to singleplayer menu

### DIFF
--- a/src/core/Add Faroe Islands map to singleplayer menu
+++ b/src/core/Add Faroe Islands map to singleplayer menu
@@ -89,6 +89,7 @@ export const mapCategories: Record<string, GameMapType[]> = {
     GameMapType.Japan,
     GameMapType.Mena,
     GameMapType.Australia,
+    GameMapType.FaroeIslands,
   ],
   fantasy: [GameMapType.Pangaea, GameMapType.Mars, GameMapType.KnownWorld],
 };


### PR DESCRIPTION
## Description:
Fixes the Faroe Islands map not showing up in the singleplayer menu

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

Nikola123
