### PR TITLE
leaderboard bugfix: show by default for medium to large screens.

### DIFF
--- a/src/client/graphics/layers/GameLeftSidebar.ts
+++ b/src/client/graphics/layers/GameLeftSidebar.ts
@@ -42,8 +42,6 @@ export class GameLeftSidebar extends LitElement implements Layer {
   }
 
   tick() {
-    if (!this.isPlayerTeamLabelVisible) return;
-
     if (!this.playerTeam && this.game.myPlayer()?.team()) {
       this.playerTeam = this.game.myPlayer()!.team();
       if (this.playerTeam) {


### PR DESCRIPTION
## Description:

removes the unnecessary check in tick() which was causing the leaderboard to not be shown by default on smaller screens.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
