### PR TITLE
Apply user-configured keybinds after initialisaing defaults to prevent accidental override

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -159,7 +159,6 @@ export class InputHandler {
       groundAttack: "KeyG",
       modifierKey: "ControlLeft",
       altKey: "AltLeft",
-      ...(JSON.parse(localStorage.getItem("settings.keybinds") ?? "{}") ?? {}),
     };
 
     // Mac users might have different keybinds
@@ -167,6 +166,8 @@ export class InputHandler {
     if (isMac) {
       this.keybinds.modifierKey = "MetaLeft"; // Use Command key on Mac
     }
+
+    Object.assign(this.keybinds, JSON.parse(localStorage.getItem("settings.keybinds") ?? "{}") ?? {});
 
     this.canvas.addEventListener("pointerdown", (e) => this.onPointerDown(e));
     window.addEventListener("pointerup", (e) => this.onPointerUp(e));


### PR DESCRIPTION
I had a frustrating experience while playing your game: I tried to open the build menu just after moving the camera, and inadvertently pressed Cmd+W, causing me to exit the game. I looked for an option to rebind the build menu but couldn't find one, so looked towards the source code and saw running `localStorage.setItem("settings.keybinds", ...)` in the console as a potential fix. Unfortunately, that solution doesn't work here, because the user-provided `modiferKey` is overridden on MacOS. For that reason, I suggest this change.