### PR TITLE
fix mirv damage scaling

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -832,12 +832,13 @@ export class DefaultConfig implements Config {
     if (nukeType !== UnitType.MIRVWarhead) {
       return (5 * humans) / Math.max(1, tilesOwned);
     }
-
-    const targetPop = 0.05 * maxPop;
+    const targetPop = 0.03 * maxPop;
     const excessPop = Math.max(0, humans - targetPop);
-    const scalingFactor = 20000;
+    const scalingFactor = 500;
 
-    return (scalingFactor * excessPop * excessPop) / (maxPop * maxPop);
+    const steepness = 2;
+    const normalizedExcess = excessPop / maxPop;
+    return scalingFactor * (1 - Math.exp(-steepness * normalizedExcess));
   }
 
   structureMinDist(): number {


### PR DESCRIPTION
## Description:

https://github.com/openfrontio/OpenFrontIO/commit/932d4f3be2cded197e5ed4712a9e9e35963b86a6 made the curve way too steep, so just one MIRVWarhead caused enormous population damage, so receiving crossfire from a nuke could cause extensive damage

This PR Makes the curve much more linear, so the first explosions aren't as deadly. Also change the asymptote to 3%, in practice it ends up being around 5%.



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
