### PR TITLE
Allies no longer embargo each other

### DIFF
--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -98,7 +98,8 @@ export class FakeHumanExecution implements Execution {
       /* When player is hostile starts embargo. Do not stop until neutral again */
       if (
         player.relation(other) <= Relation.Hostile &&
-        !player.hasEmbargoAgainst(other)
+        !player.hasEmbargoAgainst(other) &&
+        !player.isOnSameTeam(other)
       ) {
         player.addEmbargo(other, false);
       } else if (

--- a/src/core/execution/alliance/BreakAllianceExecution.ts
+++ b/src/core/execution/alliance/BreakAllianceExecution.ts
@@ -37,7 +37,7 @@ export class BreakAllianceExecution implements Execution {
       this.requestor.breakAlliance(alliance);
       this.recipient.updateRelation(this.requestor, -200);
       for (const player of this.mg.players()) {
-        if (player !== this.requestor) {
+        if (player !== this.requestor && !player.isOnSameTeam(this.requestor)) {
           player.updateRelation(this.requestor, -40);
         }
       }


### PR DESCRIPTION
## Description:

Bots on the same team as a human player will no longer embargo them if they betray an alliance with an opposing team player.
Fixes #1845 

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

sibyljudith
