### PR TITLE
make bots weaker

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -512,16 +512,12 @@ export class DefaultConfig implements Config {
 
     if (attacker.isPlayer() && defenderIsPlayer) {
       if (
-        attackerType === PlayerType.Human &&
+        (attackerType === PlayerType.Human ||
+          attackerType === PlayerType.FakeHuman) &&
         defenderType === PlayerType.Bot
       ) {
-        mag *= 0.8;
-      }
-      if (
-        attackerType === PlayerType.FakeHuman &&
-        defenderType === PlayerType.Bot
-      ) {
-        mag *= 0.8;
+        mag *= 0.6;
+        speed *= 0.6;
       }
     }
     if (attackerType === PlayerType.Bot) {


### PR DESCRIPTION
## Description:
I believe many of the complains of the game being too slow in the beginning is due to bots being stronger in v23 than v22. This PR weakens bots significants and it feels much closer to v22.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
