### PR TITLE
Fix: attack on ally even with greyed out button

### DIFF
--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -773,7 +773,7 @@ export class RadialMenu implements Layer {
 
   private handleCenterButtonClick() {
     if (this.centerButtonState === "default") {
-      if (this.params) {
+      if (this.params && this.isCenterButtonEnabled()) {
         this.centerButtonElement?.action(this.params);
       }
       return;


### PR DESCRIPTION
## Description:

Bugfix for: when clicking the central radial menu button (attack button) on an ally, the ally would be attacked. And you'd inadvertently get a traitor debuff. Even if the button was greyed out (#1426), the attack would still happen.

BEFORE:
https://github.com/user-attachments/assets/833bf587-211f-4e6e-86b8-6374ca6f3d6c

AFTER:
https://github.com/user-attachments/assets/38e4ae6d-caac-47c9-9b0d-57bacdd7a846

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout
