### PR TITLE
Radial menu: remove player info sub-radial

### DIFF
--- a/src/client/graphics/layers/RadialMenuElements.ts
+++ b/src/client/graphics/layers/RadialMenuElements.ts
@@ -293,35 +293,8 @@ export const infoMenuElement: MenuElement = {
     !params.selected || params.game.inSpawnPhase(),
   icon: infoIcon,
   color: COLORS.info,
-
-  subMenu: (params: MenuElementParams) => {
-    if (!params.selected || params.game.inSpawnPhase()) return [];
-
-    if (params.selected === params.myPlayer) {
-      return [infoPlayerElement, infoEmojiElement];
-    }
-
-    const elements: MenuElement[] = [
-      infoPlayerElement,
-      infoEmojiElement,
-      infoChatElement,
-    ];
-    if (params.myPlayer.isAlliedWith(params.selected)) {
-      elements.push(
-        allyBreakElement,
-        allyDonateGoldElement,
-        allyDonateTroopsElement,
-      );
-    } else {
-      elements.push(allyTargetElement, allyRequestElement);
-    }
-    if (params.myPlayer.hasEmbargoAgainst(params.selected)) {
-      elements.push(allyTradeElement);
-    } else {
-      elements.push(allyEmbargoElement);
-    }
-
-    return elements;
+  action: (params: MenuElementParams) => {
+    params.playerPanel.show(params.playerActions, params.tile);
   },
 };
 


### PR DESCRIPTION
## Description:

To reduce the amount of UI change, have the "i" button bring up player panel instead of submenu.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
