### PR TITLE
meta: reduce port gold multiplier & trade ship frequency

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -342,9 +342,9 @@ export class DefaultConfig implements Config {
   }
 
   tradeShipGold(dist: number, numPorts: number): Gold {
-    const baseGold = Math.floor(50000 + 130 * dist);
-    const basePortBonus = 0.2;
-    const diminishingFactor = 0.95;
+    const baseGold = Math.floor(50000 + 100 * dist);
+    const basePortBonus = 0.25;
+    const diminishingFactor = 0.9;
 
     let totalMultiplier = 1;
     for (let i = 0; i < numPorts; i++) {
@@ -361,7 +361,7 @@ export class DefaultConfig implements Config {
     }
     if (numTradeShips <= 150) {
       const additional = numTradeShips - 20;
-      return Math.pow(additional, 0.8) + 5;
+      return Math.floor(Math.pow(additional, 0.85) + 5);
     }
     return 1_000_000;
   }


### PR DESCRIPTION
## Description:

The port bonus was too high causing too many MIRVs, reduce the port bonus & reduce trade ship spawn chances slightly

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
