### PR TITLE
Enable the `@typescript-eslint/no-unsafe-argument` eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -43,7 +43,6 @@ export default [
   {
     rules: {
       // Disable rules that would fail. The failures should be fixed, and the entries here removed.
-      "@typescript-eslint/no-explicit-any": "off", // https://github.com/openfrontio/OpenFrontIO/issues/1789
       "@typescript-eslint/no-unused-expressions": "off", // https://github.com/openfrontio/OpenFrontIO/issues/1790
       "no-case-declarations": "off", // https://github.com/openfrontio/OpenFrontIO/issues/1791
     },
@@ -88,7 +87,7 @@ export default [
       "eqeqeq": "error",
       "indent": "off", // @stylistic/ts/indent
       "sort-keys": "error",
-      // "@typescript-eslint/no-unsafe-argument": "error", // TODO: Enable this rule, https://github.com/openfrontio/OpenFrontIO/issues/1780
+      "@typescript-eslint/no-unsafe-argument": "error",
       // "@typescript-eslint/no-unsafe-assignment": "error", // TODO: Enable this rule, https://github.com/openfrontio/OpenFrontIO/issues/1781
       // "@typescript-eslint/no-unsafe-member-access": "error", // TODO: Enable this rule, https://github.com/openfrontio/OpenFrontIO/issues/1783
       // "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }], // TODO: Enable this rule, https://github.com/openfrontio/OpenFrontIO/issues/1784
@@ -108,6 +107,7 @@ export default [
       "max-lines-per-function": ["error", { max: 561 }],
       "no-loss-of-precision": "error",
       "no-multi-spaces": "error",
+      "no-trailing-spaces": "error",
       "object-curly-newline": ["error", { multiline: true, consistent: true }],
       "object-curly-spacing": ["error", "always"],
       "object-property-newline": ["error", { allowAllPropertiesOnSameLine: true }],
@@ -133,6 +133,7 @@ export default [
     rules: {
       // Disabled rules for tests, configs
       "@typescript-eslint/no-explicit-any": "off",
+      "@typescript-eslint/no-unsafe-argument": "off",
       "sort-keys": "off",
     },
   },

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -125,6 +125,7 @@ export class LangSelector extends LitElement {
 
   private loadLanguage(lang: string): Record<string, string> {
     const language = this.languageMap[lang] ?? {};
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
     const flat = flattenTranslations(language);
     return flat;
   }
@@ -186,6 +187,7 @@ export class LangSelector extends LitElement {
       if (currentLangEntry) finalList.push(currentLangEntry);
       if (englishEntry) finalList.push(englishEntry);
       if (browserLangEntry) finalList.push(browserLangEntry);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       finalList.push(...list);
       if (debugLang) finalList.push(debugLang);
 
@@ -316,6 +318,7 @@ export class LangSelector extends LitElement {
         .languageList=${this.languageList}
         .currentLang=${this.currentLang}
         @language-selected=${(e: CustomEvent) =>
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           this.changeLanguage(e.detail.lang)}
         @close-modal=${() => (this.showModal = false)}
       ></language-modal>
@@ -336,6 +339,7 @@ function flattenTranslations(
     if (typeof value === "string") {
       result[fullKey] = value;
     } else if (value && typeof value === "object" && !Array.isArray(value)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       flattenTranslations(value, fullKey, result);
     } else {
       console.warn("Unknown type", typeof value, value);

--- a/src/client/LanguageModal.ts
+++ b/src/client/LanguageModal.ts
@@ -106,7 +106,9 @@ export class LanguageModal extends LitElement {
               return html`
                 <button
                   class="${buttonClasses}"
-                  @click=${() => this.selectLanguage(lang.code)}
+                  @click=${() =>
+                  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                    this.selectLanguage(lang.code)}
                 >
                   <img
                     src="/flags/${lang.svg}.svg"

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -328,6 +328,7 @@ export class Transport {
     };
     this.socket.onmessage = (event: MessageEvent) => {
       try {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         const parsed = JSON.parse(event.data);
         const result = ServerMessageSchema.safeParse(parsed);
         if (!result.success) {

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -491,15 +491,15 @@ export class RadialMenu implements Layer {
         onMouseOut(d, path);
       });
 
-      path.on("mousemove", function (event) {
-        handleMouseMove(event as MouseEvent);
+      path.on("mousemove", function (event: MouseEvent) {
+        handleMouseMove(event);
       });
 
-      path.on("click", function (event) {
+      path.on("click", function (event: Event) {
         onClick(d, event);
       });
 
-      path.on("touchstart", function (event) {
+      path.on("touchstart", function (event: Event) {
         event.preventDefault();
         event.stopPropagation();
         onClick(d, event);

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -1178,7 +1178,7 @@ export class PlayerImpl implements Player {
     const weightedPorts: Unit[] = [];
 
     for (const [i, otherPort] of ports.entries()) {
-      const expanded = new Array(otherPort.level()).fill(otherPort);
+      const expanded = new Array<Unit>(otherPort.level()).fill(otherPort);
       weightedPorts.push(...expanded);
       if (i < this.mg.config().proximityBonusPortsNb(ports.length)) {
         weightedPorts.push(...expanded);


### PR DESCRIPTION
## Description:

Enable the `@typescript-eslint/no-unsafe-argument` eslint rule.

Fixes #1780

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
