### PR TITLE
rename Event interface -> GameEvent

### DIFF
--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -41,7 +41,7 @@ import {
 
 import { translateText } from "../../Utils";
 
-interface Event {
+interface GameEvent {
   description: string;
   unsafeDescription?: boolean;
   buttons?: {
@@ -67,7 +67,7 @@ export class EventsDisplay extends LitElement implements Layer {
   public game: GameView;
 
   private active: boolean = false;
-  private events: Event[] = [];
+  private events: GameEvent[] = [];
   @state() private incomingAttacks: AttackUpdate[] = [];
   @state() private outgoingAttacks: AttackUpdate[] = [];
   @state() private outgoingLandAttacks: AttackUpdate[] = [];
@@ -160,7 +160,7 @@ export class EventsDisplay extends LitElement implements Layer {
     this.requestUpdate();
   }
 
-  private addEvent(event: Event) {
+  private addEvent(event: GameEvent) {
     this.events = [...this.events, event];
     if (this._hidden === true) {
       this.newEvents++;
@@ -475,7 +475,7 @@ export class EventsDisplay extends LitElement implements Layer {
   }
 
   private getEventDescription(
-    event: Event,
+    event: GameEvent,
   ): string | DirectiveResult<typeof UnsafeHTMLDirective> {
     return event.unsafeDescription
       ? unsafeHTML(onlyImages(event.description))


### PR DESCRIPTION
## Description:
Rename the `Event` interface `GameEvent` as `Event` shadows the browser API `Event`

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

maxion_
