### PR TITLE
Enable eslint warning for type assertions

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,10 @@ export default [
   {
     rules: {
       // Enable rules
+      "@typescript-eslint/consistent-type-assertions": [
+        "warn", // TODO: Raise this to error, https://github.com/openfrontio/OpenFrontIO/issues/1033
+        { assertionStyle: "never" },
+      ],
       "@typescript-eslint/prefer-nullish-coalescing": "error",
       eqeqeq: "error",
       "sort-keys": "error",


### PR DESCRIPTION
## Description:

Enable eslint warning for `@typescript-eslint/consistent-type-assertions`. While build warnings are generally a discouraged pattern, we are actively working to drive the number of warnings down to zero, at which point we will convert the warnings to errors.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I have read and accepted the CLA agreement (only required once).
