### PR TITLE
Hide UnitDisplay frame when all unit types are disabled

### DIFF
--- a/src/client/graphics/layers/UnitDisplay.ts
+++ b/src/client/graphics/layers/UnitDisplay.ts
@@ -89,6 +89,19 @@ export class UnitDisplay extends LitElement implements Layer {
       return null;
     }
 
+    const config = this.game.config();
+    const allDisabled =
+      config.isUnitDisabled(UnitType.City) &&
+      config.isUnitDisabled(UnitType.Factory) &&
+      config.isUnitDisabled(UnitType.Port) &&
+      config.isUnitDisabled(UnitType.DefensePost) &&
+      config.isUnitDisabled(UnitType.MissileSilo) &&
+      config.isUnitDisabled(UnitType.SAMLauncher);
+
+    if (allDisabled) {
+      return null;
+    }
+
     return html`
       <div
         class="fixed bottom-4 left-1/2 transform -translate-x-1/2 z-[1100] bg-gray-800/70 backdrop-blur-sm border border-slate-400 rounded-lg p-2 hidden lg:block"


### PR DESCRIPTION
## Description:

This PR updates the UnitDisplay component so that when all unit types (City, Factory, Port, Defense Post, Missile Silo, SAM Launcher) are disabled in the game config, the UI frame itself will also be hidden.

before
<img width="1049" alt="スクリーンショット 2025-07-10 12 49 37" src="https://github.com/user-attachments/assets/b0cf12ba-0c20-4b21-bf9f-cb17fec6817b" />
<img width="44" alt="スクリーンショット 2025-07-10 12 49 47" src="https://github.com/user-attachments/assets/61e1960b-56d4-4dc8-80e7-27e49cb2d0e3" />

after
<img width="967" alt="スクリーンショット 2025-07-10 12 48 08" src="https://github.com/user-attachments/assets/dfc90243-e4d6-4663-bff5-5be34453e80b" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
