### PR TITLE
Allow lowercase letters in clan name

### DIFF
--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -334,7 +334,7 @@ export class PlayerInfo {
     if (!name.startsWith("[") || !name.includes("]")) {
       this.clan = null;
     } else {
-      const clanMatch = name.match(/^\[([A-Z]{2,5})\]/);
+      const clanMatch = name.match(/^\[([a-zA-Z]{2,5})\]/);
       this.clan = clanMatch ? clanMatch[1] : null;
     }
   }

--- a/tests/PlayerInfo.test.ts
+++ b/tests/PlayerInfo.test.ts
@@ -38,12 +38,34 @@ describe("PlayerInfo", () => {
     test("should extract clan from name when format is [XXXXX]Name", () => {
       const playerInfo = new PlayerInfo(
         "fr",
-        "[ABCdE]PlayerName",
+        "[ABCDE]PlayerName",
         PlayerType.Human,
         null,
         "player_id",
       );
-      expect(playerInfo.clan).toBe("ABCdE");
+      expect(playerInfo.clan).toBe("ABCDE");
+    });
+
+    test("should extract clan from name when format is [xxxxx]Name", () => {
+      const playerInfo = new PlayerInfo(
+        "fr",
+        "[abcde]PlayerName",
+        PlayerType.Human,
+        null,
+        "player_id",
+      );
+      expect(playerInfo.clan).toBe("abcde");
+    });
+
+    test("should extract clan from name when format is [XxXxX]Name", () => {
+      const playerInfo = new PlayerInfo(
+        "fr",
+        "[AbCdE]PlayerName",
+        PlayerType.Human,
+        null,
+        "player_id",
+      );
+      expect(playerInfo.clan).toBe("AbCdE");
     });
 
     test("should return null when name doesn't start with [", () => {
@@ -79,7 +101,7 @@ describe("PlayerInfo", () => {
       expect(playerInfo.clan).toBeNull();
     });
 
-    test("should return null when clan tag contains non alphanumeric caracters", () => {
+    test("should return null when clan tag contains non alphanumeric characters", () => {
       const playerInfo = new PlayerInfo(
         "fr",
         "[A1c]PlayerName",

--- a/tests/PlayerInfo.test.ts
+++ b/tests/PlayerInfo.test.ts
@@ -38,12 +38,12 @@ describe("PlayerInfo", () => {
     test("should extract clan from name when format is [XXXXX]Name", () => {
       const playerInfo = new PlayerInfo(
         "fr",
-        "[ABCDE]PlayerName",
+        "[ABCdE]PlayerName",
         PlayerType.Human,
         null,
         "player_id",
       );
-      expect(playerInfo.clan).toBe("ABCDE");
+      expect(playerInfo.clan).toBe("ABCdE");
     });
 
     test("should return null when name doesn't start with [", () => {
@@ -79,10 +79,10 @@ describe("PlayerInfo", () => {
       expect(playerInfo.clan).toBeNull();
     });
 
-    test("should return null when clan tag contains non-uppercase letters", () => {
+    test("should return null when clan tag contains non alphanumeric caracters", () => {
       const playerInfo = new PlayerInfo(
         "fr",
-        "[Abc]PlayerName",
+        "[A1c]PlayerName",
         PlayerType.Human,
         null,
         "player_id",


### PR DESCRIPTION
## Description:

Added possibility to use lowercase letters in clan name.
See issue #876 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

theodoreleon.aetarax
