### PR TITLE
Balance Adjustment for Attack Mechanism

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -66,8 +66,8 @@ const numPlayersConfig = {
 } as const satisfies Record<GameMapType, [number, number, number]>;
 
 const TERRAIN_EFFECTS = {
-  [TerrainType.Plains]: { mag: 0.9, speed: 0.8 },
-  [TerrainType.Highland]: { mag: 1.1, speed: 1 },
+  [TerrainType.Plains]: { mag: 1, speed: 0.8 }, // higher speed, lower damage
+  [TerrainType.Highland]: { mag: 1.2, speed: 1 },
   [TerrainType.Mountain]: { mag: 1.3, speed: 1.25 },
 } as const;
 
@@ -545,7 +545,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.1 *
+          (attackStandardSize / attackTroops) ** 0.05 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.4,
       };
@@ -646,7 +646,7 @@ export class DefaultConfig implements Config {
     //population grows proportional to current population with growth decreasing as it approaches max
     // smaller countries recieve a boost to pop growth to speed up early game
     const baseAdditionRate = 10;
-    const basePopGrowthRate = 1300 / max + 1 / 140;
+    const basePopGrowthRate = 1000 / max + 1 / 140;
     const reproductionPop = 0.85 * player.troops() + 1.15 * player.workers();
     let toAdd = baseAdditionRate + basePopGrowthRate * reproductionPop;
     const totalPop = player.totalPopulation();

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -276,7 +276,7 @@ export class DefaultConfig implements Config {
     return 10000 + 150 * Math.pow(dist, 1.1);
   }
   tradeShipSpawnRate(numberOfPorts: number): number {
-    return Math.round(10 * Math.pow(numberOfPorts, 0.5));
+    return Math.round(10 * Math.pow(numberOfPorts, 0.4));
   }
 
   unitInfo(type: UnitType): UnitInfo {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -545,7 +545,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.1 *
+          (attackStandardSize / attackTroops) ** 0.075 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.4,
       };

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -545,7 +545,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.05 *
+          (attackStandardSize / attackTroops) ** 0.075 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.4,
       };

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -67,7 +67,7 @@ const numPlayersConfig = {
 
 const TERRAIN_EFFECTS = {
   [TerrainType.Plains]: { mag: 1, speed: 0.8 }, // higher speed, lower damage
-  [TerrainType.Highland]: { mag: 1.2, speed: 1 },
+  [TerrainType.Highland]: { mag: 1.15, speed: 1 },
   [TerrainType.Mountain]: { mag: 1.3, speed: 1.25 },
 } as const;
 
@@ -545,7 +545,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.075 *
+          (attackStandardSize / attackTroops) ** 0.1 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.4,
       };
@@ -646,8 +646,8 @@ export class DefaultConfig implements Config {
     //population grows proportional to current population with growth decreasing as it approaches max
     // smaller countries recieve a boost to pop growth to speed up early game
     const baseAdditionRate = 10;
-    const basePopGrowthRate = 1000 / max + 1 / 140;
-    const reproductionPop = 0.85 * player.troops() + 1.15 * player.workers();
+    const basePopGrowthRate = 1200 / max + 1 / 150;
+    const reproductionPop = 0.9 * player.troops() + 1.1 * player.workers();
     let toAdd = baseAdditionRate + basePopGrowthRate * reproductionPop;
     const totalPop = player.totalPopulation();
     const ratio = 1 - totalPop / max;


### PR DESCRIPTION
## Description:
Original playtests mainly focused on balancing speed. This PR adjusts attack losses further upwards for all terrain types by around 10%. Pop growth is decreased by around 10% to slightly slow game tempo. Worker growth boost is also weakened a bit to nerf super low troop meta beginning. Slight 10% speed nerf at higher attack sizes. Port spawn rate boosted.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
