### PR TITLE
Add hash to Unit interface

### DIFF
--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -324,6 +324,8 @@ export class PlayerInfo {
 }
 
 export interface Unit {
+  hash(): number;
+
   // Common properties.
   id(): number;
   type(): UnitType;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -909,7 +909,7 @@ export class PlayerImpl implements Player {
   hash(): number {
     return (
       simpleHash(this.id()) * (this.population() + this.numTilesOwned()) +
-      this._units.reduce((acc, unit) => acc + (unit as UnitImpl).hash(), 0)
+      this._units.reduce((acc, unit) => acc + unit.hash(), 0)
     );
   }
   toString(): string {


### PR DESCRIPTION
## Description:

- Add `hash()` to the `Unit` interface to avoid casts with `as`.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors