### PR TITLE
Delay win modal

### DIFF
--- a/src/client/graphics/layers/WinModal.ts
+++ b/src/client/graphics/layers/WinModal.ts
@@ -18,6 +18,9 @@ export class WinModal extends LitElement implements Layer {
   @state()
   isVisible = false;
 
+  @state()
+  showButtons = false;
+
   private _title: string;
 
   // Override to prevent shadow DOM creation
@@ -136,7 +139,9 @@ export class WinModal extends LitElement implements Layer {
       <div class="win-modal ${this.isVisible ? "visible" : ""}">
         <h2>${this._title || ""}</h2>
         ${this.innerHtml()}
-        <div class="button-container">
+        <div
+          class="button-container ${this.showButtons ? "visible" : "hidden"}"
+        >
           <button @click=${this._handleExit}>
             ${translateText("win_modal.exit")}
           </button>
@@ -170,15 +175,22 @@ export class WinModal extends LitElement implements Layer {
   }
 
   show() {
-    this.isVisible = true;
-    this.requestUpdate();
     this.eventBus.emit(new GutterAdModalEvent(true));
+    setTimeout(() => {
+      this.isVisible = true;
+      this.requestUpdate();
+    }, 1500);
+    setTimeout(() => {
+      this.showButtons = true;
+      this.requestUpdate();
+    }, 3000);
   }
 
   hide() {
-    this.isVisible = false;
-    this.requestUpdate();
     this.eventBus.emit(new GutterAdModalEvent(false));
+    this.isVisible = false;
+    this.showButtons = false;
+    this.requestUpdate();
   }
 
   private _handleExit() {


### PR DESCRIPTION
## Description:

Have the win modal come up on slight delay to allow ad loading. Have buttons appear ~2 seconds later so there is enough ad dwell time.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
