### PR TITLE
Feature - add player color in leaderboard,  playerPanel, playerOverlay

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -1,3 +1,4 @@
+import { Colord } from "colord";
 import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { unsafeHTML } from "lit/directives/unsafe-html.js";
@@ -9,6 +10,7 @@ import { Layer } from "./Layer";
 
 interface Entry {
   name: string;
+  color: Colord;
   position: number;
   score: string;
   gold: string;
@@ -79,6 +81,7 @@ export class Leaderboard extends LitElement implements Layer {
       }
       return {
         name: player.displayName(),
+        color: player.playerColor(),
         position: index + 1,
         score: formatPercentage(
           player.numTilesOwned() / numTilesWithoutFallout,
@@ -106,6 +109,7 @@ export class Leaderboard extends LitElement implements Layer {
       this.players.pop();
       this.players.push({
         name: myPlayer.displayName(),
+        color: myPlayer.playerColor(),
         position: place,
         score: formatPercentage(
           myPlayer.numTilesOwned() / this.game.numLandTiles(),
@@ -221,6 +225,20 @@ export class Leaderboard extends LitElement implements Layer {
       text-overflow: ellipsis;
     }
 
+    .player-color {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+
+    .player-color > div {
+      width: 12px;
+      height: 12px;
+      border: 1px solid rgba(0, 0, 0, 0.3);
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+
     @media (max-width: 1000px) {
       .leaderboard {
         top: 70px;
@@ -281,7 +299,14 @@ export class Leaderboard extends LitElement implements Layer {
                   @click=${() => this.handleRowClickPlayer(player.player)}
                 >
                   <td>${player.position}</td>
-                  <td class="player-name">${unsafeHTML(player.name)}</td>
+                  <td class="player-name">
+                    <div class="player-color">
+                      <div
+                        style="background-color: ${player.color.toRgbString()};"
+                      ></div>
+                      ${unsafeHTML(player.name)}
+                    </div>
+                  </td>
                   <td>${player.score}</td>
                   <td>${player.gold}</td>
                   <td>${player.troops}</td>

--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -195,10 +195,14 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
     return html`
       <div class="p-2">
         <div
-          class="text-bold text-sm lg:text-lg font-bold mb-1 inline-flex ${isFriendly
+          class="text-bold text-sm lg:text-lg font-bold mb-1 inline-flex items-center ${isFriendly
             ? "text-green-500"
             : "text-white"}"
         >
+          <div
+            class="w-4 h-4 rounded-sm border border-black/30 mr-1"
+            style="background-color: ${player.playerColor().toRgbString()}"
+          ></div>
           ${player.flag()
             ? html`<img
                 class="h-8 mr-1 aspect-[3/4]"

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -235,6 +235,10 @@ export class PlayerPanel extends LitElement implements Layer {
                        bg-opacity-50 bg-gray-700 text-opacity-90 text-white
                        rounded text-sm lg:text-xl w-full"
               >
+                <div
+                  class="w-4 h-4 rounded-sm border border-black/30 mr-1"
+                  style="background-color: ${other.playerColor().toRgbString()}"
+                ></div>
                 ${other?.name()}
               </div>
             </div>

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -1,3 +1,4 @@
+import { Colord } from "colord";
 import { Config } from "../configuration/Config";
 import { ClientID, GameID, PlayerStats } from "../Schemas";
 import { createRandomName } from "../Util";
@@ -182,12 +183,15 @@ export class PlayerView {
       ? this.anonymousName
       : this.data.name;
   }
+
   displayName(): string {
     return userSettings.anonymousNames() && this.anonymousName !== null
       ? this.anonymousName
       : this.data.name;
   }
-
+  playerColor(): Colord {
+    return this.game.playerColor(this.data.id);
+  }
   clientID(): ClientID {
     return this.data.clientID;
   }
@@ -407,6 +411,13 @@ export class GameView implements GameMap {
       return this._players.get(id);
     }
     throw Error(`player id ${id} not found`);
+  }
+
+  playerColor(id: PlayerID): Colord | null {
+    const player = this.player(id);
+    if (!player) return;
+    const theme = this.config().theme();
+    return theme.territoryColor(player);
   }
 
   players(): PlayerView[] {


### PR DESCRIPTION
## Description:

Added a visual color indicator (small square) representing each player's territory color to enhance readability and player identification.

### Applied in:
- **Leaderboard** (next to player name)
- **PlayerPanel**
- **PlayerInfoOverlay**

The color is dynamically fetched from `theme.territoryColor(...)` and displayed left of the player name using a small square element aligned with text. 
This makes it easier to associate UI elements with the player.
![image](https://github.com/user-attachments/assets/df3733fc-032b-444e-babc-20bfe4303259)
![image](https://github.com/user-attachments/assets/4068369e-a031-4bc2-92bf-e5ef079db594)
![image](https://github.com/user-attachments/assets/ba627818-8bc2-41ff-af16-2a4380775796)

---

* [x] I have added screenshots for all UI updates  
* [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced  
* [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors  

##  Discord username
mrthomas_
