### PR TITLE
Fix leaderboard overlapping quick chat modal

### DIFF
--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -12,7 +12,7 @@ export class OModal extends LitElement {
     .c-modal {
       position: fixed;
       padding: 1rem;
-      z-index: 1000;
+      z-index: 9999;
       left: 0;
       bottom: 0;
       right: 0;

--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -141,7 +141,7 @@ export class Leaderboard extends LitElement implements Layer {
       position: fixed;
       top: 10px;
       left: 10px;
-      z-index: 9999;
+      z-index: 9998;
       background-color: rgb(31 41 55 / 0.7);
       padding: 10px;
       padding-top: 0px;
@@ -192,7 +192,7 @@ export class Leaderboard extends LitElement implements Layer {
       position: fixed;
       left: 10px;
       top: 10px;
-      z-index: 9999;
+      z-index: 9998;
       background-color: rgb(31 41 55 / 0.7);
       color: white;
       border: none;


### PR DESCRIPTION
## Description:
Fix the issue where the leaderboard appears on top of the quick chat modal.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
