### PR TITLE
Add max timer condition

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -121,6 +121,7 @@
     "instant_build": "Instant build",
     "infinite_gold": "Infinite gold",
     "infinite_troops": "Infinite troops",
+    "max_timer": "Max timer (minutes)",
     "disable_nukes": "Disable Nukes",
     "enables_title": "Enable Settings",
     "start": "Start Game"
@@ -189,6 +190,7 @@
     "bots": "Bots: ",
     "bots_disabled": "Disabled",
     "disable_nations": "Disable Nations",
+    "max_timer": "Max timer (minutes)",
     "instant_build": "Instant build",
     "infinite_gold": "Infinite gold",
     "infinite_troops": "Infinite troops",

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -34,6 +34,8 @@ export class HostLobbyModal extends LitElement {
   @state() private bots: number = 400;
   @state() private infiniteGold: boolean = false;
   @state() private infiniteTroops: boolean = false;
+  @state() private maxTimer: boolean = false;
+  @state() private maxTimerValue: number | undefined = undefined;
   @state() private instantBuild: boolean = false;
   @state() private lobbyId = "";
   @state() private copySuccess = false;
@@ -303,6 +305,38 @@ export class HostLobbyModal extends LitElement {
                   </div>
                 </label>
 
+                <label
+                  for="max-timer"
+                class="option-card ${this.maxTimer ? "selected" : ""}"
+                >
+                  <div class="checkbox-icon"></div>
+                  <input
+                    type="checkbox"
+                    id="max-timer"
+                    @change=${(e: Event) => {
+                      const checked = (e.target as HTMLInputElement).checked;
+                      if (!checked) {
+                        this.maxTimerValue = undefined;
+                      }
+                      this.maxTimer = checked;
+                    }}
+                    .checked=${this.maxTimer}
+                  />
+                    ${
+                      this.maxTimer === false
+                        ? ""
+                        : html` <input
+                            type="number"
+                            id="max-timer-value"
+                            style="width: 60px; color: black; text-align: right; border-radius: 8px;"
+                            @input=${this.handleMaxTimerValueChanges}
+                            @keydown=${this.handleMaxTimerValueKeyDown}
+                          />`
+                    }
+                  <div class="option-card-title">
+                    ${translateText("host_modal.max_timer")}
+                  </div>
+                </label>
                 <hr style="width: 100%; border-top: 1px solid #444; margin: 16px 0;" />
 
                 <!-- Individual disables for structures/weapons -->
@@ -454,6 +488,25 @@ export class HostLobbyModal extends LitElement {
     this.putGameConfig();
   }
 
+  private handleMaxTimerValueKeyDown(e: KeyboardEvent) {
+    if (["-", "+", "e"].includes(e.key)) {
+      e.preventDefault();
+    }
+  }
+
+  private handleMaxTimerValueChanges(e: Event) {
+    (e.target as HTMLInputElement).value = (
+      e.target as HTMLInputElement
+    ).value.replace(/[e\+\-]/gi, "");
+    const value = parseInt((e.target as HTMLInputElement).value);
+
+    if (isNaN(value) || value < 0 || value > 400) {
+      return;
+    }
+    this.maxTimerValue = value;
+    this.putGameConfig();
+  }
+
   private async handleDisableNPCsChange(e: Event) {
     this.disableNPCs = Boolean((e.target as HTMLInputElement).checked);
     console.log(`updating disable npcs to ${this.disableNPCs}`);
@@ -490,6 +543,8 @@ export class HostLobbyModal extends LitElement {
           gameMode: this.gameMode,
           disabledUnits: this.disabledUnits,
           playerTeams: this.teamCount,
+          maxTimerValue:
+            this.maxTimer === true ? this.maxTimerValue : undefined,
         } satisfies Partial<GameConfig>),
       },
     );

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -34,6 +34,8 @@ export class SinglePlayerModal extends LitElement {
   @state() private bots: number = 400;
   @state() private infiniteGold: boolean = false;
   @state() private infiniteTroops: boolean = false;
+  @state() private maxTimer: boolean = false;
+  @state() private maxTimerValue: number | undefined = undefined;
   @state() private instantBuild: boolean = false;
   @state() private useRandomMap: boolean = false;
   @state() private gameMode: GameMode = GameMode.FFA;
@@ -271,6 +273,36 @@ export class SinglePlayerModal extends LitElement {
                   ${translateText("single_modal.infinite_troops")}
                 </div>
               </label>
+              <label
+                for="end-timer"
+                class="option-card ${this.maxTimer ? "selected" : ""}"
+              >
+                <div class="checkbox-icon"></div>
+                <input
+                  type="checkbox"
+                  id="end-timer"
+                  @change=${(e: Event) => {
+                    const checked = (e.target as HTMLInputElement).checked;
+                    if (!checked) {
+                      this.maxTimerValue = undefined;
+                    }
+                    this.maxTimer = checked;
+                  }}
+                  .checked=${this.maxTimer}
+                />
+                ${this.maxTimer === false
+                  ? ""
+                  : html` <input
+                      type="number"
+                      id="end-timer-value"
+                      style="width: 60px; color: black; text-align: right; border-radius: 8px;"
+                      @input=${this.handleMaxTimerValueChanges}
+                      @keydown=${this.handleMaxTimerValueKeyDown}
+                    />`}
+                <div class="option-card-title">
+                  ${translateText("single_modal.max_timer")}
+                </div>
+              </label>
             </div>
 
             <hr
@@ -347,6 +379,24 @@ export class SinglePlayerModal extends LitElement {
     this.infiniteTroops = Boolean((e.target as HTMLInputElement).checked);
   }
 
+  private handleMaxTimerValueKeyDown(e: KeyboardEvent) {
+    if (["-", "+", "e"].includes(e.key)) {
+      e.preventDefault();
+    }
+  }
+
+  private handleMaxTimerValueChanges(e: Event) {
+    (e.target as HTMLInputElement).value = (
+      e.target as HTMLInputElement
+    ).value.replace(/[e\+\-]/gi, "");
+    const value = parseInt((e.target as HTMLInputElement).value);
+
+    if (isNaN(value) || value < 0 || value > 400) {
+      return;
+    }
+    this.maxTimerValue = value;
+  }
+
   private handleDisableNPCsChange(e: Event) {
     this.disableNPCs = Boolean((e.target as HTMLInputElement).checked);
   }
@@ -419,6 +469,7 @@ export class SinglePlayerModal extends LitElement {
               playerTeams: this.teamCount,
               difficulty: this.selectedDifficulty,
               disableNPCs: this.disableNPCs,
+              maxTimerValue: this.maxTimer ? this.maxTimerValue : undefined,
               bots: this.bots,
               infiniteGold: this.infiniteGold,
               infiniteTroops: this.infiniteTroops,

--- a/src/client/graphics/layers/OptionsMenu.ts
+++ b/src/client/graphics/layers/OptionsMenu.ts
@@ -138,11 +138,21 @@ export class OptionsMenu extends LitElement implements Layer {
     if (updates) {
       this.hasWinner = this.hasWinner || updates[GameUpdateType.Win].length > 0;
     }
-    if (this.game.inSpawnPhase()) {
-      this.timer = 0;
-    } else if (!this.hasWinner && this.game.ticks() % 10 === 0) {
-      this.timer++;
+    const maxTimerValue = this.game.config().gameConfig().maxTimerValue;
+    if (maxTimerValue !== undefined) {
+      if (this.game.inSpawnPhase()) {
+        this.timer = maxTimerValue * 60;
+      } else if (!this.hasWinner && this.game.ticks() % 10 === 0) {
+        this.timer = Math.max(0, this.timer - 1);
+      }
+    } else {
+      if (this.game.inSpawnPhase()) {
+        this.timer = 0;
+      } else if (!this.hasWinner && this.game.ticks() % 10 === 0) {
+        this.timer++;
+      }
     }
+
     this.isVisible = true;
     this.requestUpdate();
   }
@@ -170,6 +180,10 @@ export class OptionsMenu extends LitElement implements Layer {
               class="w-[55px] h-8 lg:w-24 lg:h-10 flex items-center justify-center
                               bg-opacity-50 bg-gray-700 text-opacity-90 text-white
                               rounded text-sm lg:text-xl"
+              style="${this.game.config().gameConfig().maxTimerValue !==
+                undefined && this.timer < 60
+                ? "color: #ff8080;"
+                : ""}"
             >
               ${secondsToHms(this.timer)}
             </div>

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -131,6 +131,7 @@ export const GameConfigSchema = z.object({
   infiniteTroops: z.boolean(),
   instantBuild: z.boolean(),
   maxPlayers: z.number().optional(),
+  maxTimerValue: z.number().optional(),
   disabledUnits: z.nativeEnum(UnitType).array().optional(),
   playerTeams: z.union([z.number().optional(), z.literal(Duos)]),
 });

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -16,11 +16,16 @@ export class WinCheckExecution implements Execution {
   private active = true;
 
   private mg: Game | null = null;
+  private timer: number;
 
   constructor() {}
 
   init(mg: Game, ticks: number) {
     this.mg = mg;
+    const maxTimerValue = this.mg.config().gameConfig().maxTimerValue;
+    if (maxTimerValue !== undefined) {
+      this.timer = maxTimerValue * 60;
+    }
   }
 
   tick(ticks: number) {
@@ -28,6 +33,11 @@ export class WinCheckExecution implements Execution {
       return;
     }
     if (this.mg === null) throw new Error("Not initialized");
+
+    if (this.timer !== undefined) {
+      this.timer = Math.max(0, this.timer - 1);
+    }
+
     if (this.mg.config().gameConfig().gameMode === GameMode.FFA) {
       this.checkWinnerFFA();
     } else {
@@ -48,7 +58,8 @@ export class WinCheckExecution implements Execution {
       this.mg.numLandTiles() - this.mg.numTilesWithFallout();
     if (
       (max.numTilesOwned() / numTilesWithoutFallout) * 100 >
-      this.mg.config().percentageTilesOwnedToWin()
+        this.mg.config().percentageTilesOwnedToWin() ||
+      this.timer === 0
     ) {
       this.mg.setWinner(max, this.mg.stats().stats());
       console.log(`${max.name()} has won the game`);
@@ -78,7 +89,10 @@ export class WinCheckExecution implements Execution {
     const numTilesWithoutFallout =
       this.mg.numLandTiles() - this.mg.numTilesWithFallout();
     const percentage = (max[1] / numTilesWithoutFallout) * 100;
-    if (percentage > this.mg.config().percentageTilesOwnedToWin()) {
+    if (
+      percentage > this.mg.config().percentageTilesOwnedToWin() ||
+      this.timer === 0
+    ) {
       if (max[0] === ColoredTeams.Bot) return;
       this.mg.setWinner(max[0], this.mg.stats().stats());
       console.log(`${max[0]} has won the game`);

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -36,6 +36,7 @@ export class GameManager {
       disableNPCs: false,
       infiniteGold: false,
       infiniteTroops: false,
+      maxTimerValue: undefined,
       instantBuild: false,
       gameMode: GameMode.FFA,
       bots: 400,

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -89,6 +89,9 @@ export class GameServer {
     if (gameConfig.infiniteTroops !== undefined) {
       this.gameConfig.infiniteTroops = gameConfig.infiniteTroops;
     }
+    if (gameConfig.maxTimerValue !== undefined) {
+      this.gameConfig.maxTimerValue = gameConfig.maxTimerValue;
+    }
     if (gameConfig.instantBuild !== undefined) {
       this.gameConfig.instantBuild = gameConfig.instantBuild;
     }

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -56,6 +56,7 @@ export class MapPlaylist {
       difficulty: Difficulty.Medium,
       infiniteGold: false,
       infiniteTroops: false,
+      maxTimerValue: undefined,
       instantBuild: false,
       disableNPCs: mode === GameMode.Team,
       gameMode: mode,

--- a/tests/core/execution/WinCheckExecution.test.ts
+++ b/tests/core/execution/WinCheckExecution.test.ts
@@ -1,0 +1,91 @@
+import { WinCheckExecution } from "../../../src/core/execution/WinCheckExecution";
+import { GameMode } from "../../../src/core/game/Game";
+import { setup } from "../../util/Setup";
+
+describe("WinCheckExecution", () => {
+  let mg: any;
+  let winCheck: WinCheckExecution;
+
+  beforeEach(async () => {
+    mg = await setup("BigPlains", {
+      infiniteGold: true,
+      gameMode: GameMode.FFA,
+      maxTimerValue: 5,
+      instantBuild: true,
+    });
+    mg.setWinner = jest.fn();
+    winCheck = new WinCheckExecution();
+    winCheck.init(mg, 0);
+  });
+
+  it("should initialize timer if maxTimerValue is set", () => {
+    expect((winCheck as any).timer).toBe(300);
+  });
+
+  it("should decrement timer every 10 ticks", () => {
+    const initialTimer = (winCheck as any).timer;
+    winCheck.tick(10);
+    expect((winCheck as any).timer).toBe(initialTimer - 1);
+  });
+
+  it("should not decrement timer if ticks is not a multiple of 10", () => {
+    const initialTimer = (winCheck as any).timer;
+    winCheck.tick(7);
+    expect((winCheck as any).timer).toBe(initialTimer);
+  });
+
+  it("should call checkWinnerFFA in FFA mode", () => {
+    const spy = jest.spyOn(winCheck as any, "checkWinnerFFA");
+    winCheck.tick(10);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should call checkWinnerTeam in non-FFA mode", () => {
+    mg.config = jest.fn(() => ({
+      gameConfig: jest.fn(() => ({
+        maxTimerValue: 5,
+        gameMode: GameMode.Team,
+      })),
+      percentageTilesOwnedToWin: jest.fn(() => 50),
+    }));
+    winCheck.init(mg, 0);
+    const spy = jest.spyOn(winCheck as any, "checkWinnerTeam");
+    winCheck.tick(10);
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it("should set winner in FFA if percentage is reached", () => {
+    const player = {
+      numTilesOwned: jest.fn(() => 81),
+      name: jest.fn(() => "P1"),
+    };
+    mg.players = jest.fn(() => [player]);
+    mg.numLandTiles = jest.fn(() => 100);
+    mg.numTilesWithFallout = jest.fn(() => 0);
+    winCheck.checkWinnerFFA();
+    expect(mg.setWinner).toHaveBeenCalledWith(player, expect.anything());
+  });
+
+  it("should set winner in FFA if timer is 0", () => {
+    (winCheck as any).timer = 0;
+    const player = {
+      numTilesOwned: jest.fn(() => 10),
+      name: jest.fn(() => "P1"),
+    };
+    mg.players = jest.fn(() => [player]);
+    mg.numLandTiles = jest.fn(() => 100);
+    mg.numTilesWithFallout = jest.fn(() => 0);
+    winCheck.checkWinnerFFA();
+    expect(mg.setWinner).toHaveBeenCalledWith(player, {});
+  });
+
+  it("should not set winner if no players", () => {
+    mg.players = jest.fn(() => []);
+    winCheck.checkWinnerFFA();
+    expect(mg.setWinner).not.toHaveBeenCalled();
+  });
+
+  it("should return false for activeDuringSpawnPhase", () => {
+    expect(winCheck.activeDuringSpawnPhase()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Description:

Someone asked for a max timer win condition so this adds a max timer config. When set, the timer starts a max timer and decrease to 0.  When the timer is lower than 1 minute it becomes red.
When the timer reaches 0 the player with the biggest land wins.

![image](https://github.com/user-attachments/assets/80019b16-82c9-4fe9-9eb5-355a599b6948)
![image](https://github.com/user-attachments/assets/c7184f0f-1b48-4ed6-b004-f5c25b54f589)
![timer](https://github.com/user-attachments/assets/2d5559f7-b0d6-43f5-a5d9-1a3551cf1d34)
![win](https://github.com/user-attachments/assets/4a35a38a-dc9c-4941-a6a9-aa26062d8326)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

Vivacious Box
