### PR TITLE
Implement stop all trades functionality and UI integration

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -501,7 +501,17 @@
     "gold": "Gold",
     "troops": "Troops",
     "workers": "Workers",
-    "attack_ratio": "Attack Ratio"
+    "attack_ratio": "Attack Ratio",
+    "stop_all_trades": "Stop All Trades",
+    "stop_all_trades_tooltip": "Stop trading with all non-allied players and non-team members",
+    "start_all_trades": "Start All Trades",
+    "start_all_trades_tooltip": "Resume trading with all previously embargoed players",
+    "stop_team_trades": "Stop Team Trades",
+    "stop_team_trades_dropdown_tooltip": "Select a specific team to stop trading with",
+    "stop_team_trades_tooltip": "Stop trading with all players from {{team}}",
+    "start_team_trades_tooltip": "Resume trading with all players from {{team}}",
+    "your_team_tooltip": "Cannot change trade status with your own team",
+    "no_players_tooltip": "No players available in {{team}} to trade with"
   },
   "player_panel": {
     "gold": "Gold",

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -133,6 +133,10 @@ export class SendEmbargoIntentEvent implements GameEvent {
   ) {}
 }
 
+export class SendStopAllTradesIntentEvent implements GameEvent {
+  constructor(public readonly targetTeamId?: string | null) {}
+}
+
 export class CancelAttackIntentEvent implements GameEvent {
   constructor(public readonly attackID: string) {}
 }
@@ -222,6 +226,9 @@ export class Transport {
     this.eventBus.on(SendQuickChatEvent, (e) => this.onSendQuickChatIntent(e));
     this.eventBus.on(SendEmbargoIntentEvent, (e) =>
       this.onSendEmbargoIntent(e),
+    );
+    this.eventBus.on(SendStopAllTradesIntentEvent, (e) =>
+      this.onSendStopAllTradesIntent(e),
     );
     this.eventBus.on(SendSetTargetTroopRatioEvent, (e) =>
       this.onSendSetTargetTroopRatioEvent(e),
@@ -522,6 +529,14 @@ export class Transport {
       clientID: this.lobbyConfig.clientID,
       targetID: event.target.id(),
       action: event.action,
+    });
+  }
+
+  private onSendStopAllTradesIntent(event: SendStopAllTradesIntentEvent) {
+    this.sendIntent({
+      type: "stopAllTrades",
+      clientID: this.lobbyConfig.clientID,
+      targetTeamId: event.targetTeamId,
     });
   }
 

--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -1,13 +1,16 @@
-import { LitElement, html } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
-import { Gold } from "../../../core/game/Game";
+import { GameMode, Gold } from "../../../core/game/Game";
 import { GameView } from "../../../core/game/GameView";
 import { ClientID } from "../../../core/Schemas";
 import { AttackRatioEvent } from "../../InputHandler";
-import { SendSetTargetTroopRatioEvent } from "../../Transport";
-import { renderNumber, renderTroops } from "../../Utils";
+import {
+  SendEmbargoIntentEvent,
+  SendSetTargetTroopRatioEvent,
+  SendStopAllTradesIntentEvent,
+} from "../../Transport";
+import { renderNumber, renderTroops, translateText } from "../../Utils";
 import { UIState } from "../UIState";
 import { Layer } from "./Layer";
 
@@ -54,11 +57,19 @@ export class ControlPanel extends LitElement implements Layer {
   @state()
   private _goldPerSecond: Gold;
 
+  @state()
+  private _showTeamDropdown = false;
+
+  @state()
+  private _allTradesStopped = false;
+
   private _popRateIsIncreasing: boolean = true;
 
   private _lastPopulationIncreaseRate: number;
 
   private init_: boolean = false;
+
+  private _clickOutsideHandler: ((e: Event) => void) | null = null;
 
   init() {
     this.attackRatio = Number(
@@ -94,6 +105,19 @@ export class ControlPanel extends LitElement implements Layer {
       this.attackRatio = newAttackRatio;
       this.onAttackRatioChange(this.attackRatio);
     });
+
+    // Add click-outside handler for dropdown
+    this._clickOutsideHandler = (e: Event) => {
+      if (
+        this._showTeamDropdown &&
+        e.target instanceof Node &&
+        !this.contains(e.target)
+      ) {
+        this._showTeamDropdown = false;
+        this.requestUpdate();
+      }
+    };
+    document.addEventListener("click", this._clickOutsideHandler);
   }
 
   tick() {
@@ -165,8 +189,135 @@ export class ControlPanel extends LitElement implements Layer {
   }
 
   delta(): number {
-    const d = this._population - this.targetTroops();
-    return d;
+    return this._population - this.targetTroops();
+  }
+
+  private get isTeamGame(): boolean {
+    return this.game?.config().gameConfig().gameMode === GameMode.Team;
+  }
+
+  private getTeams() {
+    if (!this.isTeamGame) return [];
+
+    const players = this.game.playerViews();
+    const teamMap = new Map<
+      string,
+      {
+        id: string;
+        name: string;
+        color: string;
+        hasEmbargo: boolean;
+        isMyTeam: boolean;
+        hasPlayers: boolean;
+      }
+    >();
+    const myPlayer = this.game.myPlayer();
+    const myTeam = myPlayer?.team();
+
+    for (const player of players) {
+      const team = player.team();
+      if (team !== null) {
+        const teamId = team.toString();
+        if (!teamMap.has(teamId)) {
+          // Get team color from game theme
+          const teamColor = this.game.config().theme().teamColor(team);
+          // Check if this team has any players with embargoes
+          const hasEmbargo = players.some(
+            (p) =>
+              p.team() === team &&
+              myPlayer &&
+              myPlayer.hasEmbargoAgainst(p) &&
+              p !== myPlayer,
+          );
+          // Check if this team has any players at all (excluding myself)
+          const hasPlayers = players.some(
+            (p) => p.team() === team && p !== myPlayer && p.isAlive(),
+          );
+
+          teamMap.set(teamId, {
+            id: teamId,
+            name: `Team ${teamId}`,
+            color: teamColor.toHex(),
+            hasEmbargo: hasEmbargo,
+            isMyTeam: team === myTeam,
+            hasPlayers: hasPlayers,
+          });
+        }
+      }
+    }
+
+    return Array.from(teamMap.values());
+  }
+
+  private onStopAllTrades() {
+    this.eventBus.emit(new SendStopAllTradesIntentEvent());
+    this._allTradesStopped = true;
+  }
+
+  private onStartAllTrades() {
+    try {
+      // Send start trade events for all current trading partners
+      const myPlayer = this.game.myPlayer();
+      if (!myPlayer) {
+        console.warn("Cannot start trades: player not found");
+        return;
+      }
+
+      const allPlayers = this.game.playerViews();
+      for (const player of allPlayers) {
+        if (
+          player !== myPlayer &&
+          player.isAlive() &&
+          myPlayer.hasEmbargoAgainst(player)
+        ) {
+          this.eventBus.emit(new SendEmbargoIntentEvent(player, "stop"));
+        }
+      }
+      this._allTradesStopped = false;
+    } catch (error) {
+      console.error("Error starting all trades:", error);
+    }
+  }
+
+  private onToggleTeamTrades(teamId: string, hasEmbargo: boolean) {
+    try {
+      if (hasEmbargo) {
+        // Start trades with this team
+        const myPlayer = this.game.myPlayer();
+        if (!myPlayer) {
+          console.warn("Cannot toggle team trades: player not found");
+          return;
+        }
+
+        const allPlayers = this.game.playerViews();
+        for (const player of allPlayers) {
+          if (
+            player.team()?.toString() === teamId &&
+            player !== myPlayer &&
+            myPlayer.hasEmbargoAgainst(player)
+          ) {
+            this.eventBus.emit(new SendEmbargoIntentEvent(player, "stop"));
+          }
+        }
+      } else {
+        // Stop trades with this team
+        this.eventBus.emit(new SendStopAllTradesIntentEvent(teamId));
+      }
+      this._showTeamDropdown = false;
+    } catch (error) {
+      console.error("Error toggling team trades:", error);
+      this._showTeamDropdown = false;
+    }
+  }
+
+  private toggleTeamDropdown(e: Event) {
+    e.stopPropagation();
+    this._showTeamDropdown = !this._showTeamDropdown;
+  }
+
+  private handleTeamClick(e: Event, teamId: string, hasEmbargo: boolean) {
+    e.stopPropagation();
+    this.onToggleTeamTrades(teamId, hasEmbargo);
   }
 
   render() {
@@ -311,11 +462,139 @@ export class ControlPanel extends LitElement implements Layer {
             />
           </div>
         </div>
+
+        <div class="mt-3 space-y-2">
+          <button
+            @click=${this._allTradesStopped
+              ? this.onStartAllTrades
+              : this.onStopAllTrades}
+            class="w-full px-3 py-2 text-sm ${this._allTradesStopped
+              ? "bg-green-600/80 hover:bg-green-600 border-green-500/50 hover:border-green-400"
+              : "bg-yellow-600/80 hover:bg-yellow-600 border-yellow-500/50 hover:border-yellow-400"} text-white rounded border transition-all duration-200 backdrop-blur font-medium"
+            title="${this._allTradesStopped
+              ? translateText("control_panel.start_all_trades_tooltip")
+              : translateText("control_panel.stop_all_trades_tooltip")}"
+          >
+            ${this._allTradesStopped
+              ? translateText("control_panel.start_all_trades")
+              : translateText("control_panel.stop_all_trades")}
+          </button>
+
+          ${this.isTeamGame && this.getTeams().length > 0
+            ? html`
+                <div class="relative">
+                  <button
+                    @click=${this.toggleTeamDropdown}
+                    class="w-full px-3 py-2 text-sm bg-red-700/80 hover:bg-red-700 text-white rounded border border-red-600/50 hover:border-red-500 transition-all duration-200 backdrop-blur font-medium flex items-center justify-between"
+                    title="${translateText(
+                      "control_panel.stop_team_trades_dropdown_tooltip",
+                    )}"
+                  >
+                    <span
+                      >${translateText("control_panel.stop_team_trades")}</span
+                    >
+                    <span
+                      class="text-xs transition-transform duration-200 ${this
+                        ._showTeamDropdown
+                        ? "rotate-180"
+                        : ""}"
+                      >▼</span
+                    >
+                  </button>
+
+                  <!-- Dropdown Menu -->
+                  ${this._showTeamDropdown
+                    ? html`
+                        <div
+                          class="absolute bottom-full left-0 right-0 mb-1 bg-gray-800/95 backdrop-blur border border-gray-600/50 rounded shadow-lg z-50 max-h-48 overflow-y-auto"
+                        >
+                          ${this.getTeams().map(
+                            (team) => html`
+                              <button
+                                @click=${team.isMyTeam || !team.hasPlayers
+                                  ? null
+                                  : (e: Event) =>
+                                      this.handleTeamClick(
+                                        e,
+                                        team.id,
+                                        team.hasEmbargo,
+                                      )}
+                                @mousedown=${(e: Event) => e.preventDefault()}
+                                class="w-full px-3 py-2 text-left text-sm transition-colors duration-150 flex items-center space-x-3 ${team.isMyTeam ||
+                                !team.hasPlayers
+                                  ? "text-gray-500 cursor-not-allowed bg-gray-800/50"
+                                  : "text-white hover:bg-gray-700/80 cursor-pointer"}"
+                                title="${team.isMyTeam
+                                  ? translateText(
+                                      "control_panel.your_team_tooltip",
+                                      { team: team.name },
+                                    )
+                                  : !team.hasPlayers
+                                    ? translateText(
+                                        "control_panel.no_players_tooltip",
+                                        { team: team.name },
+                                      )
+                                    : team.hasEmbargo
+                                      ? translateText(
+                                          "control_panel.start_team_trades_tooltip",
+                                          { team: team.name },
+                                        )
+                                      : translateText(
+                                          "control_panel.stop_team_trades_tooltip",
+                                          { team: team.name },
+                                        )}"
+                                ?disabled=${team.isMyTeam || !team.hasPlayers}
+                              >
+                                <div
+                                  class="w-3 h-3 rounded-full flex-shrink-0 ${team.isMyTeam ||
+                                  !team.hasPlayers
+                                    ? "opacity-50"
+                                    : ""}"
+                                  style="background-color: ${team.color};"
+                                ></div>
+                                <span class="flex-1">${team.name}</span>
+                                <span
+                                  class="text-xs flex items-center space-x-1"
+                                >
+                                  ${team.isMyTeam
+                                    ? html`<span class="text-gray-500"
+                                        >Your team</span
+                                      >`
+                                    : !team.hasPlayers
+                                      ? html`<span class="text-gray-500"
+                                          >No players</span
+                                        >`
+                                      : team.hasEmbargo
+                                        ? html`<span class="text-red-400"
+                                            >🚫 Blocked</span
+                                          >`
+                                        : html`<span class="text-green-400"
+                                            >✓ Trading</span
+                                          >`}
+                                </span>
+                              </button>
+                            `,
+                          )}
+                        </div>
+                      `
+                    : ""}
+                </div>
+              `
+            : ""}
+        </div>
       </div>
     `;
   }
 
   createRenderRoot() {
     return this; // Disable shadow DOM to allow Tailwind styles
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._clickOutsideHandler) {
+      document.removeEventListener("click", this._clickOutsideHandler);
+      this._clickOutsideHandler = null;
+    }
   }
 }

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -38,6 +38,7 @@ export type Intent =
   | TargetTroopRatioIntent
   | BuildUnitIntent
   | EmbargoIntent
+  | StopAllTradesIntent
   | QuickChatIntent
   | MoveWarshipIntent
   | MarkDisconnectedIntent
@@ -57,6 +58,7 @@ export type EmojiIntent = z.infer<typeof EmojiIntentSchema>;
 export type DonateGoldIntent = z.infer<typeof DonateGoldIntentSchema>;
 export type DonateTroopsIntent = z.infer<typeof DonateTroopIntentSchema>;
 export type EmbargoIntent = z.infer<typeof EmbargoIntentSchema>;
+export type StopAllTradesIntent = z.infer<typeof StopAllTradesIntentSchema>;
 export type TargetTroopRatioIntent = z.infer<
   typeof TargetTroopRatioIntentSchema
 >;
@@ -299,6 +301,11 @@ export const EmbargoIntentSchema = BaseIntentSchema.extend({
   action: z.union([z.literal("start"), z.literal("stop")]),
 });
 
+export const StopAllTradesIntentSchema = BaseIntentSchema.extend({
+  type: z.literal("stopAllTrades"),
+  targetTeamId: z.string().nullable().optional(),
+});
+
 export const DonateGoldIntentSchema = BaseIntentSchema.extend({
   type: z.literal("donate_gold"),
   recipient: ID,
@@ -374,6 +381,7 @@ const IntentSchema = z.discriminatedUnion("type", [
   BuildUnitIntentSchema,
   UpgradeStructureIntentSchema,
   EmbargoIntentSchema,
+  StopAllTradesIntentSchema,
   MoveWarshipIntentSchema,
   QuickChatIntentSchema,
   AllianceExtensionIntentSchema,

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -22,6 +22,7 @@ import { QuickChatExecution } from "./QuickChatExecution";
 import { RetreatExecution } from "./RetreatExecution";
 import { SetTargetTroopRatioExecution } from "./SetTargetTroopRatioExecution";
 import { SpawnExecution } from "./SpawnExecution";
+import { StopAllTradesExecution } from "./StopAllTradesExecution";
 import { TargetPlayerExecution } from "./TargetPlayerExecution";
 import { TransportShipExecution } from "./TransportShipExecution";
 import { UpgradeStructureExecution } from "./UpgradeStructureExecution";
@@ -102,6 +103,8 @@ export class Executor {
         return new SetTargetTroopRatioExecution(player, intent.ratio);
       case "embargo":
         return new EmbargoExecution(player, intent.targetID, intent.action);
+      case "stopAllTrades":
+        return new StopAllTradesExecution(player, intent.targetTeamId);
       case "build_unit":
         return new ConstructionExecution(player, intent.unit, intent.tile);
       case "allianceExtension": {

--- a/src/core/execution/StopAllTradesExecution.ts
+++ b/src/core/execution/StopAllTradesExecution.ts
@@ -1,0 +1,57 @@
+import { Execution, Game, Player } from "../game/Game";
+
+export class StopAllTradesExecution implements Execution {
+  private active = true;
+
+  constructor(
+    private player: Player,
+    private readonly targetTeamId?: string | null,
+  ) {}
+
+  init(mg: Game, _: number): void {}
+
+  tick(_: number): void {
+    try {
+      const tradingPartners = this.player.tradingPartners();
+
+      for (const partner of tradingPartners) {
+        // If targetTeamId is specified, only embargo players from that team
+        if (this.targetTeamId !== undefined && this.targetTeamId !== null) {
+          const partnerTeam = partner.team();
+          if (partnerTeam?.toString() !== this.targetTeamId) {
+            continue;
+          }
+        } else {
+          // If no targetTeamId specified (undefined or null), embargo all non-allied players except same team members
+          if (this.player.isAlliedWith(partner)) {
+            continue;
+          }
+          // Don't embargo same team members
+          const myTeam = this.player.team();
+          const partnerTeam = partner.team();
+          if (
+            myTeam !== null &&
+            partnerTeam !== null &&
+            myTeam === partnerTeam
+          ) {
+            continue;
+          }
+        }
+
+        this.player.addEmbargo(partner.id(), false);
+      }
+    } catch (error) {
+      console.error("Error in StopAllTradesExecution:", error);
+    } finally {
+      this.active = false;
+    }
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/tests/core/executions/StopAllTradesExecution.test.ts
+++ b/tests/core/executions/StopAllTradesExecution.test.ts
@@ -1,0 +1,125 @@
+import { StopAllTradesExecution } from "../../../src/core/execution/StopAllTradesExecution";
+import { Game, Player } from "../../../src/core/game/Game";
+
+describe("StopAllTradesExecution", () => {
+  let mockGame: Game;
+  let mockPlayer: Player;
+  let mockTradingPartner1: Player;
+  let mockTradingPartner2: Player;
+  let mockAlliedPlayer: Player;
+
+  beforeEach(() => {
+    mockTradingPartner1 = {
+      id: jest.fn(() => "partner1"),
+      team: jest.fn(() => "team1"),
+    } as unknown as Player;
+
+    mockTradingPartner2 = {
+      id: jest.fn(() => "partner2"),
+      team: jest.fn(() => "team2"),
+    } as unknown as Player;
+
+    mockAlliedPlayer = {
+      id: jest.fn(() => "ally1"),
+      team: jest.fn(() => "team3"),
+    } as unknown as Player;
+
+    mockPlayer = {
+      tradingPartners: jest.fn(() => [
+        mockTradingPartner1,
+        mockTradingPartner2,
+        mockAlliedPlayer,
+      ]),
+      isAlliedWith: jest.fn((player: Player) => player === mockAlliedPlayer),
+      addEmbargo: jest.fn(),
+      team: jest.fn(() => "myTeam"),
+    } as unknown as Player;
+
+    mockGame = {} as unknown as Game;
+  });
+
+  it("should be active initially", () => {
+    const execution = new StopAllTradesExecution(mockPlayer);
+    expect(execution.isActive()).toBe(true);
+  });
+
+  it("should not be active during spawn phase", () => {
+    const execution = new StopAllTradesExecution(mockPlayer);
+    expect(execution.activeDuringSpawnPhase()).toBe(false);
+  });
+
+  it("should stop trades with all non-allied players when no team specified", () => {
+    const execution = new StopAllTradesExecution(mockPlayer);
+    execution.init(mockGame, 0);
+    execution.tick(0);
+
+    expect(mockPlayer.addEmbargo).toHaveBeenCalledWith("partner1", false);
+    expect(mockPlayer.addEmbargo).toHaveBeenCalledWith("partner2", false);
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalledWith("ally1", false);
+    expect(execution.isActive()).toBe(false);
+  });
+
+  it("should stop trades with specific team when team ID specified", () => {
+    const execution = new StopAllTradesExecution(mockPlayer, "team1");
+    execution.init(mockGame, 0);
+    execution.tick(0);
+
+    expect(mockPlayer.addEmbargo).toHaveBeenCalledWith("partner1", false);
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalledWith("partner2", false);
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalledWith("ally1", false);
+    expect(execution.isActive()).toBe(false);
+  });
+
+  it("should stop trades with specific team including allies when team ID specified", () => {
+    const execution = new StopAllTradesExecution(mockPlayer, "team3");
+    execution.init(mockGame, 0);
+    execution.tick(0);
+
+    expect(mockPlayer.addEmbargo).toHaveBeenCalledWith("ally1", false);
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalledWith("partner1", false);
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalledWith("partner2", false);
+    expect(execution.isActive()).toBe(false);
+  });
+
+  it("should not stop any trades when team ID specified but no players from that team", () => {
+    const execution = new StopAllTradesExecution(mockPlayer, "teamNotExist");
+    execution.init(mockGame, 0);
+    execution.tick(0);
+
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalled();
+    expect(execution.isActive()).toBe(false);
+  });
+
+  it("should handle null team ID correctly", () => {
+    const execution = new StopAllTradesExecution(mockPlayer, null);
+    execution.init(mockGame, 0);
+    execution.tick(0);
+
+    expect(mockPlayer.addEmbargo).toHaveBeenCalledWith("partner1", false);
+    expect(mockPlayer.addEmbargo).toHaveBeenCalledWith("partner2", false);
+    expect(mockPlayer.addEmbargo).not.toHaveBeenCalledWith("ally1", false);
+    expect(execution.isActive()).toBe(false);
+  });
+
+  it("should handle errors gracefully and deactivate", () => {
+    const errorMockPlayer = {
+      tradingPartners: jest.fn(() => {
+        throw new Error("Test error");
+      }),
+    } as unknown as Player;
+
+    const consoleSpy = jest.spyOn(console, "error").mockImplementation();
+    const execution = new StopAllTradesExecution(errorMockPlayer);
+
+    execution.init(mockGame, 0);
+    execution.tick(0);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "Error in StopAllTradesExecution:",
+      expect.any(Error),
+    );
+    expect(execution.isActive()).toBe(false);
+
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Description:

This pull request integrates a system that adds the possibility to stop all your trades instantly with other players / bots.
It also supports the team mode in which you can pick the team you want to trade with or not through a dropdown menu.
Allies aren't affected when you stop trading globally.

<img width="396" height="452" alt="image" src="https://github.com/user-attachments/assets/e697fdba-1fc8-48f6-9f13-723ca1e75d2c" />
<img width="395" height="458" alt="image" src="https://github.com/user-attachments/assets/46d38e73-19d1-4138-ac5d-5ebd3234018b" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

__zooo - 748518742723526727
