### PR TITLE
Reloading the page during a game should rejoin with the same clientID

### DIFF
--- a/src/client/JoinPrivateLobbyModal.ts
+++ b/src/client/JoinPrivateLobbyModal.ts
@@ -2,7 +2,7 @@ import { LitElement, html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { translateText } from "../client/Utils";
 import { GameInfo, GameInfoSchema } from "../core/Schemas";
-import { generateID } from "../core/Util";
+import { generateClientID } from "../core/Util";
 import {
   WorkerApiArchivedGameLobbySchema,
   WorkerApiGameIdExistsSchema,
@@ -214,7 +214,7 @@ export class JoinPrivateLobbyModal extends LitElement {
         new CustomEvent("join-lobby", {
           detail: {
             gameID: lobbyId,
-            clientID: generateID(),
+            clientID: generateClientID(),
           } as JoinLobbyEvent,
           bubbles: true,
           composed: true,
@@ -259,7 +259,7 @@ export class JoinPrivateLobbyModal extends LitElement {
           detail: {
             gameID: lobbyId,
             gameRecord: archiveData.gameRecord,
-            clientID: generateID(),
+            clientID: generateClientID(),
           } as JoinLobbyEvent,
           bubbles: true,
           composed: true,

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -2,6 +2,7 @@ import version from "../../resources/version.txt";
 import { UserMeResponse } from "../core/ApiSchemas";
 import { EventBus } from "../core/EventBus";
 import { GameRecord, GameStartInfo, ID } from "../core/Schemas";
+import { generateClientID } from "../core/Util";
 import { ServerConfig } from "../core/configuration/Config";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import { GameType } from "../core/game/Game";
@@ -478,7 +479,7 @@ class Client {
             : this.flagInput.getCurrentFlag(),
         playerName: this.usernameInput?.getCurrentUsername() ?? "",
         token: getPlayToken(),
-        clientID: lobby.clientID,
+        clientID: generateClientID(),
         gameStartInfo: lobby.gameStartInfo ?? lobby.gameRecord?.info,
         gameRecord: lobby.gameRecord,
       },

--- a/src/client/PublicLobby.ts
+++ b/src/client/PublicLobby.ts
@@ -4,7 +4,7 @@ import { translateText } from "../client/Utils";
 import { ApiPublicLobbiesResponseSchema } from "../core/ExpressSchemas";
 import { GameMapType, GameMode } from "../core/game/Game";
 import { GameID, GameInfo } from "../core/Schemas";
-import { generateID } from "../core/Util";
+import { generateClientID } from "../core/Util";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 
@@ -204,7 +204,7 @@ export class PublicLobby extends LitElement {
         new CustomEvent("join-lobby", {
           detail: {
             gameID: lobby.gameID,
-            clientID: generateID(),
+            clientID: generateClientID(),
           } as JoinLobbyEvent,
           bubbles: true,
           composed: true,

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -5,6 +5,7 @@ import { GameMap, TileRef } from "./game/GameMap";
 import {
   GameConfig,
   GameID,
+  ClientID,
   GameRecord,
   PlayerRecord,
   Turn,
@@ -226,6 +227,13 @@ export function generateID(): GameID {
     8,
   );
   return nanoid();
+}
+
+export function generateClientID(): ClientID {
+  const clientId = localStorage.getItem('clientId') ?? generateID();
+  localStorage.setItem('clientId', clientId);
+
+  return clientId;
 }
 
 export function toInt(num: number): bigint {

--- a/tests/core/Util.test.ts
+++ b/tests/core/Util.test.ts
@@ -1,0 +1,53 @@
+import { generateClientID } from "../../src/core/Util";
+
+describe("Util", () => {
+  class InMemoryLocalStorage {
+    private store = new Map<string, string>();
+    getItem(key: string): string | null {
+      return this.store.has(key) ? this.store.get(key)! : null;
+    }
+    setItem(key: string, value: string): void {
+      this.store.set(key, String(value));
+    }
+    removeItem(key: string): void {
+      this.store.delete(key);
+    }
+    clear(): void {
+      this.store.clear();
+    }
+  }
+
+  beforeEach(() => {
+    (globalThis as any).localStorage = new InMemoryLocalStorage();
+  });
+
+  test("creates and persists a new clientId when absent", () => {
+    expect((globalThis as any).localStorage.getItem("clientId")).toBeNull();
+
+    const id = generateClientID();
+
+    expect(typeof id).toBe("string");
+    expect(id).toMatch(/^[0-9a-zA-Z]{8}$/);
+    expect((globalThis as any).localStorage.getItem("clientId")).toBe(id);
+  });
+
+  test("reuses existing clientId if already set", () => {
+    const existing = "Ab12Cd34"; // valid 8-char id
+    (globalThis as any).localStorage.setItem("clientId", existing);
+
+    const id = generateClientID();
+
+    expect(id).toBe(existing);
+    expect((globalThis as any).localStorage.getItem("clientId")).toBe(
+      existing,
+    );
+  });
+
+  test("returns same id across multiple calls (persistence)", () => {
+    const first = generateClientID();
+    const second = generateClientID();
+
+    expect(second).toBe(first);
+    expect((globalThis as any).localStorage.getItem("clientId")).toBe(first);
+  });
+});


### PR DESCRIPTION
## Description:

This PR will fix #1204

Reloading the page during a game will rejoin with the same clientID, so the player can resume, even if they have to catch up from the start. It will use the localStorage to remember the clientID.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

WoodyDRN