### PR TITLE
Display the number of times within the Player Info Overlay

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -367,7 +367,8 @@
     "sams": "SAMs",
     "warships": "Warships",
     "health": "Health",
-    "attitude": "Attitude"
+    "attitude": "Attitude",
+    "tiles": "Tiles"
   },
   "relation": {
     "hostile": "Hostile",

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -366,7 +366,8 @@
     "missile_launchers": "ミサイル格納庫",
     "sams": "SAM",
     "health": "体力",
-    "attitude": "態度"
+    "attitude": "態度",
+    "tiles": "タイル"
   },
   "relation": {
     "hostile": "敵対的",

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -4,6 +4,10 @@ export function renderTroops(troops: number): string {
   return renderNumber(troops / 10);
 }
 
+export function renderTiles(tiles: number): string {
+  return renderNumber(tiles);
+}
+
 export function renderNumber(num: number): string {
   num = Math.max(num, 0);
 

--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -209,8 +209,6 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
         break;
     }
 
-    // player.numTilesOwned()
-
     return html`
       <div class="p-2">
         <div

--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -1,6 +1,6 @@
 import { LitElement, TemplateResult, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { translateText } from "../../../client/Utils";
+import { renderTiles, translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
 import {
   PlayerProfile,
@@ -209,6 +209,8 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
         break;
     }
 
+    // player.numTilesOwned()
+
     return html`
       <div class="p-2">
         <div
@@ -232,6 +234,10 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
         <div class="text-sm opacity-80">
           ${translateText("player_info_overlay.type")}: ${playerType}
         </div>
+        ${html`<div class="text-sm opacity-80">
+          ${translateText("player_info_overlay.tiles")}:
+          ${renderTiles(player.numTilesOwned())}
+        </div>`}
         ${player.troops() >= 1
           ? html`<div class="text-sm opacity-80" translate="no">
               ${translateText("player_info_overlay.d_troops")}:


### PR DESCRIPTION
## Description:

This PR update the Player over to show the number of tiles / size of the player being hovered on, this was something I noticed a few youtubers who play the game have been requesting, so thought I would add

<img width="819" alt="Screenshot 2025-05-17 at 17 38 16" src="https://github.com/user-attachments/assets/33e5218c-04ca-4d39-a1ad-f196b7ce81c9" />
<img width="1154" alt="Screenshot 2025-05-17 at 17 39 17" src="https://github.com/user-attachments/assets/5cfc39ea-f06a-4682-b0f7-ed9e0a202141" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added display of the number of tiles owned by the player in the player info overlay.
  - Introduced new language support for the "tiles" label in both English and Japanese interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->