### PR TITLE
reduce train frequency

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -326,7 +326,7 @@ export class DefaultConfig implements Config {
     return this._gameConfig.infiniteTroops;
   }
   trainSpawnRate(numberOfStations: number): number {
-    return Math.min(1400, Math.round(20 * Math.pow(numberOfStations, 0.5)));
+    return Math.min(1400, Math.round(40 * Math.pow(numberOfStations, 0.5)));
   }
   trainGold(): Gold {
     return BigInt(4_000);


### PR DESCRIPTION
## Description:

I played a few games and the number of trains was distracting. Cut the number of trains roughly in half, we will probably need to adjust train gold to compensate.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
