### PR TITLE
Reduce train gold from 50k->25k for teammates

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -135,7 +135,7 @@ export interface Config {
     numPlayerPorts: number,
     numPlayerTradeShips: number,
   ): number;
-  trainGold(rel: "self" | "friendly" | "other"): Gold;
+  trainGold(rel: "self" | "team" | "ally" | "other"): Gold;
   trainSpawnRate(numPlayerFactories: number): number;
   trainStationMinRange(): number;
   trainStationMaxRange(): number;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -333,10 +333,11 @@ export class DefaultConfig implements Config {
     // expected number of trains = numPlayerFactories  / trainSpawnRate(numPlayerFactories)
     return (numPlayerFactories + 10) * 20;
   }
-  trainGold(rel: "self" | "friendly" | "other"): Gold {
+  trainGold(rel: "self" | "team" | "ally" | "other"): Gold {
     switch (rel) {
-      case "friendly":
+      case "ally":
         return 50_000n;
+      case "team":
       case "other":
         return 25_000n;
       case "self":

--- a/src/core/game/TrainStation.ts
+++ b/src/core/game/TrainStation.ts
@@ -233,12 +233,18 @@ export class Cluster {
   }
 }
 
-function rel(player: Player, other: Player): "self" | "friendly" | "other" {
+function rel(
+  player: Player,
+  other: Player,
+): "self" | "team" | "ally" | "other" {
   if (player === other) {
     return "self";
   }
-  if (player.isFriendly(other)) {
-    return "friendly";
+  if (player.isOnSameTeam(other)) {
+    return "team";
+  }
+  if (player.isAlliedWith(other)) {
+    return "ally";
   }
   return "other";
 }


### PR DESCRIPTION
## Description:

Team games have been too fast because teammates can create large networks. Reduce the bonus from 50k=>25k

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
