### PR TITLE
use type & name for flare, improve checkout ux

### DIFF
--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -31,6 +31,8 @@ export interface Pattern {
   notShown?: boolean;
 }
 
+export const PURCHASE_SUCCESS_PARAM = "purchase-success";
+
 export async function patterns(
   userMe: UserMeResponse | null,
 ): Promise<Pattern[]> {
@@ -109,8 +111,8 @@ export async function handlePurchase(priceId: string) {
         },
         body: JSON.stringify({
           priceId: priceId,
-          successUrl: `${window.location.href}purchase-success`,
-          cancelUrl: `${window.location.href}purchase-cancel`,
+          successUrl: `${window.location.href}#${PURCHASE_SUCCESS_PARAM}=true`,
+          cancelUrl: `${window.location.href}#${PURCHASE_SUCCESS_PARAM}=false`,
         }),
       },
     );
@@ -139,7 +141,8 @@ export async function listAllProducts(): Promise<Map<string, StripeProduct>> {
     const products = (await response.json()) as StripeProduct[];
     const productMap = new Map<string, StripeProduct>();
     products.forEach((product) => {
-      productMap.set(product.metadata.flare, product);
+      const flare = `${product.metadata.type}:${product.metadata.name}`;
+      productMap.set(flare, product);
     });
     return productMap;
   } catch (error) {

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -7,6 +7,7 @@ import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import { GameType } from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import { joinLobby } from "./ClientGameRunner";
+import { PURCHASE_SUCCESS_PARAM } from "./Cosmetics";
 import "./DarkModeButton";
 import { DarkModeButton } from "./DarkModeButton";
 import "./FlagInput";
@@ -399,13 +400,24 @@ class Client {
 
   private handleHash() {
     const { hash } = window.location;
-    if (hash.startsWith("#")) {
-      const params = new URLSearchParams(hash.slice(1));
-      const lobbyId = params.get("join");
-      if (lobbyId && ID.safeParse(lobbyId).success) {
-        this.joinModal.open(lobbyId);
-        console.log(`joining lobby ${lobbyId}`);
-      }
+    if (!hash.startsWith("#")) {
+      return;
+    }
+    const params = new URLSearchParams(hash.slice(1));
+    const lobbyId = params.get("join");
+    if (lobbyId && ID.safeParse(lobbyId).success) {
+      this.joinModal.open(lobbyId);
+      console.log(`joining lobby ${lobbyId}`);
+    }
+
+    const purchaseSuccess = params.get(PURCHASE_SUCCESS_PARAM);
+    // TODO: Add a purchase success/failure modal
+    if (purchaseSuccess === "true") {
+      alert("Purchase successful!");
+      window.history.replaceState(null, "", window.location.pathname);
+    } else if (purchaseSuccess === "false") {
+      alert("Purchase cancelled");
+      window.history.replaceState(null, "", window.location.pathname);
     }
   }
 


### PR DESCRIPTION
## Description:

This PR does two things:

1. Instead of storing the flare itself in Stripe, store type & name metadata, and use that to  construct the corresponding flare

2. On purchase-success alert if purchase was successful or not, this should be a modal in the future.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
