### PR TITLE
FIx some issues caused by firefox repopulating input elements on tab restore

### DIFF
--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -266,6 +266,7 @@ export class UserSettingModal extends LitElement {
       <setting-slider
         label="${translateText("user_setting.attack_ratio_label")}"
         description="${translateText("user_setting.attack_ratio_desc")}"
+        id="attack-ratio-slider"
         min="1"
         max="100"
         .value=${Number(localStorage.getItem("settings.attackRatio") ?? "0.2") *
@@ -277,6 +278,7 @@ export class UserSettingModal extends LitElement {
       <setting-slider
         label="${translateText("user_setting.troop_ratio_label")}"
         description="${translateText("user_setting.troop_ratio_desc")}"
+        id="troop-ratio-slider"
         min="1"
         max="100"
         .value=${Number(localStorage.getItem("settings.troopRatio") ?? "0.95") *

--- a/src/client/components/baseComponents/setting/SettingSlider.ts
+++ b/src/client/components/baseComponents/setting/SettingSlider.ts
@@ -5,6 +5,7 @@ import { customElement, property } from "lit/decorators.js";
 export class SettingSlider extends LitElement {
   @property() label = "Setting";
   @property() description = "";
+  @property() id = "";
   @property({ type: Number }) value = 0;
   @property({ type: Number }) min = 0;
   @property({ type: Number }) max = 100;
@@ -62,7 +63,7 @@ export class SettingSlider extends LitElement {
         </div>
         <input
           type="range"
-          id="setting-slider-input"
+          id="${this.id}"
           class="setting-input slider full-width"
           min=${this.min}
           max=${this.max}

--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -133,7 +133,7 @@ export class ControlPanel extends LitElement implements Layer {
   }
 
   onAttackRatioChange(newRatio: number) {
-    this.uiState.attackRatio = newRatio;
+    if (this.uiState) this.uiState.attackRatio = newRatio;
   }
 
   renderLayer(context: CanvasRenderingContext2D) {
@@ -154,7 +154,7 @@ export class ControlPanel extends LitElement implements Layer {
   }
 
   onTroopChange(newRatio: number) {
-    this.eventBus.emit(new SendSetTargetTroopRatioEvent(newRatio));
+    this.eventBus?.emit(new SendSetTargetTroopRatioEvent(newRatio));
   }
 
   delta(): number {


### PR DESCRIPTION
## Description:
When restoring a tab (re-opening after closing the tab or the browser) firefox will re-populate any input fields on the page.
This causes the troop/attack ratio sliders to be set to incorrect values as they share the same ID, and also fires some onchange events that resulted in uncaught errors from uninitialized objects. Both have been patched

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

demonessica
