### PR TITLE
bugfix: SAMs targeting not updating owner after capture

### DIFF
--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -25,7 +25,6 @@ class SAMTargetingSystem {
 
   constructor(
     private mg: Game,
-    private player: Player,
     private sam: Unit,
   ) {}
 
@@ -82,8 +81,8 @@ class SAMTargetingSystem {
       ({ unit }) => {
         return (
           isUnit(unit) &&
-          unit.owner() !== this.player &&
-          !this.player.isFriendly(unit.owner())
+          unit.owner() !== this.sam.owner() &&
+          !this.sam.owner().isFriendly(unit.owner())
         );
       },
     );
@@ -179,11 +178,7 @@ export class SAMLauncherExecution implements Execution {
       }
       this.sam = this.player.buildUnit(UnitType.SAMLauncher, spawnTile, {});
     }
-    this.targetingSystem ??= new SAMTargetingSystem(
-      this.mg,
-      this.player,
-      this.sam,
-    );
+    this.targetingSystem ??= new SAMTargetingSystem(this.mg, this.sam);
 
     if (this.sam.isInCooldown()) {
       const frontTime = this.sam.missileTimerQueue()[0];


### PR DESCRIPTION
## Description:

After a SAM was captured, SAMTargetingSystem's player was not updated, so it thought it was still owned by the original player. So it wouldn't shoot down nukes launched from the original owner.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
