### PR TITLE
Enable the `@typescript-eslint/no-unsafe-member-access` eslint rule

### DIFF
--- a/eslint-plugin-local/rules/no-z-array.js
+++ b/eslint-plugin-local/rules/no-z-array.js
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-assignment */
 export default {
   create(context) {
     return {

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -89,7 +89,7 @@ export default [
       "sort-keys": "error",
       "@typescript-eslint/no-unsafe-argument": "error",
       "@typescript-eslint/no-unsafe-assignment": "error",
-      // "@typescript-eslint/no-unsafe-member-access": "error", // TODO: Enable this rule, https://github.com/openfrontio/OpenFrontIO/issues/1783
+      "@typescript-eslint/no-unsafe-member-access": "error",
       // "@typescript-eslint/no-unused-vars": ["error", { argsIgnorePattern: "^_" }], // TODO: Enable this rule, https://github.com/openfrontio/OpenFrontIO/issues/1784
       "@typescript-eslint/no-unused-vars": "off",
       "@typescript-eslint/prefer-for-of": "error",
@@ -129,12 +129,14 @@ export default [
       "**/*.config.{js,ts,jsx,tsx}",
       "**/*.test.{js,ts,jsx,tsx}",
       "tests/**/*.{js,ts,jsx,tsx}",
+      "eslint-plugin-local/**/*.{js,ts,jsx,tsx}",
     ],
     rules: {
       // Disabled rules for tests, configs
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-unsafe-argument": "off",
       "@typescript-eslint/no-unsafe-assignment": "off",
+      "@typescript-eslint/no-unsafe-member-access": "off",
       "sort-keys": "off",
     },
   },

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";

--- a/src/client/LanguageModal.ts
+++ b/src/client/LanguageModal.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import { LitElement, html } from "lit";
 import { customElement, property } from "lit/decorators.js";
 import { translateText } from "../client/Utils";

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -57,7 +57,7 @@ export function generateCryptoRandomUUID(): string {
 
   // Fallback using crypto.getRandomValues
   if (crypto !== undefined && "getRandomValues" in crypto) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
     return (([1e7] as any) + -1e3 + -4e3 + -8e3 + -1e11).replace(
       /[018]/g,
       (c: number): string =>
@@ -86,7 +86,9 @@ export const translateText = (
 ): string => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
   const self = translateText as any;
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   self.formatterCache ??= new Map();
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   self.lastLang ??= null;
 
   const langSelector = document.querySelector("lang-selector") as LangSelector;
@@ -102,8 +104,11 @@ export const translateText = (
     return key;
   }
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (self.lastLang !== langSelector.currentLang) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     self.formatterCache.clear();
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     self.lastLang = langSelector.currentLang;
   }
 
@@ -124,14 +129,16 @@ export const translateText = (
         ? "en"
         : langSelector.currentLang;
     const cacheKey = `${key}:${locale}:${message}`;
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
     let formatter = self.formatterCache.get(cacheKey);
 
     if (!formatter) {
       formatter = new IntlMessageFormat(message, locale);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       self.formatterCache.set(cacheKey, formatter);
     }
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     return formatter.format(params) as string;
   } catch (e) {
     console.warn("ICU format error", e);

--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -131,7 +131,7 @@ export class RadialMenu implements Layer {
         this.hideRadialMenu();
         this.eventBus.emit(new CloseRadialMenuEvent());
       })
-      .on("contextmenu", (e) => {
+      .on("contextmenu", (e: Event) => {
         e.preventDefault();
         this.hideRadialMenu();
         this.eventBus.emit(new CloseRadialMenuEvent());
@@ -178,7 +178,7 @@ export class RadialMenu implements Layer {
       .attr("r", this.config.centerButtonSize)
       .attr("fill", "transparent")
       .style("cursor", "pointer")
-      .on("click", (event) => {
+      .on("click", (event: Event) => {
         event.stopPropagation();
         this.handleCenterButtonClick();
       })

--- a/src/server/Cloudflare.ts
+++ b/src/server/Cloudflare.ts
@@ -256,9 +256,11 @@ export class Cloudflare {
     );
 
     cloudflared.stdout?.on("data", (data) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       log.info(data.toString().trim());
     });
     cloudflared.stderr?.on("data", (data) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       log.error(data.toString().trim());
     });
 

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -226,7 +226,7 @@ export class GameServer {
       );
     });
     client.ws.on("error", (error: Error) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       if ((error as any).code === "WS_ERR_UNEXPECTED_RSV_1") {
         client.ws.close(1002, "WS_ERR_UNEXPECTED_RSV_1");
       }

--- a/src/server/Gatekeeper.ts
+++ b/src/server/Gatekeeper.ts
@@ -71,6 +71,7 @@ async function getGatekeeper(): Promise<Gatekeeper> {
         "./gatekeeper/RealGatekeeper.js" as string
       ).catch(() => import("./gatekeeper/RealGatekeeper.js" as string));
 
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       if (!module || !module.RealGatekeeper) {
         console.log(
           "RealGatekeeper class not found in module, using NoOpGatekeeper",
@@ -79,6 +80,7 @@ async function getGatekeeper(): Promise<Gatekeeper> {
       }
 
       console.log("Successfully loaded real gatekeeper");
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
       return new module.RealGatekeeper();
     } catch (error) {
       console.log("Failed to load real gatekeeper:", error);

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 import cluster from "cluster";
 import express from "express";
 import rateLimit from "express-rate-limit";

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -309,7 +309,7 @@ export async function startWorker() {
     );
 
     ws.on("error", (error: Error) => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
       if ((error as any).code === "WS_ERR_UNEXPECTED_RSV_1") {
         ws.close(1002, "WS_ERR_UNEXPECTED_RSV_1");
       }


### PR DESCRIPTION
## Description:

Enable the `@typescript-eslint/no-unsafe-member-access` eslint rule.

Fixes #1783

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
