### PR TITLE
fix: dont let allies annex clusters

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -215,22 +215,40 @@ export class PlayerExecution implements Execution {
 
   private getCapturingPlayer(cluster: Set<TileRef>): Player | null {
     if (this.mg === undefined) throw new Error("Not initialized");
-    const neighborsIDs = new Set<number>();
+
+    // Collect unique neighbor IDs (excluding self) as candidates
+    const candidatesIDs = new Set<number>();
+    const selfID = this.player.smallID();
+
     for (const t of cluster) {
       for (const neighbor of this.mg.neighbors(t)) {
-        if (this.mg.ownerID(neighbor) !== this.player.smallID()) {
-          neighborsIDs.add(this.mg.ownerID(neighbor));
+        if (this.mg.ownerID(neighbor) !== selfID) {
+          candidatesIDs.add(this.mg.ownerID(neighbor));
         }
       }
     }
 
-    let largestNeighborAttack: Player | null = null;
-    let largestTroopCount = 0;
-    for (const id of neighborsIDs) {
+    // Filter out friendly and non-player candidates
+    const neighborsIDs = new Set<number>();
+    const neighbors = new Set<Player>();
+    for (const id of candidatesIDs) {
       const neighbor = this.mg.playerBySmallID(id);
-      if (!neighbor.isPlayer() || this.player.isFriendly(neighbor)) {
+      if (!neighbor.isPlayer() || neighbor.isFriendly(this.player)) {
         continue;
       }
+      neighborsIDs.add(id);
+      neighbors.add(neighbor);
+    }
+
+    // If there are no enemies, return null
+    if (neighbors.size === 0) {
+      return null;
+    }
+
+    // Get the largest attack from the neighbors
+    let largestNeighborAttack: Player | null = null;
+    let largestTroopCount = 0;
+    for (const neighbor of neighbors) {
       for (const attack of neighbor.outgoingAttacks()) {
         if (attack.target() === this.player) {
           if (attack.troops() > largestTroopCount) {
@@ -244,11 +262,8 @@ export class PlayerExecution implements Execution {
       return largestNeighborAttack;
     }
 
-    // fall back to getting mode if no attacks
+    // Fall back to getting mode if no attacks
     const mode = getMode(neighborsIDs);
-    if (!this.mg.playerBySmallID(mode).isPlayer()) {
-      return null;
-    }
     const capturing = this.mg.playerBySmallID(mode);
     if (!capturing.isPlayer()) {
       return null;


### PR DESCRIPTION
## Description:

Fixes #1685

This change ensures that allies are excluded from the `getMode()` call made by `getCapturingPlayer()` inside `removeCluster()`.

 - Previously, friendly neighbors were treated as candidates for capturing, leading to incorrect annexations in certain edge cases.
 - Added a small efficiency improvement by filtering out non-player and friendly neighbors up front to reduce total computations down-the-line.
 - Important: we can’t simply check if the `getMode(neighborsIDs)` result is a friendly. Doing so would cause the territory to go to nobody until the user is attacked. I believe the expected behavior is the largest neighboring enemy should take it automatically.

Here's an example of the new behavior in an extreme edge case:
<img width="622" height="422" alt="Screenshot 2025-08-24 at 4 56 46 PM" src="https://github.com/user-attachments/assets/c5dd9c0d-0a3c-4657-8154-e114fa920689" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

nottirb
