### PR TITLE
Fix : Donation when max pop already reached

### DIFF
--- a/src/core/execution/DonateTroopExecution.ts
+++ b/src/core/execution/DonateTroopExecution.ts
@@ -33,7 +33,7 @@ export class DonateTroopsExecution implements Execution {
     const maxDonation =
       mg.config().maxPopulation(this.recipient) -
       this.recipient.totalPopulation();
-      this.troops = Math.min(this.troops, maxDonation);
+    this.troops = Math.min(this.troops, maxDonation);
   }
 
   tick(ticks: number): void {


### PR DESCRIPTION
## Description:

Only donate up to what the receiving player can get so we don't silently loose troops

See the chat here :
![image](https://github.com/user-attachments/assets/95b0917c-b7f3-47a0-b3a0-156110e727aa)


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

theodoreleon.aetarax
