### PR TITLE
Enable the `@stylistic/object-curly-spacing` eslint rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -56,6 +56,7 @@ export default [
       // Enable rules
       "@stylistic/quotes": ["error", "double", { avoidEscape: true }],
       "@stylistic/indent": ["error", 2],
+      "@stylistic/object-curly-spacing": ["error", "always", { objectsInObjects: true }],
       "@stylistic/semi": "error",
       "@stylistic/space-infix-ops": "error",
       "@stylistic/type-annotation-spacing": [
@@ -114,7 +115,7 @@ export default [
       "no-multiple-empty-lines": ["error", { max: 1, maxEOF: 0 }],
       "no-trailing-spaces": "error",
       "object-curly-newline": ["error", { multiline: true, consistent: true }],
-      "object-curly-spacing": ["error", "always"],
+      "object-curly-spacing": "off", // @stylistic/object-curly-spacing
       "object-property-newline": ["error", { allowAllPropertiesOnSameLine: true }],
       "object-shorthand": ["error", "always"],
       "no-undef": "error",


### PR DESCRIPTION
## Description:

Enable the `@stylistic/object-curly-spacing` eslint rule.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced