### PR TITLE
eslint: Prefer `type.array()` over `z.array(type)`

### DIFF
--- a/eslint-plugin-local/plugin.js
+++ b/eslint-plugin-local/plugin.js
@@ -1,0 +1,7 @@
+import noZArray from "./rules/no-z-array.js";
+
+export default {
+  rules: {
+    "no-z-array": noZArray,
+  },
+};

--- a/eslint-plugin-local/rules/no-z-array.js
+++ b/eslint-plugin-local/rules/no-z-array.js
@@ -1,0 +1,35 @@
+export default {
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.object.name === "z" &&
+          node.callee.property.name === "array" &&
+          node.arguments.length === 1
+        ) {
+          const argSource = context.sourceCode.getText(node.arguments[0]);
+          context.report({
+            data: { type: argSource },
+            fix(fixer) {
+              return fixer.replaceText(node, `${argSource}.array()`);
+            },
+            messageId: "noZArray",
+            node,
+          });
+        }
+      },
+    };
+  },
+  meta: {
+    docs: {
+      description: "Disallow z.array(type) in favor of type.array()",
+    },
+    fixable: "code",
+    messages: {
+      noZArray: "Use `{{type}}.array()` instead of `z.array({{type}})`.",
+    },
+    schema: [],
+    type: "suggestion",
+  },
+};

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,6 +6,7 @@ import stylisticTs from "@stylistic/eslint-plugin";
 import tseslint from "typescript-eslint";
 import { fileURLToPath } from "node:url";
 import { includeIgnoreFile } from "@eslint/compat";
+import eslintPluginLocal from "./eslint-plugin-local/plugin.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -26,6 +27,8 @@ export default [
         projectService: {
           allowDefaultProject: [
             "__mocks__/fileMock.js",
+            "eslint-plugin-local/plugin.js",
+            "eslint-plugin-local/rules/no-z-array.js",
             "eslint.config.js",
             "jest.config.ts",
             "postcss.config.js",
@@ -128,6 +131,14 @@ export default [
     ],
     rules: {
       "sort-keys": "off",
+    },
+  },
+  {
+    plugins: {
+      local: eslintPluginLocal,
+    },
+    rules: {
+      "local/no-z-array": "error",
     },
   },
 ];

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -25,7 +25,7 @@ export const CosmeticsSchema = z.object({
         z.string(),
         z.object({
           name: z.string(),
-          flares: z.array(z.string()).optional(),
+          flares: z.string().array().optional(),
         }),
       ),
       color: z.record(
@@ -33,7 +33,7 @@ export const CosmeticsSchema = z.object({
         z.object({
           color: z.string(),
           name: z.string(),
-          flares: z.array(z.string()).optional(),
+          flares: z.string().array().optional(),
         }),
       ),
     })


### PR DESCRIPTION
## Description:

Prefer `type.array()` over `z.array(type)`.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced