### PR TITLE
Ensure the radial menu is within the viewport

### DIFF
--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -111,7 +111,6 @@ export class RadialMenu implements Layer {
     this.eventBus.on(CloseViewEvent, (e) => {
       this.hideRadialMenu();
     });
-    window.addEventListener("resize", this.handleResize);
   }
 
   private createMenuElement() {
@@ -768,6 +767,7 @@ export class RadialMenu implements Layer {
 
     this.renderMenuItems(this.currentMenuItems, this.currentLevel);
     this.onCenterButtonHover(true);
+    window.addEventListener("resize", this.handleResize);
   }
 
   public hideRadialMenu() {


### PR DESCRIPTION
## Description:

This PR ensures the radial menu is within the viewport.
When clicking right next to the edge of the screen in the browser, the menu will now use transition to ease itself into the viewport, so the menu will stay visible at all times.

Issue: https://github.com/openfrontio/OpenFrontIO/issues/1596

<img width="666" height="571" alt="image" src="https://github.com/user-attachments/assets/a1663b62-96a3-4bfd-830d-8ee2424834ed" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

WoodyDRN