### PR TITLE
Fix emoji exploit

### DIFF
--- a/src/core/execution/EmojiExecution.ts
+++ b/src/core/execution/EmojiExecution.ts
@@ -39,9 +39,9 @@ export class EmojiExecution implements Execution {
 
   tick(ticks: number): void {
     // prevent longer text than just one emoji
-    if (this.emoji.length > 1) {
+    if (this.emoji.length > 2) {
       consolex.warn(
-        `prevented emoji string with length longer than 1, from client: ${this.requestor}`,
+        `prevented emoji string with length longer than 2, from client: ${this.requestor}`,
       );
       this.active = false;
       return;

--- a/src/core/execution/EmojiExecution.ts
+++ b/src/core/execution/EmojiExecution.ts
@@ -38,6 +38,15 @@ export class EmojiExecution implements Execution {
   }
 
   tick(ticks: number): void {
+    // prevent longer text than just one emoji
+    if (this.emoji.length > 1) {
+      consolex.warn(
+        `prevented emoji string with length longer than 1, from client: ${this.requestor}`,
+      );
+      this.active = false;
+      return;
+    }
+
     if (this.requestor.canSendEmoji(this.recipient)) {
       this.requestor.sendEmoji(this.recipient, this.emoji);
       if (


### PR DESCRIPTION
## Description:
This should fix the exploit that allows players to send custom text as an "emoji". It does this by limiting the length of the emoji string to 2 characters (emojis are 2 instead of 1).

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:
PilkeySEK