### PR TITLE
Break alliance on launch

### DIFF
--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -19,6 +19,7 @@ export class NukeExecution implements Execution {
   private player: Player | null = null;
   private mg: Game | null = null;
   private nuke: Unit | null = null;
+  private tilesToDestroyCache: Set<TileRef> | undefined;
 
   private random: PseudoRandom;
   private pathFinder: ParabolaPathFinder;
@@ -56,6 +57,9 @@ export class NukeExecution implements Execution {
   }
 
   private tilesToDestroy(): Set<TileRef> {
+    if (this.tilesToDestroyCache !== undefined) {
+      return this.tilesToDestroyCache;
+    }
     if (this.mg === null || this.nuke === null) {
       throw new Error("Not initialized");
     }
@@ -63,10 +67,11 @@ export class NukeExecution implements Execution {
     const rand = new PseudoRandom(this.mg.ticks());
     const inner2 = magnitude.inner * magnitude.inner;
     const outer2 = magnitude.outer * magnitude.outer;
-    return this.mg.bfs(this.dst, (_, n: TileRef) => {
+    this.tilesToDestroyCache = this.mg.bfs(this.dst, (_, n: TileRef) => {
       const d2 = this.mg?.euclideanDistSquared(this.dst, n) ?? 0;
       return d2 <= outer2 && (d2 <= inner2 || rand.chance(2));
     });
+    return this.tilesToDestroyCache;
   }
 
   private breakAlliances(toDestroy: Set<TileRef>) {

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -125,6 +125,7 @@ export class NukeExecution implements Execution {
             MessageType.ERROR,
             target.id(),
           );
+          this.breakAlliances(this.tilesToDestroy());
         }
         if (this.type === UnitType.HydrogenBomb) {
           this.mg.displayIncomingUnit(
@@ -133,6 +134,7 @@ export class NukeExecution implements Execution {
             MessageType.ERROR,
             target.id(),
           );
+          this.breakAlliances(this.tilesToDestroy());
         }
 
         this.mg


### PR DESCRIPTION
## Description:

- Break alliances on launch based on speculative damage.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Behavior Changes**
  - Alliances are now immediately broken when a nuke is launched and its incoming message is displayed, rather than only at detonation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->