### PR TITLE
change enemy/ally spawn highlight colors

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -119,13 +119,19 @@ export class TerritoryLayer implements Layer {
       if (!centerTile) {
         continue;
       }
-      let color = this.theme.spawnHighlightColor();
+      let color = this.theme.selfColor();
       if (
         this.game.myPlayer() != null &&
         this.game.myPlayer() != human &&
         this.game.myPlayer().isFriendly(human)
       ) {
-        color = this.theme.selfColor();
+        color = this.theme.allyColor();
+      } else if (
+        this.game.myPlayer() != null &&
+        this.game.myPlayer() != human &&
+        !this.game.myPlayer().isFriendly(human)
+      ) {
+        color = this.theme.enemyColor();
       }
       for (const tile of this.game.bfs(
         centerTile,


### PR DESCRIPTION
It's currently hard to see who are enemies/allies in the initial spawn phase, especially when colorblind and in team games. This PR changes that by coloring the spawnhighlight of hostile/friendly players with the already existing `this.theme.enemyColor()`/`this.theme.allyColor()`.

This makes it much easier to quickly see where friendly players are spawning especially in team games.

![example](https://i.imgur.com/l6JHdOS.png)

- [ x ] I have added screenshots for all UI updates
- [ x ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ x ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors