### PR TITLE
Fix Nations building more than allowed

### DIFF
--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -443,7 +443,7 @@ export class FakeHumanExecution implements Execution {
 
   private maybeSpawnStructure(type: UnitType, maxNum: number): boolean {
     if (this.player === null) throw new Error("not initialized");
-    const units = this.player.units(type);
+    const units = this.player.unitsIncludingConstruction(type);
     if (units.length >= maxNum) {
       return false;
     }


### PR DESCRIPTION
## Description:

According to the code, Nations aren't meant to build more than 1 port, 2 cities, 1 missile silo. Of course they may acquire more if they conquer territory.

However they are seen to be building more than for example 1 missile silo in-game. While the code checks how many of a type of unit they have, it doesn't include units currently in construction.

This PR fixes that by using an existing function that includes units in construction.

Note: this nerves Nations ever so slightly, so may be noticable in the meta. Although it's a bug that's already present on v23 and before, and it could be hotfixed into v23, there's something to say to leave it for v24 testing including meta changes.

BEFORE:
![Before two silos constructed at same time](https://github.com/user-attachments/assets/b44830f9-0063-49d5-b530-bb44f65b5719)

AFTER:
https://github.com/user-attachments/assets/9b1cc5ac-89f8-48d4-a399-04535e944e79

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33