### PR TITLE
Fixed bad translation string bug for unit info modal.

### DIFF
--- a/src/client/graphics/layers/UnitInfoModal.ts
+++ b/src/client/graphics/layers/UnitInfoModal.ts
@@ -73,6 +73,15 @@ export class UnitInfoModal extends LitElement implements Layer {
     super.disconnectedCallback();
   }
 
+  buildUnitTypeTranslationString() {
+    let unitType = "";
+    if (this !== null && this.unit !== null) {
+      unitType = this.unit.type?.().toLowerCase();
+    }
+    unitType = unitType.replace(" ", "_");
+    return "unit_type." + unitType;
+  }
+
   static styles = css`
     :host {
       position: fixed;
@@ -138,7 +147,7 @@ export class UnitInfoModal extends LitElement implements Layer {
         </div>
         <div style="margin-bottom: 4px;">
           <strong>${translateText("unit_info_modal.type")}:</strong>
-          ${translateText(+"unit_type." + this.unit.type?.().toLowerCase()) ??
+          ${translateText(this.buildUnitTypeTranslationString()) ??
           translateText("unit_info_modal.unit_type_unknown")}
         </div>
         ${secondsLeft > 0

--- a/src/client/graphics/layers/UnitInfoModal.ts
+++ b/src/client/graphics/layers/UnitInfoModal.ts
@@ -79,13 +79,10 @@ export class UnitInfoModal extends LitElement implements Layer {
     super.disconnectedCallback();
   }
 
-  buildUnitTypeTranslationString() {
-    let unitType = "";
-    if (this !== null && this.unit !== null) {
-      unitType = this.unit.type?.().toLowerCase();
-    }
-    unitType = unitType.replace(" ", "_");
-    return "unit_type." + unitType;
+  private buildUnitTypeTranslationString(): string {
+    if (!this.unit) return "unit_type.unknown"; // fallback stays the same
+    const unitType = this.unit.type().toLowerCase().replace(/\s+/g, "_");
+    return `unit_type.${unitType}`;
   }
 
   static styles = css`

--- a/src/core/configuration/Colors.ts
+++ b/src/core/configuration/Colors.ts
@@ -349,7 +349,7 @@ export class ColorAllocator {
       return this.assigned.get(id)!;
     }
     if (this.availableColors.length === 0) {
-      this.availableColors = this.fallbackColors;
+      this.availableColors = [...this.fallbackColors];
     }
     const index = 0;
     const color = this.availableColors.splice(index, 1)[0];


### PR DESCRIPTION
## Description:
Just cleaning up a small oops I let slip through. 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

![image](https://github.com/user-attachments/assets/0ba4855c-5cdc-4a60-be7a-19d1651f573b)
![image](https://github.com/user-attachments/assets/8a1722b3-e44c-4927-bf90-107ecc0c155e)
![image](https://github.com/user-attachments/assets/bca33461-8913-40db-b641-d94b452999d6)
![image](https://github.com/user-attachments/assets/34e9d3f1-e886-4753-beb7-91a8e1ade65a)
![image](https://github.com/user-attachments/assets/4e3ca80a-dcdb-49ea-9742-2c0d93195ea8)

## Please put your Discord username so you can be contacted if a bug or regression is found: sii
