### PR TITLE
fix pattern modal not opening on click

### DIFF
--- a/src/client/TerritoryPatternsModal.ts
+++ b/src/client/TerritoryPatternsModal.ts
@@ -44,9 +44,10 @@ export class TerritoryPatternsModal extends LitElement {
     super.connectedCallback();
     window.addEventListener("keydown", this.handleKeyDown);
     this.updateComplete.then(() => {
-      this.updatePreview();
+      this.open().then(() => {
+        this.updatePreview();
+      });
     });
-    this.open();
   }
 
   disconnectedCallback() {
@@ -231,11 +232,21 @@ export class TerritoryPatternsModal extends LitElement {
     `;
   }
 
-  public open() {
+  public async open() {
     this.isActive = true;
-    this.modalEl?.open();
-    window.addEventListener("keydown", this.handleKeyDown);
     this.requestUpdate();
+
+    // Wait for the DOM to be updated and the o-modal element to be available
+    await this.updateComplete;
+
+    // Now modalEl should be available
+    if (this.modalEl) {
+      this.modalEl.open();
+    } else {
+      console.warn("modalEl is still null after updateComplete");
+    }
+
+    window.addEventListener("keydown", this.handleKeyDown);
   }
 
   public close() {


### PR DESCRIPTION
## Description:

Sometimes clicking the pattern button wouldn't open the pattern modal. This is because there was a race condition between opening the modal & the o-modal becoming available.

So we do `await this.updateComplete;` to ensure the o-modal is initialized before rendering.
## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
