### PR TITLE
Use trade ship travelled distance instead of Manhattan distance when calculating value

### DIFF
--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -107,7 +107,6 @@ export class TradeShipExecution implements Execution {
       case PathFindResultType.Pending:
         // Fire unit event to rerender.
         this.tradeShip.move(this.tradeShip.tile());
-        this.tilesTraveled++;
         break;
       case PathFindResultType.NextTile:
         // Update safeFromPirates status

--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -21,6 +21,7 @@ export class TradeShipExecution implements Execution {
   private tradeShip: Unit;
   private index = 0;
   private wasCaptured = false;
+  private tilesTraveled = 0;
 
   constructor(
     private _owner: PlayerID,
@@ -106,6 +107,7 @@ export class TradeShipExecution implements Execution {
       case PathFindResultType.Pending:
         // Fire unit event to rerender.
         this.tradeShip.move(this.tradeShip.tile());
+        this.tilesTraveled++;
         break;
       case PathFindResultType.NextTile:
         // Update safeFromPirates status
@@ -113,6 +115,7 @@ export class TradeShipExecution implements Execution {
           this.tradeShip.setSafeFromPirates();
         }
         this.tradeShip.move(result.tile);
+        this.tilesTraveled++;
         break;
       case PathFindResultType.PathNotFound:
         consolex.warn("captured trade ship cannot find route");
@@ -127,11 +130,7 @@ export class TradeShipExecution implements Execution {
   private complete() {
     this.active = false;
     this.tradeShip.delete(false);
-    const gold = this.mg
-      .config()
-      .tradeShipGold(
-        this.mg.manhattanDist(this.srcPort.tile(), this._dstPort.tile()),
-      );
+    const gold = this.mg.config().tradeShipGold(this.tilesTraveled);
 
     if (this.wasCaptured) {
       this.tradeShip.owner().addGold(gold);


### PR DESCRIPTION
## Description:

This PR makes trade ships actually use their traveled distance when calculating their monetary value, instead of the the Manhattan distance from port to port.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

Koranir
