### PR TITLE
Send error when closing to prevent race conditions

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -100,17 +100,6 @@ export function joinLobby(
         terrainLoad,
       ).then((r) => r.start());
     }
-    if (message.type === "error") {
-      showErrorModal(
-        message.error,
-        message.message,
-        lobbyConfig.gameID,
-        lobbyConfig.clientID,
-        true,
-        false,
-        "error_modal.connection_error",
-      );
-    }
   };
   transport.connect(onconnect, onmessage);
   return () => {
@@ -324,17 +313,6 @@ export class ClientGameRunner {
           true,
           false,
           "error_modal.desync_notice",
-        );
-      }
-      if (message.type === "error") {
-        showErrorModal(
-          message.error,
-          message.message,
-          this.lobby.gameID,
-          this.lobby.clientID,
-          true,
-          false,
-          "error_modal.connection_error",
         );
       }
       if (message.type === "turn") {

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -88,8 +88,7 @@ export type ServerMessage =
   | ServerStartGameMessage
   | ServerPingMessage
   | ServerDesyncMessage
-  | ServerPrestartMessage
-  | ServerErrorMessage;
+  | ServerPrestartMessage;
 
 export type ServerTurnMessage = z.infer<typeof ServerTurnMessageSchema>;
 export type ServerStartGameMessage = z.infer<
@@ -98,7 +97,6 @@ export type ServerStartGameMessage = z.infer<
 export type ServerPingMessage = z.infer<typeof ServerPingMessageSchema>;
 export type ServerDesyncMessage = z.infer<typeof ServerDesyncSchema>;
 export type ServerPrestartMessage = z.infer<typeof ServerPrestartMessageSchema>;
-export type ServerErrorMessage = z.infer<typeof ServerErrorSchema>;
 export type ClientSendWinnerMessage = z.infer<typeof ClientSendWinnerSchema>;
 export type ClientPingMessage = z.infer<typeof ClientPingMessageSchema>;
 export type ClientIntentMessage = z.infer<typeof ClientIntentMessageSchema>;
@@ -445,19 +443,12 @@ export const ServerDesyncSchema = z.object({
   yourHash: z.number().optional(),
 });
 
-export const ServerErrorSchema = z.object({
-  type: z.literal("error"),
-  error: z.string(),
-  message: z.string().optional(),
-});
-
 export const ServerMessageSchema = z.discriminatedUnion("type", [
   ServerTurnMessageSchema,
   ServerPrestartMessageSchema,
   ServerStartGameMessageSchema,
   ServerPingMessageSchema,
   ServerDesyncSchema,
-  ServerErrorSchema,
 ]);
 
 //

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -15,7 +15,6 @@ import {
   ClientMessageSchema,
   GameRecord,
   GameRecordSchema,
-  ServerErrorMessage,
 } from "../core/Schemas";
 import { CreateGameInputSchema, GameInputSchema } from "../core/WorkerSchemas";
 import { archive, readGameRecord } from "./Archive";
@@ -310,14 +309,8 @@ export function startWorker() {
           if (!parsed.success) {
             const error = z.prettifyError(parsed.error);
             log.warn("Error parsing client message", error);
-            ws.send(
-              JSON.stringify({
-                type: "error",
-                error: error.toString(),
-              } satisfies ServerErrorMessage),
-            );
             ws.removeAllListeners();
-            ws.close(1002, "ClientJoinMessageSchema");
+            ws.close(1002, `Failed to parse client message: ${error}`);
             return;
           }
           const clientMsg = parsed.data;
@@ -328,14 +321,8 @@ export function startWorker() {
           } else if (clientMsg.type !== "join") {
             const error = `Invalid message before join: ${JSON.stringify(clientMsg)}`;
             log.warn(error);
-            ws.send(
-              JSON.stringify({
-                type: "error",
-                error,
-              } satisfies ServerErrorMessage),
-            );
             ws.removeAllListeners();
-            ws.close(1002, "ClientJoinMessageSchema");
+            ws.close(1002, error);
             return;
           }
 


### PR DESCRIPTION
## Description:

The server sent an error message and then closed the socket after a delay. This can cause strange race conditions if client rejoins before client is removed.

Instead send the error message while closing the socket, the client will be alerted of the error message.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA aggreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
