### PR TITLE
alert on ws 1002 error

### DIFF
--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -342,7 +342,10 @@ export class Transport {
       console.log(
         `WebSocket closed. Code: ${event.code}, Reason: ${event.reason}`,
       );
-      if (event.code !== 1000 && event.code !== 1002) {
+      if (event.code === 1002) {
+        // TODO: make this a modal
+        alert(`connection refused: ${event.reason}`);
+      } else if (event.code !== 1000) {
         console.log(`recieved error code ${event.code}, reconnecting`);
         this.reconnect();
       }


### PR DESCRIPTION
## Description:

Alert the error when a user is unauthorized to join a game. Previously it would just log an error and the user would have no idea why they couldn't join a game (if for example they were using a restricted pattern). Now the user gets an alert. We should make this a proper modal in the future.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
