### PR TITLE
w-320

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -274,7 +274,7 @@
     </div>
 
     <div
-      class="bottom-0 w-full flex-col-reverse sm:flex-row z-50"
+      class="bottom-0 w-full flex-col-reverse sm:flex-row z-50 md:w-[320px]"
       style="position: fixed; pointer-events: none"
     >
       <div


### PR DESCRIPTION
## Description:

Fixes #1315

> When right clicking in the bottom part of the page, it will shows the regular Chrome right click instead of the Openfront menu.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:
PilkeySEK