### PR TITLE
Fix capturing isolated clusters

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -195,7 +195,11 @@ export class PlayerExecution implements Execution {
       }
       this.mg
         .neighbors(tr)
-        .filter((n) => this.mg?.ownerID(n) !== this.player?.smallID())
+        .filter(
+          (n) =>
+            this.mg?.ownerID(n) !== 0 &&
+            this.mg?.ownerID(n) !== this.player?.smallID(),
+        )
         .forEach((n) => enemyTiles.add(n));
     }
     if (enemyTiles.size === 0) {
@@ -265,7 +269,7 @@ export class PlayerExecution implements Execution {
     let largestTroopCount: number = 0;
     for (const id of neighborsIDs) {
       const neighbor = this.mg.playerBySmallID(id);
-      if (!neighbor.isPlayer()) {
+      if (!neighbor.isPlayer() || this.player.isFriendly(neighbor)) {
         continue;
       }
       for (const attack of neighbor.outgoingAttacks()) {

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -197,7 +197,7 @@ export class PlayerExecution implements Execution {
         .neighbors(tr)
         .filter(
           (n) =>
-            this.mg?.ownerID(n) !== 0 &&
+            this.mg?.owner(n).isPlayer() &&
             this.mg?.ownerID(n) !== this.player?.smallID(),
         )
         .forEach((n) => enemyTiles.add(n));


### PR DESCRIPTION
## Description:
Current behavior:
TerraNullius tiles are taken into account for capturing isolated clusters
Also isolated clusters can be captured by allies

It might be intended behavior but in case it is not, here is a quick fix


Before:
![capturenuke](https://github.com/user-attachments/assets/d2df37ea-cc35-496e-a7f2-0980c7af29f6)

After:
![capturenuke2](https://github.com/user-attachments/assets/55694e84-ceb3-47b9-96b7-61c9a7b51d3b)


⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️
### This will also change capturing isolated clusters while attacking as long as there is TerraNullius as a neighbor so if it is intended behavior, please discard.
⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️⚠️


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

Vivacious Box
