### PR TITLE
Update discord invite link in README.md from the translator discord to dev discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Contributions are welcome! Please feel free to submit a Pull Request.
 Translators are welcome! Please feel free to help translate into your language.
 How to help?
 
-1. Request to join the translation [Discord](https://discord.gg/rUukAnz4Ww)
+1. Request to join the dev [Discord](https://discord.gg/K9zernJB5z) (in the application form, say you want to help translate)
 1. Go to the project's Crowdin translation page: [https://crowdin.com/project/openfront-mls](https://crowdin.com/project/openfront-mls)
 1. Login if you already have an account/ Sign up if you don't have one
 1. Select the language you want to translate in/ If your language isn't on the list, click the "Request New Language" button and enter the language you want added there.


### PR DESCRIPTION
## Description:

I noticed the link to the discord for translators was still the translation discord instead of the dev discord. NOTE: Evan approved changing this already.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

pilkeysek