### PR TITLE
Fix slow singleplayer timer

### DIFF
--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -30,7 +30,7 @@ export class LocalServer {
   private allPlayersStats: AllPlayersStats = {};
 
   private turnsExecuted = 0;
-  private lastTurnCompletedTime = 0;
+  private turnStartTime = 0;
 
   private turnCheckInterval: NodeJS.Timeout;
 
@@ -47,9 +47,10 @@ export class LocalServer {
         if (
           this.isReplay ||
           Date.now() >
-            this.lastTurnCompletedTime +
-              this.lobbyConfig.serverConfig.turnIntervalMs()
+            this.turnStartTime + this.lobbyConfig.serverConfig.turnIntervalMs()
         ) {
+          this.turnStartTime = Date.now();
+          // End turn on the server means the client will start processing the turn.
           this.endTurn();
         }
       }
@@ -140,11 +141,13 @@ export class LocalServer {
     }
   }
 
+  // This is so the client can tell us when it finished processing the turn.
   public turnComplete() {
     this.turnsExecuted++;
-    this.lastTurnCompletedTime = Date.now();
   }
 
+  // endTurn in this context means the server has collected all the intents
+  // and will send the turn to the client.
   private endTurn() {
     if (this.paused) {
       return;


### PR DESCRIPTION
## Description:
The LocalServer was counting 100ms between turns, causing the timer to run slow (100ms + turn execution time), it now checks 100ms from the start of the previous turn. I've noticed it still runs a tad slow (1-2 seconds slow after 1 minute), but it's much better than before.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
