### PR TITLE
don't kick client for invalid message

### DIFF
--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -325,15 +325,9 @@ export function startWorker() {
             // Ignore ping
             return;
           } else if (clientMsg.type !== "join") {
-            const error = `Invalid message before join: ${JSON.stringify(clientMsg)}`;
-            log.warn(error);
-            ws.send(
-              JSON.stringify({
-                type: "error",
-                error,
-              } satisfies ServerErrorMessage),
+            log.warn(
+              `Invalid message before join: ${JSON.stringify(clientMsg)}`,
             );
-            ws.close(1002, "ClientJoinMessageSchema");
             return;
           }
 


### PR DESCRIPTION
## Description:

There is a race condition causing clients to send intents before joining:

1. User requests to join a Game
2. The Worker does authentication & authorization
3. User requests to send an intent before joining the game, so the request is sent to the worker

So instead of kicking the client, just log a warning and drop the message.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
