### PR TITLE
Flag fixes in several maps

### DIFF
--- a/resources/maps/Europe.json
+++ b/resources/maps/Europe.json
@@ -187,7 +187,7 @@
       "coordinates": [1254, 899],
       "name": "Slovak Republic",
       "strength": 3,
-      "flag": "SK"
+      "flag": "sk"
     },
     {
       "coordinates": [1002, 1061],
@@ -259,7 +259,7 @@
       "coordinates": [1522, 48],
       "name": "Polar Bears",
       "strength": 2,
-      "flag": "polar_bear"
+      "flag": "polar_bears"
     },
     {
       "coordinates": [821, 628],
@@ -289,13 +289,13 @@
       "coordinates": [1919, 1608],
       "name": "Hashemite Kingdom of Jordan",
       "strength": 1,
-      "flag": "hu"
+      "flag": "jo"
     },
     {
       "coordinates": [1898, 1535],
       "name": "Lebanese Republic",
       "strength": 1,
-      "flag": "hu"
+      "flag": "lb"
     }
   ]
 }

--- a/resources/maps/GatewayToTheAtlantic.json
+++ b/resources/maps/GatewayToTheAtlantic.json
@@ -19,7 +19,7 @@
       "coordinates": [1334, 537],
       "name": "Duchy of Aquitaine",
       "strength": 2,
-      "flag": "aquitane"
+      "flag": "aquitaine"
     },
     {
       "coordinates": [2115, 684],
@@ -31,7 +31,7 @@
       "coordinates": [1207, 763],
       "name": "The Basque",
       "strength": 3,
-      "flag": ""
+      "flag": "es-pv"
     },
     {
       "coordinates": [1281, 1142],
@@ -49,7 +49,7 @@
       "coordinates": [561, 764],
       "name": "Kingdom of Galicia",
       "strength": 2,
-      "flag": "galicia"
+      "flag": "es-ga"
     },
     {
       "coordinates": [1004, 1436],
@@ -115,7 +115,7 @@
       "coordinates": [1755, 1130],
       "name": "The Old Ones",
       "strength": 3,
-      "flag": "nuragic"
+      "flag": "neuragic_empire"
     },
     {
       "coordinates": [2097, 1670],
@@ -151,7 +151,7 @@
       "coordinates": [1017, 180],
       "name": "Kingdom of Brittany",
       "strength": 2,
-      "flag": "britanny"
+      "flag": "brittany"
     },
     {
       "coordinates": [2072, 567],
@@ -175,7 +175,7 @@
       "coordinates": [1475, 1657],
       "name": "French Foreign Legion",
       "strength": 3,
-      "flag": "french_foreign_legion"
+      "flag": "French foreign legion"
     },
     {
       "coordinates": [1685, 417],

--- a/resources/maps/Mars.json
+++ b/resources/maps/Mars.json
@@ -13,7 +13,7 @@
       "coordinates": [122, 750],
       "name": "USSR",
       "strength": 2,
-      "flag": ""
+      "flag": "ussr"
     },
     {
       "coordinates": [1232, 735],

--- a/resources/maps/NorthAmerica.json
+++ b/resources/maps/NorthAmerica.json
@@ -283,7 +283,7 @@
       "coordinates": [1189, 240],
       "name": "Polar Bears",
       "strength": 3,
-      "flag": "polar_bear"
+      "flag": "polar_bears"
     },
     {
       "coordinates": [1480, 343],


### PR DESCRIPTION
## Description:

Thanks to J.Dimlight for reporting this.

Flag images were not displayed on maps. Or the wrong flag was displayed. Because of no flag code, or pointing to non-existant or incorrect flag file names.

There are currently no flags to display for these Nations, as there is no flag file present in resources:

Gateway to the Atlantic
- Jesuit Monks
- Wine

Japan and Neighbors:
- Sakhalin

Mars:
- European Space Agency

South America:
- The Biggest Snakes
- Normal Capybaras
- Just Otters

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
