### PR TITLE
Balance Update

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -646,7 +646,7 @@ export class DefaultConfig implements Config {
     // smaller countries recieve a boost to pop growth to speed up early game
     const baseAdditionRate = 10;
     const basePopGrowthRate = 1200 / max + 1 / 200;
-    const reproductionPop = 0.95 * player.troops() + 1.05 * player.workers();
+    const reproductionPop = player.troops() + 1.15 * player.workers();
     let toAdd = baseAdditionRate + basePopGrowthRate * reproductionPop;
     const totalPop = player.totalPopulation();
     const ratio = 1 - totalPop / max;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -66,9 +66,9 @@ const numPlayersConfig = {
 } as const satisfies Record<GameMapType, [number, number, number]>;
 
 const TERRAIN_EFFECTS = {
-  [TerrainType.Plains]: { mag: 1.1, speed: 0.8 }, // higher speed, lower damage
-  [TerrainType.Highland]: { mag: 1.2, speed: 1 },
-  [TerrainType.Mountain]: { mag: 1.3, speed: 1.25 },
+  [TerrainType.Plains]: { mag: 1, speed: 0.8 }, // higher speed, lower damage
+  [TerrainType.Highland]: { mag: 1.1, speed: 1 },
+  [TerrainType.Mountain]: { mag: 1.2, speed: 1.2 },
 } as const;
 
 export abstract class DefaultServerConfig implements ServerConfig {
@@ -246,7 +246,7 @@ export class DefaultConfig implements Config {
     return 6;
   }
   defensePostSpeedMultiplier(): number {
-    return 3;
+    return 3.5;
   }
   playerTeams(): number | typeof Duos {
     return this._gameConfig.playerTeams ?? 0;
@@ -276,7 +276,7 @@ export class DefaultConfig implements Config {
     return 10000 + 150 * Math.pow(dist, 1.1);
   }
   tradeShipSpawnRate(numberOfPorts: number): number {
-    return Math.round(10 * Math.pow(numberOfPorts, 0.4));
+    return Math.round(10 * Math.pow(numberOfPorts, 0.3));
   }
 
   unitInfo(type: UnitType): UnitInfo {
@@ -532,11 +532,14 @@ export class DefaultConfig implements Config {
         ? this.traitorDefenseDebuff()
         : 1;
       const baseTroopLoss = 16;
-      const baseTileCost = 30;
+      const attackLossModifier = 1.3;
+      const baseTileCost = 33;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
-          mag * (baseTroopLoss + defenderDensity * traitorDebuff),
+          mag *
+          (baseTroopLoss +
+            attackLossModifier * defenderDensity * traitorDebuff),
         defenderTroopLoss: defenderDensity,
         tilesPerTickUsed:
           baseTileCost *
@@ -642,8 +645,8 @@ export class DefaultConfig implements Config {
     //population grows proportional to current population with growth decreasing as it approaches max
     // smaller countries recieve a boost to pop growth to speed up early game
     const baseAdditionRate = 10;
-    const basePopGrowthRate = 1100 / max + 1 / 160;
-    const reproductionPop = 0.9 * player.troops() + 1.1 * player.workers();
+    const basePopGrowthRate = 1200 / max + 1 / 200;
+    const reproductionPop = 0.95 * player.troops() + 1.05 * player.workers();
     let toAdd = baseAdditionRate + basePopGrowthRate * reproductionPop;
     const totalPop = player.totalPopulation();
     const ratio = 1 - totalPop / max;
@@ -674,11 +677,11 @@ export class DefaultConfig implements Config {
   }
 
   goldAdditionRate(player: Player): number {
-    return 0.045 * player.workers() ** 0.7;
+    return 0.08 * player.workers() ** 0.65;
   }
 
   troopAdjustmentRate(player: Player): number {
-    const maxDiff = this.maxPopulation(player) / 500;
+    const maxDiff = this.maxPopulation(player) / 600;
     const target = player.population() * player.targetTroopRatio();
     const diff = target - player.troops();
     if (Math.abs(diff) < maxDiff) {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -243,10 +243,10 @@ export class DefaultConfig implements Config {
     return 40;
   }
   defensePostLossMultiplier(): number {
-    return 6;
+    return 8;
   }
   defensePostSpeedMultiplier(): number {
-    return 3.5;
+    return 4;
   }
   playerTeams(): number | typeof Duos {
     return this._gameConfig.playerTeams ?? 0;
@@ -533,7 +533,7 @@ export class DefaultConfig implements Config {
         : 1;
       const baseTroopLoss = 16;
       const attackLossModifier = 1.3;
-      const baseTileCost = 48;
+      const baseTileCost = 44;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -533,7 +533,7 @@ export class DefaultConfig implements Config {
         : 1;
       const baseTroopLoss = 16;
       const attackLossModifier = 1.3;
-      const baseTileCost = 33;
+      const baseTileCost = 41;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
@@ -544,7 +544,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.1 *
+          (attackStandardSize / attackTroops) ** 0.15 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.35,
       };

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -533,7 +533,7 @@ export class DefaultConfig implements Config {
         : 1;
       const baseTroopLoss = 16;
       const attackLossModifier = 1.3;
-      const baseTileCost = 41;
+      const baseTileCost = 48;
       const attackStandardSize = 10_000;
       return {
         attackerTroopLoss:
@@ -544,7 +544,7 @@ export class DefaultConfig implements Config {
         tilesPerTickUsed:
           baseTileCost *
           within(defenderDensity, 3, 100) ** 0.2 *
-          (attackStandardSize / attackTroops) ** 0.15 *
+          (attackStandardSize / attackTroops) ** 0.2 *
           speed *
           within(attackRatio, 0.1, 20) ** 0.35,
       };


### PR DESCRIPTION
## Description:
This update does the following:

slight nerf to gold production by large players
Speed boost for very large attacks
5% speed buff for mountains
Defense post boost
small trade ship spawn rate increase
attack losses up 20% for all attacks
small speed effect boost for defense posts
20% population growth decrease for large players
nerfed worker growth boost slightly
nerfed troop/worker conversion rate
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
