### PR TITLE
adjust meta: MIRV 25M, reduce SAM price

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -479,8 +479,8 @@ export class DefaultConfig implements Config {
               ? 0n
               : BigInt(
                   Math.min(
-                    3_000_000,
-                    (p.unitsConstructed(UnitType.SAMLauncher) + 1) * 1_500_000,
+                    2_000_000,
+                    (p.unitsConstructed(UnitType.SAMLauncher) + 1) * 1_000_000,
                   ),
                 ),
           territoryBound: true,

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -435,7 +435,7 @@ export class DefaultConfig implements Config {
           cost: (p: Player) =>
             p.type() === PlayerType.Human && this.infiniteGold()
               ? 0n
-              : 35_000_000n,
+              : 25_000_000n,
           territoryBound: false,
         };
       case UnitType.MIRVWarhead:


### PR DESCRIPTION
## Description:

35M seems to high, I'm only seeing them used rarely now.

v24 nerfed SAMs as they can only target missiles as they are landing, so make them cheaper to compensate. 

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
