### PR TITLE
add spawn ads

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -24,7 +24,7 @@ import { SinglePlayerModal } from "./SinglePlayerModal";
 import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
 import { UsernameInput } from "./UsernameInput";
-import { generateCryptoRandomUUID } from "./Utils";
+import { generateCryptoRandomUUID, incrementGamesPlayed } from "./Utils";
 import "./components/NewsButton";
 import { NewsButton } from "./components/NewsButton";
 import "./components/baseComponents/Button";
@@ -365,6 +365,7 @@ class Client {
       () => {
         this.joinModal.close();
         this.publicLobby.stop();
+        incrementGamesPlayed();
 
         try {
           window.PageOS.session.newPageView();

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -168,3 +168,11 @@ export function getAltKey(): string {
     return "Alt";
   }
 }
+
+export function getGamesPlayed(): number {
+  return parseInt(localStorage.getItem("gamesPlayed") || "0");
+}
+
+export function incrementGamesPlayed(): void {
+  localStorage.setItem("gamesPlayed", (getGamesPlayed() + 1).toString());
+}

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -16,7 +16,6 @@ import { GutterAdModal } from "./layers/GutterAdModal";
 import { HeadsUpMessage } from "./layers/HeadsUpMessage";
 import { Layer } from "./layers/Layer";
 import { Leaderboard } from "./layers/Leaderboard";
-import { LeftInGameAd } from "./layers/LeftInGameAd";
 import { MainRadialMenu } from "./layers/MainRadialMenu";
 import { MultiTabModal } from "./layers/MultiTabModal";
 import { NameLayer } from "./layers/NameLayer";
@@ -24,6 +23,7 @@ import { OptionsMenu } from "./layers/OptionsMenu";
 import { PlayerInfoOverlay } from "./layers/PlayerInfoOverlay";
 import { PlayerPanel } from "./layers/PlayerPanel";
 import { ReplayPanel } from "./layers/ReplayPanel";
+import { SpawnAd } from "./layers/SpawnAd";
 import { SpawnTimer } from "./layers/SpawnTimer";
 import { StructureLayer } from "./layers/StructureLayer";
 import { TeamStats } from "./layers/TeamStats";
@@ -198,13 +198,11 @@ export function createRenderer(
   unitInfoModal.structureLayer = structureLayer;
   // unitInfoModal.eventBus = eventBus;
 
-  const leftInGameAd = document.querySelector(
-    "left-in-game-ad",
-  ) as LeftInGameAd;
-  if (!(leftInGameAd instanceof LeftInGameAd)) {
-    console.error("left in game ad not found");
+  const spawnAd = document.querySelector("spawn-ad") as SpawnAd;
+  if (!(spawnAd instanceof SpawnAd)) {
+    console.error("spawn ad not found");
   }
-  leftInGameAd.g = game;
+  spawnAd.g = game;
 
   const gutterAdModal = document.querySelector(
     "gutter-ad-modal",
@@ -249,7 +247,7 @@ export function createRenderer(
     headsUpMessage,
     unitInfoModal,
     multiTabModal,
-    leftInGameAd,
+    spawnAd,
     gutterAdModal,
   ];
 

--- a/src/client/graphics/layers/GutterAdModal.ts
+++ b/src/client/graphics/layers/GutterAdModal.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { EventBus, GameEvent } from "../../../core/EventBus";
+import { getGamesPlayed } from "../../Utils";
 import { Layer } from "./Layer";
 
 export class GutterAdModalEvent implements GameEvent {
@@ -29,13 +30,15 @@ export class GutterAdModal extends LitElement implements Layer {
   }
 
   init() {
-    this.eventBus.on(GutterAdModalEvent, (event) => {
-      if (event.isVisible) {
-        this.show();
-      } else {
-        this.hide();
-      }
-    });
+    if (getGamesPlayed() > 1) {
+      this.eventBus.on(GutterAdModalEvent, (event) => {
+        if (event.isVisible) {
+          this.show();
+        } else {
+          this.hide();
+        }
+      });
+    }
   }
 
   tick() {}

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -283,7 +283,6 @@
         style="pointer-events: auto"
       >
         <control-panel></control-panel>
-        <left-in-game-ad></left-in-game-ad>
       </div>
     </div>
 
@@ -368,6 +367,7 @@
     <unit-info-modal></unit-info-modal>
     <news-modal></news-modal>
     <game-left-sidebar></game-left-sidebar>
+    <spawn-ad></spawn-ad>
     <div
       id="language-modal"
       class="fixed inset-0 bg-black bg-opacity-50 z-50 hidden flex justify-center items-center"


### PR DESCRIPTION
## Description:

Adds a bottom rail add during the spawn phase if player has played over 5 games.
Also only show the death screen ad if player has played a couple of games.

This keeps the experience ad-free for the first few games.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:
evan
