### PR TITLE
Fix overly permissive regular expression range

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -133,7 +133,7 @@ export const TeamSchema = z.string();
 const SafeString = z
   .string()
   .regex(
-    /^([a-zA-Z0-9\s.,!?@#$%&*()-_+=\[\]{}|;:"'\/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|üÜ])*$/,
+    /^([a-zA-Z0-9\s.,!?@#$%&*()\-_+=\[\]{}|;:"'\/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|üÜ])*$/,
   )
   .max(1000);
 


### PR DESCRIPTION
## Description:

Add escaping to the `-` character to prevent it from specifying a character range.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Original description

Potential fix for [https://github.com/openfrontio/OpenFrontIO/security/code-scanning/6](https://github.com/openfrontio/OpenFrontIO/security/code-scanning/6)

To fix the issue, we will replace the ambiguous range `)-_` with an explicit list of the intended characters. This ensures that the regular expression is unambiguous and matches only the desired characters. We will carefully review the rest of the regular expression to ensure no other overly permissive ranges exist. The updated regular expression will maintain the same functionality while being more precise.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved the clarity of character validation for safe strings, ensuring consistent handling of special characters. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->