### PR TITLE
Update HeadsUpMessage.ts to support translations

### DIFF
--- a/resources/lang/debug.json
+++ b/resources/lang/debug.json
@@ -164,5 +164,8 @@
     "Balanced": "difficulty.Balanced",
     "Intense": "difficulty.Intense",
     "Impossible": "difficulty.Impossible"
+  },
+  "heads_up_message": {
+    "choose_spawn": "heads_up_message.choose_spawn"
   }
 }

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -428,5 +428,8 @@
     "copied": "Copied!",
     "failed_copy": "Failed to copy",
     "desync_notice": "You are desynced from other players. What you see might differ from other players."
+  },
+  "heads_up_message": {
+    "choose_spawn": "Choose a starting location"
   }
 }

--- a/src/client/graphics/layers/HeadsUpMessage.ts
+++ b/src/client/graphics/layers/HeadsUpMessage.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { GameView } from "../../../core/game/GameView";
+import { translateText } from "../../Utils";
 import { Layer } from "./Layer";
 
 @customElement("heads-up-message")
@@ -39,7 +40,7 @@ export class HeadsUpMessage extends LitElement implements Layer {
                     backdrop-blur-md text-white text-md lg:text-xl p-1 lg:p-2"
         @contextmenu=${(e) => e.preventDefault()}
       >
-        Choose a starting location
+        ${translateText("heads_up_message.choose_spawn")}
       </div>
     `;
   }


### PR DESCRIPTION
## Description:

This change fixes the spawn message to use `translateText()`. I'll ensure I don't miss this again.

![image](https://github.com/user-attachments/assets/76868b1c-701d-4035-bc55-34f3635ecf06)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

.spicydll
