### PR TITLE
Fix/Attack alliance traitor bug

### DIFF
--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -16,8 +16,6 @@ import { FlatBinaryHeap } from "./utils/FlatBinaryHeap"; // adjust path if neede
 
 const malusForRetreat = 25;
 export class AttackExecution implements Execution {
-  private breakAlliance = false;
-  private wasAlliedAtInit = false; // Store alliance state at initialization
   private active: boolean = true;
   private toConquer = new FlatBinaryHeap();
 
@@ -64,6 +62,17 @@ export class AttackExecution implements Execution {
 
     if (this._owner === this.target) {
       console.error(`Player ${this._owner} cannot attack itself`);
+      this.active = false;
+      return;
+    }
+
+    // ALLIANCE CHECK
+    if (this.target.isPlayer() && this._owner.isFriendly(this.target)) {
+      console.warn(
+        `${this._owner.displayName()} cannot attack ${this.target.displayName()} ` +
+          "because they are friendly (allied or same team)",
+      );
+
       this.active = false;
       return;
     }
@@ -149,11 +158,6 @@ export class AttackExecution implements Execution {
     }
 
     if (this.target.isPlayer()) {
-      // Store the alliance state at initialization time to prevent race conditions
-      this.wasAlliedAtInit = this._owner.isAlliedWith(this.target);
-      if (this.wasAlliedAtInit) {
-        this.breakAlliance = true;
-      }
       this.target.updateRelation(this._owner, -80);
     }
   }
@@ -222,18 +226,7 @@ export class AttackExecution implements Execution {
       return;
     }
 
-    const alliance = targetPlayer
-      ? this._owner.allianceWith(targetPlayer)
-      : null;
-    if (this.breakAlliance && alliance !== null) {
-      this.breakAlliance = false;
-      this._owner.breakAlliance(alliance);
-    }
-    if (
-      targetPlayer &&
-      this._owner.isAlliedWith(targetPlayer) &&
-      !this.wasAlliedAtInit
-    ) {
+    if (targetPlayer && this._owner.isFriendly(targetPlayer)) {
       // In this case a new alliance was created AFTER the attack started.
       // We should retreat to avoid the attacker becoming a traitor.
       this.retreat();

--- a/src/core/execution/BotExecution.ts
+++ b/src/core/execution/BotExecution.ts
@@ -69,6 +69,14 @@ export class BotExecution implements Execution {
     if (toAttack !== null) {
       const odds = this.bot.isFriendly(toAttack) ? 6 : 3;
       if (this.random.chance(odds)) {
+        // Check and break alliance before attacking if needed
+        if (this.bot.isAlliedWith(toAttack)) {
+          const alliance = this.bot.allianceWith(toAttack);
+          if (alliance !== null) {
+            this.bot.breakAlliance(alliance);
+          }
+        }
+
         this.behavior.sendAttack(toAttack);
         return;
       }

--- a/src/core/execution/utils/BotBehavior.ts
+++ b/src/core/execution/utils/BotBehavior.ts
@@ -230,7 +230,9 @@ export class BotBehavior {
   }
 
   sendAttack(target: Player | TerraNullius) {
-    if (target.isPlayer() && this.player.isOnSameTeam(target)) return;
+    // Skip attacking friendly targets (allies or teammates) - decision to break alliances should be made by caller
+    if (target.isPlayer() && this.player.isFriendly(target)) return;
+
     const maxTroops = this.game.config().maxTroops(this.player);
     const reserveRatio = target.isPlayer()
       ? this.reserveRatio
@@ -242,7 +244,7 @@ export class BotBehavior {
       new AttackExecution(
         troops,
         this.player,
-        target.isPlayer() ? target.id() : null,
+        target.isPlayer() ? target.id() : this.game.terraNullius().id(),
       ),
     );
   }

--- a/tests/Attack.test.ts
+++ b/tests/Attack.test.ts
@@ -196,14 +196,18 @@ describe("Attack race condition with alliance requests", () => {
     expect(playerB.outgoingAttacks()).toHaveLength(0);
   });
 
-  it("should mark attacker as traitor when alliance existed before attack", async () => {
+  it("should prevent player from attacking allied player", async () => {
     // Create an alliance between Player A and Player B
     const allianceRequest = playerA.createAllianceRequest(playerB);
     if (allianceRequest) {
       allianceRequest.accept();
     }
 
-    // Player A attacks Player B (should break the alliance)
+    // Verify alliance exists
+    expect(playerA.isAlliedWith(playerB)).toBe(true);
+    expect(playerB.isAlliedWith(playerA)).toBe(true);
+
+    // Player A tries to attack Player B (should be blocked)
     const attackExecution = new AttackExecution(
       null,
       playerA,
@@ -217,8 +221,11 @@ describe("Attack race condition with alliance requests", () => {
       game.executeNextTick();
     }
 
-    // Player A should be marked as traitor because they attacked an ally
-    expect(playerA.isTraitor()).toBe(true);
+    // No ongoing attacks should exist for either side
+    expect(playerA.outgoingAttacks()).toHaveLength(0);
+    expect(playerB.outgoingAttacks()).toHaveLength(0);
+    expect(playerA.incomingAttacks()).toHaveLength(0);
+    expect(playerB.incomingAttacks()).toHaveLength(0);
   });
 
   test("should cancel alliance requests if the recipient attacks", async () => {

--- a/tests/BotBehavior.test.ts
+++ b/tests/BotBehavior.test.ts
@@ -227,3 +227,197 @@ describe("BotBehavior.handleAllianceExtensionRequests", () => {
     expect(mockGame.addExecution).not.toHaveBeenCalled();
   });
 });
+
+describe("BotBehavior Attack Behavior", () => {
+  let game: Game;
+  let bot: Player;
+  let human: Player;
+  let botBehavior: BotBehavior;
+
+  // Helper functions for tile assignment
+  function assignAlternatingLandTiles(
+    game: Game,
+    players: Player[],
+    totalTiles: number,
+  ) {
+    let assigned = 0;
+    game.map().forEachTile((tile) => {
+      if (assigned >= totalTiles) return;
+      if (!game.map().isLand(tile)) return;
+      const player = players[assigned % players.length];
+      player.conquer(tile);
+      assigned++;
+    });
+  }
+
+  function assignNLandTiles(game: Game, player: Player, count: number) {
+    let assigned = 0;
+    game.map().forEachTile((tile) => {
+      if (assigned >= count) return;
+      if (!game.map().isLand(tile)) return;
+      player.conquer(tile);
+      assigned++;
+    });
+  }
+
+  beforeEach(async () => {
+    game = await setup("big_plains", {
+      infiniteGold: true,
+      instantBuild: true,
+      infiniteTroops: true,
+    });
+
+    const botInfo = new PlayerInfo(
+      "bot_test",
+      PlayerType.Bot,
+      null,
+      "bot_test",
+    );
+    const humanInfo = new PlayerInfo(
+      "human_test",
+      PlayerType.Human,
+      null,
+      "human_test",
+    );
+
+    game.addPlayer(botInfo);
+    game.addPlayer(humanInfo);
+
+    bot = game.player("bot_test");
+    human = game.player("human_test");
+
+    // Give both players some tiles and troops
+    assignAlternatingLandTiles(game, [bot, human], 10);
+
+    bot.addTroops(1000);
+    human.addTroops(1000);
+
+    const random = new PseudoRandom(42);
+    botBehavior = new BotBehavior(random, game, bot, 0.5, 0.5, 0.2);
+
+    // Skip spawn phase
+    let safety = 10_000;
+    while (game.inSpawnPhase() && safety-- > 0) {
+      game.executeNextTick();
+    }
+    expect(safety).toBeGreaterThan(0); // sanity: spawn ended
+  });
+
+  test("bot cannot attack allied player", () => {
+    // Form alliance (bot creates request to human)
+    const allianceRequest = bot.createAllianceRequest(human);
+    allianceRequest?.accept();
+
+    expect(bot.isAlliedWith(human)).toBe(true);
+    expect(bot.isFriendly(human)).toBe(true);
+
+    // Count attacks before
+    const attacksBefore = bot.outgoingAttacks().length;
+    // Ensure troop gate isn't the reason this test passes
+    bot.addTroops(50_000);
+
+    // Bot tries to attack ally (should be blocked by your isFriendly check)
+    botBehavior.sendAttack(human);
+
+    // Execute a few ticks to process the attacks
+    game.executeNextTick();
+    game.executeNextTick();
+
+    // Alliance should remain intact (no silent break)
+    expect(bot.isAlliedWith(human)).toBe(true);
+    expect(bot.isFriendly(human)).toBe(true);
+    expect(human.incomingAttacks()).toHaveLength(0);
+    // Should be same number of attacks (no new attack created)
+    expect(bot.outgoingAttacks()).toHaveLength(attacksBefore);
+  });
+
+  test("nation cannot attack allied player", () => {
+    // Create nation
+    const nationInfo = new PlayerInfo(
+      "nation_test",
+      PlayerType.FakeHuman,
+      null,
+      "nation_test",
+    );
+    game.addPlayer(nationInfo);
+    const nation = game.player("nation_test");
+
+    // Use helper for tile assignment
+    assignAlternatingLandTiles(game, [bot, human, nation], 21); // 21 to ensure each gets 7 tiles
+
+    nation.addTroops(1000);
+
+    const nationBehavior = new BotBehavior(
+      new PseudoRandom(42),
+      game,
+      nation,
+      0.5,
+      0.5,
+      0.2,
+    );
+
+    // Alliance between nation and human
+    const allianceRequest = nation.createAllianceRequest(human);
+    allianceRequest?.accept();
+
+    expect(nation.isAlliedWith(human)).toBe(true);
+    expect(nation.isFriendly(human)).toBe(true);
+
+    const attacksBefore = nation.outgoingAttacks().length;
+    // Ensure troop gate isn't the reason this test passes
+    nation.addTroops(50_000);
+
+    // Nation tries to attack ally (should be blocked)
+    nationBehavior.sendAttack(human);
+
+    // Execute a few ticks to process the attacks
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(nation.isAlliedWith(human)).toBe(true);
+    expect(nation.isFriendly(human)).toBe(true);
+    expect(nation.outgoingAttacks()).toHaveLength(attacksBefore);
+  });
+
+  test("bot can attack unallied player", () => {
+    // Ensure no alliance exists
+    expect(bot.isAlliedWith(human)).toBe(false);
+    expect(bot.isFriendly(human)).toBe(false);
+
+    bot.addTroops(50_000); // Add a lot of troops
+
+    const attacksBefore = bot.outgoingAttacks().length;
+
+    // Bot should be able to attack non-ally
+    botBehavior.sendAttack(human);
+
+    // Execute a few ticks to process the attacks
+    game.executeNextTick();
+    game.executeNextTick();
+
+    // Should create new attack against unallied human
+    expect(bot.outgoingAttacks().length).toBeGreaterThan(attacksBefore);
+    expect(human.incomingAttacks().length).toBeGreaterThan(0);
+    const hasHumanTarget = bot
+      .outgoingAttacks()
+      .some((a) => a.target() === human);
+    expect(hasHumanTarget).toBe(true);
+  });
+
+  test("bot can attack TerraNullius (expansion)", () => {
+    const attacksBefore = bot.outgoingAttacks().length;
+
+    // Bot should be able to expand to neutral territory
+    botBehavior.sendAttack(game.terraNullius());
+
+    // Execute a few ticks to process the attacks
+    game.executeNextTick();
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(bot.outgoingAttacks().length).toBeGreaterThan(attacksBefore);
+    const tn = game.terraNullius();
+    const hasTNTarget = bot.outgoingAttacks().some((a) => a.target() === tn);
+    expect(hasTNTarget).toBe(true);
+  });
+});

--- a/tests/core/game/GameImpl.test.ts
+++ b/tests/core/game/GameImpl.test.ts
@@ -79,6 +79,12 @@ describe("GameImpl", () => {
     game.executeNextTick();
     game.executeNextTick();
 
+    // STEP 1: First betray (manually break alliance)
+    const alliance = attacker.allianceWith(defender);
+    expect(alliance).toBeTruthy();
+    attacker.breakAlliance(alliance!);
+
+    // STEP 2: Then attack after betrayal
     game.addExecution(new AttackExecution(100, attacker, defender.id()));
 
     do {
@@ -86,6 +92,7 @@ describe("GameImpl", () => {
     } while (attacker.outgoingAttacks().length > 0);
 
     expect(attacker.isTraitor()).toBe(false);
+    expect(attacker.allianceWith(defender)).toBeFalsy();
   });
 
   test("Do become traitor when betraying active player", async () => {
@@ -110,6 +117,13 @@ describe("GameImpl", () => {
     game.executeNextTick();
     game.executeNextTick();
 
+    // First betray (manually break alliance)
+    const alliance = attacker.allianceWith(defender);
+    expect(alliance).toBeTruthy();
+    attacker.breakAlliance(alliance!);
+
+    game.executeNextTick();
+
     game.addExecution(new AttackExecution(100, attacker, defender.id()));
 
     do {
@@ -117,5 +131,6 @@ describe("GameImpl", () => {
     } while (attacker.outgoingAttacks().length > 0);
 
     expect(attacker.isTraitor()).toBe(true);
+    expect(attacker.allianceWith(defender)).toBeFalsy();
   });
 });


### PR DESCRIPTION
Fix - Issue https://github.com/openfrontio/OpenFrontIO/issues/1866

## Description:

This PR fixes a critical race condition bug where players could unintentionally receive the traitor debuff when alliance requests were accepted mid-attack.

Describe the PR.
Critical Bug Fixes #1866:

Root Cause: Players could bypass UI alliance checks ( isFriendly() ) by accepting alliances and immediately attacking after that, causing the server to treat the attack as betrayal
Solution: Added server-side alliance validation in AttackExecution.init()
This ensures attacks on allies are blocked at the server level.

 -Bots, for now, can not betray before attacking (needs another PR to add the logic for bots to betray).

Testing:
- Race condition scenarios tested
- Alliance honor behavior verified
- Edge cases (TerraNullius, non-allies) tested

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

abodcraft1


