### PR TITLE
Another Balance Change

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -536,7 +536,7 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 23;
+      const baseTileCost = 25;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
@@ -547,7 +547,7 @@ export class DefaultConfig implements Config {
           within(defenderDensity, 3, 100) ** 0.2 *
           (attackStandardSize / attackTroops) ** 0.075 *
           speed *
-          within(attackRatio, 0.1, 20) ** 0.4,
+          within(attackRatio, 0.1, 20) ** 0.35,
       };
     } else {
       return {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -536,7 +536,7 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 26;
+      const baseTileCost = 29;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
@@ -547,13 +547,13 @@ export class DefaultConfig implements Config {
           within(defenderDensity, 3, 100) ** 0.2 *
           (attackStandardSize / attackTroops) ** 0.075 *
           speed *
-          within(attackRatio, 0.1, 20) ** 0.35,
+          within(attackRatio, 0.1, 20) ** 0.4,
       };
     } else {
       return {
         attackerTroopLoss: 16 * mag,
         defenderTroopLoss: 0,
-        tilesPerTickUsed: 31 * speed,
+        tilesPerTickUsed: 492 * speed * within(attackTroops, 1, 10000) ** -0.3,
       };
     }
   }

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -646,7 +646,7 @@ export class DefaultConfig implements Config {
     //population grows proportional to current population with growth decreasing as it approaches max
     // smaller countries recieve a boost to pop growth to speed up early game
     const baseAdditionRate = 10;
-    const basePopGrowthRate = 1200 / max + 1 / 150;
+    const basePopGrowthRate = 1100 / max + 1 / 160;
     const reproductionPop = 0.9 * player.troops() + 1.1 * player.workers();
     let toAdd = baseAdditionRate + basePopGrowthRate * reproductionPop;
     const totalPop = player.totalPopulation();

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -536,7 +536,7 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 26;
+      const baseTileCost = 29;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
@@ -545,7 +545,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.075 *
+          (attackStandardSize / attackTroops) ** 0.1 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.4,
       };

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -230,7 +230,7 @@ export class DefaultConfig implements Config {
   falloutDefenseModifier(falloutRatio: number): number {
     // falloutRatio is between 0 and 1
     // So defense modifier is between [3, 1]
-    return 3 - falloutRatio * 2;
+    return 2 - falloutRatio;
   }
   SAMCooldown(): number {
     return 75;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -536,7 +536,7 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 29;
+      const baseTileCost = 30;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
@@ -547,7 +547,7 @@ export class DefaultConfig implements Config {
           within(defenderDensity, 3, 100) ** 0.2 *
           (attackStandardSize / attackTroops) ** 0.1 *
           speed *
-          within(attackRatio, 0.1, 20) ** 0.4,
+          within(attackRatio, 0.1, 20) ** 0.35,
       };
     } else {
       return {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -536,7 +536,7 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 25;
+      const baseTileCost = 26;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -66,8 +66,8 @@ const numPlayersConfig = {
 } as const satisfies Record<GameMapType, [number, number, number]>;
 
 const TERRAIN_EFFECTS = {
-  [TerrainType.Plains]: { mag: 1, speed: 0.8 }, // higher speed, lower damage
-  [TerrainType.Highland]: { mag: 1.15, speed: 1 },
+  [TerrainType.Plains]: { mag: 1.1, speed: 0.8 }, // higher speed, lower damage
+  [TerrainType.Highland]: { mag: 1.2, speed: 1 },
   [TerrainType.Mountain]: { mag: 1.3, speed: 1.25 },
 } as const;
 

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -536,7 +536,7 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 29;
+      const baseTileCost = 26;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:


### PR DESCRIPTION
## Description:
Reduces attack speed for large attacks. A further 10% increase in attacker losses. minor 5% decrease in pop growth. Attacks against Terra Nullius fade away as in v22.

This addresses the community poll finding that many players consider current troop movements to be too fast. The latter two changes help nerf attacking and slowdown snowballing.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
