### PR TITLE
Fix for two formatPercentage functions

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -269,9 +269,6 @@ export class Leaderboard extends LitElement implements Layer {
 
 function formatPercentage(value: number): string {
   const perc = value * 100;
-  if (perc > 99.5) return "100%";
-  if (perc < 0.01) return "0%";
-  if (perc < 0.1) return perc.toPrecision(1) + "%";
   if (Number.isNaN(perc)) return "0%";
-  return perc.toPrecision(2) + "%";
+  return perc.toFixed(1) + "%";
 }

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -167,8 +167,6 @@ export class TeamStats extends LitElement implements Layer {
 
 function formatPercentage(value: number): string {
   const perc = value * 100;
-  if (perc > 99.5) return "100%";
-  if (perc < 0.01) return "0%";
-  if (perc < 0.1) return perc.toPrecision(1) + "%";
+  if (Number.isNaN(perc)) return "0%";
   return perc.toPrecision(2) + "%";
 }


### PR DESCRIPTION
Closes #1656

## Description:

Change: Simplification of the function to display percentages with one decimal place without limitation.
Result: Percentages are now displayed with one rounded decimal place (e.g. 15.5%, 99.6%) without automatic replacement of extreme values.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

kipstzz