### PR TITLE
Added eslint rule sort keys #1629 

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,6 +43,17 @@ export default [
       "@typescript-eslint/no-unused-expressions": "off",
       "@typescript-eslint/no-unused-vars": "off",
       "no-case-declarations": "off",
+      "sort-keys": [
+        "off",
+        "asc",
+        {
+          allowLineSeparatedGroups: false,
+          caseSensitive: true,
+          ignoreComputedKeys: false,
+          minKeys: 2,
+          natural: true,
+        },
+      ],
     },
   },
   {


### PR DESCRIPTION
## Description:

Added new sort keys rule for the linter. Declared all the configurations for the rule explicitly as I believe this will make refactoring easier in future. All configurations are the same as the default specified in the Eslint documentation apart from `natural` I changed to true so `1 10 2 3 4` is not considered a natural sequence. 

The rule is introduced as disabled as it currently identifies nearly 1600 errors. 

Relates to #1629 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME: robin_el_banco
