### PR TITLE
Fix the stale disconnected (Zzz) icon persisting when a client reconnects

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -184,6 +184,11 @@ export class GameServer {
     this.activeClients.push(client);
     client.lastPing = Date.now();
 
+    // If there was a previously-connected client, and it is currently disconnected, and will be replaced by a new client, resend the 'mark-disconnected = false' intent so all clients can receive the update
+    if (this.allClients.get(client.clientID)?.isDisconnected) {
+      this.markClientDisconnected(client, false);
+    }
+
     this.allClients.set(client.clientID, client);
 
     client.ws.removeAllListeners("message");


### PR DESCRIPTION
Fix the stale disconnected (Zzz) icon persisting when a client reconnects

## Description:

Refer to issue #1630 

This change modifies the GameServer.addClient function to send the mark_disconnected = false intent when a client that was previously disconnected gets replaced by a newly joined client with the same clientID. Under the old logic, this mark_disconnected = false intent is not sent if the client was disconnected for longer than 60 seconds before reconnecting.


https://github.com/user-attachments/assets/5e0ce1c3-9519-4f39-aa80-e46f1275649c



## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

slyty
