### PR TITLE
Fix attack speed bug introduced by #740

### DIFF
--- a/src/core/game/AttackImpl.ts
+++ b/src/core/game/AttackImpl.ts
@@ -84,8 +84,10 @@ export class AttackImpl implements Attack {
   }
 
   addBorderTile(tile: TileRef): void {
-    this._borderSize += 1;
-    this._border.add(tile);
+    if (!this._border.has(tile)) {
+      this._borderSize += 1;
+      this._border.add(tile);
+    }
   }
 
   removeBorderTile(tile: TileRef): void {


### PR DESCRIPTION
## Description:

The borderSize in #740 was not properly computed (incrementing it even if the tile to add to the border was already in the border)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

leo21_
