### PR TITLE
Replacing array of units in PlayerImpl with map

### DIFF
--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -189,9 +189,9 @@ export class UnitImpl implements Unit {
         break;
     }
     this._lastOwner = this._owner;
-    this._lastOwner._units = this._lastOwner._units.filter((u) => u !== this);
+    this._lastOwner.deleteUnit(this);
     this._owner = newOwner;
-    this._owner._units.push(this);
+    this._owner.addUnit(this);
     this.mg.addUpdate(this.toUpdate());
     this.mg.displayMessage(
       `Your ${this.type()} was captured by ${newOwner.displayName()}`,
@@ -220,7 +220,7 @@ export class UnitImpl implements Unit {
     if (!this.isActive()) {
       throw new Error(`cannot delete ${this} not active`);
     }
-    this._owner._units = this._owner._units.filter((b) => b !== this);
+    this._owner.deleteUnit(this);
     this._active = false;
     this.mg.addUpdate(this.toUpdate());
     this.mg.removeUnit(this);

--- a/tests/PlayerImpl.test.ts
+++ b/tests/PlayerImpl.test.ts
@@ -107,4 +107,27 @@ describe("PlayerImpl", () => {
     }
     expect(other.canSendAllianceRequest(player)).toBe(false);
   });
+
+  test("Can find units by type", () => {
+    expect(player.unitsOwned(UnitType.DefensePost)).toBe(0);
+    expect(player.unitsConstructed(UnitType.DefensePost)).toBe(0);
+    expect(player.unitCount(UnitType.DefensePost)).toBe(0);
+    var defensePost = player.buildUnit(UnitType.DefensePost, game.ref(0, 0), {});
+    expect(player.unitsOwned(UnitType.DefensePost)).toBe(1);
+    expect(player.unitsConstructed(UnitType.DefensePost)).toBe(1);
+    expect(player.unitCount(UnitType.DefensePost)).toBe(1);
+    defensePost.delete();
+    expect(player.unitsOwned(UnitType.DefensePost)).toBe(0);
+    expect(player.unitsConstructed(UnitType.DefensePost)).toBe(1);
+    expect(player.unitCount(UnitType.DefensePost)).toBe(0);
+  });
+
+  test("Can switch owners of units", () => {
+    var defensePost = player.buildUnit(UnitType.DefensePost, game.ref(0, 0), {});
+    expect(player.unitsOwned(UnitType.DefensePost)).toBe(1);
+    expect(other.unitsOwned(UnitType.DefensePost)).toBe(0);
+    defensePost.setOwner(other);
+    expect(player.unitsOwned(UnitType.DefensePost)).toBe(0);
+    expect(other.unitsOwned(UnitType.DefensePost)).toBe(1);
+  });
 });


### PR DESCRIPTION
## Description:

Instead of iterating over all units to pick out units of a certain type, we can use a map and check arrays keyed by type.

There are other places where this pattern can be used (like `GameView`). If these changes are deemed acceptable, we should consider replacing arrays of units with maps.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

bypie5
