### PR TITLE
Remove clientID, persistentID, gameID from ClientBaseMessageSchema, TurnSchema

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -275,7 +275,6 @@ export class ClientGameRunner {
           while (turn.turnNumber - 1 > this.turnsSeen) {
             this.worker.sendTurn({
               turnNumber: this.turnsSeen,
-              gameID: turn.gameID,
               intents: [],
             });
             this.turnsSeen++;

--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -127,7 +127,6 @@ export class LocalServer {
     }
     const pastTurn: Turn = {
       turnNumber: this.turns.length,
-      gameID: this.lobbyConfig.gameStartInfo.gameID,
       intents: this.intents,
     };
     this.turns.push(pastTurn);

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -356,8 +356,6 @@ export const ServerMessageSchema = z.union([
 
 const ClientBaseMessageSchema = z.object({
   type: z.enum(["winner", "join", "intent", "ping", "log", "hash"]),
-  clientID: ID,
-  persistentID: SafeString.nullable(), // WARNING: persistent id is private.
   gameID: ID,
 });
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -289,7 +289,6 @@ const IntentSchema = z.union([
 
 export const TurnSchema = z.object({
   turnNumber: z.number(),
-  gameID: ID,
   intents: z.array(IntentSchema),
   // The hash of the game state at the end of the turn.
   hash: z.number().nullable().optional(),
@@ -356,7 +355,6 @@ export const ServerMessageSchema = z.union([
 
 const ClientBaseMessageSchema = z.object({
   type: z.enum(["winner", "join", "intent", "ping", "log", "hash"]),
-  gameID: ID,
 });
 
 export const ClientSendWinnerSchema = ClientBaseMessageSchema.extend({

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -126,10 +126,14 @@ export class GameServer {
       (c) => c.clientID == client.clientID,
     );
     if (existing != null) {
-      if (client.persistentID != existing.persistentID) {
-        console.warn(
-          `client ${client.clientID} cannot rejoin game, persistent id mismatch: exist pid: ${existing.persistentID}, new pid: ${client.persistentID}`,
-        );
+      if (client.persistentID !== existing.persistentID) {
+        this.log.error("persistent ids do not match", {
+          clientID: client.clientID,
+          clientIP: client.ip,
+          clientPersistentID: client.persistentID,
+          existingIP: existing.ip,
+          existingPersistentID: existing.persistentID,
+        });
         return;
       }
       existing.ws.removeAllListeners("message");
@@ -152,34 +156,17 @@ export class GameServer {
           } catch (error) {
             throw Error(`error parsing schema for ${client.ip}`);
           }
-          if (this.allClients.has(clientMsg.clientID)) {
-            const client = this.allClients.get(clientMsg.clientID);
-            if (client.persistentID != clientMsg.persistentID) {
-              this.log.warn(
-                `Client ID ${clientMsg.clientID} sent incorrect id ${clientMsg.persistentID}, does not match persistent id ${client.persistentID}`,
-                {
-                  clientID: clientMsg.clientID,
-                  persistentID: clientMsg.persistentID,
-                },
-              );
-              return;
-            }
-          }
-
-          // Clear out persistent id to make sure it doesn't get sent to other clients.
-          clientMsg.persistentID = null;
-
           if (clientMsg.type == "intent") {
             if (clientMsg.gameID != this.id) {
               this.log.warn("client sent to wrong game", {
-                clientID: clientMsg.clientID,
-                persistentID: clientMsg.persistentID,
+                clientID: client.clientID,
+                persistentID: client.persistentID,
               });
               return;
             }
-            if (clientMsg.intent.clientID != clientMsg.clientID) {
+            if (clientMsg.intent.clientID != client.clientID) {
               this.log.warn(
-                `client id mismatch, client message: ${clientMsg.clientID}, intent client id ${clientMsg.intent.clientID}`,
+                `client id mismatch, client: ${client.clientID}, intent: ${clientMsg.intent.clientID}`,
               );
               return;
             }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -157,13 +157,6 @@ export class GameServer {
             throw Error(`error parsing schema for ${client.ip}`);
           }
           if (clientMsg.type == "intent") {
-            if (clientMsg.gameID != this.id) {
-              this.log.warn("client sent to wrong game", {
-                clientID: client.clientID,
-                persistentID: client.persistentID,
-              });
-              return;
-            }
             if (clientMsg.intent.clientID != client.clientID) {
               this.log.warn(
                 `client id mismatch, client: ${client.clientID}, intent: ${clientMsg.intent.clientID}`,
@@ -320,7 +313,6 @@ export class GameServer {
   private endTurn() {
     const pastTurn: Turn = {
       turnNumber: this.turns.length,
-      gameID: this.id,
       intents: this.intents,
     };
     this.turns.push(pastTurn);


### PR DESCRIPTION
## Description:

Remove the devils `clientID`, `persistentID`, and `gameID` from `ClientBaseMessageSchema`, as well as `gameID` from `TurnSchema`. These values are already known through the `Client` object that is hoisted into the relevant handler.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors
