### PR TITLE
allow names to go on top of radiation

### DIFF
--- a/src/client/graphics/NameBoxCalculator.ts
+++ b/src/client/graphics/NameBoxCalculator.ts
@@ -91,7 +91,9 @@ export function createGrid(
       if (game.isOnMap(cell)) {
         const tile = game.ref(cell.x, cell.y);
         grid[x - scaledBoundingBox.min.x][y - scaledBoundingBox.min.y] =
-          game.isLake(tile) || game.owner(tile) === player; // TODO: okay if lake
+          game.isLake(tile) ||
+          game.owner(tile) === player ||
+          game.hasFallout(tile);
       }
     }
   }


### PR DESCRIPTION
## Description:

I noticed after MIRVs, player names would be very small, or even not shown, because the MIRV would litter the player territory with radiation. This PR allows the name to go over irradiated land. It occasionally led to strange name placement, like if a small nation was h-bombed, then half the name could end up on the radiation, but it was still clear who the nation was. Overall it feels like an improvement.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
