### PR TITLE
Use array index access instead of .at

### DIFF
--- a/src/core/execution/EmojiExecution.ts
+++ b/src/core/execution/EmojiExecution.ts
@@ -41,7 +41,7 @@ export class EmojiExecution implements Execution {
   }
 
   tick(ticks: number): void {
-    const emojiString = flattenedEmojiTable.at(this.emoji);
+    const emojiString = flattenedEmojiTable[this.emoji];
     if (emojiString === undefined) {
       consolex.warn(
         `cannot send emoji ${this.emoji} from ${this.requestor} to ${this.recipient}`,


### PR DESCRIPTION
## Description:

Use array index access instead of `.at` to try to fix a user-reported erorr.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors