### PR TITLE
Update deployment script to wait for deployment to come online

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -116,6 +116,37 @@ jobs:
           echo "::group::deploy.sh"
           ./deploy.sh "$ENV" "$HOST" "$SUBDOMAIN"
           echo "::endgroup::"
+      - name: Wait for deployment to start
+        run: |
+          echo "::group::Wait for deployment to start"
+          set -euxo pipefail
+          while [ "$(curl -s https://${FQDN}/commit.txt)" != "${GITHUB_SHA}" ]; do
+            if [ "$SECONDS" -ge 300 ]; then
+              echo "Timeout: deployment did not start within 5 minutes"
+              exit 1
+            fi
+            sleep 10
+          done
+          echo "::endgroup::"
+      - name: Notify PR 🚀
+        if: ${{ success() && github.event_name == 'push'
+          && github.repository != 'openfrontio/OpenFrontIO'
+          }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euxo pipefail
+          if [ -z "$GH_TOKEN" ]; then
+            echo "No GH_TOKEN found, skipping"
+            exit 0;
+          fi
+          echo "Checking for open PR from $GITHUB_HEAD_REF..."
+          pr_url=$(gh pr list --head "$GITHUB_HEAD_REF" --state open --json url -q '.[0].url')
+          if [ -z "$pr_url" ]; then
+            echo "No open PR found for branch $GITHUB_HEAD_REF"
+            exit 0;
+          fi
+          gh pr comment "$pr_url" --body "🚀 Deployed ${GITHUB_SHA} to [$FQDN](https://$FQDN)."
       - name: Update deployment status ✅
         if: success()
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,7 @@ jobs:
     # Don't deploy on push if this is a fork
     if: ${{ github.event_name == 'workflow_dispatch' || github.repository == 'openfrontio/OpenFrontIO' }}
     # Use different logic based on event type
-    name: Deploy to ${{
+    name: ${{
       github.event_name == 'push'
       && (github.ref_name == 'main' && 'openfront.dev'
       || format('{0}.openfront.dev', github.ref_name))


### PR DESCRIPTION
## Description:

- Wait up to five minutes for the deployment to come online
- Re-add the `Notify PR 🚀` step, disabled on the main repo for now

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors