### PR TITLE
Feat(code): Convert new team colours to RGB

### DIFF
--- a/src/core/configuration/Colors.ts
+++ b/src/core/configuration/Colors.ts
@@ -2,11 +2,11 @@ import { colord, Colord } from "colord";
 
 export const red: Colord = colord({ r: 235, g: 53, b: 53 }); // Bright Red
 export const blue: Colord = colord({ r: 41, g: 98, b: 255 }); // Royal Blue
-export const teal = colord({ h: 172, s: 66, l: 50 });
-export const purple = colord({ h: 271, s: 81, l: 56 });
-export const yellow = colord({ h: 45, s: 93, l: 47 });
-export const orange = colord({ h: 25, s: 95, l: 53 });
-export const green = colord({ h: 128, s: 49, l: 50 });
+export const teal = colord({ r: 43, g: 212, b: 189 });
+export const purple = colord({ r: 146, g: 52, b: 234 });
+export const yellow = colord({ r: 231, g: 176, b: 8 });
+export const orange = colord({ r: 249, s: 116, l: 21 });
+export const green = colord({ r: 65, g: 190, b: 82 });
 export const botColor: Colord = colord({ r: 210, g: 206, b: 200 }); // Muted Beige Gray
 
 export const territoryColors: Colord[] = [

--- a/src/core/configuration/Colors.ts
+++ b/src/core/configuration/Colors.ts
@@ -5,7 +5,7 @@ export const blue: Colord = colord({ r: 41, g: 98, b: 255 }); // Royal Blue
 export const teal = colord({ r: 43, g: 212, b: 189 });
 export const purple = colord({ r: 146, g: 52, b: 234 });
 export const yellow = colord({ r: 231, g: 176, b: 8 });
-export const orange = colord({ r: 249, s: 116, l: 21 });
+export const orange = colord({ r: 249, g: 116, b: 21 });
 export const green = colord({ r: 65, g: 190, b: 82 });
 export const botColor: Colord = colord({ r: 210, g: 206, b: 200 }); // Muted Beige Gray
 


### PR DESCRIPTION
## Description:

This PR converts the game colours for the extra teams to RGB format to match the rest of the colours defined in that file. I can confirm that the colours still look normal:

<img width="1440" alt="Screenshot 2025-04-30 at 10 06 00 PM" src="https://github.com/user-attachments/assets/b1544867-8afb-4d52-ae33-21003f7479fc" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

mOctave
