### PR TITLE
Remove maxTokenAge

### DIFF
--- a/src/server/jwt.ts
+++ b/src/server/jwt.ts
@@ -31,7 +31,6 @@ export async function verifyClientToken(
       algorithms: ["EdDSA"],
       issuer,
       audience,
-      maxTokenAge: "6 days",
     });
     const result = TokenPayloadSchema.safeParse(payload);
     if (!result.success) {


### PR DESCRIPTION
## Description:

Remove the `maxTokenAge` argument, as this prevents players from using valid tokens on the final day of the 7-day session. The `jwtVerify` function already verifies that the `exp` claim is in the future and the `iat` claim is in the past, so there is no concern about using expired tokens.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors