### PR TITLE
removed duplicate Papua New Guinea

### DIFF
--- a/resources/maps/oceania/manifest.json
+++ b/resources/maps/oceania/manifest.json
@@ -24,12 +24,6 @@
       "strength": 1
     },
     {
-      "coordinates": [686, 407],
-      "flag": "pg",
-      "name": "Papua New Guinea",
-      "strength": 1
-    },
-    {
       "coordinates": [436, 407],
       "flag": "tl",
       "name": "Timor-Leste",


### PR DESCRIPTION
## Description:

In the Oceania map, there are two Papua New Guinea countries defined. This PR removes one. https://discord.com/channels/1284581928254701718/1405936449853063228

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

loymdayddaud