### PR TITLE
Fix invite link in Join Lobby

### DIFF
--- a/src/client/JoinPrivateLobbyModal.ts
+++ b/src/client/JoinPrivateLobbyModal.ts
@@ -137,7 +137,14 @@ export class JoinPrivateLobbyModal extends LitElement {
 
   private setLobbyId(id: string) {
     if (id.startsWith("http")) {
-      this.lobbyIdInput.value = id.split("join/")[1];
+      if (id.includes("#join=")) {
+        const params = new URLSearchParams(id.split("#")[1]);
+        this.lobbyIdInput.value = params.get("join") || id;
+      } else if (id.includes("join/")) {
+        this.lobbyIdInput.value = id.split("join/")[1];
+      } else {
+        this.lobbyIdInput.value = id;
+      }
     } else {
       this.lobbyIdInput.value = id;
     }
@@ -154,7 +161,14 @@ export class JoinPrivateLobbyModal extends LitElement {
 
       let lobbyId: string;
       if (clipText.startsWith("http")) {
-        lobbyId = clipText.split("join/")[1];
+        if (clipText.includes("#join=")) {
+          const params = new URLSearchParams(clipText.split("#")[1]);
+          lobbyId = params.get("join") || clipText;
+        } else if (clipText.includes("join/")) {
+          lobbyId = clipText.split("join/")[1];
+        } else {
+          lobbyId = clipText;
+        }
       } else {
         lobbyId = clipText;
       }

--- a/src/client/JoinPrivateLobbyModal.ts
+++ b/src/client/JoinPrivateLobbyModal.ts
@@ -135,19 +135,23 @@ export class JoinPrivateLobbyModal extends LitElement {
     );
   }
 
-  private setLobbyId(id: string) {
-    if (id.startsWith("http")) {
-      if (id.includes("#join=")) {
-        const params = new URLSearchParams(id.split("#")[1]);
-        this.lobbyIdInput.value = params.get("join") || id;
-      } else if (id.includes("join/")) {
-        this.lobbyIdInput.value = id.split("join/")[1];
+  private extractLobbyIdFromUrl(input: string): string {
+    if (input.startsWith("http")) {
+      if (input.includes("#join=")) {
+        const params = new URLSearchParams(input.split("#")[1]);
+        return params.get("join") ?? input;
+      } else if (input.includes("join/")) {
+        return input.split("join/")[1];
       } else {
-        this.lobbyIdInput.value = id;
+        return input;
       }
     } else {
-      this.lobbyIdInput.value = id;
+      return input;
     }
+  }
+
+  private setLobbyId(id: string) {
+    this.lobbyIdInput.value = this.extractLobbyIdFromUrl(id);
   }
 
   private handleChange(e: Event) {
@@ -158,22 +162,7 @@ export class JoinPrivateLobbyModal extends LitElement {
   private async pasteFromClipboard() {
     try {
       const clipText = await navigator.clipboard.readText();
-
-      let lobbyId: string;
-      if (clipText.startsWith("http")) {
-        if (clipText.includes("#join=")) {
-          const params = new URLSearchParams(clipText.split("#")[1]);
-          lobbyId = params.get("join") || clipText;
-        } else if (clipText.includes("join/")) {
-          lobbyId = clipText.split("join/")[1];
-        } else {
-          lobbyId = clipText;
-        }
-      } else {
-        lobbyId = clipText;
-      }
-
-      this.lobbyIdInput.value = lobbyId;
+      this.setLobbyId(clipText);
     } catch (err) {
       console.error("Failed to read clipboard contents: ", err);
     }


### PR DESCRIPTION
Closes #1694 

## Description:

Currently when you paste the invitation ( [https://openfront.io#join=QwIr5aK4](https://openfront.io/#join=QwIr5aK4) ) it puts undefined in the input so I made this issue to make a PR and fix the problem.

<img width="410" height="370" alt="image" src="https://github.com/user-attachments/assets/d2cf4321-49e3-4e81-987e-66eff2e4d14c" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

kipstzz
