### PR TITLE
Only allow custom name if logged in - fixes #1636

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6416,7 +6416,7 @@
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.13.3.tgz",
       "integrity": "sha512-ZaDETVWnm6FE0fc+c2UE8MHYVS3Fe91o5vkmGfgwGXFbxYvAjKSqxM/j4cRc9T7VZNSJjriXq58XkfCp3Y6f+w==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6458,6 +6458,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6474,6 +6475,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6490,6 +6492,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -6506,6 +6509,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6522,6 +6526,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6538,6 +6543,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6554,6 +6560,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6570,6 +6577,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6586,6 +6594,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6602,6 +6611,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "Apache-2.0 AND MIT",
       "optional": true,
       "os": [
@@ -6615,7 +6625,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
       "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@swc/jest": {
@@ -6640,7 +6650,7 @@
       "version": "0.1.23",
       "resolved": "https://registry.npmjs.org/@swc/types/-/types-0.1.23.tgz",
       "integrity": "sha512-u1iIVZV9Q0jxY+yM2vw/hZGDNudsN85bBpTqzAQ9rzkxW9D+e3aEM4Han+ow518gSewkXgjmEK0BD79ZcNVgPw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@swc/counter": "^0.1.3"
@@ -19714,6 +19724,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -316,7 +316,10 @@ class Client {
         territoryModal.onUserMe(null);
         if (this.usernameInput) {
           this.usernameInput.disabled = true;
-          this.usernameInput.resetToAnonymous();
+          const current = this.usernameInput.getCurrentUsername();
+          if (!/^Anon\d{3}$/.test(current)) {
+            this.usernameInput.resetToAnonymous();
+          }
         }
       } else {
         // Authorized

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -93,7 +93,7 @@ class Client {
   private publicLobby: PublicLobby;
   private readonly userSettings: UserSettings = new UserSettings();
 
-  constructor() {}
+  constructor() { }
 
   initialize(): void {
     const gameVersion = document.getElementById(
@@ -314,15 +314,22 @@ class Client {
         loginDiscordButton.translationKey = "main.login_discord";
         logoutDiscordButton.hidden = true;
         territoryModal.onUserMe(null);
+        if (this.usernameInput) {
+          this.usernameInput.disabled = true;
+          this.usernameInput.resetToAnonymous();
+        }
       } else {
         // Authorized
         console.log(
           `Your player ID is ${userMeResponse.player.publicId}\n` +
-            "Sharing this ID will allow others to view your game history and stats.",
+          "Sharing this ID will allow others to view your game history and stats.",
         );
         loginDiscordButton.translationKey = "main.logged_in";
         loginDiscordButton.hidden = true;
         territoryModal.onUserMe(userMeResponse);
+        if (this.usernameInput) {
+          this.usernameInput.disabled = false;
+        }
       }
     };
 

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -13,6 +13,7 @@ const usernameKey = "username";
 @customElement("username-input")
 export class UsernameInput extends LitElement {
   @state() private username = "";
+  @property({ type: Boolean }) disabled = true; // controlled externally
   @property({ type: String }) validationError = "";
   private _isValid = true;
   private readonly userSettings: UserSettings = new UserSettings();
@@ -30,7 +31,9 @@ export class UsernameInput extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    // Initialize with stored username
     this.username = this.getStoredUsername();
+    // Dispatch username event on initialization
     this.dispatchUsernameEvent();
   }
 
@@ -39,6 +42,7 @@ export class UsernameInput extends LitElement {
       <input
         type="text"
         .value=${this.username}
+        ?disabled=${this.disabled}
         @input=${this.handleChange}
         @change=${this.handleChange}
         placeholder="${translateText("username.enter_username")}"
@@ -62,6 +66,8 @@ export class UsernameInput extends LitElement {
   }
 
   private handleChange(e: Event) {
+    if (this.disabled) return; // Ignore changes if disabled
+
     const input = e.target as HTMLInputElement;
     this.username = input.value.trim();
     const result = validateUsername(this.username);
@@ -114,5 +120,11 @@ export class UsernameInput extends LitElement {
 
   public isValid(): boolean {
     return this._isValid;
+  }
+
+  public resetToAnonymous(): void {
+    this.username = this.generateNewUsername();
+    this.dispatchUsernameEvent();
+    this.requestUpdate();
   }
 }


### PR DESCRIPTION
## Description:

This PR ensures that users can only set a custom name if they are logged in. If the user is not authenticated, the option to set a custom name is disabled or hidden. This addresses issue #1636.


## Please complete the following:-
- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
   ansh2848

<img width="766" height="599" alt="Screenshot 2025-08-21 003657" src="https://github.com/user-attachments/assets/29fecd12-e56e-47fe-a390-7e22c4942215" />

<img width="873" height="761" alt="Screenshot 2025-08-21 144000" src="https://github.com/user-attachments/assets/829f228a-103b-464b-a531-60b7e3e1ca7f" />
