### PR TITLE
Feat : Auto remove embargoes that were automatically created

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -108,7 +108,7 @@ export interface Config {
   boatMaxNumber(): number;
   allianceDuration(): Tick;
   allianceRequestCooldown(): Tick;
-  embargoDuration(): Tick;
+  temporaryEmbargoDuration(): Tick;
   targetDuration(): Tick;
   targetCooldown(): Tick;
   emojiMessageCooldown(): Tick;

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -108,6 +108,7 @@ export interface Config {
   boatMaxNumber(): number;
   allianceDuration(): Tick;
   allianceRequestCooldown(): Tick;
+  embargoDuration(): Tick;
   targetDuration(): Tick;
   targetCooldown(): Tick;
   emojiMessageCooldown(): Tick;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -415,7 +415,7 @@ export class DefaultConfig implements Config {
   allianceDuration(): Tick {
     return 600 * 10; // 10 minutes.
   }
-  embargoDuration(): Tick {
+  temporaryEmbargoDuration(): Tick {
     return 300 * 10; // 5 minutes.
   }
 

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -415,6 +415,10 @@ export class DefaultConfig implements Config {
   allianceDuration(): Tick {
     return 600 * 10; // 10 minutes.
   }
+  embargoDuration(): Tick {
+    return 300 * 10; // 5 minutes.
+  }
+
   percentageTilesOwnedToWin(): number {
     if (this._gameConfig.gameMode == GameMode.Team) {
       return 95;

--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -79,8 +79,8 @@ export class AttackExecution implements Execution {
         targetPlayer.type() != PlayerType.Bot &&
         this._owner.type() != PlayerType.Bot
       ) {
-        // Don't let bots embargo since they can't trade anyways.
-        targetPlayer.addEmbargo(this._owner.id());
+        // Don't let bots embargo since they can't trade anyway.
+        targetPlayer.addEmbargo(this._owner.id(), true);
       }
     }
 

--- a/src/core/execution/EmbargoExecution.ts
+++ b/src/core/execution/EmbargoExecution.ts
@@ -23,7 +23,7 @@ export class EmbargoExecution implements Execution {
   }
 
   tick(_: number): void {
-    if (this.action == "start") this.player.addEmbargo(this.targetID);
+    if (this.action == "start") this.player.addEmbargo(this.targetID, false);
     else this.player.stopEmbargo(this.targetID);
 
     this.active = false;

--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -96,7 +96,7 @@ export class FakeHumanExecution implements Execution {
         this.player.relation(other) <= Relation.Hostile &&
         !this.player.hasEmbargoAgainst(other)
       ) {
-        this.player.addEmbargo(other.id());
+        this.player.addEmbargo(other.id(), false);
       } else if (
         this.player.relation(other) >= Relation.Neutral &&
         this.player.hasEmbargoAgainst(other)

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -97,6 +97,16 @@ export class PlayerExecution implements Execution {
       }
     }
 
+    const embargoes = this.player.getEmbargoes();
+    for (const embargo of embargoes) {
+      if (
+        embargo.willExpire &&
+        this.mg.ticks() - embargo.createdAt > this.mg.config().embargoDuration()
+      ) {
+        this.player.stopEmbargo(embargo.target);
+      }
+    }
+
     if (ticks - this.lastCalc > this.ticksPerClusterCalc) {
       if (this.player.lastTileChange() > this.lastCalc) {
         this.lastCalc = ticks;

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -100,8 +100,9 @@ export class PlayerExecution implements Execution {
     const embargoes = this.player.getEmbargoes();
     for (const embargo of embargoes) {
       if (
-        embargo.willExpire &&
-        this.mg.ticks() - embargo.createdAt > this.mg.config().embargoDuration()
+        embargo.isTemporary &&
+        this.mg.ticks() - embargo.createdAt >
+          this.mg.config().temporaryEmbargoDuration()
       ) {
         this.player.stopEmbargo(embargo.target);
       }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -449,6 +449,7 @@ export interface Player {
   addEmbargo(other: PlayerID, willExpire: boolean): void;
   getEmbargoes(): Embargo[];
   stopEmbargo(other: PlayerID): void;
+  stopExpiringEmbargo(other: PlayerID): void;
   canTrade(other: Player): boolean;
 
   // Attacking.

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -342,6 +342,12 @@ export interface TerraNullius {
   smallID(): number;
 }
 
+export interface Embargo {
+  createdAt: Tick;
+  willExpire: boolean;
+  target: PlayerID;
+}
+
 export interface Player {
   // Basic Info
   smallID(): number;
@@ -440,7 +446,8 @@ export interface Player {
   // Embargo
   hasEmbargoAgainst(other: Player): boolean;
   tradingPartners(): Player[];
-  addEmbargo(other: PlayerID): void;
+  addEmbargo(other: PlayerID, willExpire: boolean): void;
+  getEmbargoes(): Embargo[];
   stopEmbargo(other: PlayerID): void;
   canTrade(other: Player): boolean;
 

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -344,7 +344,7 @@ export interface TerraNullius {
 
 export interface Embargo {
   createdAt: Tick;
-  willExpire: boolean;
+  isTemporary: boolean;
   target: PlayerID;
 }
 
@@ -446,10 +446,10 @@ export interface Player {
   // Embargo
   hasEmbargoAgainst(other: Player): boolean;
   tradingPartners(): Player[];
-  addEmbargo(other: PlayerID, willExpire: boolean): void;
+  addEmbargo(other: PlayerID, isTemporary: boolean): void;
   getEmbargoes(): Embargo[];
   stopEmbargo(other: PlayerID): void;
-  stopExpiringEmbargo(other: PlayerID): void;
+  endTemporaryEmbargo(other: PlayerID): void;
   canTrade(other: Player): boolean;
 
   // Attacking.

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -221,16 +221,27 @@ export class GameImpl implements Game {
 
   acceptAllianceRequest(request: AllianceRequestImpl) {
     this.allianceRequests = this.allianceRequests.filter((ar) => ar != request);
+
+    const requestor = request.requestor();
+    const recipient = request.recipient();
+
     const alliance = new AllianceImpl(
       this,
-      request.requestor() as PlayerImpl,
-      request.recipient() as PlayerImpl,
+      requestor as PlayerImpl,
+      recipient as PlayerImpl,
       this._ticks,
     );
     this.alliances_.push(alliance);
     (request.requestor() as PlayerImpl).pastOutgoingAllianceRequests.push(
       request,
     );
+
+    // Automatically remove embargoes only if they were automatically created
+    if (requestor.hasEmbargoAgainst(recipient))
+      requestor.stopExpiringEmbargo(recipient.id());
+    if (recipient.hasEmbargoAgainst(requestor))
+      recipient.stopExpiringEmbargo(requestor.id());
+
     this.addUpdate({
       type: GameUpdateType.AllianceRequestReply,
       request: request.toUpdate(),

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -238,9 +238,9 @@ export class GameImpl implements Game {
 
     // Automatically remove embargoes only if they were automatically created
     if (requestor.hasEmbargoAgainst(recipient))
-      requestor.stopExpiringEmbargo(recipient.id());
+      requestor.endTemporaryEmbargo(recipient.id());
     if (recipient.hasEmbargoAgainst(requestor))
-      recipient.stopExpiringEmbargo(requestor.id());
+      recipient.endTemporaryEmbargo(requestor.id());
 
     this.addUpdate({
       type: GameUpdateType.AllianceRequestReply,

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -602,6 +602,13 @@ export class PlayerImpl implements Player {
     this.embargoes.delete(other);
   }
 
+  stopExpiringEmbargo(other: PlayerID): void {
+    if (this.embargoes.has(other) && !this.embargoes.get(other).willExpire)
+      return;
+
+    this.stopEmbargo(other);
+  }
+
   tradingPartners(): Player[] {
     return this.mg
       .players()

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -583,13 +583,13 @@ export class PlayerImpl implements Player {
     return !embargo && other.id() != this.id();
   }
 
-  addEmbargo(other: PlayerID, willExpire: boolean): void {
-    if (this.embargoes.has(other) && !this.embargoes.get(other).willExpire)
+  addEmbargo(other: PlayerID, isTemporary: boolean): void {
+    if (this.embargoes.has(other) && !this.embargoes.get(other).isTemporary)
       return;
 
     this.embargoes.set(other, {
       createdAt: this.mg.ticks(),
-      willExpire: willExpire,
+      isTemporary: isTemporary,
       target: other,
     });
   }
@@ -602,8 +602,8 @@ export class PlayerImpl implements Player {
     this.embargoes.delete(other);
   }
 
-  stopExpiringEmbargo(other: PlayerID): void {
-    if (this.embargoes.has(other) && !this.embargoes.get(other).willExpire)
+  endTemporaryEmbargo(other: PlayerID): void {
+    if (this.embargoes.has(other) && !this.embargoes.get(other).isTemporary)
       return;
 
     this.stopEmbargo(other);

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -21,6 +21,7 @@ import {
   BuildableUnit,
   Cell,
   ColoredTeams,
+  Embargo,
   EmojiMessage,
   Gold,
   MessageType,
@@ -73,7 +74,7 @@ export class PlayerImpl implements Player {
 
   markedTraitorTick = -1;
 
-  private embargoes: Set<PlayerID> = new Set();
+  private embargoes = new Map<PlayerID, Embargo>();
 
   public _borderTiles: Set<TileRef> = new Set();
 
@@ -142,7 +143,7 @@ export class PlayerImpl implements Player {
       troops: this.troops(),
       targetTroopRatio: this.targetTroopRatio(),
       allies: this.alliances().map((a) => a.other(this).smallID()),
-      embargoes: this.embargoes,
+      embargoes: new Set([...this.embargoes.keys()].map((p) => p.toString())),
       isTraitor: this.isTraitor(),
       targets: this.targets().map((p) => p.smallID()),
       outgoingEmojis: this.outgoingEmojis(),
@@ -582,8 +583,19 @@ export class PlayerImpl implements Player {
     return !embargo && other.id() != this.id();
   }
 
-  addEmbargo(other: PlayerID): void {
-    this.embargoes.add(other);
+  addEmbargo(other: PlayerID, willExpire: boolean): void {
+    if (this.embargoes.has(other) && !this.embargoes.get(other).willExpire)
+      return;
+
+    this.embargoes.set(other, {
+      createdAt: this.mg.ticks(),
+      willExpire: willExpire,
+      target: other,
+    });
+  }
+
+  getEmbargoes(): Embargo[] {
+    return [...this.embargoes.values()];
   }
 
   stopEmbargo(other: PlayerID): void {


### PR DESCRIPTION
## Description:

Adds two fields to an Embargo : 
- `createdAt` : the tick at which it was created
- `willExpire` : whether the embargo will expire on its own

An embargo will remove itself only if the player didn't intentionally set it. It expires either when an alliance is made, or if enough time has passed (according to the `embargoDuration` config entry).

I put 5 minutes for `embargoDuration` by default, which seems reasonable to me.

closes #702 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

leo21_
