### PR TITLE
Ensure teams are of an even size

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -26,10 +26,15 @@ export enum GameEnv {
   Prod,
 }
 
+export type LobbyConfig = {
+  maxPlayers: number;
+  numPlayerTeams: number | undefined;
+};
+
 export interface ServerConfig {
   turnIntervalMs(): number;
   gameCreationRate(): number;
-  lobbyMaxPlayers(map: GameMapType, mode: GameMode): number;
+  calcLobbyConfig(map: GameMapType, mode: GameMode): LobbyConfig;
   numWorkers(): number;
   workerIndex(gameID: GameID): number;
   workerPath(gameID: GameID): string;

--- a/src/core/configuration/DevConfig.ts
+++ b/src/core/configuration/DevConfig.ts
@@ -1,7 +1,7 @@
-import { UnitInfo, UnitType } from "../game/Game";
+import { GameMapType, GameMode, UnitInfo, UnitType } from "../game/Game";
 import { UserSettings } from "../game/UserSettings";
 import { GameConfig } from "../Schemas";
-import { GameEnv, ServerConfig } from "./Config";
+import { GameEnv, LobbyConfig, ServerConfig } from "./Config";
 import { DefaultConfig, DefaultServerConfig } from "./DefaultConfig";
 
 export class DevServerConfig extends DefaultServerConfig {
@@ -17,8 +17,20 @@ export class DevServerConfig extends DefaultServerConfig {
     return 5 * 1000;
   }
 
-  lobbyMaxPlayers(): number {
-    return Math.random() < 0.5 ? 2 : 3;
+  calcLobbyConfig(map: GameMapType, mode: GameMode): LobbyConfig {
+    switch (mode) {
+      case GameMode.Team:
+        if (Math.random() < 0.5) {
+          return { maxPlayers: 6, numPlayerTeams: 3 };
+        } else {
+          return { maxPlayers: 4, numPlayerTeams: 2 };
+        }
+      case GameMode.FFA:
+        return {
+          maxPlayers: Math.random() < 0.5 ? 2 : 3,
+          numPlayerTeams: undefined,
+        };
+    }
   }
 
   samWarheadHittingChance(): number {

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -45,13 +45,12 @@ export class MapPlaylist {
   public gameConfig(): GameConfig {
     const { map, mode } = this.getNextMap();
 
-    const numPlayerTeams =
-      mode === GameMode.Team ? 2 + Math.floor(Math.random() * 5) : undefined;
+    const { maxPlayers, numPlayerTeams } = config.calcLobbyConfig(map, mode);
 
     // Create the default public game config (from your GameManager)
     return {
       gameMap: map,
-      maxPlayers: config.lobbyMaxPlayers(map, mode),
+      maxPlayers: maxPlayers,
       gameType: GameType.Public,
       difficulty: Difficulty.Medium,
       infiniteGold: false,

--- a/tests/DefaultServerConfig.test.ts
+++ b/tests/DefaultServerConfig.test.ts
@@ -1,0 +1,78 @@
+import { GameEnv } from "../src/core/configuration/Config";
+import { DefaultServerConfig } from "../src/core/configuration/DefaultConfig";
+import { GameMapType, GameMode } from "../src/core/game/Game";
+
+/**
+ * Mock out maxPlayersForMap, to avoid test-churn
+ */
+class MockedServerConfig extends DefaultServerConfig {
+  constructor(private mockMaxPlayersForMap: number) {
+    super();
+  }
+
+  public override maxPlayersForMap(map: GameMapType): number {
+    expect(map).toBe("ignored");
+    return this.mockMaxPlayersForMap;
+  }
+  jwtAudience(): string {
+    throw new Error("Method not implemented.");
+  }
+  numWorkers(): number {
+    throw new Error("Method not implemented.");
+  }
+  env(): GameEnv {
+    throw new Error("Method not implemented.");
+  }
+}
+
+describe("calcLobbyConfig", () => {
+  beforeEach(() => {
+    // The default config generates a random number of teams.
+    // Just fix the random value for these tests
+    jest.spyOn(Math, "random").mockReturnValue(0.5);
+  });
+
+  afterEach(() => {
+    jest.spyOn(Math, "random").mockRestore();
+  });
+
+  it("Simple case for Team mode", () => {
+    const config = new MockedServerConfig(50);
+    const result = config.calcLobbyConfig(
+      "ignored" as GameMapType,
+      GameMode.Team,
+    );
+
+    expect(result).toEqual({
+      maxPlayers: 72,
+      numPlayerTeams: 4,
+    });
+  });
+
+  it("Correctly rounds for team mode", () => {
+    const config = new MockedServerConfig(25);
+    const result = config.calcLobbyConfig(
+      "ignored" as GameMapType,
+      GameMode.Team,
+    );
+
+    expect(result).toEqual({
+      // 25 * 1.5 = 37.5 -> 38
+      maxPlayers: 36,
+      numPlayerTeams: 4,
+    });
+  });
+
+  it("should return correct values for FFA mode", () => {
+    const config = new MockedServerConfig(80);
+    const result = config.calcLobbyConfig(
+      "ignored" as GameMapType,
+      GameMode.FFA,
+    );
+
+    expect(result).toEqual({
+      maxPlayers: 80,
+      numPlayerTeams: undefined,
+    });
+  });
+});

--- a/tests/util/TestServerConfig.ts
+++ b/tests/util/TestServerConfig.ts
@@ -1,6 +1,10 @@
 import { JWK } from "jose";
-import { GameEnv, ServerConfig } from "../../src/core/configuration/Config";
-import { GameMapType } from "../../src/core/game/Game";
+import {
+  GameEnv,
+  LobbyConfig,
+  ServerConfig,
+} from "../../src/core/configuration/Config";
+import { GameMapType, GameMode } from "../../src/core/game/Game";
 import { GameID } from "../../src/core/Schemas";
 
 export class TestServerConfig implements ServerConfig {
@@ -34,7 +38,7 @@ export class TestServerConfig implements ServerConfig {
   gameCreationRate(): number {
     throw new Error("Method not implemented.");
   }
-  lobbyMaxPlayers(map: GameMapType): number {
+  calcLobbyConfig(map: GameMapType, mode: GameMode): LobbyConfig {
     throw new Error("Method not implemented.");
   }
   numWorkers(): number {


### PR DESCRIPTION
## Description:
Previously we calculated the number of teams, then separately calculated the maximum players (defined for a Team game as 1.5x the recommended map amount), and then assigned players across these teams. This resulted in uneven teams, e.g. 50 players split across 6 teams would leave 4 teams with 8 players and 2 teams with 9 players, which is unfair. 

So now we calculate the number of players based on the number of teams, and that initial 50 would be reduced to 48 players to make it even for 6 teams of 8.

FFA is unchanged.
Lobbies are unchanged -- they can have unbalanced teams if they want.

NOTE: ~~Conflicts with #736 and #745 ?~~ I've rebased to account for these changes.

Fixes issue #841


## Testing

Unit-tests still work,
I locally hack my version of DevConfig to use DefaultConfig, change the playlist to alternate between FFA and Team and then sit there watching the games fly by with wonderful counts of 48, 72, etc,

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

`poddster`