### PR TITLE
bugfix: Crash during replay

### DIFF
--- a/src/client/graphics/layers/ChatDisplay.ts
+++ b/src/client/graphics/layers/ChatDisplay.ts
@@ -80,7 +80,7 @@ export class ChatDisplay extends LitElement implements Layer {
   tick() {
     // this.active = true;
     const updates = this.game.updatesSinceLastTick();
-    if (updates === null) throw new Error("null updates");
+    if (updates === null) return;
     const messages = updates[GameUpdateType.DisplayEvent] as
       | DisplayMessageUpdate[]
       | undefined;


### PR DESCRIPTION
## Description:

During local development, joining a game immediately after it ends to watch a replay results a crash.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors