### PR TITLE
fix team leaderboard margin

### DIFF
--- a/src/client/graphics/layers/GameLeftSidebar.ts
+++ b/src/client/graphics/layers/GameLeftSidebar.ts
@@ -142,7 +142,7 @@ export class GameLeftSidebar extends LitElement implements Layer {
         <div class="block lg:flex flex-wrap gap-2">
           <leader-board .visible=${this.isLeaderboardShow}></leader-board>
           <team-stats
-            class=${`flex-1 ${this.isTeamLeaderboardShow ? "sm:mt-4 lg:mt-12" : ""}`}
+            class="flex-1"
             .visible=${this.isTeamLeaderboardShow && this.isTeamGame}
           ></team-stats>
         </div>


### PR DESCRIPTION
## Description:

The team leaderboard had a large top margin. This PR aligns the team leaderboard with the player leaderboard.

<img width="758" height="541" alt="Screenshot 2025-07-17 at 8 55 04 AM" src="https://github.com/user-attachments/assets/9c9b6b67-e448-4419-8625-644e6e8584c7" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
