### PR TITLE
Sort leader board

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -39,7 +39,6 @@ export class Leaderboard extends LitElement implements Layer {
 
   players: Entry[] = [];
 
-  @state()
   private sortColumn: "owned" | "gold" = "owned";
 
   @state()

--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -40,6 +40,9 @@ export class Leaderboard extends LitElement implements Layer {
   players: Entry[] = [];
 
   @state()
+  private sortColumn: "owned" | "gold" = "owned";
+
+  @state()
   private _leaderboardHidden = true;
   private _shownOnInit = false;
   private showTopFive = true;
@@ -62,13 +65,33 @@ export class Leaderboard extends LitElement implements Layer {
     }
   }
 
+  private setSort(column: "owned" | "gold") {
+    this.sortColumn = column;
+    this.updateLeaderboard();
+  }
+
   private updateLeaderboard() {
     if (this.game === null) throw new Error("Not initialized");
     const myPlayer = this.game.myPlayer();
 
-    const sorted = this.game
-      .playerViews()
-      .sort((a, b) => b.numTilesOwned() - a.numTilesOwned());
+    const sorted = this.game.playerViews().slice();
+
+    sorted.sort((a, b) => {
+      let valueA: number, valueB: number;
+      switch (this.sortColumn) {
+        case "gold":
+          valueA = a.gold();
+          valueB = b.gold();
+          break;
+        case "owned":
+        default:
+          valueA = a.numTilesOwned();
+          valueB = b.numTilesOwned();
+          break;
+      }
+
+      return valueB - valueA;
+    });
 
     const numTilesWithoutFallout =
       this.game.numLandTiles() - this.game.numTilesWithFallout();
@@ -273,10 +296,19 @@ export class Leaderboard extends LitElement implements Layer {
         <table>
           <thead>
             <tr>
-              <th>${translateText("leaderboard.rank")}</th>
+              <th @click=${() => this.setSort("owned")} style="cursor: pointer">
+                ${translateText("leaderboard.rank")}
+                ${this.sortColumn === "owned" ? "↓" : ""}
+              </th>
               <th>${translateText("leaderboard.player")}</th>
-              <th>${translateText("leaderboard.owned")}</th>
-              <th>${translateText("leaderboard.gold")}</th>
+              <th @click=${() => this.setSort("owned")} style="cursor: pointer">
+                ${translateText("leaderboard.owned")}
+                ${this.sortColumn === "owned" ? "↓" : ""}
+              </th>
+              <th @click=${() => this.setSort("gold")} style="cursor: pointer">
+                ${translateText("leaderboard.gold")}
+                ${this.sortColumn === "gold" ? "↓" : ""}
+              </th>
               <th>${translateText("leaderboard.troops")}</th>
             </tr>
           </thead>


### PR DESCRIPTION
add very basic sort options to the leaderboard.
It allow the player to sort by "gold" or by "owned land".
to keep a simple interface, I didn't add it on every column, and only on DESC

My goal was to simplify the hunt of rich players. Or just watching potiential MIRV threat.

![Capture d'écran 2025-06-02 113329](https://github.com/user-attachments/assets/07759120-c08f-4ea7-92ec-0fffb8fdf8ad)


![Capture d'écran 2025-06-02 113338](https://github.com/user-attachments/assets/3acb5290-a36d-420b-9c9d-697819c67e1c)


<NapNap>
