### PR TITLE
Enhance <o-modal> component with layout control options

### DIFF
--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -71,7 +71,7 @@ export class OModal extends LitElement {
       backdrop-filter: blur(8px);
     }
 
-    .c-modal__content__special {
+    .c-modal > .content.special {
       position: relative;
       color: #fff;
       padding: 1.4rem;

--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -108,7 +108,7 @@ export class OModal extends LitElement {
                   <div class="c-modal__close" @click=${this.close}>X</div>
                 </header>
                 <section
-                  class="c-modal__content${this.special ? "__special" : ""}"
+                  class="content${this.special ? " special" : ""}"
                   style=${`${this.disableScroll ? "overflow: hidden;" : ""}`}
                 >
                   <slot></slot>

--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -98,7 +98,7 @@ export class OModal extends LitElement {
         ? html`
             <aside class="c-modal">
               <div
-                class="c-modal__wrapper${this.special ? "__special" : ""}"
+                class="wrapper${this.special ? " special" : ""}"
                 style=${`height: ${this.heightRatio ? this.heightRatio * 100 + "vh" : "auto"};`}
               >
                 <header class="c-modal__header">

--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -7,6 +7,9 @@ export class OModal extends LitElement {
   @state() public isModalOpen = false;
   @property({ type: String }) title = "";
   @property({ type: String }) translationKey = "";
+  @property({ type: Number }) heightRatio?: number;
+  @property({ type: Boolean }) disableScroll = false;
+  @property({ type: Boolean }) special = false;
 
   static styles = css`
     .c-modal {
@@ -29,6 +32,16 @@ export class OModal extends LitElement {
       border-radius: 8px;
       min-width: 340px;
       max-width: 860px;
+    }
+
+    .c-modal__wrapper__special {
+      background: #23232382;
+      border-radius: 8px;
+      min-width: 340px;
+      max-width: 1000px;
+      display: flex;
+      flex-direction: column;
+      height: 100%;
     }
 
     .c-modal__header {
@@ -57,6 +70,16 @@ export class OModal extends LitElement {
       overflow-y: auto;
       backdrop-filter: blur(8px);
     }
+
+    .c-modal__content__special {
+      position: relative;
+      color: #fff;
+      padding: 1.4rem;
+      flex-grow: 1;
+      max-height: 100%;
+      overflow-y: auto;
+      backdrop-filter: blur(8px);
+    }
   `;
   public open() {
     this.isModalOpen = true;
@@ -74,14 +97,20 @@ export class OModal extends LitElement {
       ${this.isModalOpen
         ? html`
             <aside class="c-modal">
-              <div class="c-modal__wrapper">
+              <div
+                class="c-modal__wrapper${this.special ? "__special" : ""}"
+                style=${`height: ${this.heightRatio ? this.heightRatio * 100 + "vh" : "auto"};`}
+              >
                 <header class="c-modal__header">
                   ${`${this.translationKey}` === ""
                     ? `${this.title}`
                     : `${translateText(this.translationKey)}`}
                   <div class="c-modal__close" @click=${this.close}>X</div>
                 </header>
-                <section class="c-modal__content">
+                <section
+                  class="c-modal__content${this.special ? "__special" : ""}"
+                  style=${`${this.disableScroll ? "overflow: hidden;" : ""}`}
+                >
                   <slot></slot>
                 </section>
               </div>

--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -34,7 +34,7 @@ export class OModal extends LitElement {
       max-width: 860px;
     }
 
-    .c-modal__wrapper__special {
+    .c-modal > .wrapper.special {
       background: #23232382;
       border-radius: 8px;
       min-width: 340px;


### PR DESCRIPTION
## Description:
This change does not affect any existing functionality, but it increases the flexibility of the <o-modal> component.

- heightRatio?: number
Allows specifying a custom modal height based on viewport height (e.g., heightRatio=0.75 → 75% of vh).
- disableScroll: boolean (default: false)
Disables vertical scrolling inside the modal content area when enabled.
- special: boolean (default: false)
Switches the modal to an alternative layout:
> - Increases max width (860px → 1000px)
> - Enables full-height (height: 100%)
> - Uses vertical flex layout for more complex modal UIs (e.g., editors)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri
