### PR TITLE
Disable send button when required player not selected in quick chat

### DIFF
--- a/src/client/graphics/layers/ChatModal.ts
+++ b/src/client/graphics/layers/ChatModal.ts
@@ -171,9 +171,13 @@ export class ChatModal extends LitElement {
         </div>
         <div class="chat-send">
           <button
-            class="chat-send-button"
+            class="chat-send-button ${!this.previewText ||
+            (this.requiresPlayerSelection && !this.selectedPlayer)
+              ? "chat-send-button-disabled"
+              : ""}"
             @click=${this.sendChatMessage}
-            ?disabled=${!this.previewText}
+            ?disabled=${!this.previewText ||
+            (this.requiresPlayerSelection && !this.selectedPlayer)}
           >
             ${translateText("chat.send")}
           </button>

--- a/src/client/graphics/layers/ChatModal.ts
+++ b/src/client/graphics/layers/ChatModal.ts
@@ -171,10 +171,7 @@ export class ChatModal extends LitElement {
         </div>
         <div class="chat-send">
           <button
-            class="chat-send-button ${!this.previewText ||
-            (this.requiresPlayerSelection && !this.selectedPlayer)
-              ? "chat-send-button-disabled"
-              : ""}"
+            class="chat-send-button"
             @click=${this.sendChatMessage}
             ?disabled=${!this.previewText ||
             (this.requiresPlayerSelection && !this.selectedPlayer)}

--- a/src/client/styles/modal/chat.css
+++ b/src/client/styles/modal/chat.css
@@ -57,6 +57,11 @@
   cursor: pointer;
 }
 
+.chat-send-button-disabled {
+  background: #666;
+  cursor: not-allowed;
+}
+
 .chat-column {
   display: flex;
   flex-direction: column;

--- a/src/client/styles/modal/chat.css
+++ b/src/client/styles/modal/chat.css
@@ -57,7 +57,7 @@
   cursor: pointer;
 }
 
-.chat-send-button-disabled {
+.chat-send-button:disabled {
   background: #666;
   cursor: not-allowed;
 }


### PR DESCRIPTION
## Description:
This PR prevents players from sending Quick Chat messages that require a player target ([P1]) unless a player has been selected. The Send button is now disabled in such cases and visually dimmed for clarity.
## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - The chat send button is now disabled if a required player selection is missing, preventing unintended sends.

- **Style**
  - The chat send button visually indicates when it is disabled with a gray background and a not-allowed cursor.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->