### PR TITLE
Redraw buildings out of range of nukes

### DIFF
--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -12,6 +12,8 @@ import { ParabolaPathFinder } from "../pathfinding/PathFinding";
 import { PseudoRandom } from "../PseudoRandom";
 import { NukeType } from "../StatsSchemas";
 
+const SPRITE_RADIUS = 6;
+
 export class NukeExecution implements Execution {
   private active = true;
   private mg: Game;
@@ -221,6 +223,10 @@ export class NukeExecution implements Execution {
         }
       }
     }
+
+    this.redrawBuildings(
+      (magnitude.outer + SPRITE_RADIUS) * (magnitude.outer + SPRITE_RADIUS),
+    );
     this.active = false;
     this.nuke.setReachedTarget();
     this.nuke.delete(false);
@@ -229,6 +235,23 @@ export class NukeExecution implements Execution {
     this.mg
       .stats()
       .bombLand(this.player, this.target(), this.nuke.type() as NukeType);
+  }
+
+  private redrawBuildings(range: number) {
+    for (const unit of this.mg.units()) {
+      if (
+        unit.type() === UnitType.City ||
+        unit.type() === UnitType.Construction ||
+        unit.type() === UnitType.DefensePost ||
+        unit.type() === UnitType.SAMLauncher ||
+        unit.type() === UnitType.MissileSilo ||
+        unit.type() === UnitType.Port
+      ) {
+        if (this.mg.euclideanDistSquared(this.dst, unit.tile()) < range) {
+          unit.touch();
+        }
+      }
+    }
   }
 
   owner(): Player {

--- a/tests/core/executions/NukeExecution.test.ts
+++ b/tests/core/executions/NukeExecution.test.ts
@@ -1,0 +1,72 @@
+import { NukeExecution } from "../../../src/core/execution/NukeExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../../../src/core/game/Game";
+import { setup } from "../../util/Setup";
+import { TestConfig } from "../../util/TestConfig";
+import { executeTicks } from "../../util/utils";
+
+let game: Game;
+let player: Player;
+
+describe("NukeExecution", () => {
+  beforeEach(async () => {
+    game = await setup("BigPlains", { infiniteGold: true, instantBuild: true });
+
+    (game.config() as TestConfig).nukeMagnitudes = jest.fn(() => ({
+      inner: 10,
+      outer: 10,
+    }));
+    const player_info = new PlayerInfo(
+      "us",
+      "player_id",
+      PlayerType.Human,
+      null,
+      "player_id",
+    );
+    game.addPlayer(player_info);
+
+    while (game.inSpawnPhase()) {
+      game.executeNextTick();
+    }
+
+    player = game.player("player_id");
+  });
+
+  test("nuke should destroy buildings and redraw out of range buildings", async () => {
+    // Build a city at (1,1)
+    player.buildUnit(UnitType.City, game.ref(1, 1), {});
+    // Build a missile silo in range
+    player.buildUnit(UnitType.MissileSilo, game.ref(1, 10), {});
+    // Build a SAM out of range
+    const sam = player.buildUnit(UnitType.SAMLauncher, game.ref(1, 11), {});
+    sam.touch = jest.fn();
+    // Build a Defense post out of range AND out of redraw range
+    const defensePost = player.buildUnit(
+      UnitType.DefensePost,
+      game.ref(1, 17),
+      {},
+    );
+    defensePost.touch = jest.fn();
+    // Add a nuke execution targeting the city
+    const nukeExec = new NukeExecution(
+      UnitType.AtomBomb,
+      player,
+      game.ref(1, 1),
+      game.ref(1, 2),
+    );
+    game.addExecution(nukeExec);
+    // Run enough ticks for the nuke to detonate
+    executeTicks(game, 10);
+    // The city and silo should be destroyed
+    expect(player.units(UnitType.City)).toHaveLength(0);
+    expect(player.units(UnitType.MissileSilo)).toHaveLength(0);
+    expect(player.units(UnitType.SAMLauncher)).toHaveLength(1);
+    expect(sam.touch).toHaveBeenCalled();
+    expect(defensePost.touch).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description:

When buildings are stacked on each other, the buildings under are not redrawn when the stacked building is destroyed

### Before:
![image](https://github.com/user-attachments/assets/08acd6e2-a45f-4cc1-b263-89be1d994a12)

### After:
![nukeredraw](https://github.com/user-attachments/assets/75a7b666-0281-4f59-8f79-55ef114130b8)


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

Vivacious Box
