### PR TITLE
fix(dark-mode-button): delete the duplicated dark mode button

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -242,7 +242,6 @@
       </div>
     </div>
 
-    <dark-mode-button></dark-mode-button>
     <!-- Main container with responsive padding -->
     <main class="flex justify-center flex-grow">
       <div class="container pt-12">


### PR DESCRIPTION
## Description:

Fix the overlapping dark mode button. It happened because there was a duplicate in the index.html

Linked issue: https://github.com/openfrontio/OpenFrontIO/issues/659

## Media

Before:
https://github.com/user-attachments/assets/09ab3449-1503-4da0-84d9-e0d1fa61507b

After:
https://github.com/user-attachments/assets/0c0ef2ad-5071-4030-baa9-a9fb85edd1e9

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

Nilsfram
