### PR TITLE
Internationalization: Add i18n support for login/auth messages in main

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -572,5 +572,11 @@
       "grogu_head": "Grogu Head",
       "grogu": "Grogu"
     }
+  },
+  "auth": {
+    "login_required": "Login is required to access this website.",
+    "redirecting": "You are being redirected...",
+    "not_authorized": "You are not authorized to access this website.",
+    "contact_admin": "If you believe you are seeing this message in error, please contact the website administrator."
   }
 }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -27,7 +27,11 @@ import { TerritoryPatternsModal } from "./TerritoryPatternsModal";
 import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
 import { UsernameInput } from "./UsernameInput";
-import { generateCryptoRandomUUID, incrementGamesPlayed } from "./Utils";
+import {
+  generateCryptoRandomUUID,
+  incrementGamesPlayed,
+  translateText,
+} from "./Utils";
 import "./components/NewsButton";
 import { NewsButton } from "./components/NewsButton";
 import "./components/baseComponents/Button";
@@ -229,8 +233,8 @@ class Client {
                 text-align: center;
                 box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
               ">
-                <p style="margin-bottom: 1em;">Login is required to access this website.</p>
-                <p style="margin-bottom: 1.5em;">You are being redirected...</p>
+                <p style="margin-bottom: 1em;">${translateText("auth.login_required")}</p>
+                <p style="margin-bottom: 1.5em;">${translateText("auth.redirecting")}</p>
                 <div style="width: 100%; height: 8px; background-color: #444; border-radius: 4px; overflow: hidden;">
                   <div style="
                     height: 100%;
@@ -272,8 +276,8 @@ class Client {
                 text-align: center;
                 box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5);
               ">
-                <p style="margin-bottom: 1em;">You are not authorized to access this website.</p>
-                <p>If you believe you are seeing this message in error, please contact the website administrator.</p>
+                <p style="margin-bottom: 1em;">${translateText("auth.not_authorized")}</p>
+                <p>${translateText("auth.contact_admin")}</p>
               </div>
             </div>
             <div class="bg-image"></div>


### PR DESCRIPTION
## Description:
Internationalized all authentication-related messages shown before login or when unauthorized (e.g. "Login is required to access this website.") using the `translateText` function.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
