### PR TITLE
Cap lobby sizes at 150

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -147,7 +147,7 @@ export abstract class DefaultServerConfig implements ServerConfig {
     const [l, m, s] = numPlayersConfig[map] ?? [50, 30, 20];
     const r = Math.random();
     const base = r < 0.3 ? l : r < 0.6 ? m : s;
-    return mode === GameMode.Team ? Math.ceil(base * 1.5) : base;
+    return Math.min(mode === GameMode.Team ? Math.ceil(base * 1.5) : base, 150);
   }
 
   workerIndex(gameID: GameID): number {


### PR DESCRIPTION
## Description:
Currenly, it's possible for the World map to reach 225 players. This PR caps it at just 150.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
Nikola123
