### PR TITLE
Break alliances when launching nukes

### DIFF
--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -52,6 +52,16 @@ export class NukeExecution implements Execution {
     return this.mg.owner(this.dst);
   }
 
+  private tilesToDestroyPrediction(): Set<TileRef> {
+    const magnitude = this.mg.config().nukeMagnitudes(this.nuke.type());
+    const inner2 = magnitude.inner * magnitude.inner;
+    const outer2 = magnitude.outer * magnitude.outer;
+    return this.mg.bfs(this.dst, (_, n: TileRef) => {
+      const d2 = this.mg.euclideanDistSquared(this.dst, n);
+      return d2 <= outer2 && d2 <= inner2;
+    });
+  }
+
   private tilesToDestroy(): Set<TileRef> {
     const magnitude = this.mg.config().nukeMagnitudes(this.nuke.type());
     const rand = new PseudoRandom(this.mg.ticks());
@@ -98,6 +108,7 @@ export class NukeExecution implements Execution {
       this.nuke = this.player.buildUnit(this.type, spawn, {
         detonationDst: this.dst,
       });
+      this.breakAlliances(this.tilesToDestroyPrediction());
       if (this.mg.hasOwner(this.dst)) {
         const target = this.mg.owner(this.dst) as Player;
         if (this.type == UnitType.AtomBomb) {

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -52,24 +52,16 @@ export class NukeExecution implements Execution {
     return this.mg.owner(this.dst);
   }
 
-  private tilesToDestroyPrediction(): Set<TileRef> {
-    const magnitude = this.mg.config().nukeMagnitudes(this.nuke.type());
-    const inner2 = magnitude.inner * magnitude.inner;
-    const outer2 = magnitude.outer * magnitude.outer;
-    return this.mg.bfs(this.dst, (_, n: TileRef) => {
-      const d2 = this.mg.euclideanDistSquared(this.dst, n);
-      return d2 <= outer2 && d2 <= inner2;
-    });
-  }
-
-  private tilesToDestroy(): Set<TileRef> {
+  private tilesToDestroy(useRandomRange: boolean): Set<TileRef> {
     const magnitude = this.mg.config().nukeMagnitudes(this.nuke.type());
     const rand = new PseudoRandom(this.mg.ticks());
     const inner2 = magnitude.inner * magnitude.inner;
     const outer2 = magnitude.outer * magnitude.outer;
     return this.mg.bfs(this.dst, (_, n: TileRef) => {
       const d2 = this.mg.euclideanDistSquared(this.dst, n);
-      return d2 <= outer2 && (d2 <= inner2 || rand.chance(2));
+      return (
+        d2 <= outer2 && (!useRandomRange || d2 <= inner2 || rand.chance(2))
+      );
     });
   }
 
@@ -108,7 +100,7 @@ export class NukeExecution implements Execution {
       this.nuke = this.player.buildUnit(this.type, spawn, {
         detonationDst: this.dst,
       });
-      this.breakAlliances(this.tilesToDestroyPrediction());
+      this.breakAlliances(this.tilesToDestroy(false));
       if (this.mg.hasOwner(this.dst)) {
         const target = this.mg.owner(this.dst) as Player;
         if (this.type == UnitType.AtomBomb) {
@@ -171,7 +163,7 @@ export class NukeExecution implements Execution {
 
   private detonate() {
     const magnitude = this.mg.config().nukeMagnitudes(this.nuke.type());
-    const toDestroy = this.tilesToDestroy();
+    const toDestroy = this.tilesToDestroy(true);
     this.breakAlliances(toDestroy);
 
     for (const tile of toDestroy) {


### PR DESCRIPTION
## Description:

Currently nukes break alliances only when detonating on allied tiles, bypassing all allied SAM defenses
This add a prediction phase to launching a nuke that breaks alliance if the tiles impacted are allied.
It uses max range and no random for nuke impact so there might be cases where the random detonation would not have broke the alliance (it needs to destroy more than 100 tiles before considering it an attack on ally)

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

VivaciousBox