### PR TITLE
Allow manually setting pattern for testing

### DIFF
--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -426,9 +426,12 @@ export class SinglePlayerModal extends LitElement {
       console.warn("Flag input element not found");
     }
     const patternName = this.userSettings.getSelectedPatternName();
-    const pattern = patternName
-      ? (await getCosmetics())?.patterns[patternName]
-      : undefined;
+    let pattern: string | undefined = undefined;
+    if (this.userSettings.getDevOnlyPattern()) {
+      pattern = this.userSettings.getDevOnlyPattern();
+    } else if (patternName) {
+      pattern = (await getCosmetics())?.patterns[patternName]?.pattern;
+    }
     this.dispatchEvent(
       new CustomEvent("join-lobby", {
         detail: {
@@ -444,7 +447,7 @@ export class SinglePlayerModal extends LitElement {
                   flagInput.getCurrentFlag() === "xx"
                     ? ""
                     : flagInput.getCurrentFlag(),
-                pattern: pattern?.pattern,
+                pattern: pattern,
               },
             ],
             config: {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -111,6 +111,11 @@ export class UserSettings {
     }
   }
 
+  // For development only. Used for testing patterns, set in the console manually.
+  getDevOnlyPattern(): string | undefined {
+    return localStorage.getItem("dev-pattern") ?? undefined;
+  }
+
   getSelectedPatternName(): string | undefined {
     return localStorage.getItem(PATTERN_KEY) ?? undefined;
   }


### PR DESCRIPTION
## Description:

This pr allows setting the pattern manually in using the dev console so we can see how it looks before uploading.

To set it: set the b64 pattern in local storage with key: dev-pattern.

This will override set pattern. Only works in singleplayer mode.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
