### PR TITLE
Fix the clipping bug when a warship has no path

### DIFF
--- a/src/core/execution/WarshipExecution.ts
+++ b/src/core/execution/WarshipExecution.ts
@@ -54,11 +54,13 @@ export class WarshipExecution implements Execution {
     switch (result.type) {
       case PathFindResultType.Completed:
         this.warship.setMoveTarget(null);
+        this.warship.move(this.warship.tile());
         return;
       case PathFindResultType.NextTile:
         this.warship.move(result.tile);
         break;
       case PathFindResultType.Pending:
+        this.warship.move(this.warship.tile());
         break;
       case PathFindResultType.PathNotFound:
         consolex.log(`path not found to target`);
@@ -98,11 +100,13 @@ export class WarshipExecution implements Execution {
       switch (result.type) {
         case PathFindResultType.Completed:
           this.patrolTile = this.randomTile();
+          this.warship.move(this.warship.tile());
           break;
         case PathFindResultType.NextTile:
           this.warship.move(result.tile);
           break;
         case PathFindResultType.Pending:
+          this.warship.move(this.warship.tile());
           return;
         case PathFindResultType.PathNotFound:
           consolex.log(`path not found to patrol tile`);
@@ -227,11 +231,13 @@ export class WarshipExecution implements Execution {
         case PathFindResultType.Completed:
           this._owner.captureUnit(this.target);
           this.target = null;
+          this.warship.move(this.warship.tile());
           return;
         case PathFindResultType.NextTile:
           this.warship.move(result.tile);
           break;
         case PathFindResultType.Pending:
+          this.warship.move(this.warship.tile());
           break;
         case PathFindResultType.PathNotFound:
           consolex.log(`path not found to target`);


### PR DESCRIPTION
## Description:
Fix the clipping issue when a warship does not move.
Add a move order to current position when warship has completed its current path or is pending a new path.

![image](https://github.com/user-attachments/assets/e529fb9c-8969-490a-aada-ce0d2b3d5b84)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
