### PR TITLE
Fix broken flag images

### DIFF
--- a/src/client/data/countries.json
+++ b/src/client/data/countries.json
@@ -473,7 +473,7 @@
     "name": "Comoros"
   },
   {
-    "code": "communist flag",
+    "code": "Communist flag",
     "name": "Communist Flag"
   },
   {
@@ -740,7 +740,7 @@
     "name": "Franks"
   },
   {
-    "code": "french foreign legion",
+    "code": "French foreign legion",
     "name": "French Foreign Legion"
   },
   {
@@ -1188,7 +1188,7 @@
     "name": "Luxembourg"
   },
   {
-    "code": "lydia",
+    "code": "Lydia",
     "continent": "Asia",
     "name": "Lydia"
   },
@@ -1238,7 +1238,7 @@
     "name": "Malta"
   },
   {
-    "code": "Māori Flag",
+    "code": "Māori flag",
     "continent": "Oceania",
     "name": "Māori Flag"
   },
@@ -1466,7 +1466,7 @@
     "name": "Normandy"
   },
   {
-    "code": "North Karelia",
+    "code": "North karelia",
     "continent": "Europe",
     "name": "North Karelia"
   },


### PR DESCRIPTION
## Description:

Some flag images are missing from the flag menu, and can thus not be used as a flag by the player in the game. 

This this fixes that by equating the names in countries.json to the filenames of the flags.

Example of missing flag image from before this fix:

![afbeelding](https://github.com/user-attachments/assets/ec7aecdc-ee69-4852-98f9-14f3dc05febc)


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
