### PR TITLE
Prevent Attack Spam

### DIFF
--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -120,6 +120,10 @@ export class AttackExecution implements Execution {
       new Set<TileRef>(),
     );
 
+    const penalty = Math.floor(this._owner.population() * 0.01);
+    this._owner.removeTroops(penalty);
+    console.log(penalty);
+
     if (this.sourceTile !== null) {
       this.addNeighbors(this.sourceTile);
     } else {

--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -122,7 +122,6 @@ export class AttackExecution implements Execution {
 
     const penalty = Math.floor(this._owner.population() * 0.01);
     this._owner.removeTroops(penalty);
-    console.log(penalty);
 
     if (this.sourceTile !== null) {
       this.addNeighbors(this.sourceTile);


### PR DESCRIPTION
## Description:
This PR assigns a small cost (1% of population) to creating each new attack. This nerfs the strategy of spamming 1% size attacks against an enemy to max pop growth and encourages more normal >10% attack sizes.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
