### PR TITLE
Fix: display actual Alliance extension message instead of translation key

### DIFF
--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -351,8 +351,15 @@ export class EventsDisplay extends LitElement implements Layer {
       }
     }
 
+    let description: string = event.message;
+    if (event.isKey !== undefined && event.isKey) {
+      if (event.message.startsWith("events_display.")) {
+        description = translateText(event.message, event.params ?? {});
+      }
+    }
+
     this.addEvent({
-      description: event.message,
+      description: description,
       createdAt: this.game.ticks(),
       highlight: true,
       type: event.messageType,

--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -352,9 +352,9 @@ export class EventsDisplay extends LitElement implements Layer {
     }
 
     let description: string = event.message;
-    if (event.isKey !== undefined && event.isKey) {
+    if (event.params !== undefined) {
       if (event.message.startsWith("events_display.")) {
-        description = translateText(event.message, event.params ?? {});
+        description = translateText(event.message, event.params);
       }
     }
 

--- a/src/core/execution/alliance/AllianceExtensionExecution.ts
+++ b/src/core/execution/alliance/AllianceExtensionExecution.ts
@@ -48,7 +48,6 @@ export class AllianceExtensionExecution implements Execution {
         this.from.id(),
         undefined,
         { name: to.displayName() },
-        true,
       );
       mg.displayMessage(
         "events_display.alliance_renewed",
@@ -56,7 +55,6 @@ export class AllianceExtensionExecution implements Execution {
         this.toID,
         undefined,
         { name: this.from.displayName() },
-        true,
       );
     }
   }

--- a/src/core/execution/alliance/AllianceExtensionExecution.ts
+++ b/src/core/execution/alliance/AllianceExtensionExecution.ts
@@ -46,11 +46,17 @@ export class AllianceExtensionExecution implements Execution {
         "events_display.alliance_renewed",
         MessageType.ALLIANCE_ACCEPTED,
         this.from.id(),
+        undefined,
+        { name: to.displayName() },
+        true,
       );
       mg.displayMessage(
         "events_display.alliance_renewed",
         MessageType.ALLIANCE_ACCEPTED,
         this.toID,
+        undefined,
+        { name: this.from.displayName() },
+        true,
       );
     }
   }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -668,7 +668,6 @@ export interface Game extends GameMap {
     playerID: PlayerID | null,
     goldAmount?: bigint,
     params?: Record<string, string | number>,
-    isKey?: boolean,
   ): void;
   displayIncomingUnit(
     unitID: number,

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -667,6 +667,8 @@ export interface Game extends GameMap {
     type: MessageType,
     playerID: PlayerID | null,
     goldAmount?: bigint,
+    params?: Record<string, string | number>,
+    isKey?: boolean,
   ): void;
   displayIncomingUnit(
     unitID: number,

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -675,6 +675,8 @@ export class GameImpl implements Game {
     type: MessageType,
     playerID: PlayerID | null,
     goldAmount?: bigint,
+    params?: Record<string, string | number>,
+    isKey?: boolean,
   ): void {
     let id: number | null = null;
     if (playerID !== null) {
@@ -686,6 +688,8 @@ export class GameImpl implements Game {
       message: message,
       playerID: id,
       goldAmount: goldAmount,
+      params: params,
+      isKey: isKey,
     });
   }
 

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -676,7 +676,6 @@ export class GameImpl implements Game {
     playerID: PlayerID | null,
     goldAmount?: bigint,
     params?: Record<string, string | number>,
-    isKey?: boolean,
   ): void {
     let id: number | null = null;
     if (playerID !== null) {
@@ -689,7 +688,6 @@ export class GameImpl implements Game {
       playerID: id,
       goldAmount: goldAmount,
       params: params,
-      isKey: isKey,
     });
   }
 

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -217,7 +217,6 @@ export interface DisplayMessageUpdate {
   goldAmount?: bigint;
   playerID: number | null;
   params?: Record<string, string | number>;
-  isKey?: boolean;
 }
 
 export type DisplayChatMessageUpdate = {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -216,6 +216,8 @@ export interface DisplayMessageUpdate {
   messageType: MessageType;
   goldAmount?: bigint;
   playerID: number | null;
+  params?: Record<string, string | number>;
+  isKey?: boolean;
 }
 
 export type DisplayChatMessageUpdate = {


### PR DESCRIPTION
## Description:

On Alliance extension, the key "events_display.alliance_renewed" is displayed in the Event Panel. Reported in https://discord.com/channels/1284581928254701718/1397197460085932184

Since displayMessage doesn't expect or do translations, just puts out hardcoded English messages so far, it doesn't do anything with the recieved key and just puts it in the Event Panel as is. This PR fixes it as a follow-up of #1359.

With this, it also introduces a base which can be used to translate hardcoded messages coming from other Executions. That is out of the scope of this PR.

PRs #1532 and #1536 both fix issues with Alliance Renewal in v24. If possible approve 1532 (this one) first and then 1536 not too far after if github can indeed merge them.

BEFORE:
<img width="533" height="353" alt="alliancerenewbefore" src="https://github.com/user-attachments/assets/b97f7279-8daf-4049-96fb-1d5a1e360ec4" />

AFTER: 
(tested locally with Nations by not checking their answer; they normally don't answer to alliance renewal request  which is another issue)

<img width="787" height="406" alt="After fix" src="https://github.com/user-attachments/assets/9fc3a0e2-b151-486f-b6ef-692177e387ad" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
