### PR TITLE
Reintroduce commit metadata in the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,8 @@ RUN npm ci --omit=dev
 
 # Final image
 FROM base
-
+ARG GIT_COMMIT=unknown
+ENV GIT_COMMIT="$GIT_COMMIT"
 RUN apt-get update && apt-get install -y \
     nginx \
     supervisor \


### PR DESCRIPTION
## Description:
This PR fixes a regression where the `GIT_COMMIT` environment variable was no longer available in the final container image after a recent Dockerfile refactoring.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [X] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

aaa4xu
