### PR TITLE
Fix: "Game speed" not "Replay speed" during Single player game

### DIFF
--- a/src/client/graphics/layers/GameRightSidebar.ts
+++ b/src/client/graphics/layers/GameRightSidebar.ts
@@ -76,7 +76,9 @@ export class GameRightSidebar extends LitElement implements Layer {
 
   private toggleReplayPanel(): void {
     this._isReplayVisible = !this._isReplayVisible;
-    this.eventBus.emit(new ShowReplayPanelEvent(this._isReplayVisible));
+    this.eventBus.emit(
+      new ShowReplayPanelEvent(this._isReplayVisible, this._isSinglePlayer),
+    );
   }
 
   private onPauseButtonClick() {

--- a/src/client/graphics/layers/ReplayPanel.ts
+++ b/src/client/graphics/layers/ReplayPanel.ts
@@ -11,7 +11,10 @@ import { translateText } from "../../Utils";
 import { Layer } from "./Layer";
 
 export class ShowReplayPanelEvent {
-  constructor(public visible: boolean = true) {}
+  constructor(
+    public visible: boolean = true,
+    public isSingleplayer: boolean = false,
+  ) {}
 }
 
 @customElement("replay-panel")
@@ -36,6 +39,7 @@ export class ReplayPanel extends LitElement implements Layer {
     if (this.eventBus) {
       this.eventBus.on(ShowReplayPanelEvent, (event: ShowReplayPanelEvent) => {
         this.visible = event.visible;
+        this.isSingleplayer = event.isSingleplayer;
       });
     }
   }


### PR DESCRIPTION
## Description:

Fix for regression. In #1145, "Game speed" was added to show in Single player instead of "Replay speed", and then in #1243 again. But after the changes in #1415 it no longer worked, although some code remained.

Before:
<img width="417" height="161" alt="Replay speed when in single player game" src="https://github.com/user-attachments/assets/ff9aac99-6948-4c10-bb30-36ba5973c12e" />

After:
<img width="392" height="178" alt="Game speed instead of Replay speed" src="https://github.com/user-attachments/assets/3beb712a-2539-46c5-a50a-eda593a5417c" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
