### PR TITLE
Change spawnhighlight colors of allies/enemies

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -13,7 +13,6 @@ import { GameView, PlayerView } from "../../../core/game/GameView";
 import { PseudoRandom } from "../../../core/PseudoRandom";
 import { AlternateViewEvent, DragEvent } from "../../InputHandler";
 import { Layer } from "./Layer";
-import { red } from "../../../core/configuration/Colors";
 
 export class TerritoryLayer implements Layer {
   private canvas: HTMLCanvasElement;

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -119,16 +119,19 @@ export class TerritoryLayer implements Layer {
       if (!centerTile) {
         continue;
       }
-      let color = this.theme.spawnHighlightColor();
-      if (this.game.myPlayer().isFriendly(human) || this.game.myPlayer().id() == human.id()) {
-        color = this.theme.spawnHighlightColorFriendly();
-      }
+      let color = this.theme.selfColor();
       if (
         this.game.myPlayer() != null &&
         this.game.myPlayer() != human &&
         this.game.myPlayer().isFriendly(human)
       ) {
-        color = this.theme.selfColor();
+        color = this.theme.allyColor();
+      } else if (
+        this.game.myPlayer() != null &&
+        this.game.myPlayer() != human &&
+        !this.game.myPlayer().isFriendly(human)
+      ) {
+        color = this.theme.enemyColor();
       }
       for (const tile of this.game.bfs(
         centerTile,

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -13,6 +13,7 @@ import { GameView, PlayerView } from "../../../core/game/GameView";
 import { PseudoRandom } from "../../../core/PseudoRandom";
 import { AlternateViewEvent, DragEvent } from "../../InputHandler";
 import { Layer } from "./Layer";
+import { red } from "../../../core/configuration/Colors";
 
 export class TerritoryLayer implements Layer {
   private canvas: HTMLCanvasElement;
@@ -120,6 +121,9 @@ export class TerritoryLayer implements Layer {
         continue;
       }
       let color = this.theme.spawnHighlightColor();
+      if (this.game.myPlayer().isFriendly(human) || this.game.myPlayer().id() == human.id()) {
+        color = this.theme.spawnHighlightColorFriendly();
+      }
       if (
         this.game.myPlayer() != null &&
         this.game.myPlayer() != human &&

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -156,4 +156,5 @@ export interface Theme {
   allyColor(): Colord;
   enemyColor(): Colord;
   spawnHighlightColor(): Colord;
+  spawnHighlightColorFriendly(): Colord;
 }

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -40,6 +40,7 @@ export const pastelTheme = new (class implements Theme {
   private _enemyColor = colord({ r: 255, g: 0, b: 0 });
 
   private _spawnHighlightColor = colord({ r: 255, g: 213, b: 79 });
+  private _spawnHighlightColorFriendly = colord({ r: 166, g: 166, b: 166 })
 
   teamColor(team: Team): Colord {
     switch (team) {
@@ -177,5 +178,9 @@ export const pastelTheme = new (class implements Theme {
 
   spawnHighlightColor(): Colord {
     return this._spawnHighlightColor;
+  }
+
+  spawnHighlightColorFriendly(): Colord {
+    return this._spawnHighlightColorFriendly;
   }
 })();

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -40,6 +40,7 @@ export const pastelThemeDark = new (class implements Theme {
   private _enemyColor = colord({ r: 255, g: 0, b: 0 });
 
   private _spawnHighlightColor = colord({ r: 255, g: 213, b: 79 });
+  private _spawnHighlightColorFriendly = colord({ r: 166, g: 166, b: 166 })
 
   teamColor(team: Team): Colord {
     switch (team) {
@@ -179,5 +180,9 @@ export const pastelThemeDark = new (class implements Theme {
 
   spawnHighlightColor(): Colord {
     return this._spawnHighlightColor;
+  }
+
+  spawnHighlightColorFriendly(): Colord {
+    return this._spawnHighlightColorFriendly;
   }
 })();


### PR DESCRIPTION
It's currently hard to see who are enemies/allies in the initial spawn phase, especially when colorblind and in team games. This PR changes that by coloring the spawnhighlight of hostile/friendly players with the already existing `this.theme.enemyColor()`/`this.theme.allyColor()`.

This makes it much easier to quickly see where friendly players are spawning especially in team games.

![example](https://i.imgur.com/l6JHdOS.png)

- [ x ] I have added screenshots for all UI updates
- [ x ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ x ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors
- [ x  ] 
## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
