### PR TITLE
Fix Regex to allow german Umlaute

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -162,7 +162,7 @@ export const TeamSchema = z.string();
 const SafeString = z
   .string()
   .regex(
-    /^([a-zA-Z0-9\s.,!?@#$%&*()\-_+=\[\]{}|;:"'/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[üÜöÖäÄ])*$/u
+    /^([a-zA-Z0-9\s.,!?@#$%&*()\-_+=[\]{}|;:"'/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[üÜöÖäÄ])*$/u,
   )
   .max(1000);
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -162,7 +162,7 @@ export const TeamSchema = z.string();
 const SafeString = z
   .string()
   .regex(
-    /^([a-zA-Z0-9\s.,!?@#$%&*()\-_+=[\]{}|;:"'/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|üÜ])*$/,
+    /^([a-zA-Z0-9\s.,!?@#$%&*()\-_+=\[\]{}|;:"'/\u00a9|\u00ae|[\u2000-\u3300]|\ud83c[\ud000-\udfff]|\ud83d[\ud000-\udfff]|\ud83e[\ud000-\udfff]|[üÜöÖäÄ])*$/u
   )
   .max(1000);
 

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -22,7 +22,7 @@ const matcher = new RegExpMatcher({
 export const MIN_USERNAME_LENGTH = 3;
 export const MAX_USERNAME_LENGTH = 27;
 
-const validPattern = /^[a-zA-Z0-9_[\] 🐈🍀üÜ]+$/u;
+const validPattern = /^[a-zA-Z0-9_[\] 🐈🍀üÜöÖäÄ]+$/u;
 
 const shadowNames = [
   "NicePeopleOnly",


### PR DESCRIPTION
## Description:

Modified the regex pattern.

1) Allow Umlaute in usernames on client-side
2) Allow Umlaute in usernames on server-side

Before only the name "üÜüÜ" would have been possible as the pattern was
|üÜ -> or "üÜ" as a combined sequence
|[üöäÜÖÄ] -> or either one of these letters



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA aggreement (only required once).

Not 100% sure what/where else to test. I started couple of private lobbies with various names.

## Please put your Discord username so you can be contacted if a bug or regression is found:

[UN nvm]
