### PR TITLE
cloudflare fixed tunnel name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -59,8 +59,13 @@ COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY startup.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/startup.sh
 
-RUN mkdir -p /tmp/.cloudflared && chmod 777 /tmp/.cloudflared
-ENV CF_CONFIG_DIR=/tmp/.cloudflared
+RUN mkdir -p /etc/cloudflared && \
+    chown -R node:node /etc/cloudflared && \
+    chmod -R 755 /etc/cloudflared
+
+# Set Cloudflared config directory to a volume mount location
+ENV CF_CONFIG_PATH=/etc/cloudflared/config.yml
+ENV CF_CREDS_PATH=/etc/cloudflared/creds.json
 
 # Use the startup script as the entrypoint
 ENTRYPOINT ["/usr/local/bin/startup.sh"]

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -60,7 +60,8 @@ export interface ServerConfig {
   subdomain(): string;
   cloudflareAccountId(): string;
   cloudflareApiToken(): string;
-  cloudflareConfigDir(): string;
+  cloudflareConfigPath(): string;
+  cloudflareCredsPath(): string;
 }
 
 export interface NukeMagnitude {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -78,9 +78,13 @@ export abstract class DefaultServerConfig implements ServerConfig {
   cloudflareApiToken(): string {
     return process.env.CF_API_TOKEN ?? "";
   }
-  cloudflareConfigDir(): string {
-    return process.env.CF_CONFIG_DIR ?? "";
+  cloudflareConfigPath(): string {
+    return process.env.CF_CONFIG_PATH ?? "";
   }
+  cloudflareCredsPath(): string {
+    return process.env.CF_CREDS_PATH ?? "";
+  }
+
   private publicKey: JWK;
   abstract jwtAudience(): string;
   jwtIssuer(): string {

--- a/src/server/Server.ts
+++ b/src/server/Server.ts
@@ -36,7 +36,8 @@ async function setupTunnels() {
   const cloudflare = new Cloudflare(
     config.cloudflareAccountId(),
     config.cloudflareApiToken(),
-    config.cloudflareConfigDir(),
+    config.cloudflareConfigPath(),
+    config.cloudflareCredsPath(),
   );
 
   const domainToService = new Map<string, string>().set(
@@ -51,11 +52,15 @@ async function setupTunnels() {
     );
   }
 
-  const tunnel = await cloudflare.createTunnel({
-    subdomain: config.subdomain(),
-    domain: config.domain(),
-    subdomainToService: domainToService,
-  } as TunnelConfig);
+  if (!(await cloudflare.configAlreadyExists())) {
+    await cloudflare.createTunnel({
+      subdomain: config.subdomain(),
+      domain: config.domain(),
+      subdomainToService: domainToService,
+    } as TunnelConfig);
+  } else {
+    console.log("Config already exists, skipping tunnel creation");
+  }
 
-  await cloudflare.startCloudflared(tunnel.configPath);
+  await cloudflare.startCloudflared();
 }

--- a/tests/util/TestServerConfig.ts
+++ b/tests/util/TestServerConfig.ts
@@ -4,7 +4,10 @@ import { GameMapType } from "../../src/core/game/Game";
 import { GameID } from "../../src/core/Schemas";
 
 export class TestServerConfig implements ServerConfig {
-  cloudflareConfigDir(): string {
+  cloudflareConfigPath(): string {
+    throw new Error("Method not implemented.");
+  }
+  cloudflareCredsPath(): string {
     throw new Error("Method not implemented.");
   }
   domain(): string {

--- a/update.sh
+++ b/update.sh
@@ -58,10 +58,15 @@ else
 fi
 
 echo "Starting new container for ${HOST} environment..."
+
+# Remove any existing volume for this container if it exists
+docker volume rm "cloudflared-${CONTAINER_NAME}" 2> /dev/null || true
+
 docker run -d \
     --restart="${RESTART}" \
     --env-file "$ENV_FILE" \
     --name "${CONTAINER_NAME}" \
+    -v "cloudflared-${CONTAINER_NAME}:/etc/cloudflared" \
     "${DOCKER_IMAGE}"
 
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
## Description:
The binary created a new tunnel on startup, and if the container crashed looped, then it would generate 100s of tunnels causing us to reach the 1000 tunnel limit.

Now the config is stored on a mounted volume, so if the container restarts it sees the existing config and does not create a new tunnel.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan