### PR TITLE
c-modal_content, Overflow Behavior

### DIFF
--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -54,7 +54,7 @@ export class OModal extends LitElement {
       color: #fff;
       padding: 1.4rem;
       max-height: 60dvh;
-      overflow-y: scroll;
+      overflow-y: auto;
       backdrop-filter: blur(8px);
     }
   `;


### PR DESCRIPTION
## Description:
Updating the modal_content overflow behavior from "scroll" to "auto" presents the scroll-bar when content overflows on the Y axis but hides it when not necessary to view all content.

**New behavior**
![image](https://github.com/user-attachments/assets/0a2365ed-f676-4267-8bd7-22d77ea43f90)

**Previous behavior**
![image2](https://github.com/user-attachments/assets/b2175f4a-e044-4262-b751-22c917bf519a)

This maintains the functionality of the Language dialog but hides the scrollbar when necessary in the Join Lobby dialog. This automatic behavior should further apply to any dialogs making use of the `c-modal_content` class.


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

ajaxburger
