### PR TITLE
Hide disabled unit types in PlayerInfoOverlay according to game config

### DIFF
--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -250,66 +250,86 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
           ${translateText("player_info_overlay.gold")}:
           ${renderNumber(player.gold())}
         </div>
-        <div class="text-sm opacity-80" translate="no">
-          ${translateText("player_info_overlay.ports")}:
-          ${player.units(UnitType.Port).length}
-          ${player
-            .units(UnitType.Port)
-            .map((unit) => unit.level())
-            .reduce((a, b) => a + b, 0) > 1
-            ? html`(${translateText("player_info_overlay.levels")}:
-              ${player
-                .units(UnitType.Port)
-                .map((unit) => unit.level())
-                .reduce((a, b) => a + b, 0)})`
-            : ""}
-        </div>
-        <div class="text-sm opacity-80" translate="no">
-          ${translateText("player_info_overlay.cities")}:
-          ${player.units(UnitType.City).length}
-          ${player
-            .units(UnitType.City)
-            .map((unit) => unit.level())
-            .reduce((a, b) => a + b, 0) > 1
-            ? html`(${translateText("player_info_overlay.levels")}:
-              ${player
-                .units(UnitType.City)
-                .map((unit) => unit.level())
-                .reduce((a, b) => a + b, 0)})`
-            : ""}
-        </div>
-        <div class="text-sm opacity-80" translate="no">
-          ${translateText("player_info_overlay.missile_launchers")}:
-          ${player.units(UnitType.MissileSilo).length}
-          ${player
-            .units(UnitType.MissileSilo)
-            .map((unit) => unit.level())
-            .reduce((a, b) => a + b, 0) > 1
-            ? html`(${translateText("player_info_overlay.levels")}:
-              ${player
-                .units(UnitType.MissileSilo)
-                .map((unit) => unit.level())
-                .reduce((a, b) => a + b, 0)})`
-            : ""}
-        </div>
-        <div class="text-sm opacity-80" translate="no">
-          ${translateText("player_info_overlay.sams")}:
-          ${player.units(UnitType.SAMLauncher).length}
-          ${player
-            .units(UnitType.SAMLauncher)
-            .map((unit) => unit.level())
-            .reduce((a, b) => a + b, 0) > 1
-            ? html`(${translateText("player_info_overlay.levels")}:
-              ${player
-                .units(UnitType.SAMLauncher)
-                .map((unit) => unit.level())
-                .reduce((a, b) => a + b, 0)})`
-            : ""}
-        </div>
-        <div class="text-sm opacity-80" translate="no">
-          ${translateText("player_info_overlay.warships")}:
-          ${player.units(UnitType.Warship).length}
-        </div>
+        ${!this.game.config().isUnitDisabled(UnitType.Port)
+          ? html`
+              <div class="text-sm opacity-80" translate="no">
+                ${translateText("player_info_overlay.ports")}:
+                ${player.units(UnitType.Port).length}
+                ${player
+                  .units(UnitType.Port)
+                  .map((unit) => unit.level())
+                  .reduce((a, b) => a + b, 0) > 1
+                  ? html`(${translateText("player_info_overlay.levels")}:
+                    ${player
+                      .units(UnitType.Port)
+                      .map((unit) => unit.level())
+                      .reduce((a, b) => a + b, 0)})`
+                  : ""}
+              </div>
+            `
+          : ""}
+        ${!this.game.config().isUnitDisabled(UnitType.City)
+          ? html`
+              <div class="text-sm opacity-80" translate="no">
+                ${translateText("player_info_overlay.cities")}:
+                ${player.units(UnitType.City).length}
+                ${player
+                  .units(UnitType.City)
+                  .map((unit) => unit.level())
+                  .reduce((a, b) => a + b, 0) > 1
+                  ? html`(${translateText("player_info_overlay.levels")}:
+                    ${player
+                      .units(UnitType.City)
+                      .map((unit) => unit.level())
+                      .reduce((a, b) => a + b, 0)})`
+                  : ""}
+              </div>
+            `
+          : ""}
+        ${!this.game.config().isUnitDisabled(UnitType.MissileSilo)
+          ? html`
+              <div class="text-sm opacity-80" translate="no">
+                ${translateText("player_info_overlay.missile_launchers")}:
+                ${player.units(UnitType.MissileSilo).length}
+                ${player
+                  .units(UnitType.MissileSilo)
+                  .map((unit) => unit.level())
+                  .reduce((a, b) => a + b, 0) > 1
+                  ? html`(${translateText("player_info_overlay.levels")}:
+                    ${player
+                      .units(UnitType.MissileSilo)
+                      .map((unit) => unit.level())
+                      .reduce((a, b) => a + b, 0)})`
+                  : ""}
+              </div>
+            `
+          : ""}
+        ${!this.game.config().isUnitDisabled(UnitType.SAMLauncher)
+          ? html`
+              <div class="text-sm opacity-80" translate="no">
+                ${translateText("player_info_overlay.sams")}:
+                ${player.units(UnitType.SAMLauncher).length}
+                ${player
+                  .units(UnitType.SAMLauncher)
+                  .map((unit) => unit.level())
+                  .reduce((a, b) => a + b, 0) > 1
+                  ? html`(${translateText("player_info_overlay.levels")}:
+                    ${player
+                      .units(UnitType.SAMLauncher)
+                      .map((unit) => unit.level())
+                      .reduce((a, b) => a + b, 0)})`
+                  : ""}
+              </div>
+            `
+          : ""}
+        ${!this.game.config().isUnitDisabled(UnitType.Warship)
+          ? html`
+              <div class="text-sm opacity-80" translate="no">
+                ${translateText("player_info_overlay.warships")}:
+                ${player.units(UnitType.Warship).length}
+              </div>
+            `
+          : ""}
         ${relationHtml}
       </div>
     `;

--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -65,11 +65,29 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
 
   private lastMouseUpdate = 0;
 
+  private isPortDisabled = false;
+  private isCityDisabled = false;
+  private isMissileSiloDisabled = false;
+  private isSAMLauncherDisabled = false;
+  private isWarshipDisabled = false;
+
   init() {
     this.eventBus.on(MouseMoveEvent, (e: MouseMoveEvent) =>
       this.onMouseEvent(e),
     );
     this._isActive = true;
+
+    this.isPortDisabled = this.game.config().isUnitDisabled(UnitType.Port);
+    this.isCityDisabled = this.game.config().isUnitDisabled(UnitType.City);
+    this.isMissileSiloDisabled = this.game
+      .config()
+      .isUnitDisabled(UnitType.MissileSilo);
+    this.isSAMLauncherDisabled = this.game
+      .config()
+      .isUnitDisabled(UnitType.SAMLauncher);
+    this.isWarshipDisabled = this.game
+      .config()
+      .isUnitDisabled(UnitType.Warship);
   }
 
   private onMouseEvent(event: MouseMoveEvent) {
@@ -250,7 +268,7 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
           ${translateText("player_info_overlay.gold")}:
           ${renderNumber(player.gold())}
         </div>
-        ${!this.game.config().isUnitDisabled(UnitType.Port)
+        ${!this.isPortDisabled
           ? html`
               <div class="text-sm opacity-80" translate="no">
                 ${translateText("player_info_overlay.ports")}:
