### PR TITLE
Fix issue where territory-patterns-modal is occasionally not translated

### DIFF
--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -208,6 +208,7 @@ export class LangSelector extends LitElement {
       "user-setting",
       "o-modal",
       "o-button",
+      "territory-patterns-modal",
     ];
 
     document.title = this.translateText("main.title") ?? document.title;


### PR DESCRIPTION
## Description:

Fixes a problem where the territory-patterns-modal sometimes appears in the previous language if it is opened immediately after changing the language.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri