### PR TITLE
Fix: Automatically Close Flag Input Modal on Game Start

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -492,6 +492,7 @@ class Client {
           "territory-patterns-modal",
           "language-modal",
           "news-modal",
+          "flag-input-modal",
         ].forEach((tag) => {
           const modal = document.querySelector(tag) as HTMLElement & {
             close?: () => void;


### PR DESCRIPTION
## Description:

This PR ensures that the flag selection modal is automatically closed when a game starts.
Fix: https://github.com/openfrontio/OpenFrontIO/issues/1047

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
