### PR TITLE
allow trains & railroads between non-allies

### DIFF
--- a/src/core/game/TrainStation.ts
+++ b/src/core/game/TrainStation.ts
@@ -229,10 +229,7 @@ export class Cluster {
   availableForTrade(player: Player): Set<TrainStation> {
     const tradingStations = new Set<TrainStation>();
     for (const station of this.stations) {
-      if (
-        station.unit.owner() === player ||
-        station.unit.owner().isFriendly(player)
-      ) {
+      if (station.tradeAvailable(player)) {
         tradingStations.add(station);
       }
     }


### PR DESCRIPTION
## Description:

I think it makes sense to allow trains between non-allies, but give a bonus to land trade between players who are allies.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
