### PR TITLE
Fix role lookup

### DIFF
--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -24,7 +24,7 @@ interface StripeProduct {
 export interface Pattern {
   name: string;
   key: string;
-  roleGroup?: string;
+  roles: string[];
   price?: string;
   priceId?: string;
   lockedReason?: string;
@@ -39,7 +39,9 @@ export async function patterns(
       return {
         name: patternData.name,
         key,
-        roleGroup: patternData.role_group,
+        roles: patternData.role_group
+          ? (COSMETICS.role_groups[patternData.role_group] ?? [])
+          : [],
       };
     },
   );
@@ -75,8 +77,10 @@ function addRestrictions(
     return;
   }
 
-  const roles = userMe.player.roles ?? [];
-  if (roles.some((role) => role === pattern.roleGroup)) {
+  const myRoles = userMe.player.roles ?? [];
+  if (
+    pattern.roles.some((authorizedRole) => myRoles.includes(authorizedRole))
+  ) {
     // Pattern is unlocked by role
     return;
   }


### PR DESCRIPTION
## Description:

adb0d070740c3a5fd177e74d6b962bf7c6408db3 created a role lookup regression. It was comparing role name, not role id.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
