### PR TITLE
remove unload warning.

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -442,10 +442,6 @@
           document.documentElement.classList.remove("preload");
         });
       });
-      window.addEventListener("beforeunload", function (e) {
-        e.preventDefault();
-        e.returnValue = "Are you sure you want to leave?";
-      });
     </script>
 
     <!-- Playwire ads -->


### PR DESCRIPTION
## Description:

The unload alert is triggered when purchasing items causing bad ux. We already have unload alert in-game if you are still alive so this seems unnecessary.

reverts: https://github.com/openfrontio/OpenFrontIO/commit/ac8a841e40d0e9d290877b1fe71a0f9456758fa5

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
