### PR TITLE
fix: `num_land_tiles` in map manifest.json files + helper script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "start:client": "webpack serve --open --node-env development",
     "start:server": "node --loader ts-node/esm --experimental-specifier-resolution=node src/server/Server.ts",
     "start:server-dev": "cross-env GAME_ENV=dev node --loader ts-node/esm --experimental-specifier-resolution=node src/server/Server.ts",
+    "gen:mapdata": "node --loader ts-node/esm --experimental-specifier-resolution=node scripts/MapMetadata.ts",
     "dev": "cross-env GAME_ENV=dev concurrently \"npm run start:client\" \"npm run start:server-dev\"",
     "tunnel": "npm run build-prod && npm run start:server",
     "test": "jest",

--- a/resources/maps/africa/manifest.json
+++ b/resources/maps/africa/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 2032,
-    "num_land_tiles": 2266710,
+    "num_land_tiles": 2184135,
     "width": 1950
   },
   "mini_map": {
     "height": 1016,
-    "num_land_tiles": 559837,
+    "num_land_tiles": 538153,
     "width": 975
   },
   "name": "Africa",

--- a/resources/maps/asia/manifest.json
+++ b/resources/maps/asia/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1200,
-    "num_land_tiles": 1124099,
+    "num_land_tiles": 1079855,
     "width": 2000
   },
   "mini_map": {
     "height": 600,
-    "num_land_tiles": 277784,
+    "num_land_tiles": 266262,
     "width": 1000
   },
   "name": "Asia",

--- a/resources/maps/australia/manifest.json
+++ b/resources/maps/australia/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1500,
-    "num_land_tiles": 1338638,
+    "num_land_tiles": 1319763,
     "width": 2000
   },
   "mini_map": {
     "height": 750,
-    "num_land_tiles": 333175,
+    "num_land_tiles": 328215,
     "width": 1000
   },
   "name": "Australia",

--- a/resources/maps/baikal/manifest.json
+++ b/resources/maps/baikal/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1564,
-    "num_land_tiles": 2234157,
+    "num_land_tiles": 2181746,
     "width": 2500
   },
   "mini_map": {
     "height": 782,
-    "num_land_tiles": 554725,
+    "num_land_tiles": 540863,
     "width": 1250
   },
   "name": "Baikal",

--- a/resources/maps/betweentwoseas/manifest.json
+++ b/resources/maps/betweentwoseas/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1062,
-    "num_land_tiles": 1541211,
+    "num_land_tiles": 1483208,
     "width": 1778
   },
   "mini_map": {
     "height": 531,
-    "num_land_tiles": 380567,
+    "num_land_tiles": 365411,
     "width": 889
   },
   "name": "BetweenTwoSeas",

--- a/resources/maps/blacksea/manifest.json
+++ b/resources/maps/blacksea/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1100,
-    "num_land_tiles": 1201650,
+    "num_land_tiles": 1153632,
     "width": 1500
   },
   "mini_map": {
     "height": 550,
-    "num_land_tiles": 296740,
+    "num_land_tiles": 284219,
     "width": 750
   },
   "name": "BlackSea",

--- a/resources/maps/britannia/manifest.json
+++ b/resources/maps/britannia/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1396,
-    "num_land_tiles": 980143,
+    "num_land_tiles": 938800,
     "width": 2000
   },
   "mini_map": {
     "height": 698,
-    "num_land_tiles": 241934,
+    "num_land_tiles": 231151,
     "width": 1000
   },
   "name": "Britannia",

--- a/resources/maps/deglaciatedantarctica/manifest.json
+++ b/resources/maps/deglaciatedantarctica/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1840,
-    "num_land_tiles": 1171253,
+    "num_land_tiles": 1079790,
     "width": 2300
   },
   "mini_map": {
     "height": 920,
-    "num_land_tiles": 287132,
+    "num_land_tiles": 262417,
     "width": 1150
   },
   "name": "Deglaciated Antarctica",

--- a/resources/maps/eastasia/manifest.json
+++ b/resources/maps/eastasia/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1646,
-    "num_land_tiles": 928056,
+    "num_land_tiles": 879264,
     "width": 1562
   },
   "mini_map": {
     "height": 823,
-    "num_land_tiles": 228603,
+    "num_land_tiles": 215238,
     "width": 781
   },
   "name": "East Asia",

--- a/resources/maps/europe/manifest.json
+++ b/resources/maps/europe/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1674,
-    "num_land_tiles": 2501136,
+    "num_land_tiles": 2318609,
     "width": 2350
   },
   "mini_map": {
     "height": 837,
-    "num_land_tiles": 610071,
+    "num_land_tiles": 563296,
     "width": 1175
   },
   "name": "Europe",

--- a/resources/maps/europeclassic/manifest.json
+++ b/resources/maps/europeclassic/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1000,
-    "num_land_tiles": 1046542,
+    "num_land_tiles": 1008469,
     "width": 2000
   },
   "mini_map": {
     "height": 500,
-    "num_land_tiles": 258385,
+    "num_land_tiles": 248793,
     "width": 1000
   },
   "name": "Europe",

--- a/resources/maps/falklandislands/manifest.json
+++ b/resources/maps/falklandislands/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1400,
-    "num_land_tiles": 929295,
+    "num_land_tiles": 859274,
     "width": 2100
   },
   "mini_map": {
     "height": 700,
-    "num_land_tiles": 226784,
+    "num_land_tiles": 208351,
     "width": 1050
   },
   "name": "Falkland Islands",

--- a/resources/maps/faroeislands/manifest.json
+++ b/resources/maps/faroeislands/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 2000,
-    "num_land_tiles": 458869,
+    "num_land_tiles": 424994,
     "width": 1600
   },
   "mini_map": {
     "height": 1000,
-    "num_land_tiles": 111960,
+    "num_land_tiles": 103147,
     "width": 800
   },
   "name": "Faroe Islands",

--- a/resources/maps/gatewaytotheatlantic/manifest.json
+++ b/resources/maps/gatewaytotheatlantic/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1968,
-    "num_land_tiles": 2291474,
+    "num_land_tiles": 2239818,
     "width": 2216
   },
   "mini_map": {
     "height": 984,
-    "num_land_tiles": 568298,
+    "num_land_tiles": 555003,
     "width": 1108
   },
   "name": "GatewayToTheAtlantic",

--- a/resources/maps/giantworldmap/manifest.json
+++ b/resources/maps/giantworldmap/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1948,
-    "num_land_tiles": 2544294,
+    "num_land_tiles": 2333974,
     "width": 4110
   },
   "mini_map": {
     "height": 974,
-    "num_land_tiles": 618860,
+    "num_land_tiles": 564737,
     "width": 2055
   },
   "name": "Giant_World_Map",

--- a/resources/maps/halkidiki/manifest.json
+++ b/resources/maps/halkidiki/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1760,
-    "num_land_tiles": 1777270,
+    "num_land_tiles": 1729369,
     "width": 2200
   },
   "mini_map": {
     "height": 880,
-    "num_land_tiles": 441119,
+    "num_land_tiles": 428074,
     "width": 1100
   },
   "name": "Halkidiki",

--- a/resources/maps/iceland/manifest.json
+++ b/resources/maps/iceland/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1500,
-    "num_land_tiles": 1123359,
+    "num_land_tiles": 1098655,
     "width": 2000
   },
   "mini_map": {
     "height": 750,
-    "num_land_tiles": 279119,
+    "num_land_tiles": 272699,
     "width": 1000
   },
   "name": "Iceland",

--- a/resources/maps/italia/manifest.json
+++ b/resources/maps/italia/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1272,
-    "num_land_tiles": 806817,
+    "num_land_tiles": 780495,
     "width": 1360
   },
   "mini_map": {
     "height": 636,
-    "num_land_tiles": 199974,
+    "num_land_tiles": 192915,
     "width": 680
   },
   "name": "Italia",

--- a/resources/maps/mars/manifest.json
+++ b/resources/maps/mars/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1000,
-    "num_land_tiles": 1384168,
+    "num_land_tiles": 1354047,
     "width": 2000
   },
   "mini_map": {
     "height": 500,
-    "num_land_tiles": 343861,
+    "num_land_tiles": 335950,
     "width": 1000
   },
   "name": "Mars",

--- a/resources/maps/mena/manifest.json
+++ b/resources/maps/mena/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 964,
-    "num_land_tiles": 1672209,
+    "num_land_tiles": 1621317,
     "width": 2200
   },
   "mini_map": {
     "height": 482,
-    "num_land_tiles": 413783,
+    "num_land_tiles": 400552,
     "width": 1100
   },
   "name": "MENA",

--- a/resources/maps/northamerica/manifest.json
+++ b/resources/maps/northamerica/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1448,
-    "num_land_tiles": 1412703,
+    "num_land_tiles": 1243623,
     "width": 2800
   },
   "mini_map": {
     "height": 724,
-    "num_land_tiles": 339357,
+    "num_land_tiles": 295689,
     "width": 1400
   },
   "name": "NorthAmerica",

--- a/resources/maps/oceania/manifest.json
+++ b/resources/maps/oceania/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1000,
-    "num_land_tiles": 216012,
+    "num_land_tiles": 194648,
     "width": 2000
   },
   "mini_map": {
     "height": 500,
-    "num_land_tiles": 52422,
+    "num_land_tiles": 46767,
     "width": 1000
   },
   "name": "Oceania",

--- a/resources/maps/pangaea/manifest.json
+++ b/resources/maps/pangaea/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1000,
-    "num_land_tiles": 450234,
+    "num_land_tiles": 420336,
     "width": 1000
   },
   "mini_map": {
     "height": 500,
-    "num_land_tiles": 110270,
+    "num_land_tiles": 102357,
     "width": 500
   },
   "name": "Pangaea",

