### PR TITLE
Improve unit updates & reloading

### DIFF
--- a/src/core/execution/MissileSiloExecution.ts
+++ b/src/core/execution/MissileSiloExecution.ts
@@ -34,16 +34,14 @@ export class MissileSiloExecution implements Execution {
       }
     }
 
-    const frontTime = this.silo.ticksLeftInCooldown();
+    // frontTime is the time the earliest missile fired.
+    const frontTime = this.silo.missileTimerQueue()[0];
     if (frontTime === undefined) {
       return;
     }
 
     const cooldown =
       this.mg.config().SiloCooldown() - (this.mg.ticks() - frontTime);
-    if (typeof cooldown === "number" && cooldown >= 0) {
-      this.silo.touch();
-    }
 
     if (cooldown <= 0) {
       this.silo.reloadMissile();

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -190,16 +190,13 @@ export class SAMLauncherExecution implements Execution {
       }
     }
 
-    const frontTime = this.sam.ticksLeftInCooldown();
+    const frontTime = this.sam.missileTimerQueue()[0];
     if (frontTime === undefined) {
       return;
     }
 
     const cooldown =
       this.mg.config().SAMCooldown() - (this.mg.ticks() - frontTime);
-    if (typeof cooldown === "number" && cooldown >= 0) {
-      this.sam.touch();
-    }
 
     if (cooldown <= 0) {
       this.sam.reloadMissile();

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -438,7 +438,7 @@ export interface Unit {
   launch(): void;
   reloadMissile(): void;
   isInCooldown(): boolean;
-  ticksLeftInCooldown(): Tick | undefined;
+  missileTimerQueue(): number[];
 
   // Trade Ships
   setSafeFromPirates(): void; // Only for trade ships

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -116,7 +116,6 @@ export interface UnitUpdate {
   health?: number;
   constructionType?: UnitType;
   missileTimerQueue: number[];
-  readyMissileCount: number;
   level: number;
   hasTrainStation: boolean;
   trainType?: TrainType; // Only for trains

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -27,8 +27,8 @@ export class UnitImpl implements Unit {
   private _constructionType: UnitType | undefined;
   private _lastOwner: PlayerImpl | null = null;
   private _troops: number;
+  // Number of missiles in cooldown, if empty all missiles are ready.
   private _missileTimerQueue: number[] = [];
-  private _readyMissileCount: number = 1;
   private _hasTrainStation: boolean = false;
   private _patrolTile: TileRef | undefined;
   private _level: number = 1;
@@ -128,7 +128,6 @@ export class UnitImpl implements Unit {
       targetUnitId: this._targetUnit?.id() ?? undefined,
       targetTile: this.targetTile() ?? undefined,
       missileTimerQueue: this._missileTimerQueue,
-      readyMissileCount: this._readyMissileCount,
       level: this.level(),
       hasTrainStation: this._hasTrainStation,
       trainType: this._trainType,
@@ -297,7 +296,6 @@ export class UnitImpl implements Unit {
 
   launch(): void {
     this._missileTimerQueue.push(this.mg.ticks());
-    this._readyMissileCount--;
     this.mg.addUpdate(this.toUpdate());
   }
 
@@ -306,12 +304,15 @@ export class UnitImpl implements Unit {
   }
 
   isInCooldown(): boolean {
-    return this._readyMissileCount === 0;
+    return this._missileTimerQueue.length === this._level;
+  }
+
+  missileTimerQueue(): number[] {
+    return this._missileTimerQueue;
   }
 
   reloadMissile(): void {
     this._missileTimerQueue.shift();
-    this._readyMissileCount++;
     this.mg.addUpdate(this.toUpdate());
   }
 
@@ -374,7 +375,7 @@ export class UnitImpl implements Unit {
   increaseLevel(): void {
     this._level++;
     if ([UnitType.MissileSilo, UnitType.SAMLauncher].includes(this.type())) {
-      this._readyMissileCount++;
+      this._missileTimerQueue.push(this.mg.ticks());
     }
     this.mg.addUpdate(this.toUpdate());
   }

--- a/tests/client/graphics/UILayer.test.ts
+++ b/tests/client/graphics/UILayer.test.ts
@@ -65,6 +65,7 @@ describe("UILayer", () => {
       tile: () => ({}),
       owner: () => ({}),
       isActive: () => true,
+      createdAt: () => 1,
     } as unknown as UnitView;
     ui.drawHealthBar(unit);
     expect(ui["allHealthBars"].has(1)).toBe(true);
@@ -111,7 +112,7 @@ describe("UILayer", () => {
       tile: () => ({}),
       isActive: () => true,
     } as unknown as UnitView;
-    ui.drawLoadingBar(unit, 5);
+    ui.createLoadingBar(unit);
     expect(ui["allProgressBars"].has(2)).toBe(true);
   });
 
@@ -145,6 +146,7 @@ describe("UILayer", () => {
       owner: () => ({ id: () => 1 }),
       tile: () => ({}),
       isActive: () => true,
+      createdAt: () => 1,
     } as unknown as UnitView;
     ui.onUnitEvent(unit);
     expect(ui["allProgressBars"].has(2)).toBe(true);


### PR DESCRIPTION
## Description:

Previously upgrading a unit would have it reload immediately, eg upgrading missile silo 1=>2 gives it 2 missiles immediately. With this change it must reload the missile. Same with SAMs. This prevents users from spamming upgrades as missiles are coming in.

Fix the progress reloading bar. Previously it only showed the SAM/silo as reloading when it was completely out of missiles. Now it shows roughly how many missiles are available (eg level 5 fires 3 missiles, now progress bar is at 40%). It also shows progress of missiles reloading. If no missiles are available, progress bar is empty

There was a bug where if a silo of SAM was in cooldown it would be updated each tick, causing the sprite/icon to be rerendered each tick.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
