### PR TITLE
Remove babel-jest from devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -79,7 +79,6 @@
         "@types/systeminformation": "^3.23.1",
         "@types/ws": "^8.5.11",
         "autoprefixer": "^10.4.20",
-        "babel-jest": "^30.0.0",
         "binary-base64-loader": "^1.0.0",
         "canvas": "^3.1.0",
         "chai": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "@types/systeminformation": "^3.23.1",
     "@types/ws": "^8.5.11",
     "autoprefixer": "^10.4.20",
-    "babel-jest": "^30.0.0",
     "binary-base64-loader": "^1.0.0",
     "canvas": "^3.1.0",
     "chai": "^5.1.1",


### PR DESCRIPTION
## Description:

Tiny change, remove babel-jest from devDependencies. 

(This PR was intented to remove more from package-lock.json. So we could get rid of two npm warnings about deprecated glob version, and unsupported inflight from the underlying test-exclude dependency which is part of the babel-plugin-istanbul dependency.

But then i found out that more packages have babel-jest and babel-plugin-istanbul as dependencies themselves.

However, we don't use babel-jest directly. Normally it is used as a transformer for tests, but we use ts-jest for that in jest.config.ts. And we don't use it anywhere else. That's why we don't need it in devdependencies, even if other packages still install it.

https://jestjs.io/docs/code-transformation
https://www.npmjs.com/package/babel-jest
https://kulshekhar.github.io/ts-jest/ )

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33