### PR TITLE
change defaults to reflect meta

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -18,13 +18,13 @@ export class ControlPanel extends LitElement implements Layer {
   public uiState: UIState;
 
   @state()
-  private attackRatio: number = 0.2;
+  private attackRatio: number = 0.3;
 
   @state()
-  private targetTroopRatio = 0.95;
+  private targetTroopRatio = 0.6;
 
   @state()
-  private currentTroopRatio = 0.95;
+  private currentTroopRatio = 0.6;
 
   @state()
   private _population: number;
@@ -61,10 +61,10 @@ export class ControlPanel extends LitElement implements Layer {
 
   init() {
     this.attackRatio = Number(
-      localStorage.getItem("settings.attackRatio") ?? "0.2",
+      localStorage.getItem("settings.attackRatio") ?? "0.3",
     );
     this.targetTroopRatio = Number(
-      localStorage.getItem("settings.troopRatio") ?? "0.95",
+      localStorage.getItem("settings.troopRatio") ?? "0.6",
     );
     this.init_ = true;
     this.uiState.attackRatio = this.attackRatio;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -109,7 +109,7 @@ export class PlayerImpl implements Player {
   ) {
     this._flag = playerInfo.flag;
     this._name = sanitizeUsername(playerInfo.name);
-    this._targetTroopRatio = 95n;
+    this._targetTroopRatio = 60n;
     this._troops = toInt(startTroops);
     this._workers = 0n;
     this._gold = 0n;


### PR DESCRIPTION
## Description:
Changes default target troop ratio and attack size to reflect better early game strategies in v23
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
