### PR TITLE
remove player id from Schemas, fix archive bug

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -201,7 +201,6 @@ export class ClientGameRunner {
     }
     const players: PlayerRecord[] = [
       {
-        playerID: this.myPlayer.id(),
         persistentID: getPersistentID(),
         username: this.lobby.playerName,
         clientID: this.lobby.clientID,

--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -176,7 +176,6 @@ export class LocalServer {
     }
     const players: PlayerRecord[] = [
       {
-        playerID: this.lobbyConfig.clientID, // hack?
         persistentID: getPersistentID(),
         username: this.lobbyConfig.playerName,
         clientID: this.lobbyConfig.clientID,

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -435,7 +435,6 @@ export class SinglePlayerModal extends LitElement {
             gameID: gameID,
             players: [
               {
-                playerID: generateID(),
                 clientID,
                 username: usernameInput.getCurrentUsername(),
                 flag:

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -48,7 +48,7 @@ export async function createGameRunner(
           : fixProfaneUsername(sanitize(p.username)),
         PlayerType.Human,
         p.clientID,
-        p.playerID,
+        random.nextID(),
       ),
   );
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -338,7 +338,6 @@ export const ServerPrestartMessageSchema = ServerBaseMessageSchema.extend({
 });
 
 export const PlayerSchema = z.object({
-  playerID: ID,
   clientID: ID,
   username: SafeString,
   flag: SafeString.optional(),

--- a/src/server/Archive.ts
+++ b/src/server/Archive.ts
@@ -78,18 +78,17 @@ async function archiveAnalyticsToR2(gameRecord: GameRecord) {
 
 async function archiveFullGameToR2(gameRecord: GameRecord) {
   // Create a deep copy to avoid modifying the original
-  const recordCopy = JSON.parse(JSON.stringify(gameRecord));
+  const recordCopy: GameRecord = JSON.parse(JSON.stringify(gameRecord));
 
   // Players may see this so make sure to clear PII
   recordCopy.info.players.forEach((p) => {
-    p.ip = "REDACTED";
     p.persistentID = "REDACTED";
   });
 
   try {
     await r2.putObject({
       Bucket: bucket,
-      Key: `${gameFolder}/${recordCopy.id}`,
+      Key: `${gameFolder}/${recordCopy.info.gameID}`,
       Body: JSON.stringify(recordCopy),
       ContentType: "application/json",
     });

--- a/src/server/Client.ts
+++ b/src/server/Client.ts
@@ -1,15 +1,12 @@
 import WebSocket from "ws";
 import { TokenPayload } from "../core/ApiSchemas";
-import { PlayerID, Tick } from "../core/game/Game";
+import { Tick } from "../core/game/Game";
 import { ClientID } from "../core/Schemas";
-import { generateID } from "../core/Util";
 
 export class Client {
   public lastPing: number;
 
   public hashes: Map<Tick, number> = new Map();
-
-  public readonly playerID: PlayerID = generateID();
 
   constructor(
     public readonly clientID: ClientID,

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -300,7 +300,6 @@ export class GameServer {
       gameID: this.id,
       config: this.gameConfig,
       players: this.activeClients.map((c) => ({
-        playerID: c.playerID,
         username: c.username,
         clientID: c.clientID,
         flag: c.flag,
@@ -547,7 +546,6 @@ export class GameServer {
         this.log.warn(`Unable to find stats for clientID ${client.clientID}`);
       }
       return {
-        playerID: client.playerID,
         clientID: client.clientID,
         username: client.username,
         persistentID: client.persistentID,


### PR DESCRIPTION
## Description:

Remove all references to playerID in the archive schema, since we reference players by client id.
Also fixed the game not archiving bug, due to invalid reference.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
