### PR TITLE
Experimental Info Layer for Territory Visibility

### DIFF
--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -30,6 +30,7 @@ import { SpawnTimer } from "./layers/SpawnTimer";
 import { StructureLayer } from "./layers/StructureLayer";
 import { TeamStats } from "./layers/TeamStats";
 import { TerrainLayer } from "./layers/TerrainLayer";
+import { TerritoryInfoLayer } from "./layers/TerritoryInfoLayer";
 import { TerritoryLayer } from "./layers/TerritoryLayer";
 import { TopBar } from "./layers/TopBar";
 import { UILayer } from "./layers/UILayer";
@@ -215,28 +216,55 @@ export function createRenderer(
   }
   gutterAdModal.eventBus = eventBus;
 
+  // Create all layer instances first
+  const terrainLayer = new TerrainLayer(game, transformHandler);
+  const territoryLayer = new TerritoryLayer(
+    game,
+    eventBus,
+    transformHandler,
+    userSettings,
+  );
+  const railroadLayer = new RailroadLayer(game);
+  const territoryInfoLayer = new TerritoryInfoLayer(
+    game,
+    eventBus,
+    transformHandler,
+    territoryLayer,
+  );
+  const unitLayer = new UnitLayer(game, eventBus, transformHandler);
+  const fxLayer = new FxLayer(game);
+  const uiLayer = new UILayer(game, eventBus, transformHandler);
+  const nameLayer = new NameLayer(game, transformHandler, eventBus);
+  const mainRadialMenu = new MainRadialMenu(
+    eventBus,
+    game,
+    transformHandler,
+    emojiTable as EmojiTable,
+    buildMenu,
+    uiState,
+    playerPanel,
+  );
+  const spawnTimer = new SpawnTimer(game, transformHandler);
+
+  // Organize layers in rendering order
   const layers: Layer[] = [
-    new TerrainLayer(game, transformHandler),
-    new TerritoryLayer(game, eventBus, transformHandler, userSettings),
-    new RailroadLayer(game),
+    // Background layers (transformed)
+    terrainLayer,
+    territoryLayer,
+    railroadLayer,
+    territoryInfoLayer,
     structureLayer,
-    new UnitLayer(game, eventBus, transformHandler),
-    new FxLayer(game),
-    new UILayer(game, eventBus, transformHandler),
-    new NameLayer(game, transformHandler),
+    unitLayer,
+    fxLayer,
+
+    // UI layers (not transformed)
+    uiLayer,
+    nameLayer,
     eventsDisplay,
     chatDisplay,
     buildMenu,
-    new MainRadialMenu(
-      eventBus,
-      game,
-      transformHandler,
-      emojiTable as EmojiTable,
-      buildMenu,
-      uiState,
-      playerPanel,
-    ),
-    new SpawnTimer(game, transformHandler),
+    mainRadialMenu,
+    spawnTimer,
     leaderboard,
     gameLeftSidebar,
     controlPanel,

--- a/src/client/graphics/layers/TerritoryInfoLayer.ts
+++ b/src/client/graphics/layers/TerritoryInfoLayer.ts
@@ -1,0 +1,232 @@
+import { EventBus } from "../../../core/EventBus";
+import { TileRef } from "../../../core/game/GameMap";
+import { GameView, PlayerView } from "../../../core/game/GameView";
+import { CtrlKeyStateEvent, MouseOverEvent } from "../../InputHandler";
+import { TransformHandler } from "../TransformHandler";
+import { Layer } from "./Layer";
+import { TerritoryLayer } from "./TerritoryLayer";
+
+const DARKEN_COLOR = "rgba(64, 64, 64, 1)";
+const LAYER_ALPHA = 0.75;
+
+export class TerritoryInfoLayer implements Layer {
+  private finalMaskCanvas: HTMLCanvasElement;
+  private finalMaskContext: CanvasRenderingContext2D;
+  private isVisible: boolean = false;
+  private highlightedTerritory: PlayerView | null | undefined = undefined;
+  private hightlightedTiles: Set<TileRef> = new Set();
+  private lastMousePosition: { x: number; y: number } | null = null;
+  private layerMaskPending: boolean = false;
+
+  constructor(
+    private game: GameView,
+    private eventBus: EventBus,
+    private transformHandler: TransformHandler,
+    private territoryLayer: TerritoryLayer,
+  ) {}
+
+  shouldTransform(): boolean {
+    return true;
+  }
+
+  init() {
+    this.eventBus.on(CtrlKeyStateEvent, (e) => this.onCtrlKeyStateChange(e));
+    this.eventBus.on(MouseOverEvent, (e) => this.onMouseOver(e));
+    this.initializeCanvas();
+  }
+
+  dispose() {
+    this.eventBus.off(CtrlKeyStateEvent, (e) => this.onCtrlKeyStateChange(e));
+    this.eventBus.off(MouseOverEvent, (e) => this.onMouseOver(e));
+  }
+
+  private initializeCanvas() {
+    // Main canvas for final effect - copy from TerritoryLayer and darken
+    this.finalMaskCanvas = document.createElement("canvas");
+    const finalMaskContext = this.finalMaskCanvas.getContext("2d", {
+      alpha: true,
+    });
+    if (finalMaskContext === null) throw new Error("2d context not supported");
+    this.finalMaskContext = finalMaskContext;
+    this.finalMaskCanvas.width = this.game.width();
+    this.finalMaskCanvas.height = this.game.height();
+  }
+
+  onCtrlKeyStateChange(event: CtrlKeyStateEvent) {
+    this.isVisible = event.isPressed;
+
+    if (event.isPressed) {
+      requestAnimationFrame(() => {
+        this.updateMask();
+
+        // Check current mouse position and update highlighted territory
+        if (this.lastMousePosition) {
+          this.updateHighlightedTerritory();
+        }
+      });
+    } else {
+      // If Ctrl is released, clear everything
+      this.highlightedTerritory = undefined;
+      this.updateMask();
+    }
+  }
+
+  onMouseOver(event: MouseOverEvent) {
+    this.lastMousePosition = { x: event.x, y: event.y };
+    this.updateHighlightedTerritory();
+  }
+
+  private updateHighlightedTerritory() {
+    if (!this.isVisible) {
+      return;
+    }
+
+    if (!this.lastMousePosition) {
+      return;
+    }
+
+    const cell = this.transformHandler.screenToWorldCoordinates(
+      this.lastMousePosition.x,
+      this.lastMousePosition.y,
+    );
+    if (!this.game.isValidCoord(cell.x, cell.y)) {
+      return;
+    }
+
+    const previousTerritory = this.highlightedTerritory;
+    const territory = this.findTerritoryAtCell(cell);
+
+    if (territory) {
+      this.highlightedTerritory = territory;
+    } else {
+      this.highlightedTerritory = null;
+    }
+
+    if (previousTerritory?.id() !== this.highlightedTerritory?.id()) {
+      this.updateMask();
+    }
+  }
+
+  private findTerritoryAtCell(cell: { x: number; y: number }) {
+    const tile = this.game.ref(cell.x, cell.y);
+    if (!tile) {
+      return null;
+    }
+    // If the tile has no owner, it is either a fallout tile or a terra nullius tile.
+    if (!this.game.hasOwner(tile)) {
+      return null;
+    }
+    return this.game.owner(tile) as PlayerView;
+  }
+
+  private updateMask() {
+    if (!this.isVisible) {
+      this.finalMaskContext.clearRect(
+        0,
+        0,
+        this.game.width(),
+        this.game.height(),
+      );
+      return;
+    }
+
+    if (this.layerMaskPending) return;
+    this.layerMaskPending = true;
+
+    // Get the TerritoryLayer's canvas and copy it
+    const territoryCanvas = this.territoryLayer.getCanvas();
+
+    if (!territoryCanvas) {
+      console.error("Territory canvas not available");
+      return;
+    }
+
+    // Clear the canvas first
+    this.finalMaskContext.clearRect(
+      0,
+      0,
+      this.game.width(),
+      this.game.height(),
+    );
+
+    // Draw the territory canvas with a darken filter
+    this.finalMaskContext.globalCompositeOperation = "source-over";
+    this.finalMaskContext.fillStyle = DARKEN_COLOR;
+    this.finalMaskContext.fillRect(0, 0, this.game.width(), this.game.height());
+
+    // Use destination-in to only keep the non-transparent areas from territory
+    this.finalMaskContext.globalCompositeOperation = "destination-in";
+    this.finalMaskContext.drawImage(territoryCanvas, 0, 0);
+
+    // If a territory is highlighted, remove it from the darken mask
+    if (this.highlightedTerritory) {
+      // Use destination-out to remove the highlighted territory from the darken mask
+      this.finalMaskContext.globalCompositeOperation = "destination-out";
+      this.finalMaskContext.fillStyle = "rgba(255, 255, 255, 1)";
+
+      this.game.forEachTile((tile) => {
+        if (this.game.hasOwner(tile)) {
+          const owner = this.game.owner(tile) as PlayerView;
+          if (owner === this.highlightedTerritory) {
+            this.finalMaskContext.fillRect(
+              this.game.x(tile),
+              this.game.y(tile),
+              1,
+              1,
+            );
+          }
+        }
+      });
+
+      this.finalMaskContext.globalCompositeOperation = "source-over";
+    }
+    this.layerMaskPending = false;
+  }
+
+  renderLayer(context: CanvasRenderingContext2D) {
+    if (this.isVisible) {
+      const currentAlpha = context.globalAlpha;
+      context.globalAlpha = LAYER_ALPHA;
+
+      // Cache the transform values to avoid repeated calculations
+      const offsetX = -this.game.width() / 2;
+      const offsetY = -this.game.height() / 2;
+
+      context.drawImage(
+        this.finalMaskCanvas,
+        offsetX,
+        offsetY,
+        this.game.width(),
+        this.game.height(),
+      );
+
+      context.globalAlpha = currentAlpha;
+    }
+  }
+
+  tick() {
+    if (this.isVisible) {
+      // Check if any tiles have been updated
+      const recentlyUpdatedTiles = this.game.recentlyUpdatedTiles();
+      if (recentlyUpdatedTiles.length > 0) {
+        this.updateMask();
+
+        // Check if the highlighted needs to be updated
+        if (this.highlightedTerritory) {
+          const hasTerritoryUpdates = recentlyUpdatedTiles.some(
+            (tile) =>
+              this.game.hasOwner(tile) &&
+              this.game.owner(tile)?.id() === this.highlightedTerritory?.id(),
+          );
+
+          const hasIncomingAttacks =
+            this.highlightedTerritory.incomingAttacks().length > 0;
+
+          if (hasTerritoryUpdates || hasIncomingAttacks) {
+            this.updateHighlightedTerritory();
+          }
+        }
+      }
+    }
+  }
+}

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -368,4 +368,8 @@ export class TerritoryLayer implements Layer {
     const y = this.game.y(tile);
     this.highlightContext.clearRect(x, y, 1, 1);
   }
+
+  getCanvas(): HTMLCanvasElement | null {
+    return this.canvas || null;
+  }
 }


### PR DESCRIPTION
## Description:

This pull request introduces a new experimental info layer that appears when the player holds **Ctrl**. Its main purpose is to help players:

- Identify other players' territories  
- Hide player names for a clearer view of the builds 
- Highlight territories on mouseover

This layer is a UX/UI experiment and could eventually be merged with the existing **UnitLayer** (shown when the **spacebar** is pressed).  
In the meantime, I encourage you to test it and share your feedback.

### Ideas to explore next:
- Different mask colors for enemies vs. allies  
- Displaying player stats  
- …

> _Note: This PR was created during a partial "vibe coding" session._ 

Related Issues:
* https://github.com/openfrontio/OpenFrontIO/issues/900
* https://github.com/openfrontio/OpenFrontIO/issues/484 

![OpenFront (ALPHA)](https://github.com/user-attachments/assets/1d37ec95-f2fa-4864-be11-34ae5c6da8b0)
![image](https://github.com/user-attachments/assets/9593e45a-1af3-4542-8c4b-4ea48ac6b7bd)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

devalnor