### PR TITLE
Remove Yenisei from public multiplayer games

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -44,7 +44,6 @@ const frequency: Partial<Record<GameMapName, number>> = {
   Halkidiki: 1,
   StraitOfGibraltar: 1,
   Italia: 1,
-  Yenisei: 1,
   Pluto: 1,
 };
 


### PR DESCRIPTION
## Description:

The map is very large and the game lagged a lot on this map during playtests. So remove it from public lobbies.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
