### PR TITLE
added the ability to see players Flag inside the player panel with full flag name.

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -537,7 +537,8 @@
     "yes": "Yes",
     "no": "No",
     "none": "None",
-    "alliances": "Alliances"
+    "alliances": "Alliances",
+    "flag": "Flag"
   },
   "replay_panel": {
     "replay_speed": "Replay speed",

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -14,6 +14,7 @@ import {
 import { customElement, state } from "lit/decorators.js";
 import { renderNumber, renderTroops } from "../../Utils";
 import { ChatModal } from "./ChatModal";
+import Countries from "../../data/countries.json";
 import { EmojiTable } from "./EmojiTable";
 import { EventBus } from "../../../core/EventBus";
 import { Layer } from "./Layer";
@@ -243,6 +244,33 @@ export class PlayerPanel extends LitElement implements Layer {
     const canTarget = this.actions?.interaction?.canTarget;
     const canEmbargo = this.actions?.interaction?.canEmbargo;
 
+    //flag icon in the playerPanel
+    const flagDiv = document.createElement("div");
+    const flagImg = document.createElement("img");
+    const flagName = document.createElement("span");
+    let displayFlagInPanel = false;
+
+    const getFlagName = async (countryCode: string): Promise<string | undefined> => {
+      type Country = {
+        code: string;
+        continent?: string;
+        name: string;
+      };
+
+      const countryName: Country | undefined = Countries.find((c)=> c.code === countryCode);
+      return countryName?.name;
+    };
+
+    if(other.cosmetics.flag !== null && other.cosmetics.flag !== undefined) {
+      const flag = other?.cosmetics.flag;
+      displayFlagInPanel = true;
+      getFlagName(other.cosmetics.flag).then((name) => {flagName.textContent = name ?? "";});
+      flagImg.src = "/flags/" + flag + ".svg";
+      flagImg.width = 50;
+      flagImg.height = 50;
+
+      flagDiv.appendChild(flagImg);
+    }
     return html`
       <div
         class="fixed inset-0 flex items-center justify-center z-[1001] pointer-events-none overflow-auto"
@@ -274,6 +302,18 @@ export class PlayerPanel extends LitElement implements Layer {
                        rounded text-sm lg:text-xl w-full"
                 >
                   ${other?.name()}
+                </div>
+              </div>
+              <!-- Flag -->
+              <div">
+                <div class="text-white text-opacity-80 text-sm px-2 ${displayFlagInPanel ? "" : "hidden"}">
+                    ${translateText("player_panel.flag")}
+                </div>
+                <div
+                  class="px-4 h-8 lg:h-10 flex items-center justify-center gap-4
+                  bg-opacity-50 bg-gray-700 text-opacity-90 text-white
+                  rounded text-sm lg:text-xl w-full  ${displayFlagInPanel ? "" : "hidden"}">
+                  ${flagName} ${flagDiv}
                 </div>
               </div>
 

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -245,32 +245,13 @@ export class PlayerPanel extends LitElement implements Layer {
     const canEmbargo = this.actions?.interaction?.canEmbargo;
 
     //flag icon in the playerPanel
-    const flagDiv = document.createElement("div");
     const flagImg = document.createElement("img");
-    const flagName = document.createElement("span");
-    let displayFlagInPanel = false;
+    // Compute flag data for declarative rendering
 
-    const getFlagName = async (countryCode: string): Promise<string | undefined> => {
-      type Country = {
-        code: string;
-        continent?: string;
-        name: string;
-      };
+    const flagCode = other.cosmetics.flag;
+    const country = typeof flagCode === "string" ? Countries.find((c) => c.code === flagCode) : undefined;
+    const flagName = country?.name;
 
-      const countryName: Country | undefined = Countries.find((c)=> c.code === countryCode);
-      return countryName?.name;
-    };
-
-    if(other.cosmetics.flag !== null && other.cosmetics.flag !== undefined) {
-      const flag = other?.cosmetics.flag;
-      displayFlagInPanel = true;
-      getFlagName(other.cosmetics.flag).then((name) => {flagName.textContent = name ?? "";});
-      flagImg.src = "/flags/" + flag + ".svg";
-      flagImg.width = 50;
-      flagImg.height = 50;
-
-      flagDiv.appendChild(flagImg);
-    }
     return html`
       <div
         class="fixed inset-0 flex items-center justify-center z-[1001] pointer-events-none overflow-auto"
@@ -305,18 +286,22 @@ export class PlayerPanel extends LitElement implements Layer {
                 </div>
               </div>
               <!-- Flag -->
-              <div">
-                <div class="text-white text-opacity-80 text-sm px-2 ${displayFlagInPanel ? "" : "hidden"}">
-                    ${translateText("player_panel.flag")}
-                </div>
-                <div
-                  class="px-4 h-8 lg:h-10 flex items-center justify-center gap-4
-                  bg-opacity-50 bg-gray-700 text-opacity-90 text-white
-                  rounded text-sm lg:text-xl w-full  ${displayFlagInPanel ? "" : "hidden"}">
-                  ${flagName} ${flagDiv}
-                </div>
-              </div>
-
+              ${country
+                ? html`
+                    <div>
+                      <div class="text-white text-opacity-80 text-sm px-2">
+                        ${translateText("player_panel.flag")}
+                      </div>
+                      <div
+                        class="px-4 h-8 lg:h-10 flex items-center justify-center gap-4
+                        bg-opacity-50 bg-gray-700 text-opacity-90 text-white
+                        rounded text-sm lg:text-xl w-full"
+                      >
+                        ${flagName} <img src="/flags/${flagCode}.svg" width=60 height=60>
+                      </div>
+                    </div>
+                  `
+                : ""}
               <!-- Resources section -->
               <div class="grid grid-cols-2 gap-2">
                 <div class="flex flex-col gap-1">

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -245,9 +245,6 @@ export class PlayerPanel extends LitElement implements Layer {
     const canEmbargo = this.actions?.interaction?.canEmbargo;
 
     //flag icon in the playerPanel
-    const flagImg = document.createElement("img");
-    // Compute flag data for declarative rendering
-
     const flagCode = other.cosmetics.flag;
     const country = typeof flagCode === "string" ? Countries.find((c) => c.code === flagCode) : undefined;
     const flagName = country?.name;


### PR DESCRIPTION
## Description:

Sometimes I found it interesting to know what flag players choose, now its possible with this new feature.

Feature added to the players panel.

- Added the Full flag name
- Added the flag svg
- countries with no flag, the whole section will be hidden
<img width="250" height="388" alt="My own Flag" src="https://github.com/user-attachments/assets/69eda520-83f7-4864-8cc1-f19419f13143" />

<img width="250" height="388" alt="Bot with flag" src="https://github.com/user-attachments/assets/1d4e9fbd-1b63-4dae-8bf7-38d3e78a3c80" />

<img width="250" height="388" alt="Bot with no flag" src="https://github.com/user-attachments/assets/7ae06b30-4e26-49d6-a136-23d82c11b1f6" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory ( Made local tests seems to all work with long or short names)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## My discord:

boostry
