### PR TITLE
Add auto-assign PR creator workflow

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -1,0 +1,2 @@
+# Set addAssignees to 'author' to set the PR creator as the assignee. https://github.com/kentaro-m/auto-assign-action
+addAssignees: author

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,8 +24,6 @@ jobs:
       pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
-        with:
-          addAssignees: author
 
   validate-description:
     name: Validate Description

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -20,6 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.event.action == 'opened'
+    permissions:
+      pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
 

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -15,6 +15,14 @@ on:
 permissions: {}
 
 jobs:
+  auto-assign:
+    name: Auto-assign author of a PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event.action == 'opened'
+    steps:
+      - uses: kentaro-m/auto-assign-action@v2.0.0
+
   validate-description:
     name: Validate Description
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -24,6 +24,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: kentaro-m/auto-assign-action@v2.0.0
+        with:
+          addAssignees: author
 
   validate-description:
     name: Validate Description


### PR DESCRIPTION
## Description:

Adds GitHub Action to automatically assign PR creator to their own pull request when opened.

Tested here: [PR](https://github.com/floriankilian/OpenFrontIO/pull/2)
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
- [ ] I understand that submitting code with bugs that could have been caught through manual testing blocks releases and new features for all contributors

## Please put your Discord username so you can be contacted if a bug or regression is found:

[UN] nvm
