### PR TITLE
Fix modal not closing when game starts

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -447,6 +447,9 @@ class Client {
           "game-top-bar",
           "help-modal",
           "user-setting",
+          "territory-patterns-modal",
+          "language-modal",
+          "news-modal",
         ].forEach((tag) => {
           const modal = document.querySelector(tag) as HTMLElement & {
             close?: () => void;


### PR DESCRIPTION
## Description:
When a player joins a public game and opens a modal (such as the news modal) while waiting for the game to start, the modal is not dismissed when the game begins. This leaves the modal visible even after the match has started.

<img width="1374" height="841" alt="スクリーンショット 2025-07-20 10 25 16" src="https://github.com/user-attachments/assets/e7170e79-0f4c-442a-bbb9-cce23aa676e7" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri