### PR TITLE
Fix: Modal background color does not cover entire content when alwaysMaximized is set

### DIFF
--- a/src/client/components/baseComponents/Modal.ts
+++ b/src/client/components/baseComponents/Modal.ts
@@ -26,7 +26,6 @@ export class OModal extends LitElement {
     }
 
     .c-modal__wrapper {
-      background: #23232382;
       border-radius: 8px;
       min-width: 340px;
       max-width: 860px;
@@ -62,6 +61,7 @@ export class OModal extends LitElement {
     }
 
     .c-modal__content {
+      background: #23232382;
       position: relative;
       color: #fff;
       padding: 1.4rem;


### PR DESCRIPTION
## Description:

This PR fixes a visual bug where, when the `alwaysMaximized` property is enabled on the modal component (`o-modal`), the background color does not cover the entire content area, especially when the content is scrollable or overflows.

before
It is noticeable that a black border appears between the first and second lines from the bottom
<img width="929" height="722" alt="スクリーンショット 2025-08-05 17 03 16" src="https://github.com/user-attachments/assets/c6ecdd90-2210-4f23-8737-68bd24a0957e" />

after
<img width="916" height="718" alt="スクリーンショット 2025-08-05 17 06 54" src="https://github.com/user-attachments/assets/bcfb2a91-8b06-4185-84da-5430a789c46a" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri