### PR TITLE
increase MIRV warhead distance, after improved pseudorandom

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -169,7 +169,7 @@ export class MirvExecution implements Execution {
 
   private proximityCheck(tile: TileRef, taken: TileRef[]): boolean {
     for (const t of taken) {
-      if (this.mg.manhattanDist(tile, t) < 25) {
+      if (this.mg.manhattanDist(tile, t) < 55) {
         return true;
       }
     }


### PR DESCRIPTION
## Description:

seedrandom provides much better randomization (https://github.com/openfrontio/OpenFrontIO/commit/77fd82b4b4b2b43e455d8db6100b64f10fdbb680) causing MIRV warheads to cover the target much more efficiently, and wiping out much more territory than in v24. This change makes the MIRV more similar to v24. 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
