### PR TITLE
Fix Leaderboard: convert NaN into 0%

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -285,5 +285,6 @@ function formatPercentage(value: number): string {
   if (perc > 99.5) return "100%";
   if (perc < 0.01) return "0%";
   if (perc < 0.1) return perc.toPrecision(1) + "%";
+  if (isNaN(perc)) return "0%";
   return perc.toPrecision(2) + "%";
 }

--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -285,6 +285,6 @@ function formatPercentage(value: number): string {
   if (perc > 99.5) return "100%";
   if (perc < 0.01) return "0%";
   if (perc < 0.1) return perc.toPrecision(1) + "%";
-  if (isNaN(perc)) return "0%";
+  if (Number.isNaN(perc)) return "0%";
   return perc.toPrecision(2) + "%";
 }


### PR DESCRIPTION
## Description:

In edge cases, where all land is fallout, Owned % could be NaN%. Have it converted to 0% in such cases.

https://discord.com/channels/1359946986937258015/1383735051195514880

BEFORE:
<img width="1059" alt="Before" src="https://github.com/user-attachments/assets/a84bffe4-4a96-4175-897f-68be33778653" />

AFTER:
It's a little hard to test (especially when currently you can't get in the old build menu and the new radial menu doesn't let you nuke yourself). But the code speaks for itself i hope.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33