### PR TITLE
Add pause button when replaying

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -112,6 +112,7 @@ export async function createClientGame(
   const config = await getConfig(
     lobbyConfig.gameStartInfo.config,
     userSettings,
+    lobbyConfig.gameRecord != null,
   );
   let gameMap: TerrainMapData | null = null;
 
@@ -243,6 +244,7 @@ export class ClientGameRunner {
         this.stop(true);
         return;
       }
+      this.transport.turnComplete();
       gu.updates[GameUpdateType.Hash].forEach((hu: HashUpdate) => {
         this.eventBus.emit(new SendHashEvent(hu.tick, hu.hash));
       });

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -263,7 +263,12 @@ export class Transport {
     onconnect: () => void,
     onmessage: (message: ServerMessage) => void,
   ) {
-    this.localServer = new LocalServer(this.lobbyConfig, onconnect, onmessage);
+    this.localServer = new LocalServer(
+      this.lobbyConfig,
+      onconnect,
+      onmessage,
+      this.lobbyConfig.gameRecord != null,
+    );
     this.localServer.start();
   }
 
@@ -316,6 +321,12 @@ export class Transport {
 
   public reconnect() {
     this.connect(this.onconnect, this.onmessage);
+  }
+
+  public turnComplete() {
+    if (this.isLocal) {
+      this.localServer.turnComplete();
+    }
   }
 
   private onSendLogEvent(event: SendLogEvent) {

--- a/src/client/graphics/layers/OptionsMenu.ts
+++ b/src/client/graphics/layers/OptionsMenu.ts
@@ -122,7 +122,8 @@ export class OptionsMenu extends LitElement implements Layer {
   init() {
     console.log("init called from OptionsMenu");
     this.showPauseButton =
-      this.game.config().gameConfig().gameType == GameType.Singleplayer;
+      this.game.config().gameConfig().gameType == GameType.Singleplayer ||
+      this.game.config().isReplay();
     this.isVisible = true;
     this.requestUpdate();
   }

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -136,6 +136,7 @@ export interface Config {
   defaultNukeSpeed(): number;
   nukeDeathFactor(humans: number, tilesOwned: number): number;
   structureMinDist(): number;
+  isReplay(): boolean;
 }
 
 export interface Theme {

--- a/src/core/configuration/ConfigLoader.ts
+++ b/src/core/configuration/ConfigLoader.ts
@@ -12,15 +12,16 @@ export let cachedSC: ServerConfig = null;
 export async function getConfig(
   gameConfig: GameConfig,
   userSettings: UserSettings | null = null,
+  isReplay: boolean = false,
 ): Promise<Config> {
   const sc = await getServerConfigFromClient();
   switch (sc.env()) {
     case GameEnv.Dev:
-      return new DevConfig(sc, gameConfig, userSettings);
+      return new DevConfig(sc, gameConfig, userSettings, isReplay);
     case GameEnv.Preprod:
     case GameEnv.Prod:
       consolex.log("using prod config");
-      return new DefaultConfig(sc, gameConfig, userSettings);
+      return new DefaultConfig(sc, gameConfig, userSettings, isReplay);
     default:
       throw Error(`unsupported server configuration: ${process.env.GAME_ENV}`);
   }

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -158,7 +158,11 @@ export class DefaultConfig implements Config {
     private _serverConfig: ServerConfig,
     private _gameConfig: GameConfig,
     private _userSettings: UserSettings,
+    private _isReplay: boolean,
   ) {}
+  isReplay(): boolean {
+    return this._isReplay;
+  }
 
   samHittingChance(): number {
     return 0.8;

--- a/src/core/configuration/DevConfig.ts
+++ b/src/core/configuration/DevConfig.ts
@@ -41,8 +41,13 @@ export class DevServerConfig extends DefaultServerConfig {
 }
 
 export class DevConfig extends DefaultConfig {
-  constructor(sc: ServerConfig, gc: GameConfig, us: UserSettings) {
-    super(sc, gc, us);
+  constructor(
+    sc: ServerConfig,
+    gc: GameConfig,
+    us: UserSettings,
+    isReplay: boolean,
+  ) {
+    super(sc, gc, us, isReplay);
   }
 
   // numSpawnPhaseTurns(): number {

--- a/tests/util/Setup.ts
+++ b/tests/util/Setup.ts
@@ -42,7 +42,12 @@ export async function setup(
     instantBuild: false,
     ..._gameConfig,
   };
-  const config = new TestConfig(serverConfig, gameConfig, new UserSettings());
+  const config = new TestConfig(
+    serverConfig,
+    gameConfig,
+    new UserSettings(),
+    false,
+  );
 
   // Create and return the game
   return createGame(humans, [], gameMap, miniGameMap, config);


### PR DESCRIPTION
## Description:

This PR does two things:

1. Allow pausing on replay
2. As part of the refactoring, in singleplayer games, LocalServer now waits for the last turn to complete execution before sending the next turn. Previously, low end devices would sometimes fall behind getting the "playing the past" bug where commands were delayed. Now when a devices cannot keep up, the entire game slows down.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