--- a/resources/maps/southamerica/manifest.json
+++ b/resources/maps/southamerica/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 2378,
-    "num_land_tiles": 1513764,
+    "num_land_tiles": 1411064,
     "width": 1746
   },
   "mini_map": {
     "height": 1189,
-    "num_land_tiles": 369899,
+    "num_land_tiles": 342861,
     "width": 873
   },
   "name": "Americas",

--- a/resources/maps/straitofgibraltar/manifest.json
+++ b/resources/maps/straitofgibraltar/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1476,
-    "num_land_tiles": 2015157,
+    "num_land_tiles": 1998085,
     "width": 2902
   },
   "mini_map": {
     "height": 738,
-    "num_land_tiles": 502404,
+    "num_land_tiles": 498123,
     "width": 1451
   },
   "name": "Strait of Gibraltar",

--- a/resources/maps/world/manifest.json
+++ b/resources/maps/world/manifest.json
@@ -1,12 +1,12 @@
 {
   "map": {
     "height": 1000,
-    "num_land_tiles": 702094,
+    "num_land_tiles": 651609,
     "width": 2000
   },
   "mini_map": {
     "height": 500,
-    "num_land_tiles": 171447,
+    "num_land_tiles": 158550,
     "width": 1000
   },
   "name": "World",

--- a/scripts/MapMetadata.ts
+++ b/scripts/MapMetadata.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs/promises";
+
+import { GameMapType } from "../src/core/game/Game";
+import { MapManifest } from "../src/core/game/TerrainMapLoader";
+
+const isLand = (b: number) => Boolean(b & (1 << 7));
+
+async function FixAllMapTileCt() {
+  for (const mapTypeKey of Object.keys(GameMapType)) {
+    const fileName = mapTypeKey.toLowerCase();
+    const mapType = GameMapType[mapTypeKey as keyof typeof GameMapType];
+
+    const manifest = JSON.parse(
+      await fs.readFile(`./resources/maps/${fileName}/manifest.json`, "utf-8"),
+    ) as MapManifest;
+    const { map, mini_map } = manifest;
+
+    const bin = await fs.readFile(`./resources/maps/${fileName}/map.bin`);
+    const miniBin = await fs.readFile(
+      `./resources/maps/${fileName}/mini_map.bin`,
+    );
+
+    let numLand = 0;
+    let numLandMini = 0;
+
+    for (let i = 0; i < map.width * map.height; i++)
+      if (isLand(bin[i])) numLand++;
+    for (let i = 0; i < mini_map.width * mini_map.height; i++)
+      if (isLand(miniBin[i])) numLandMini++;
+
+    if (map.num_land_tiles !== numLand)
+      console.log(
+        `Map "${mapType}" has incorrect count. Current: ${map.num_land_tiles}, Correct: ${numLand}`,
+      );
+    if (mini_map.num_land_tiles !== numLandMini)
+      console.log(
+        `Map "${mapType}" (mini) has incorrect count. Current: ${mini_map.num_land_tiles}, Correct: ${numLandMini}`,
+      );
+
+    const shouldCorrect =
+      map.num_land_tiles !== numLand || mini_map.num_land_tiles !== numLandMini;
+    if (!shouldCorrect) continue;
+
+    await fs.writeFile(
+      `./resources/maps/${fileName}/manifest.json`,
+      JSON.stringify(
+        {
+          ...manifest,
+          map: {
+            ...manifest.map,
+            num_land_tiles: numLand,
+          },
+          mini_map: {
+            ...manifest.mini_map,
+            num_land_tiles: numLandMini,
+          },
+        },
+        undefined,
+        2,
+      ),
+    );
+  }
+}
+
+FixAllMapTileCt().then(() => {
+  console.log("Success");
+  process.exit(0);
+});

--- a/src/core/game/TerrainMapLoader.ts
+++ b/src/core/game/TerrainMapLoader.ts
@@ -47,7 +47,7 @@ export async function loadTerrainMap(
     await mapFiles.miniMapBin(),
   );
   const result = {
-    manifest: await mapFiles.manifest(),
+    manifest,
     gameMap: gameMap,
     miniGameMap: miniGameMap,
   };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,7 @@
     "resources/**/*",
     "generated/**/*",
     "tests/**/*",
-    "src/scripts"
+    "scripts/**/*"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description:

Fixes #1409 

All of the maps seemed to be slightly off with their  `num_land_tiles` causing players not to actually get 100% on the leaderboard when they have the entire board. Likely also screws with the 80% check, too.

Please, help me test this! I have tested this on the North America and Iceland maps so far and it works great. I'll continue testing other maps when I can, but it should be the exact count for each map. The script also works nicely.

<img width="2337" height="1148" alt="image" src="https://github.com/user-attachments/assets/61aba853-8f92-48c9-bf14-2919a29eacf8" />
<img width="2153" height="1143" alt="image" src="https://github.com/user-attachments/assets/0e8a4fe5-3c81-4211-89ec-473bfb63b457" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors
