### PR TITLE
Improve tradeship spawn rates fixes #1541

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -129,7 +129,7 @@ export interface Config {
   defaultDonationAmount(sender: Player): number;
   unitInfo(type: UnitType): UnitInfo;
   tradeShipGold(dist: number, numPorts: number): Gold;
-  tradeShipSpawnRate(numberOfPorts: number): number;
+  tradeShipSpawnRate(numTradeShips: number, numPlayerPorts: number): number;
   trainGold(): Gold;
   trainSpawnRate(numberOfStations: number): number;
   trainStationMinRange(): number;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -342,28 +342,28 @@ export class DefaultConfig implements Config {
   }
 
   tradeShipGold(dist: number, numPorts: number): Gold {
-    const baseGold = Math.floor(50000 + 100 * dist);
-    const basePortBonus = 0.25;
-    const diminishingFactor = 0.9;
-
-    let totalMultiplier = 1;
-    for (let i = 0; i < numPorts; i++) {
-      totalMultiplier += basePortBonus * Math.pow(diminishingFactor, i);
-    }
-
-    return BigInt(Math.floor(baseGold * totalMultiplier));
+    const baseGold = 25000 + 100 * dist;
+    const portBonus = 1 + 0.5 * Math.sqrt(numPorts - 1);
+    return BigInt(Math.floor(portBonus * baseGold));
   }
 
-  // Chance to spawn a trade ship in one second,
-  tradeShipSpawnRate(numTradeShips: number): number {
-    if (numTradeShips < 20) {
-      return 5;
+  tradeShipSpawnRate(numTradeShips: number, numPlayerPorts: number): number {
+    if (numTradeShips >= 150) {
+      return 1_000_000;
     }
-    if (numTradeShips <= 150) {
-      const additional = numTradeShips - 20;
-      return Math.floor(Math.pow(additional, 0.85) + 5);
-    }
-    return 1_000_000;
+    const baseSpawnRate = Math.floor(Math.pow(numTradeShips, 0.7) + 10);
+
+    const multiplier = (10 * numPlayerPorts ** 0.5 + numPlayerPorts) / 10;
+    return Math.floor(baseSpawnRate * multiplier);
+  }
+
+  expectedTradeShipSpawnRate(
+    numTradeShips: number,
+    numPlayerPorts: number,
+  ): number {
+    const spawnRate = this.tradeShipSpawnRate(numTradeShips, numPlayerPorts);
+    const expectedSpawn = numPlayerPorts * (1 / spawnRate);
+    return expectedSpawn;
   }
 
   unitInfo(type: UnitType): UnitInfo {

--- a/src/core/execution/PortExecution.ts
+++ b/src/core/execution/PortExecution.ts
@@ -78,7 +78,10 @@ export class PortExecution implements Execution {
 
   shouldSpawnTradeShip(): boolean {
     const numTradeShips = this.mg.unitCount(UnitType.TradeShip);
-    const spawnRate = this.mg.config().tradeShipSpawnRate(numTradeShips);
+    const numPlayerPorts = this.player.unitCount(UnitType.Port);
+    const spawnRate = this.mg
+      .config()
+      .tradeShipSpawnRate(numTradeShips, numPlayerPorts);
     for (let i = 0; i < this.port!.level(); i++) {
       if (this.random.chance(spawnRate)) {
         return true;


### PR DESCRIPTION
## Description:

The previous behavior had trade ship spawn rate decrease as the number of trade ships on the map increased. This was problematic because large players with many ports could starve out smaller players.

This change has the trade ship spawn rate decrease as number of ports increases, but increases the value of trade ships to compensate. It also decreases as a function of number of tradeships, but it is less of a factor as before.

Gold per trade ship scales with goldMultiplier(), but tradeship spawn rate decreases with sqrt(goldMultiplier()), this ensures that more ports => more gold.

After roughly 10-15 ports the increase trails off, preventing large players from gaining too much gold.


<img width="949" height="846" alt="Screenshot 2025-08-08 at 12 20 34 PM" src="https://github.com/user-attachments/assets/8b75a938-4bcf-4c3e-9fed-f69ce5245064" />

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA agreement (only required once).

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
