### PR TITLE
Feat : focus unit when clicking on warnings in chat

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -77,7 +77,8 @@ export class MirvExecution implements Execution {
       const y = Math.max(0, this.mg.y(this.dst) - 500) + 50;
       this.separateDst = this.mg.ref(x, y);
 
-      this.mg.displayMessage(
+      this.mg.displayIncomingUnit(
+        this.nuke.id(),
         `⚠️⚠️⚠️ ${this.player.name()} - MIRV INBOUND ⚠️⚠️⚠️`,
         MessageType.ERROR,
         this.targetPlayer.id(),

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -101,14 +101,16 @@ export class NukeExecution implements Execution {
       if (this.mg.hasOwner(this.dst)) {
         const target = this.mg.owner(this.dst) as Player;
         if (this.type == UnitType.AtomBomb) {
-          this.mg.displayMessage(
+          this.mg.displayIncomingUnit(
+            this.nuke.id(),
             `${this.player.name()} - atom bomb inbound`,
             MessageType.ERROR,
             target.id(),
           );
         }
         if (this.type == UnitType.HydrogenBomb) {
-          this.mg.displayMessage(
+          this.mg.displayIncomingUnit(
+            this.nuke.id(),
             `${this.player.name()} - hydrogen bomb inbound`,
             MessageType.ERROR,
             target.id(),
@@ -124,7 +126,7 @@ export class NukeExecution implements Execution {
           );
       }
 
-      // after sending an nuke set the missilesilo on cooldown
+      // after sending a nuke set the missilesilo on cooldown
       const silo = this.player
         .units(UnitType.MissileSilo)
         .find((silo) => silo.tile() === spawn);

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -67,15 +67,6 @@ export class TransportShipExecution implements Execution {
 
     this.attacker = mg.player(this.attackerID);
 
-    // Notify the target player about the incoming naval invasion
-    if (this.targetID && this.targetID !== mg.terraNullius().id()) {
-      mg.displayMessage(
-        `Naval invasion incoming from ${this.attacker.displayName()}`,
-        MessageType.WARN,
-        this.targetID,
-      );
-    }
-
     if (
       this.attacker.units(UnitType.TransportShip).length >=
       mg.config().boatMaxNumber()
@@ -144,6 +135,21 @@ export class TransportShipExecution implements Execution {
       this.troops,
       this.src,
     );
+
+    // Notify the target player about the incoming naval invasion
+    if (this.targetID && this.targetID !== mg.terraNullius().id()) {
+      // mg.displayMessage(
+      //   `Naval invasion incoming from ${this.attacker.displayName()}`,
+      //   MessageType.WARN,
+      //   this.targetID,
+      // );
+      mg.displayIncomingUnit(
+        this.boat.id(),
+        `Naval invasion incoming from ${this.attacker.displayName()}`,
+        MessageType.WARN,
+        this.targetID,
+      );
+    }
   }
 
   tick(ticks: number) {

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -138,11 +138,6 @@ export class TransportShipExecution implements Execution {
 
     // Notify the target player about the incoming naval invasion
     if (this.targetID && this.targetID !== mg.terraNullius().id()) {
-      // mg.displayMessage(
-      //   `Naval invasion incoming from ${this.attacker.displayName()}`,
-      //   MessageType.WARN,
-      //   this.targetID,
-      // );
       mg.displayIncomingUnit(
         this.boat.id(),
         `Naval invasion incoming from ${this.attacker.displayName()}`,

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -508,6 +508,12 @@ export interface Game extends GameMap {
     type: MessageType,
     playerID: PlayerID | null,
   ): void;
+  displayIncomingUnit(
+    unitID: number,
+    message: string,
+    type: MessageType,
+    playerID: PlayerID,
+  ): void;
 
   displayChat(
     message: string,

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -628,6 +628,24 @@ export class GameImpl implements Game {
       recipient: recipient,
     });
   }
+
+  displayIncomingUnit(
+    unitID: number,
+    message: string,
+    type: MessageType,
+    playerID: PlayerID,
+  ): void {
+    const id = this.player(playerID).smallID();
+
+    this.addUpdate({
+      type: GameUpdateType.UnitIncoming,
+      unitID: unitID,
+      message: message,
+      messageType: type,
+      playerID: id,
+    });
+  }
+
   addUnit(u: Unit) {
     this.unitGrid.addUnit(u);
   }

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -38,6 +38,7 @@ export enum GameUpdateType {
   Emoji,
   Win,
   Hash,
+  UnitIncoming,
 }
 
 export type GameUpdate =
@@ -53,7 +54,8 @@ export type GameUpdate =
   | TargetPlayerUpdate
   | EmojiUpdate
   | WinUpdate
-  | HashUpdate;
+  | HashUpdate
+  | UnitIncomingUpdate;
 
 export interface TileUpdateWrapper {
   type: GameUpdateType.Tile;
@@ -181,4 +183,12 @@ export interface HashUpdate {
   type: GameUpdateType.Hash;
   tick: Tick;
   hash: number;
+}
+
+export interface UnitIncomingUpdate {
+  type: GameUpdateType.UnitIncoming;
+  unitID: number;
+  message: string;
+  messageType: MessageType;
+  playerID: number;
 }


### PR DESCRIPTION
## Description:

Enables you to click on the `Naval invasion incoming from X` or `X - atom bomb inbound` messages to focus the camera on the incoming unit (boat or nuke). Works for boats, atom bombs, hydrogen bombs and MIRVs.

Nothing changes in looks, only the fact that the messages are clickable.

closes #641 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

leo21_
