### PR TITLE
Feature/cooldown break alliance

### DIFF
--- a/resources/lang/bg.json
+++ b/resources/lang/bg.json
@@ -153,6 +153,7 @@
     "options_title": "Опции",
     "bots": "Ботове: ",
     "bots_disabled": "Изключено",
+    "break_alliance_cooldown": "Време за изчакване преди прекъсване на съюз (в секунди)",
     "disable_nations": "Изключване на нации",
     "instant_build": "Незабавно построяване",
     "infinite_gold": "Безкрайно злато",

--- a/resources/lang/bn.json
+++ b/resources/lang/bn.json
@@ -152,6 +152,7 @@
     "options_title": "বিকল্পসমূহ",
     "bots": "বট: ",
     "bots_disabled": "নিষ্ক্রিয়",
+    "break_alliance_cooldown": "জোট ভাঙার কুলডাউন সময় (সেকেন্ডে)",
     "disable_nations": "জাতি নিষ্ক্রিয় করুন",
     "instant_build": "তাৎক্ষণিক নির্মাণ",
     "infinite_gold": "অসীম সোনা",

--- a/resources/lang/de.json
+++ b/resources/lang/de.json
@@ -142,6 +142,7 @@
     "options_title": "Optionen",
     "bots": "Bots:",
     "bots_disabled": "Deaktiviert",
+    "break_alliance_cooldown": "Abklingzeit für das Beenden eines Bündnisses (in Sekunden)",
     "disable_nations": "Nationen deaktivieren",
     "instant_build": "Sofortiges Bauen",
     "infinite_gold": "Unendlich Gold",

--- a/resources/lang/debug.json
+++ b/resources/lang/debug.json
@@ -144,6 +144,7 @@
     "options_title": "host_modal.options_title",
     "bots": "host_modal.bots",
     "bots_disabled": "host_modal.bots_disabled",
+    "break_alliance_cooldown": "host_modal.break_alliance_cooldown",
     "disable_nations": "host_modal.disable_nations",
     "instant_build": "host_modal.instant_build",
     "infinite_gold": "host_modal.infinite_gold",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -164,7 +164,7 @@
     "options_title": "Options",
     "bots": "Bots: ",
     "bots_disabled": "Disabled",
-    "break_alliance_cooldown": "Cooldown break alliance(seconds)",
+    "break_alliance_cooldown": "Alliance break cooldown (in seconds)",
     "disable_nations": "Disable Nations",
     "instant_build": "Instant build",
     "infinite_gold": "Infinite gold",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -164,6 +164,7 @@
     "options_title": "Options",
     "bots": "Bots: ",
     "bots_disabled": "Disabled",
+    "break_alliance_cooldown": "Cooldown break alliance(seconds)",
     "disable_nations": "Disable Nations",
     "instant_build": "Instant build",
     "infinite_gold": "Infinite gold",

--- a/resources/lang/eo.json
+++ b/resources/lang/eo.json
@@ -153,6 +153,7 @@
     "options_title": "Opcioj",
     "bots": "Robotoj :",
     "bots_disabled": "Malŝaltita",
+    "break_alliance_cooldown": "Malvarmiĝtempo por rompi aliancon (en sekundoj)",
     "disable_nations": "Malŝalti naciojn",
     "instant_build": "Tujkonstruaĵo",
     "infinite_gold": "Senfina oro",

--- a/resources/lang/es.json
+++ b/resources/lang/es.json
@@ -151,6 +151,7 @@
     "options_title": "Opciones",
     "bots": "Bots: ",
     "bots_disabled": "Deshabilitados",
+    "break_alliance_cooldown": "Tiempo de espera para romper la alianza (en segundos)",
     "disable_nations": "Deshabilitar Naciones",
     "instant_build": "Construcción instantánea",
     "infinite_gold": "Oro infinito",

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -153,6 +153,7 @@
     "options_title": "Paramètres",
     "bots": "Bots : ",
     "bots_disabled": "Désactivé",
+    "break_alliance_cooldown": "Délai avant rupture d'alliance (en secondes)",
     "disable_nations": "Désactiver les nations",
     "instant_build": "Construction instantanée",
     "infinite_gold": "Or infini",

--- a/resources/lang/hi.json
+++ b/resources/lang/hi.json
@@ -152,6 +152,7 @@
     "options_title": "विकल्प",
     "bots": "बॉट: ",
     "bots_disabled": "निष्क्रिय",
+    "break_alliance_cooldown": "गठबंधन तोड़ने का कूलडाउन समय (सेकंड में)",
     "disable_nations": "राष्ट्र निष्क्रिय करें",
     "instant_build": "तुरंत निर्माण",
     "infinite_gold": "असीमित सोना",

--- a/resources/lang/it.json
+++ b/resources/lang/it.json
@@ -152,6 +152,7 @@
     "options_title": "Opzioni",
     "bots": "Bot: ",
     "bots_disabled": "Disabilitato",
+    "break_alliance_cooldown": "Tempo di attesa per rompere l'alleanza (in secondi)",
     "disable_nations": "Disabilita Nazioni",
     "instant_build": "Costruzione Istantanea ",
     "infinite_gold": "Oro infinito",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -154,6 +154,7 @@
     "options_title": "オプション",
     "bots": "ボット数: ",
     "bots_disabled": "無効",
+    "break_alliance_cooldown": "同盟を解除するクールダウン時間（秒）",
     "disable_nations": "実在する国家を無効化",
     "instant_build": "実在する国家を無効化",
     "infinite_gold": "資金無限",

--- a/resources/lang/nl.json
+++ b/resources/lang/nl.json
@@ -153,6 +153,7 @@
     "options_title": "Opties",
     "bots": "Bots:",
     "bots_disabled": "Uitgeschakeld",
+    "break_alliance_cooldown": "Wachttijd om alliantie te verbreken (in seconden)",
     "disable_nations": "Naties uitschakelen",
     "instant_build": "Bouwwachttijd uitschakelen",
     "infinite_gold": "Oneindig goud",

--- a/resources/lang/pl.json
+++ b/resources/lang/pl.json
@@ -153,6 +153,7 @@
     "options_title": "Opcje",
     "bots": "Boty: ",
     "bots_disabled": "Wyłączone",
+    "break_alliance_cooldown": "Czas odczekania przed zerwaniem sojuszu (w sekundach)",
     "disable_nations": "Wyłącz Państwa",
     "instant_build": "Natychmiastowa budowa",
     "infinite_gold": "Nieskończone złoto",

--- a/resources/lang/pt_br.json
+++ b/resources/lang/pt_br.json
@@ -142,6 +142,7 @@
     "options_title": "Opções",
     "bots": "Bots: ",
     "bots_disabled": "Desativado",
+    "break_alliance_cooldown": "Время ожидания перед разрывом союза (в секундах)",
     "disable_nations": "Desativar Nações",
     "instant_build": "Construção instantânea",
     "infinite_gold": "Ouro infinito",

--- a/resources/lang/ru.json
+++ b/resources/lang/ru.json
@@ -153,6 +153,7 @@
     "options_title": "Настройки",
     "bots": "Боты: ",
     "bots_disabled": "Отключены",
+    "break_alliance_cooldown": "Cooldown break alliance(seconds)",
     "disable_nations": "Отключить нации",
     "instant_build": "Мгновенная стройка",
     "infinite_gold": "Неограниченное золото",

--- a/resources/lang/sh.json
+++ b/resources/lang/sh.json
@@ -153,6 +153,7 @@
     "options_title": "Opcije",
     "bots": "Botovi: ",
     "bots_disabled": "Onemogućeni",
+    "break_alliance_cooldown": "Vreme čekanja pre raskida saveza (u sekundama)",
     "disable_nations": "Onemogući nacije",
     "instant_build": "Neposredna izgradnja",
     "infinite_gold": "Beskrajno zlato",

--- a/resources/lang/tr.json
+++ b/resources/lang/tr.json
@@ -142,6 +142,7 @@
     "options_title": "Seçenekler",
     "bots": "Botları:",
     "bots_disabled": "Devre Dışı",
+    "break_alliance_cooldown": "İttifakı bozma bekleme süresi (saniye olarak)",
     "disable_nations": "Ulusları Devre Dışı Bırak",
     "instant_build": "Anında İnşa",
     "infinite_gold": "Sınırsız Altın",

--- a/resources/lang/uk.json
+++ b/resources/lang/uk.json
@@ -153,6 +153,7 @@
     "options_title": "Налаштування",
     "bots": "Боти: ",
     "bots_disabled": "Відключено",
+    "break_alliance_cooldown": "Час очікування перед розривом союзу (в секундах)",
     "disable_nations": "Відключити нації",
     "instant_build": "Миттєве будівництво",
     "infinite_gold": "Нескінченне золото",

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -246,7 +246,7 @@ export class HostLobbyModal extends LitElement {
                   id="alliance-break-cooldown"
                   min="0"
                   max="600"
-                  step="1"
+                  step="10"
                   @input=${this.handleAllianceBreakCooldownChange}
                   @change=${this.handleAllianceBreakCooldownChange}
                   .value="${String(this.allianceBreakCooldown)}"

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -33,6 +33,7 @@ export class HostLobbyModal extends LitElement {
   @state() private teamCount: number | typeof Duos = 2;
   @state() private disableNukes: boolean = false;
   @state() private bots: number = 400;
+  @state() private allianceBreakCooldown: number = 60;
   @state() private infiniteGold: boolean = false;
   @state() private infiniteTroops: boolean = false;
   @state() private instantBuild: boolean = false;
@@ -239,7 +240,22 @@ export class HostLobbyModal extends LitElement {
                   }
                 </div>
               </label>
-
+              <label for="alliance-break-cooldown" class="option-card">
+                <input
+                  type="range"
+                  id="alliance-break-cooldown"
+                  min="0"
+                  max="600"
+                  step="1"
+                  @input=${this.handleAllianceBreakCooldownChange}
+                  @change=${this.handleAllianceBreakCooldownChange}
+                  .value="${String(this.allianceBreakCooldown)}"
+                />
+                <div class="option-card-title">
+                  <span>${translateText("host_modal.break_alliance_cooldown")}</span>
+                  ${this.allianceBreakCooldown}
+                </div>
+              </label>
                 <label
                   for="disable-npcs"
                   class="option-card ${this.disableNPCs ? "selected" : ""}"
@@ -489,6 +505,15 @@ export class HostLobbyModal extends LitElement {
     }, 300);
   }
 
