### PR TITLE
Show random pattern on end screen

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -430,6 +430,8 @@
     "not_enough_money": "Not enough money"
   },
   "win_modal": {
+    "support_openfront": "Support OpenFront!",
+    "territory_pattern": "Purchase a territory pattern to support OpenFront!",
     "died": "You died",
     "your_team": "Your team won!",
     "other_team": "{team} team has won!",

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -12,7 +12,7 @@ export async function fetchPatterns(
   }
 
   const patterns: Map<string, Pattern> = new Map();
-  const playerFlares = new Set(userMe?.player.flares);
+  const playerFlares = new Set(userMe?.player?.flares ?? []);
 
   for (const name in cosmetics.patterns) {
     const patternData = cosmetics.patterns[name];

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -2,7 +2,7 @@ import { UserMeResponse } from "../core/ApiSchemas";
 import { Cosmetics, CosmeticsSchema, Pattern } from "../core/CosmeticSchemas";
 import { getApiBase, getAuthHeader } from "./jwt";
 
-export async function patterns(
+export async function fetchPatterns(
   userMe: UserMeResponse | null,
 ): Promise<Map<string, Pattern>> {
   const cosmetics = await getCosmetics();

--- a/src/client/TerritoryPatternsModal.ts
+++ b/src/client/TerritoryPatternsModal.ts
@@ -110,8 +110,7 @@ export class TerritoryPatternsModal extends LitElement {
       >
         <pattern-button
           .pattern=${null}
-          .onSelect=${(p: Pattern | null) => this.selectPattern(p)}
-          .onPurchase=${(priceId: string) => handlePurchase(priceId)}
+          .onSelect=${(p: Pattern | null) => this.selectPattern(null)}
         ></pattern-button>
         ${buttons}
       </div>

--- a/src/client/components/PatternButton.ts
+++ b/src/client/components/PatternButton.ts
@@ -1,0 +1,111 @@
+// components/PatternButton.ts
+import { html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { Pattern } from "../../core/CosmeticSchemas";
+import { generatePreviewDataUrl } from "../TerritoryPatternsModal";
+import { translateText } from "../Utils";
+
+export const BUTTON_WIDTH = 150;
+
+@customElement("pattern-button")
+export class PatternButton extends LitElement {
+  @property({ type: Object })
+  pattern: Pattern | null = null;
+
+  @property({ type: Function })
+  onSelect?: (pattern: Pattern | null) => void;
+
+  @property({ type: Function })
+  onPurchase?: (priceId: string) => void;
+
+  // Override to prevent shadow DOM creation (matching WinModal)
+  createRenderRoot() {
+    return this;
+  }
+
+  private renderPatternPreview(pattern: string): TemplateResult {
+    const dataUrl = generatePreviewDataUrl(pattern, BUTTON_WIDTH, BUTTON_WIDTH);
+    return html`<img
+      src="${dataUrl}"
+      alt="Pattern preview"
+      class="w-full h-full object-contain"
+      style="image-rendering: pixelated; image-rendering: -moz-crisp-edges; image-rendering: crisp-edges;"
+    />`;
+  }
+
+  private renderBlankPreview(): TemplateResult {
+    return html`<div
+      class="w-full h-full bg-gray-100 border border-gray-300 rounded"
+    ></div>`;
+  }
+
+  private translatePatternName(prefix: string, patternName: string): string {
+    const translation = translateText(`${prefix}.${patternName}`);
+    if (translation.startsWith(prefix)) {
+      return patternName[0].toUpperCase() + patternName.substring(1);
+    }
+    return translation;
+  }
+
+  private handleClick() {
+    const isDefaultPattern = this.pattern === null;
+    if (isDefaultPattern || this.pattern?.product === null) {
+      this.onSelect?.(this.pattern);
+    }
+  }
+
+  private handlePurchase(e: Event) {
+    e.stopPropagation();
+    if (this.pattern?.product) {
+      this.onPurchase?.(this.pattern.product.priceId);
+    }
+  }
+
+  render() {
+    const isDefaultPattern = this.pattern === null;
+    const isPurchasable = !isDefaultPattern && this.pattern?.product !== null;
+
+    return html`
+      <div
+        class="flex flex-col items-center gap-2 p-3 bg-white/10 rounded-lg max-w-[200px]"
+      >
+        <button
+          class="bg-white/90 border-2 border-black/10 rounded-lg p-2 cursor-pointer transition-all duration-200 w-full
+                 hover:bg-white hover:-translate-y-0.5 hover:shadow-lg hover:shadow-black/20
+                 disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:translate-y-0 disabled:hover:shadow-none"
+          ?disabled=${isPurchasable}
+          @click=${this.handleClick}
+        >
+          <div class="text-sm font-bold text-gray-800 mb-2 text-center">
+            ${isDefaultPattern
+              ? translateText("territory_patterns.pattern.default")
+              : this.translatePatternName(
+                  "territory_patterns.pattern",
+                  this.pattern!.name,
+                )}
+          </div>
+          <div
+            class="w-[120px] h-[120px] flex items-center justify-center bg-white rounded p-1 mx-auto"
+          >
+            ${isDefaultPattern
+              ? this.renderBlankPreview()
+              : this.renderPatternPreview(this.pattern!.pattern)}
+          </div>
+        </button>
+
+        ${isPurchasable
+          ? html`
+              <button
+                class="w-full px-4 py-2 bg-green-500 text-white border-0 rounded-md text-sm font-semibold cursor-pointer transition-colors duration-200
+                   hover:bg-green-600"
+                @click=${this.handlePurchase}
+              >
+                ${translateText("territory_patterns.purchase")}
+                (${this.pattern!.product!.price})
+              </button>
+            `
+          : null}
+      </div>
+    `;
+  }
+}


### PR DESCRIPTION
## Description:

To advertise patterns, show a random, purchasable pattern on the end screen.

* Refactored the pattern button into a reusable PatternButton lit component
* Used tailwind instead of CSS for styling because the CSS affects lit components due to using the light-dom
* Removed the tooltip, didn't seem necessary since there is already a big "purchase" button under the pattern

<img width="383" height="556" alt="Screenshot 2025-08-25 at 1 26 26 PM" src="https://github.com/user-attachments/assets/3f109cea-2759-4a07-9322-4a1a30b43503" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
