### PR TITLE
Fix build menu on water tile

### DIFF
--- a/src/client/graphics/layers/RadialMenuElements.ts
+++ b/src/client/graphics/layers/RadialMenuElements.ts
@@ -310,7 +310,7 @@ export const buildMenuElement: MenuElement = {
   color: COLORS.build,
 
   subMenu: (params: MenuElementParams) => {
-    if (params === undefined || params.selected === null) return [];
+    if (params === undefined) return [];
 
     const unitTypes: Set<UnitType> = new Set<UnitType>();
     if (params.selected === params.myPlayer) {


### PR DESCRIPTION
## Description:

This PR accidentally introduced a regression: https://github.com/openfrontio/OpenFrontIO/pull/1192

The build menu part of the new radial menu now doesn't open on a water tile, so you can't build a warship.

Fix is removing the unnecessary check for params.selected === null, as it may actually be null in this case. Only check needed to keep PR1192's problem fixed for the Build menu is the params === undefined check.

BEFORE:
https://github.com/user-attachments/assets/54e0fb3d-8bb1-4263-989a-81fd63ec1f5b

AFTER 1:
https://github.com/user-attachments/assets/056d30d0-b50c-46dd-bdc0-ee90349212ef

AFTER 2, showing that PR1192 issue is still fixed (no errors in console):
https://github.com/user-attachments/assets/df598635-20a5-4d45-a1fc-1e8193f71db3

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
