### PR TITLE
Fix border color changes edge cases

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -5,7 +5,7 @@ import { EventBus } from "../../../core/EventBus";
 import { Cell, PlayerType, UnitType } from "../../../core/game/Game";
 import {
   euclDistFN,
-  manhattanDistFN,
+  euclideanDistSquaredFN,
   TileRef,
 } from "../../../core/game/GameMap";
 import { GameUpdateType, UnitUpdate } from "../../../core/game/GameUpdates";
@@ -64,17 +64,18 @@ export class TerritoryLayer implements Layer {
     this.game.recentlyUpdatedTiles().forEach((t) => this.enqueueTile(t));
     this.game.updatesSinceLastTick()[GameUpdateType.Unit].forEach((u) => {
       const update = u as UnitUpdate;
-      if (update.unitType == UnitType.DefensePost && update.isActive) {
+      if (update.unitType == UnitType.DefensePost) {
         const tile = update.pos;
         this.game
           .bfs(
             tile,
-            manhattanDistFN(tile, this.game.config().defensePostRange()),
+            euclideanDistSquaredFN(tile, this.game.config().defensePostRange()),
           )
           .forEach((t) => {
             if (
-              this.game.isBorder(t) &&
-              this.game.ownerID(t) == update.ownerID
+              (this.game.isBorder(t) &&
+                this.game.ownerID(t) == update.ownerID) ||
+              this.game.ownerID(t) == update.lastOwnerID
             ) {
               this.enqueueTile(t);
             }

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -3,11 +3,7 @@ import { Colord } from "colord";
 import { Theme } from "../../../core/configuration/Config";
 import { EventBus } from "../../../core/EventBus";
 import { Cell, PlayerType, UnitType } from "../../../core/game/Game";
-import {
-  euclDistFN,
-  euclideanDistSquaredFN,
-  TileRef,
-} from "../../../core/game/GameMap";
+import { euclDistFN, TileRef } from "../../../core/game/GameMap";
 import { GameUpdateType, UnitUpdate } from "../../../core/game/GameUpdates";
 import { GameView, PlayerView } from "../../../core/game/GameView";
 import { PseudoRandom } from "../../../core/PseudoRandom";
@@ -67,10 +63,7 @@ export class TerritoryLayer implements Layer {
       if (update.unitType == UnitType.DefensePost) {
         const tile = update.pos;
         this.game
-          .bfs(
-            tile,
-            euclideanDistSquaredFN(tile, this.game.config().defensePostRange()),
-          )
+          .bfs(tile, euclDistFN(tile, this.game.config().defensePostRange()))
           .forEach((t) => {
             if (
               (this.game.isBorder(t) &&

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -66,9 +66,9 @@ export class TerritoryLayer implements Layer {
           .bfs(tile, euclDistFN(tile, this.game.config().defensePostRange()))
           .forEach((t) => {
             if (
-              (this.game.isBorder(t) &&
-                this.game.ownerID(t) == update.ownerID) ||
-              this.game.ownerID(t) == update.lastOwnerID
+              this.game.isBorder(t) &&
+              (this.game.ownerID(t) == update.ownerID ||
+                this.game.ownerID(t) == update.lastOwnerID)
             ) {
               this.enqueueTile(t);
             }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -344,6 +344,7 @@ export interface Unit {
   setWarshipTarget(target: Unit): void; // warship only
   warshipTarget(): Unit;
 
+  setOwner(owner: Player): void;
   setCooldown(triggerCooldown: boolean): void;
   ticksLeftInCooldown(cooldownDuration: number): Tick;
   isCooldown(): boolean;

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -374,6 +374,25 @@ export function manhattanDistFN(
   }
 }
 
+export function euclideanDistSquaredFN(
+  root: TileRef,
+  dist: number,
+  center: boolean = false,
+): (gm: GameMap, tile: TileRef) => boolean {
+  if (!center) {
+    return (gm: GameMap, n: TileRef) =>
+      gm.euclideanDistSquared(root, n) <= dist * dist;
+  } else {
+    return (gm: GameMap, n: TileRef) => {
+      const rootX = gm.x(root) - 0.5;
+      const rootY = gm.y(root) - 0.5;
+      const dx = Math.abs(gm.x(n) - rootX);
+      const dy = Math.abs(gm.y(n) - rootY);
+      return dx * dx + dy * dy <= dist * dist;
+    };
+  }
+}
+
 export function rectDistFN(
   root: TileRef,
   dist: number,

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -374,25 +374,6 @@ export function manhattanDistFN(
   }
 }
 
-export function euclideanDistSquaredFN(
-  root: TileRef,
-  dist: number,
-  center: boolean = false,
-): (gm: GameMap, tile: TileRef) => boolean {
-  if (!center) {
-    return (gm: GameMap, n: TileRef) =>
-      gm.euclideanDistSquared(root, n) <= dist * dist;
-  } else {
-    return (gm: GameMap, n: TileRef) => {
-      const rootX = gm.x(root) - 0.5;
-      const rootY = gm.y(root) - 0.5;
-      const dx = Math.abs(gm.x(n) - rootX);
-      const dy = Math.abs(gm.y(n) - rootY);
-      return dx * dx + dy * dy <= dist * dist;
-    };
-  }
-}
-
 export function rectDistFN(
   root: TileRef,
   dist: number,

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -68,6 +68,7 @@ export interface UnitUpdate {
   troops: number;
   id: number;
   ownerID: number;
+  lastOwnerID?: number;
   // TODO: make these tilerefs
   pos: TileRef;
   lastPos: TileRef;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -684,7 +684,7 @@ export class PlayerImpl implements Player {
     if (unit.owner() == this) {
       throw new Error(`Cannot capture unit, ${this} already owns ${unit}`);
     }
-    (unit as UnitImpl).setOwner(this);
+    unit.setOwner(this);
   }
 
   buildUnit<T extends UnitType>(

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -684,23 +684,7 @@ export class PlayerImpl implements Player {
     if (unit.owner() == this) {
       throw new Error(`Cannot capture unit, ${this} already owns ${unit}`);
     }
-    const prev = unit.owner();
-    (prev as PlayerImpl)._units = (prev as PlayerImpl)._units.filter(
-      (u) => u != unit,
-    );
-    (unit as UnitImpl)._owner = this;
-    this._units.push(unit as UnitImpl);
-    this.mg.addUpdate(unit.toUpdate());
-    this.mg.displayMessage(
-      `${unit.type()} captured by ${this.displayName()}`,
-      MessageType.ERROR,
-      prev.id(),
-    );
-    this.mg.displayMessage(
-      `Captured ${unit.type()} from ${prev.displayName()}`,
-      MessageType.SUCCESS,
-      this.id(),
-    );
+    (unit as UnitImpl).setOwner(this);
   }
 
   buildUnit<T extends UnitType>(

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -2,7 +2,6 @@ import { simpleHash, toInt, withinInt } from "../Util";
 import {
   AllUnitParams,
   MessageType,
-  Player,
   Tick,
   Unit,
   UnitInfo,
@@ -23,7 +22,7 @@ export class UnitImpl implements Unit {
   private _safeFromPiratesCooldown: number; // Only for trade ships
   private _lastSetSafeFromPirates: number; // Only for trade ships
   private _constructionType: UnitType = undefined;
-
+  private _lastOwner: PlayerImpl | null = null;
   private _troops: number;
   private _cooldownTick: Tick | null = null;
   private _dstPort: Unit | null = null; // Only for trade ships
@@ -66,6 +65,7 @@ export class UnitImpl implements Unit {
       id: this._id,
       troops: this._troops,
       ownerID: this._owner.smallID(),
+      lastOwnerID: this._lastOwner?.smallID(),
       isActive: this._active,
       pos: this._tile,
       lastPos: this._lastTile,
@@ -119,15 +119,25 @@ export class UnitImpl implements Unit {
     return this.mg.unitInfo(this._type);
   }
 
-  setOwner(newOwner: Player): void {
-    const oldOwner = this._owner;
-    oldOwner._units = oldOwner._units.filter((u) => u != this);
-    this._owner = newOwner as PlayerImpl;
+  captured(): void {
+    this._lastOwner = this._owner;
+  }
+
+  setOwner(newOwner: PlayerImpl): void {
+    this._lastOwner = this._owner;
+    this._lastOwner._units = this._lastOwner._units.filter((u) => u != this);
+    this._owner = newOwner;
+    this._owner._units.push(this);
     this.mg.addUpdate(this.toUpdate());
     this.mg.displayMessage(
       `Your ${this.type()} was captured by ${newOwner.displayName()}`,
       MessageType.ERROR,
-      oldOwner.id(),
+      this._lastOwner.id(),
+    );
+    this.mg.displayMessage(
+      `Captured ${this.type()} from ${this._lastOwner.displayName()}`,
+      MessageType.SUCCESS,
+      newOwner.id(),
     );
   }
 

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -119,10 +119,6 @@ export class UnitImpl implements Unit {
     return this.mg.unitInfo(this._type);
   }
 
-  captured(): void {
-    this._lastOwner = this._owner;
-  }
-
   setOwner(newOwner: PlayerImpl): void {
     this._lastOwner = this._owner;
     this._lastOwner._units = this._lastOwner._units.filter((u) => u != this);


### PR DESCRIPTION
## Description:

Fixes a couple of bugs with the defended border color:
- When a defense post is destroyed it doesnt redraw defended border to normal ones
- The distance to draw borders at unit update is not the same as territory update
- When a defense post changes owner, only the directly touching borders were redrawn. Had to refactor units a bit so it keeps track of the last owner

## Gifs:
Before fix:
![image](https://github.com/user-attachments/assets/99b2763c-9c49-4d5d-8059-a9f938e8cef8)


After fix:
![capture](https://github.com/user-attachments/assets/4ebf388d-91e4-4e9e-bc96-9fe6e02cd9ea)
![destruct](https://github.com/user-attachments/assets/5a1204a8-d5c4-473f-8f4d-5cc46cd19080)



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

VivaciousBox
