### PR TITLE
Flag fixes for Europe map and for Brittany in flag menu and Gateway To the Atlantic map

### DIFF
--- a/resources/maps/Europe.json
+++ b/resources/maps/Europe.json
@@ -13,7 +13,7 @@
       "coordinates": [451, 785],
       "name": "England",
       "strength": 2,
-      "flag": "england"
+      "flag": "gb-eng"
     },
     {
       "coordinates": [285, 1253],
@@ -235,13 +235,13 @@
       "coordinates": [278, 742],
       "name": "Wales",
       "strength": 2,
-      "flag": "wales"
+      "flag": "gb-wls"
     },
     {
       "coordinates": [296, 601],
       "name": "Scotland",
       "strength": 1,
-      "flag": "scotland"
+      "flag": "gb-sct"
     },
     {
       "coordinates": [2239, 3215],

--- a/src/client/data/countries.json
+++ b/src/client/data/countries.json
@@ -300,7 +300,7 @@
     "name": "British Indian Ocean Territory"
   },
   {
-    "code": "Brittany",
+    "code": "brittany",
     "continent": "Europe",
     "name": "Brittany"
   },


### PR DESCRIPTION
## Description:

As reported here https://discord.com/channels/1284581928254701718/1377035663404433490

Flag names in Europe.json didn't correspond with those in Countries.json for: England, Scotland, Wales. So the Nations' flags weren't displayed in-game. Changed them in Europe.json.

The flag of Brittanny was looked up as 'britanny' by both the flag menu and GatewayToTheAtlantic.json. Changed its name in Countries.json to correspond with this so the flag shows up in flag menu and in-game.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
