### PR TITLE
SAMs should target only nukes aimed at nearby targets

### DIFF
--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -19,7 +19,7 @@ export class SAMLauncherExecution implements Execution {
   private active: boolean = true;
 
   private searchRangeRadius = 80;
-  private targetRangeRadius = 120; // Generous range to allow for area protections
+  private targetRangeRadius = 120; // Nuke's target should be in this range to be focusable
   // As MIRV go very fast we have to detect them very early but we only
   // shoot the one targeting very close (MIRVWarheadProtectionRadius)
   private MIRVWarheadSearchRadius = 400;

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -19,7 +19,7 @@ export class SAMLauncherExecution implements Execution {
   private active: boolean = true;
 
   private searchRangeRadius = 80;
-  private destinationRangeRadius = 200; // Generous range to allow for area protections
+  private targetRangeRadius = 120; // Generous range to allow for area protections
   // As MIRV go very fast we have to detect them very early but we only
   // shoot the one targeting very close (MIRVWarheadProtectionRadius)
   private MIRVWarheadSearchRadius = 400;
@@ -47,15 +47,14 @@ export class SAMLauncherExecution implements Execution {
     this.player = mg.player(this.ownerId);
   }
 
-  private nukeDestinationInRange(nuke: Unit) {
-    if (this.sam === null) {
+  private nukeTargetInRange(nuke: Unit) {
+    const targetTile = nuke.targetTile();
+    if (this.sam === null || targetTile === undefined) {
       return false;
     }
-    const destinationRangeSquared =
-      this.destinationRangeRadius * this.destinationRangeRadius;
+    const targetRangeSquared = this.targetRangeRadius * this.targetRangeRadius;
     return (
-      squaredDistance(this.mg, this.sam.tile(), nuke.tile()) <
-      destinationRangeSquared
+      squaredDistance(this.mg, this.sam.tile(), targetTile) < targetRangeSquared
     );
   }
 
@@ -70,7 +69,7 @@ export class SAMLauncherExecution implements Execution {
         ({ unit }) =>
           unit.owner() !== this.player &&
           !this.player.isFriendly(unit.owner()) &&
-          this.nukeDestinationInRange(unit),
+          this.nukeTargetInRange(unit),
       );
 
     return (

--- a/src/core/execution/Util.ts
+++ b/src/core/execution/Util.ts
@@ -6,6 +6,21 @@ export function getSpawnTiles(gm: GameMap, tile: TileRef): TileRef[] {
   );
 }
 
+export function squaredDistance(
+  gm: GameMap,
+  tileA: TileRef,
+  tileB: TileRef,
+): number {
+  const aX = gm.x(tileA);
+  const aY = gm.y(tileA);
+  const bX = gm.x(tileB);
+  const bY = gm.y(tileB);
+  const dx = bX - aX;
+  const dy = bY - aY;
+  const distSquared = dx * dx + dy * dy;
+  return distSquared;
+}
+
 export function closestTwoTiles(
   gm: GameMap,
   x: Iterable<TileRef>,


### PR DESCRIPTION
## Description:

Current SAM are targeting any nuke in range. It can be frustrating when a random SAM from another player is in the path of your nuke, specially since they follow a curved trajectory so there is little room for the user to change the nuke path.

This change how the SAM intercepts nukes: it only selects those whose targets are nearby the SAM.
The "target-range" is quite generous so it will still allow people to defend against Hydrogen bombs, while preventing random SAM to intercept your valued nukes.

https://github.com/user-attachments/assets/0d8be2ac-e04d-44a4-a67e-54836cce8899



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

IngloriousTom
