### PR TITLE
kick existing client when duplicate persistent id is found

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -147,7 +147,9 @@ export class GameServer {
           existingIP: ipAnonymize(conflicting.ip),
           existingPersistentID: conflicting.persistentID,
         });
-        return;
+        // Kick the existing client instead of the new one, because this was causing issues when
+        // a client wanted to replay the game afterwards.
+        this.kickClient(conflicting.clientID);
       }
     }
 


### PR DESCRIPTION
## Description:
Kick the existing client instead of the new client because this was causing issues with replays. Players were unable to replay a game if they were a player.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

<DISCORD USERNAME>
