### PR TITLE
fix squad allocator color palette

### DIFF
--- a/src/core/configuration/ColorAllocator.ts
+++ b/src/core/configuration/ColorAllocator.ts
@@ -76,9 +76,7 @@ export class ColorAllocator {
       case ColoredTeams.Bot:
         return botColor;
       default:
-        return this.availableColors[
-          simpleHash(team) % this.availableColors.length
-        ];
+        return this.assignColor(team);
     }
   }
 }


### PR DESCRIPTION
## Description:

We were just doing a simple hash of the team id, causing them to be random. now we use the the color delta function for squads as well.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
