### PR TITLE
transport ship execution: don't refund troops when max boat limit hit

### DIFF
--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -76,7 +76,6 @@ export class TransportShipExecution implements Execution {
         this.attacker.id(),
       );
       this.active = false;
-      this.attacker.addTroops(this.troops);
       return;
     }
 


### PR DESCRIPTION
## Description:

The TransportShipExecution was refunding the troops when max boat limit was hit, but the troops were never deducted in the first place, giving extra troops.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
