### PR TITLE
Record additional stats for players

### DIFF
--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -88,6 +88,11 @@ export const OTHER_INDEX_CAPTURE = 2; // Structures captured
 export const OTHER_INDEX_LOST = 3; // Structures/warships destroyed/captured by others
 export const OTHER_INDEX_UPGRADE = 4; // Structures upgraded
 
+// Emojis
+export const EMOJI_INDEX_SENT = 0; // Emojis sent 1 on 1
+export const EMOJI_INDEX_RECV = 1; // Emojis received 1 on 1
+export const EMOJI_INDEX_BROADCAST = 2; // Emojis broadcasted to all players
+
 const BigIntStringSchema = z.preprocess((val) => {
   if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
   if (typeof val === "bigint") return val;
@@ -105,6 +110,7 @@ export const PlayerStatsSchema = z
     bombs: z.partialRecord(BombUnitSchema, AtLeastOneNumberSchema).optional(),
     gold: AtLeastOneNumberSchema.optional(),
     units: z.partialRecord(OtherUnitSchema, AtLeastOneNumberSchema).optional(),
+    emojis: AtLeastOneNumberSchema.optional(),
   })
   .optional();
 export type PlayerStats = z.infer<typeof PlayerStatsSchema>;

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -101,6 +101,11 @@ export const QUICKCHAT_INDEX_RECV = 1; // QuickChats received
 export const TARGET_INDEX_SENT = 0; // Targeting a player (outgoing)
 export const TARGET_INDEX_RECV = 1; // Targeting received (incoming)
 
+// Bots, Nations, Players conquered
+export const CONQUER_INDEX_BOT = 0; // Bots conquered
+export const CONQUER_INDEX_NATION = 1; // Nations conquered
+export const CONQUER_INDEX_PLAYER = 2; // Players conquered
+
 const BigIntStringSchema = z.preprocess((val) => {
   if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
   if (typeof val === "bigint") return val;
@@ -121,6 +126,7 @@ export const PlayerStatsSchema = z
     emojis: AtLeastOneNumberSchema.optional(),
     quickchats: AtLeastOneNumberSchema.optional(),
     targets: AtLeastOneNumberSchema.optional(),
+    conquers: AtLeastOneNumberSchema.optional(),
   })
   .optional();
 export type PlayerStats = z.infer<typeof PlayerStatsSchema>;

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -106,6 +106,10 @@ export const CONQUER_INDEX_BOT = 0; // Bots conquered
 export const CONQUER_INDEX_NATION = 1; // Nations conquered
 export const CONQUER_INDEX_PLAYER = 2; // Players conquered
 
+// Troops
+export const TROOPS_INDEX_SENT = 0; // Troops sent to other players
+export const TROOPS_INDEX_RECV = 1; // Troops received from other players
+
 const BigIntStringSchema = z.preprocess((val) => {
   if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
   if (typeof val === "bigint") return val;
@@ -127,6 +131,7 @@ export const PlayerStatsSchema = z
     quickchats: AtLeastOneNumberSchema.optional(),
     targets: AtLeastOneNumberSchema.optional(),
     conquers: AtLeastOneNumberSchema.optional(),
+    troopsDonated: AtLeastOneNumberSchema.optional(),
   })
   .optional();
 export type PlayerStats = z.infer<typeof PlayerStatsSchema>;

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -110,6 +110,10 @@ export const CONQUER_INDEX_PLAYER = 2; // Players conquered
 export const TROOPS_INDEX_SENT = 0; // Troops sent to other players
 export const TROOPS_INDEX_RECV = 1; // Troops received from other players
 
+// Gold Donations
+export const GOLD_DONATED_INDEX_SENT = 0; // Gold sent to other players
+export const GOLD_DONATED_INDEX_RECV = 1; // Gold received from other players
+
 const BigIntStringSchema = z.preprocess((val) => {
   if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
   if (typeof val === "bigint") return val;
@@ -132,6 +136,7 @@ export const PlayerStatsSchema = z
     targets: AtLeastOneNumberSchema.optional(),
     conquers: AtLeastOneNumberSchema.optional(),
     troopsDonated: AtLeastOneNumberSchema.optional(),
+    goldDonated: AtLeastOneNumberSchema.optional(),
   })
   .optional();
 export type PlayerStats = z.infer<typeof PlayerStatsSchema>;

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -97,6 +97,10 @@ export const EMOJI_INDEX_BROADCAST = 2; // Emojis broadcasted to all players
 export const QUICKCHAT_INDEX_SENT = 0; // QuickChats sent
 export const QUICKCHAT_INDEX_RECV = 1; // QuickChats received
 
+// Targets
+export const TARGET_INDEX_SENT = 0; // Targeting a player (outgoing)
+export const TARGET_INDEX_RECV = 1; // Targeting received (incoming)
+
 const BigIntStringSchema = z.preprocess((val) => {
   if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
   if (typeof val === "bigint") return val;
@@ -116,6 +120,7 @@ export const PlayerStatsSchema = z
     units: z.partialRecord(OtherUnitSchema, AtLeastOneNumberSchema).optional(),
     emojis: AtLeastOneNumberSchema.optional(),
     quickchats: AtLeastOneNumberSchema.optional(),
+    targets: AtLeastOneNumberSchema.optional(),
   })
   .optional();
 export type PlayerStats = z.infer<typeof PlayerStatsSchema>;

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -93,6 +93,10 @@ export const EMOJI_INDEX_SENT = 0; // Emojis sent 1 on 1
 export const EMOJI_INDEX_RECV = 1; // Emojis received 1 on 1
 export const EMOJI_INDEX_BROADCAST = 2; // Emojis broadcasted to all players
 
+// QuickChats
+export const QUICKCHAT_INDEX_SENT = 0; // QuickChats sent
+export const QUICKCHAT_INDEX_RECV = 1; // QuickChats received
+
 const BigIntStringSchema = z.preprocess((val) => {
   if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
   if (typeof val === "bigint") return val;
@@ -111,6 +115,7 @@ export const PlayerStatsSchema = z
     gold: AtLeastOneNumberSchema.optional(),
     units: z.partialRecord(OtherUnitSchema, AtLeastOneNumberSchema).optional(),
     emojis: AtLeastOneNumberSchema.optional(),
+    quickchats: AtLeastOneNumberSchema.optional(),
   })
   .optional();
 export type PlayerStats = z.infer<typeof PlayerStatsSchema>;

--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -343,6 +343,15 @@ export class AttackExecution implements Execution {
 
     this.mg.conquerPlayer(this._owner, this.target);
 
+    // Record stats of conquered players
+    if (this.target.type() === PlayerType.Bot) {
+      this.mg.stats().recordConquer(this._owner, "bot");
+    } else if (this.target.type() === PlayerType.FakeHuman) {
+      this.mg.stats().recordConquer(this._owner, "nation");
+    } else if (this.target.type() === PlayerType.Human) {
+      this.mg.stats().recordConquer(this._owner, "player");
+    }
+
     for (let i = 0; i < 10; i++) {
       for (const tile of this.target.tiles()) {
         const borders = this.mg

--- a/src/core/execution/DonateGoldExecution.ts
+++ b/src/core/execution/DonateGoldExecution.ts
@@ -5,6 +5,8 @@ export class DonateGoldExecution implements Execution {
 
   private active = true;
 
+  private mg: Game;
+
   constructor(
     private sender: Player,
     private recipientID: PlayerID,
@@ -20,6 +22,8 @@ export class DonateGoldExecution implements Execution {
 
     this.recipient = mg.player(this.recipientID);
     this.gold ??= this.sender.gold() / 3n;
+
+    this.mg = mg;
   }
 
   tick(ticks: number): void {
@@ -28,6 +32,7 @@ export class DonateGoldExecution implements Execution {
       this.sender.canDonate(this.recipient) &&
       this.sender.donateGold(this.recipient, this.gold)
     ) {
+      this.mg.stats().goldSend(this.sender, this.recipient, this.gold); // stats for donated gold
       this.recipient.updateRelation(this.sender, 50);
     } else {
       console.warn(

--- a/src/core/execution/DonateTroopExecution.ts
+++ b/src/core/execution/DonateTroopExecution.ts
@@ -5,6 +5,8 @@ export class DonateTroopsExecution implements Execution {
 
   private active = true;
 
+  private mg: Game;
+
   constructor(
     private sender: Player,
     private recipientID: PlayerID,
@@ -23,6 +25,8 @@ export class DonateTroopsExecution implements Execution {
     const maxDonation =
       mg.config().maxTroops(this.recipient) - this.recipient.troops();
     this.troops = Math.min(this.troops, maxDonation);
+
+    this.mg = mg;
   }
 
   tick(ticks: number): void {
@@ -31,6 +35,7 @@ export class DonateTroopsExecution implements Execution {
       this.sender.canDonate(this.recipient) &&
       this.sender.donateTroops(this.recipient, this.troops)
     ) {
+      this.mg.stats().troopsSend(this.sender, this.recipient, this.troops); // stats for donated troops (uses backend # and not UI)
       this.recipient.updateRelation(this.sender, 50);
     } else {
       console.warn(

--- a/src/core/execution/EmojiExecution.ts
+++ b/src/core/execution/EmojiExecution.ts
@@ -13,6 +13,8 @@ export class EmojiExecution implements Execution {
 
   private active = true;
 
+  private mg: Game;
+
   constructor(
     private requestor: Player,
     private recipientID: PlayerID | typeof AllPlayers,
@@ -30,6 +32,8 @@ export class EmojiExecution implements Execution {
       this.recipientID === AllPlayers
         ? AllPlayers
         : mg.player(this.recipientID);
+
+    this.mg = mg;
   }
 
   tick(ticks: number): void {
@@ -40,6 +44,15 @@ export class EmojiExecution implements Execution {
       );
     } else if (this.requestor.canSendEmoji(this.recipient)) {
       this.requestor.sendEmoji(this.recipient, emojiString);
+
+      if (this.recipient === AllPlayers) {
+        // track a broadcast
+        this.mg.stats().emojiBroadcast(this.requestor);
+      } else {
+        // track a DM
+        this.mg.stats().emojiSend(this.requestor, this.recipient);
+      }
+
       if (
         emojiString === "🖕" &&
         this.recipient !== AllPlayers &&

--- a/src/core/execution/QuickChatExecution.ts
+++ b/src/core/execution/QuickChatExecution.ts
@@ -47,6 +47,8 @@ export class QuickChatExecution implements Execution {
       this.recipient.id(),
     );
 
+    this.mg.stats().quickChatSend(this.sender, this.recipient);
+
     console.log(
       `[QuickChat] ${this.sender.name} → ${this.recipient.displayName}: ${message}`,
     );

--- a/src/core/execution/TargetPlayerExecution.ts
+++ b/src/core/execution/TargetPlayerExecution.ts
@@ -2,6 +2,7 @@ import { Execution, Game, Player, PlayerID } from "../game/Game";
 
 export class TargetPlayerExecution implements Execution {
   private target: Player;
+  private mg: Game;
 
   private active = true;
 
@@ -11,6 +12,8 @@ export class TargetPlayerExecution implements Execution {
   ) {}
 
   init(mg: Game, ticks: number): void {
+    this.mg = mg;
+
     if (!mg.hasPlayer(this.targetID)) {
       console.warn(`TargetPlayerExecution: target ${this.targetID} not found`);
       this.active = false;
@@ -23,6 +26,7 @@ export class TargetPlayerExecution implements Execution {
   tick(ticks: number): void {
     if (this.requestor.canTarget(this.target)) {
       this.requestor.target(this.target);
+      this.mg.stats().targetSend(this.requestor, this.target);
       this.target.updateRelation(this.requestor, -40);
     }
     this.active = false;

--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -111,4 +111,7 @@ export interface Stats {
 
   // Player sends troops to another player
   troopsSend(player: Player, target: Player, troops: number | bigint): void;
+
+  // Player sends gold to another player
+  goldSend(player: Player, target: Player, gold: number | bigint): void;
 }

--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -102,4 +102,7 @@ export interface Stats {
 
   // Player sends a quick chat to another player
   quickChatSend(player: Player, target: Player): void;
+
+  // Player targets another player
+  targetSend(player: Player, target: Player): void;
 }

--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -105,4 +105,7 @@ export interface Stats {
 
   // Player targets another player
   targetSend(player: Player, target: Player): void;
+
+  // Player conquers a bot, nation, or player
+  recordConquer(player: Player, type: "bot" | "nation" | "player"): void;
 }

--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -93,4 +93,10 @@ export interface Stats {
 
   // Player loses a unit of type
   unitLose(player: Player, type: OtherUnitType): void;
+
+  // Player sends an emoji to another player
+  emojiSend(player: Player, target: Player): void;
+
+  // Player broadcasts an emoji to all players
+  emojiBroadcast(player: Player): void;
 }

--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -108,4 +108,7 @@ export interface Stats {
 
   // Player conquers a bot, nation, or player
   recordConquer(player: Player, type: "bot" | "nation" | "player"): void;
+
+  // Player sends troops to another player
+  troopsSend(player: Player, target: Player, troops: number | bigint): void;
 }

--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -99,4 +99,7 @@ export interface Stats {
 
   // Player broadcasts an emoji to all players
   emojiBroadcast(player: Player): void;
+
+  // Player sends a quick chat to another player
+  quickChatSend(player: Player, target: Player): void;
 }

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -17,6 +17,8 @@ import {
   EMOJI_INDEX_BROADCAST,
   EMOJI_INDEX_RECV,
   EMOJI_INDEX_SENT,
+  GOLD_DONATED_INDEX_RECV,
+  GOLD_DONATED_INDEX_SENT,
   GOLD_INDEX_STEAL,
   GOLD_INDEX_TRADE,
   GOLD_INDEX_WAR,
@@ -185,6 +187,14 @@ export class StatsImpl implements Stats {
     p.troopsDonated[index] += _bigint(value);
   }
 
+  private _addGoldDonated(player: Player, index: number, value: BigIntLike) {
+    const p = this._makePlayerStats(player);
+    if (p === undefined) return;
+    p.goldDonated ??= [0n, 0n];
+    while (p.goldDonated.length <= index) p.goldDonated.push(0n);
+    p.goldDonated[index] += _bigint(value);
+  }
+
   attack(
     player: Player,
     target: Player | TerraNullius,
@@ -335,5 +345,10 @@ export class StatsImpl implements Stats {
   troopsSend(player: Player, target: Player, troops: BigIntLike): void {
     this._addTroops(player, TROOPS_INDEX_SENT, troops);
     this._addTroops(target, TROOPS_INDEX_RECV, troops);
+  }
+
+  goldSend(player: Player, target: Player, gold: number | bigint): void {
+    this._addGoldDonated(player, GOLD_DONATED_INDEX_SENT, gold);
+    this._addGoldDonated(target, GOLD_DONATED_INDEX_RECV, gold);
   }
 }

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -33,6 +33,8 @@ import {
   QUICKCHAT_INDEX_SENT,
   TARGET_INDEX_RECV,
   TARGET_INDEX_SENT,
+  TROOPS_INDEX_RECV,
+  TROOPS_INDEX_SENT,
   unitTypeToBombUnit,
   unitTypeToOtherUnit,
 } from "../StatsSchemas";
@@ -173,6 +175,14 @@ export class StatsImpl implements Stats {
     p.conquers ??= [0n, 0n, 0n];
     while (p.conquers.length <= index) p.conquers.push(0n);
     p.conquers[index] += 1n;
+  }
+
+  private _addTroops(player: Player, index: number, value: BigIntLike) {
+    const p = this._makePlayerStats(player);
+    if (p === undefined) return;
+    p.troopsDonated ??= [0n, 0n];
+    while (p.troopsDonated.length <= index) p.troopsDonated.push(0n);
+    p.troopsDonated[index] += _bigint(value);
   }
 
   attack(
@@ -320,5 +330,10 @@ export class StatsImpl implements Stats {
         this._addConquer(player, CONQUER_INDEX_PLAYER);
         break;
     }
+  }
+
+  troopsSend(player: Player, target: Player, troops: BigIntLike): void {
+    this._addTroops(player, TROOPS_INDEX_SENT, troops);
+    this._addTroops(target, TROOPS_INDEX_RECV, troops);
   }
 }

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -11,6 +11,9 @@ import {
   BOMB_INDEX_INTERCEPT,
   BOMB_INDEX_LAND,
   BOMB_INDEX_LAUNCH,
+  CONQUER_INDEX_BOT,
+  CONQUER_INDEX_NATION,
+  CONQUER_INDEX_PLAYER,
   EMOJI_INDEX_BROADCAST,
   EMOJI_INDEX_RECV,
   EMOJI_INDEX_SENT,
@@ -164,6 +167,14 @@ export class StatsImpl implements Stats {
     p.targets[index] += 1n;
   }
 
+  private _addConquer(player: Player, index: number) {
+    const p = this._makePlayerStats(player);
+    if (p === undefined) return;
+    p.conquers ??= [0n, 0n, 0n];
+    while (p.conquers.length <= index) p.conquers.push(0n);
+    p.conquers[index] += 1n;
+  }
+
   attack(
     player: Player,
     target: Player | TerraNullius,
@@ -295,5 +306,19 @@ export class StatsImpl implements Stats {
   targetSend(player: Player, target: Player): void {
     this._addTarget(player, TARGET_INDEX_SENT);
     this._addTarget(target, TARGET_INDEX_RECV);
+  }
+
+  recordConquer(player: Player, type: "bot" | "nation" | "player"): void {
+    switch (type) {
+      case "bot":
+        this._addConquer(player, CONQUER_INDEX_BOT);
+        break;
+      case "nation":
+        this._addConquer(player, CONQUER_INDEX_NATION);
+        break;
+      case "player":
+        this._addConquer(player, CONQUER_INDEX_PLAYER);
+        break;
+    }
   }
 }

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -28,6 +28,8 @@ import {
   PlayerStats,
   QUICKCHAT_INDEX_RECV,
   QUICKCHAT_INDEX_SENT,
+  TARGET_INDEX_RECV,
+  TARGET_INDEX_SENT,
   unitTypeToBombUnit,
   unitTypeToOtherUnit,
 } from "../StatsSchemas";
@@ -152,6 +154,14 @@ export class StatsImpl implements Stats {
     p.quickchats ??= [0n, 0n];
     while (p.quickchats.length <= index) p.quickchats.push(0n);
     p.quickchats[index] += 1n;
+  }
+
+  private _addTarget(player: Player, index: number) {
+    const p = this._makePlayerStats(player);
+    if (p === undefined) return;
+    p.targets ??= [0n, 0n];
+    while (p.targets.length <= index) p.targets.push(0n);
+    p.targets[index] += 1n;
   }
 
   attack(
@@ -280,5 +290,10 @@ export class StatsImpl implements Stats {
   quickChatSend(player: Player, target: Player): void {
     this._addQuickChat(player, QUICKCHAT_INDEX_SENT);
     this._addQuickChat(target, QUICKCHAT_INDEX_RECV);
+  }
+
+  targetSend(player: Player, target: Player): void {
+    this._addTarget(player, TARGET_INDEX_SENT);
+    this._addTarget(target, TARGET_INDEX_RECV);
   }
 }

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -11,6 +11,9 @@ import {
   BOMB_INDEX_INTERCEPT,
   BOMB_INDEX_LAND,
   BOMB_INDEX_LAUNCH,
+  EMOJI_INDEX_BROADCAST,
+  EMOJI_INDEX_RECV,
+  EMOJI_INDEX_SENT,
   GOLD_INDEX_STEAL,
   GOLD_INDEX_TRADE,
   GOLD_INDEX_WAR,
@@ -133,6 +136,14 @@ export class StatsImpl implements Stats {
     p.units[type][index] += _bigint(value);
   }
 
+  private _addEmoji(player: Player, index: number) {
+    const p = this._makePlayerStats(player);
+    if (p === undefined) return;
+    p.emojis ??= [0n, 0n, 0n];
+    while (p.emojis.length <= index) p.emojis.push(0n);
+    p.emojis[index] += 1n;
+  }
+
   attack(
     player: Player,
     target: Player | TerraNullius,
@@ -245,5 +256,14 @@ export class StatsImpl implements Stats {
 
   unitLose(player: Player, type: OtherUnitType): void {
     this._addOtherUnit(player, type, OTHER_INDEX_LOST, 1);
+  }
+
+  emojiSend(player: Player, target: Player): void {
+    this._addEmoji(player, EMOJI_INDEX_SENT);
+    this._addEmoji(target, EMOJI_INDEX_RECV);
+  }
+
+  emojiBroadcast(player: Player) {
+    this._addEmoji(player, EMOJI_INDEX_BROADCAST);
   }
 }

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -26,6 +26,8 @@ import {
   OTHER_INDEX_UPGRADE,
   OtherUnitType,
   PlayerStats,
+  QUICKCHAT_INDEX_RECV,
+  QUICKCHAT_INDEX_SENT,
   unitTypeToBombUnit,
   unitTypeToOtherUnit,
 } from "../StatsSchemas";
@@ -142,6 +144,14 @@ export class StatsImpl implements Stats {
     p.emojis ??= [0n, 0n, 0n];
     while (p.emojis.length <= index) p.emojis.push(0n);
     p.emojis[index] += 1n;
+  }
+
+  private _addQuickChat(player: Player, index: number) {
+    const p = this._makePlayerStats(player);
+    if (p === undefined) return;
+    p.quickchats ??= [0n, 0n];
+    while (p.quickchats.length <= index) p.quickchats.push(0n);
+    p.quickchats[index] += 1n;
   }
 
   attack(
@@ -265,5 +275,10 @@ export class StatsImpl implements Stats {
 
   emojiBroadcast(player: Player) {
     this._addEmoji(player, EMOJI_INDEX_BROADCAST);
+  }
+
+  quickChatSend(player: Player, target: Player): void {
+    this._addQuickChat(player, QUICKCHAT_INDEX_SENT);
+    this._addQuickChat(target, QUICKCHAT_INDEX_RECV);
   }
 }

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -259,6 +259,36 @@ describe("Stats", () => {
     });
   });
 
+  test("quickChatSend", () => {
+    stats.quickChatSend(player1, player2);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        quickchats: [1n, 0n],
+      },
+      client2: {
+        quickchats: [0n, 1n],
+      },
+    });
+    stats.quickChatSend(player1, player2);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        quickchats: [2n, 0n],
+      },
+      client2: {
+        quickchats: [0n, 2n],
+      },
+    });
+    stats.quickChatSend(player2, player1);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        quickchats: [2n, 1n],
+      },
+      client2: {
+        quickchats: [1n, 2n],
+      },
+    });
+  });
+
   test("stringify", () => {
     stats.unitLose(player1, UnitType.Port);
     expect(JSON.stringify(stats.stats(), replacer)).toBe(

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -375,6 +375,38 @@ describe("Stats", () => {
     });
   });
 
+  test("goldSend", () => {
+    stats.goldSend(player1, player2, 1000n);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        goldDonated: [1000n, 0n],
+      },
+      client2: {
+        goldDonated: [0n, 1000n],
+      },
+    });
+
+    stats.goldSend(player1, player2, 500n);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        goldDonated: [1500n, 0n],
+      },
+      client2: {
+        goldDonated: [0n, 1500n],
+      },
+    });
+
+    stats.goldSend(player2, player1, 250n);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        goldDonated: [1500n, 250n],
+      },
+      client2: {
+        goldDonated: [250n, 1500n],
+      },
+    });
+  });
+
   test("stringify", () => {
     stats.unitLose(player1, UnitType.Port);
     expect(JSON.stringify(stats.stats(), replacer)).toBe(

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -211,6 +211,54 @@ describe("Stats", () => {
     });
   });
 
+  test("emojiSend", () => {
+    stats.emojiSend(player1, player2);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        emojis: [1n, 0n, 0n],
+      },
+      client2: {
+        emojis: [0n, 1n, 0n],
+      },
+    });
+    stats.emojiSend(player1, player2);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        emojis: [2n, 0n, 0n],
+      },
+      client2: {
+        emojis: [0n, 2n, 0n],
+      },
+    });
+    stats.emojiSend(player2, player1);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        emojis: [2n, 1n, 0n],
+      },
+      client2: {
+        emojis: [1n, 2n, 0n],
+      },
+    });
+  });
+
+  test("emojiBroadcast", () => {
+    stats.emojiBroadcast(player1);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        emojis: [0n, 0n, 1n],
+      },
+    });
+
+    // multiple broadcasts accumulate
+    stats.emojiBroadcast(player1);
+    stats.emojiBroadcast(player1);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        emojis: [0n, 0n, 3n],
+      },
+    });
+  });
+
   test("stringify", () => {
     stats.unitLose(player1, UnitType.Port);
     expect(JSON.stringify(stats.stats(), replacer)).toBe(

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -289,6 +289,36 @@ describe("Stats", () => {
     });
   });
 
+  test("targetSend", () => {
+    stats.targetSend(player1, player2);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        targets: [1n, 0n],
+      },
+      client2: {
+        targets: [0n, 1n],
+      },
+    });
+    stats.targetSend(player1, player2);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        targets: [2n, 0n],
+      },
+      client2: {
+        targets: [0n, 2n],
+      },
+    });
+    stats.targetSend(player2, player1);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        targets: [2n, 1n],
+      },
+      client2: {
+        targets: [1n, 2n],
+      },
+    });
+  });
+
   test("stringify", () => {
     stats.unitLose(player1, UnitType.Port);
     expect(JSON.stringify(stats.stats(), replacer)).toBe(

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -343,6 +343,38 @@ describe("Stats", () => {
     });
   });
 
+  test("troopsSend", () => {
+    stats.troopsSend(player1, player2, 100);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        troopsDonated: [100n, 0n],
+      },
+      client2: {
+        troopsDonated: [0n, 100n],
+      },
+    });
+
+    stats.troopsSend(player1, player2, 50);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        troopsDonated: [150n, 0n],
+      },
+      client2: {
+        troopsDonated: [0n, 150n],
+      },
+    });
+
+    stats.troopsSend(player2, player1, 25);
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        troopsDonated: [150n, 25n],
+      },
+      client2: {
+        troopsDonated: [25n, 150n],
+      },
+    });
+  });
+
   test("stringify", () => {
     stats.unitLose(player1, UnitType.Port);
     expect(JSON.stringify(stats.stats(), replacer)).toBe(

--- a/tests/Stats.test.ts
+++ b/tests/Stats.test.ts
@@ -319,6 +319,30 @@ describe("Stats", () => {
     });
   });
 
+  test("recordConquer", () => {
+    stats.recordConquer(player1, "bot");
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        conquers: [1n, 0n, 0n],
+      },
+    });
+    stats.recordConquer(player1, "nation");
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        conquers: [1n, 1n, 0n],
+      },
+    });
+    stats.recordConquer(player2, "player");
+    expect(stats.stats()).toStrictEqual({
+      client1: {
+        conquers: [1n, 1n, 0n],
+      },
+      client2: {
+        conquers: [0n, 0n, 1n],
+      },
+    });
+  });
+
   test("stringify", () => {
     stats.unitLose(player1, UnitType.Port);
     expect(JSON.stringify(stats.stats(), replacer)).toBe(


### PR DESCRIPTION
## Description:

This PR adds statistics tracking for player interactions as was requested in [issue 1254](https://github.com/openfrontio/OpenFrontIO/issues/1254), including
- emojis sent/received 1-on-1 & broadcasts to all players
- quick chats sent/received between players
- targeting actions sent/received between players
- troops sent/received between players
- gold sent/received between players
- bots/nations/players eliminated

Tests have been added to Stats.test.ts.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [x] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

zingbing
