### PR TITLE
bugfix: transport ship was using start troops, not ship troops to determine attack

### DIFF
--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -37,7 +37,7 @@ export class TransportShipExecution implements Execution {
     private attacker: Player,
     private targetID: PlayerID | null,
     private ref: TileRef,
-    private troops: number,
+    private startTroops: number,
     private src: TileRef | null,
   ) {}
 
@@ -88,11 +88,11 @@ export class TransportShipExecution implements Execution {
       this.target = mg.player(this.targetID);
     }
 
-    this.troops ??= this.mg
+    this.startTroops ??= this.mg
       .config()
       .boatAttackAmount(this.attacker, this.target);
 
-    this.troops = Math.min(this.troops, this.attacker.troops());
+    this.startTroops = Math.min(this.startTroops, this.attacker.troops());
 
     this.dst = targetTransportTile(this.mg, this.ref);
     if (this.dst === null) {
@@ -130,7 +130,7 @@ export class TransportShipExecution implements Execution {
     }
 
     this.boat = this.attacker.buildUnit(UnitType.TransportShip, this.src, {
-      troops: this.troops,
+      troops: this.startTroops,
     });
 
     // Notify the target player about the incoming naval invasion
@@ -145,7 +145,9 @@ export class TransportShipExecution implements Execution {
     }
 
     // Record stats
-    this.mg.stats().boatSendTroops(this.attacker, this.target, this.troops);
+    this.mg
+      .stats()
+      .boatSendTroops(this.attacker, this.target, this.boat.troops());
   }
 
   tick(ticks: number) {
@@ -180,16 +182,16 @@ export class TransportShipExecution implements Execution {
           // Record stats
           this.mg
             .stats()
-            .boatArriveTroops(this.attacker, this.target, this.troops);
+            .boatArriveTroops(this.attacker, this.target, this.boat.troops());
           return;
         }
         this.attacker.conquer(this.dst);
         if (this.target.isPlayer() && this.attacker.isFriendly(this.target)) {
-          this.attacker.addTroops(this.troops);
+          this.attacker.addTroops(this.boat.troops());
         } else {
           this.mg.addExecution(
             new AttackExecution(
-              this.troops,
+              this.boat.troops(),
               this.attacker,
               this.targetID,
               this.dst,
@@ -203,7 +205,7 @@ export class TransportShipExecution implements Execution {
         // Record stats
         this.mg
           .stats()
-          .boatArriveTroops(this.attacker, this.target, this.troops);
+          .boatArriveTroops(this.attacker, this.target, this.boat.troops());
         return;
       case PathFindResultType.NextTile:
         this.boat.move(result.node);
@@ -213,7 +215,7 @@ export class TransportShipExecution implements Execution {
       case PathFindResultType.PathNotFound:
         // TODO: add to poisoned port list
         console.warn(`path not found to dst`);
-        this.attacker.addTroops(this.troops);
+        this.attacker.addTroops(this.boat.troops());
         this.boat.delete(false);
         this.active = false;
         return;


### PR DESCRIPTION
## Description:

This caused an issue when getting nuked, the transport ships were not decreasing

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
