### PR TITLE
increase player panel z index so it is on top of spawn timer

### DIFF
--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -233,7 +233,7 @@ export class PlayerPanel extends LitElement implements Layer {
 
     return html`
       <div
-        class="fixed inset-0 flex items-center justify-center z-50 pointer-events-none overflow-auto"
+        class="fixed inset-0 flex items-center justify-center z-[1001] pointer-events-none overflow-auto"
         @contextmenu=${(e) => e.preventDefault()}
         @wheel=${(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
## Description:

The spawn timer menu was blocking the exit button of the player panel on mobile

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
