### PR TITLE
fix team color

### DIFF
--- a/src/core/configuration/ColorAllocator.ts
+++ b/src/core/configuration/ColorAllocator.ts
@@ -48,7 +48,7 @@ export class ColorAllocator {
       case ColoredTeams.Bot:
         return botTeamColors;
       default:
-        throw new Error(`Unknown team color: ${team}`);
+        return [this.assignColor(team)];
     }
   }
 


### PR DESCRIPTION
## Description:

Fix color assignment crashing squad games.

For squad games, teams are assigned 1,2,3, etc. So the ColorAllocator cannot find them and throws an exception.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