@@ -268,7 +286,7 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
               </div>
             `
           : ""}
-        ${!this.game.config().isUnitDisabled(UnitType.City)
+        ${!this.isCityDisabled
           ? html`
               <div class="text-sm opacity-80" translate="no">
                 ${translateText("player_info_overlay.cities")}:
@@ -286,7 +304,7 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
               </div>
             `
           : ""}
-        ${!this.game.config().isUnitDisabled(UnitType.MissileSilo)
+        ${!this.isMissileSiloDisabled
           ? html`
               <div class="text-sm opacity-80" translate="no">
                 ${translateText("player_info_overlay.missile_launchers")}:
@@ -304,7 +322,7 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
               </div>
             `
           : ""}
-        ${!this.game.config().isUnitDisabled(UnitType.SAMLauncher)
+        ${!this.isSAMLauncherDisabled
           ? html`
               <div class="text-sm opacity-80" translate="no">
                 ${translateText("player_info_overlay.sams")}:
@@ -322,7 +340,7 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
               </div>
             `
           : ""}
-        ${!this.game.config().isUnitDisabled(UnitType.Warship)
+        ${!this.isWarshipDisabled
           ? html`
               <div class="text-sm opacity-80" translate="no">
                 ${translateText("player_info_overlay.warships")}:


### PR DESCRIPTION
## Description:
This PR updates the PlayerInfoOverlay to hide any unit types that are disabled via game config (`isUnitDisabled`). The overlay now only displays enabled unit types, similar to the behavior in `unit-display`.
<img width="1104" alt="スクリーンショット 2025-07-10 12 40 43" src="https://github.com/user-attachments/assets/0dce5a29-6d93-45b7-9008-f27c491c46fa" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