+  private handleAllianceBreakCooldownChange(e: Event) {
+    const value = parseInt((e.target as HTMLInputElement).value);
+    if (isNaN(value) || value < 0 || value > 600) {
+      return;
+    }
+    // Update the display value immediately
+    this.allianceBreakCooldown = value;
+  }
+
   private handleInstantBuildChange(e: Event) {
     this.instantBuild = Boolean((e.target as HTMLInputElement).checked);
     this.putGameConfig();
@@ -539,6 +564,7 @@ export class HostLobbyModal extends LitElement {
           disableNPCs: this.disableNPCs,
           disableNukes: this.disableNukes,
           bots: this.bots,
+          allianceBreakCooldown: this.allianceBreakCooldown,
           infiniteGold: this.infiniteGold,
           infiniteTroops: this.infiniteTroops,
           instantBuild: this.instantBuild,

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -222,7 +222,9 @@ class Client {
     }
 
     document
-      .querySelectorAll("#bots-count, #private-lobby-bots-count")
+      .querySelectorAll(
+        "#bots-count, #private-lobby-bots-count, #alliance-break-cooldown",
+      )
       .forEach((slider) => {
         updateSliderProgress(slider);
         slider.addEventListener("input", () => updateSliderProgress(slider));

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -33,6 +33,7 @@ export class SinglePlayerModal extends LitElement {
   @state() private disableNPCs: boolean = false;
   @state() private disableNukes: boolean = false;
   @state() private bots: number = 400;
+  @state() private allianceBreakCooldown: number = 60;
   @state() private infiniteGold: boolean = false;
   @state() private infiniteTroops: boolean = false;
   @state() private instantBuild: boolean = false;
@@ -209,7 +210,26 @@ export class SinglePlayerModal extends LitElement {
                     : this.bots}
                 </div>
               </label>
-
+              <label for="alliance-break-cooldown" class="option-card">
+                <input
+                  type="range"
+                  id="alliance-break-cooldown"
+                  min="0"
+                  max="600"
+                  step="1"
+                  @input=${this.handleAllianceBreakCooldownChange}
+                  @change=${this.handleAllianceBreakCooldownChange}
+                  .value="${String(this.allianceBreakCooldown)}"
+                />
+                <div class="option-card-title">
+                  <span
+                    >${translateText(
+                      "host_modal.break_alliance_cooldown",
+                    )}</span
+                  >
+                  ${this.allianceBreakCooldown}
+                </div>
+              </label>
               <label
                 for="singleplayer-modal-disable-npcs"
                 class="option-card ${this.disableNPCs ? "selected" : ""}"
@@ -373,6 +393,14 @@ export class SinglePlayerModal extends LitElement {
     }
     this.bots = value;
   }
+  private handleAllianceBreakCooldownChange(e: Event) {
+    const value = parseInt((e.target as HTMLInputElement).value);
+    if (isNaN(value) || value < 0 || value > 600) {
+      return;
+    }
+    // Update the display value immediately
+    this.allianceBreakCooldown = value;
+  }
 
   private handleInstantBuildChange(e: Event) {
     this.instantBuild = Boolean((e.target as HTMLInputElement).checked);
@@ -458,6 +486,7 @@ export class SinglePlayerModal extends LitElement {
               disableNPCs: this.disableNPCs,
               disableNukes: this.disableNukes,
               bots: this.bots,
+              allianceBreakCooldown: this.allianceBreakCooldown,
               infiniteGold: this.infiniteGold,
               infiniteTroops: this.infiniteTroops,
               instantBuild: this.instantBuild,

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -216,7 +216,7 @@ export class SinglePlayerModal extends LitElement {
                   id="alliance-break-cooldown"
                   min="0"
                   max="600"
-                  step="1"
+                  step="10"
                   @input=${this.handleAllianceBreakCooldownChange}
                   @change=${this.handleAllianceBreakCooldownChange}
                   .value="${String(this.allianceBreakCooldown)}"

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -246,6 +246,7 @@ label.option-card:hover {
 }
 
 #bots-count,
+#alliance-break-cooldown,
 #private-lobby-bots-count {
   width: 80%;
   height: 16px;
@@ -256,18 +257,21 @@ label.option-card:hover {
 
 /* Firefox */
 #bots-count::-moz-range-track,
+#alliance-break-cooldown::-moz-range-track,
 #private-lobby-bots-count::-moz-range-track {
   height: 8px;
   background: white;
 }
 
 #bots-count::-moz-range-progress,
+#alliance-break-cooldown::-moz-range-progress,
 #private-lobby-bots-count::-moz-range-progress {
   height: 8px;
   background-color: #0075ff;
 }
 
 #bots-count::-moz-range-thumb,
+#alliance-break-cooldown::-moz-range-thumb,
 #private-lobby-bots-count::-moz-range-thumb {
   height: 16px;
   width: 16px;
@@ -278,6 +282,7 @@ label.option-card:hover {
 
 /* Chrome */
 #bots-count::-webkit-slider-runnable-track,
+#alliance-break-cooldown::-webkit-slider-runnable-track,
 #private-lobby-bots-count::-webkit-slider-runnable-track {
   height: 8px;
   background: linear-gradient(
@@ -288,6 +293,7 @@ label.option-card:hover {
 }
 
 #bots-count::-webkit-slider-thumb,
+#alliance-break-cooldown::-webkit-slider-thumb,
 #private-lobby-bots-count::-webkit-slider-thumb {
   -webkit-appearance: none;
   height: 16px;

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -190,12 +190,14 @@ export class GameRunner {
 
     if (this.game.hasOwner(tile)) {
       const other = this.game.owner(tile) as Player;
+      const currentAlliance = player.allianceWith(other);
       actions.interaction = {
         sharedBorder: player.sharesBorderWith(other),
         canSendEmoji: player.canSendEmoji(other),
         canTarget: player.canTarget(other),
         canSendAllianceRequest: player.canSendAllianceRequest(other),
-        canBreakAlliance: player.isAlliedWith(other),
+        canBreakAlliance:
+          player.isAlliedWith(other) && currentAlliance.canBeBreak(),
         canDonate: player.canDonate(other),
         canEmbargo: !player.hasEmbargoAgainst(other),
       };

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -117,6 +117,7 @@ const GameConfigSchema = z.object({
   gameMode: z.nativeEnum(GameMode),
   disableNPCs: z.boolean(),
   bots: z.number().int().min(0).max(400),
+  allianceBreakCooldown: z.number().int().min(0).max(600),
   infiniteGold: z.boolean(),
   infiniteTroops: z.boolean(),
   instantBuild: z.boolean(),

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -67,6 +67,7 @@ export interface Config {
   numBots(): number;
   spawnNPCs(): boolean;
   isUnitDisabled(unitType: UnitType): boolean;
+  allianceBreakCooldown(): number;
   bots(): number;
   infiniteGold(): boolean;
   infiniteTroops(): boolean;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -238,6 +238,9 @@ export class DefaultConfig implements Config {
   bots(): number {
     return this._gameConfig.bots;
   }
+  allianceBreakCooldown(): number {
+    return this._gameConfig.allianceBreakCooldown;
+  }
   instantBuild(): boolean {
     return this._gameConfig.instantBuild;
   }

--- a/src/core/game/AllianceImpl.ts
+++ b/src/core/game/AllianceImpl.ts
@@ -32,4 +32,11 @@ export class AllianceImpl implements MutableAlliance {
   expire(): void {
     this.mg.expireAlliance(this);
   }
+
+  canBeBreak(): boolean {
+    const allianceBreakCooldown = this.mg.config().allianceBreakCooldown();
+    if (!allianceBreakCooldown) return true;
+    //Convert allianceBreakCooldown in tick * 10
+    return this.mg.ticks() - this.createdAt() >= allianceBreakCooldown * 10;
+  }
 }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -241,6 +241,7 @@ export interface Alliance {
   requestor(): Player;
   recipient(): Player;
   createdAt(): Tick;
+  canBeBreak(): boolean;
   other(player: Player): Player;
 }
 

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -40,6 +40,7 @@ export class GameManager {
       gameMode: GameMode.FFA,
       bots: 400,
       disabledUnits: [],
+      allianceBreakCooldown: 60,
       ...gameConfig,
     });
     this.games.set(id, game);

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -80,6 +80,9 @@ export class GameServer {
     if (gameConfig.bots != null) {
       this.gameConfig.bots = gameConfig.bots;
     }
+    if (gameConfig.allianceBreakCooldown != null) {
+      this.gameConfig.allianceBreakCooldown = gameConfig.allianceBreakCooldown;
+    }
     if (gameConfig.infiniteGold != null) {
       this.gameConfig.infiniteGold = gameConfig.infiniteGold;
     }

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -56,6 +56,7 @@ export class MapPlaylist {
       instantBuild: false,
       disableNPCs: mode == GameMode.Team,
       disableNukes: false,
+      allianceBreakCooldown: 0,
       gameMode: mode,
       playerTeams: numPlayerTeams,
       bots: 400,

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -161,6 +161,7 @@ export function startWorker() {
         infiniteTroops: req.body.infiniteTroops,
         instantBuild: req.body.instantBuild,
         bots: req.body.bots,
+        allianceBreakCooldown: req.body.allianceBreakCooldown,
         disableNPCs: req.body.disableNPCs,
         disabledUnits: req.body.disabledUnits,
         gameMode: req.body.gameMode,


### PR DESCRIPTION
## Description:
This pull request introduces a new configuration option to define a minimum delay before a player can betray an alliance.

## Purpose:
The goal is to encourage players to honor their alliances for a minimum amount of time, while still keeping betrayal as a valid strategic element of gameplay.

## Behavior:
Playlist games: the delay is set to 0 seconds by default (no gameplay change), but it is still configurable in the code for future adjustments if needed.

Custom and solo games: the delay is configurable between 0 and 10 minutes, with a default value of 60 seconds.

![image](https://github.com/user-attachments/assets/3a55acc3-7e2a-41f0-8e10-3db4cbd5cc26)
![image](https://github.com/user-attachments/assets/9248668a-4086-4aea-8d20-2580419e817c)



## Please complete the following:

* [x] I have added screenshots for all UI updates
* [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
* [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Discord username:

MrThomas_
