### PR TITLE
Improve Player Spawn Visibility With Red Flag Icon

### DIFF
--- a/resources/images/RedFlagIcon.svg
+++ b/resources/images/RedFlagIcon.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 100 100" width="100" height="100">
+  <rect x="15" y="11.923" width="4" height="78.077" fill="#8B4513" stroke="#654321" stroke-width="1" style=""/>
+  <rect x="19.192" y="15.096" width="12.795" height="30" fill="#FF0000" stroke="#CC0000" stroke-width="1" style=""/>
+  <rect x="12" y="88" width="10" height="2" fill="#654321"/>
+  <rect x="14.86" y="38.644" width="4.17" height="3.661" fill="#FF0000" stroke="#CC0000" stroke-width="1" style="stroke-width: 1;"/>
+  <rect x="14.948" y="18.626" width="4.17" height="3.661" fill="#FF0000" stroke="#CC0000" stroke-width="1" style="stroke-width: 1;"/>
+  <rect x="28.541" y="16.046" width="27.507" height="29.561" fill="#FF0000" stroke="#CC0000" stroke-width="1" style="stroke-width: 1;"/>
+  <rect x="55.855" y="14.422" width="9.877" height="29.561" fill="#FF0000" stroke="#CC0000" stroke-width="1" style="stroke-width: 1;"/>
+  <rect x="52.252" y="16.489" width="3.077" height="28.711" style="fill: rgb(254, 191, 191);"/>
+  <rect x="63.066" y="14.775" width="2.195" height="28.711" style="fill: rgb(254, 191, 191); stroke-width: 1;"/>
+</svg>

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -38,6 +38,7 @@ export class TerritoryLayer implements Layer {
   // Used for spawn highlighting
   private highlightCanvas: HTMLCanvasElement | undefined;
   private highlightContext: CanvasRenderingContext2D | undefined;
+  private spawnFlagIcon: HTMLImageElement | null = null;
 
   private highlightedTerritory: PlayerView | null = null;
 
@@ -60,6 +61,18 @@ export class TerritoryLayer implements Layer {
     this.userSettings = userSettings;
     this.theme = game.config().theme();
     this.cachedTerritoryPatternsEnabled = undefined;
+    this.loadSpawnFlagIcon();
+  }
+
+  private loadSpawnFlagIcon() {
+    this.spawnFlagIcon = new Image();
+    this.spawnFlagIcon.src = "/images/RedFlagIcon.svg";
+    this.spawnFlagIcon.onload = () => {
+      console.log("Spawn flag icon loaded successfully");
+    };
+    this.spawnFlagIcon.onerror = () => {
+      console.error("Failed to load spawn flag icon");
+    };
   }
 
   shouldTransform(): boolean {
@@ -193,6 +206,19 @@ export class TerritoryLayer implements Layer {
         if (!this.game.hasOwner(tile)) {
           this.paintHighlightTile(tile, color, 255);
         }
+      }
+
+      if (this.spawnFlagIcon && this.spawnFlagIcon.complete && this.highlightContext) {
+        const iconSize = 32;
+        const offsetX = center.x - iconSize / 5;
+        const offsetY = center.y - iconSize;
+        this.highlightContext.drawImage(
+          this.spawnFlagIcon,
+          offsetX,
+          offsetY,
+          iconSize,
+          iconSize,
+        );
       }
     }
   }

--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -16,6 +16,7 @@ import { PseudoRandom } from "../../../core/PseudoRandom";
 import { Theme } from "../../../core/configuration/Config";
 import { TransformHandler } from "../TransformHandler";
 import { UserSettings } from "../../../core/game/UserSettings";
+import spawnFlagIcon from "../../../../resources/images/RedFlagIcon.svg";
 
 export class TerritoryLayer implements Layer {
   private readonly userSettings: UserSettings;
@@ -38,7 +39,7 @@ export class TerritoryLayer implements Layer {
   // Used for spawn highlighting
   private highlightCanvas: HTMLCanvasElement | undefined;
   private highlightContext: CanvasRenderingContext2D | undefined;
-  private spawnFlagIcon: HTMLImageElement | null = null;
+  private readonly spawnFlagIconImage: HTMLImageElement | null = null;
 
   private highlightedTerritory: PlayerView | null = null;
 
@@ -61,18 +62,8 @@ export class TerritoryLayer implements Layer {
     this.userSettings = userSettings;
     this.theme = game.config().theme();
     this.cachedTerritoryPatternsEnabled = undefined;
-    this.loadSpawnFlagIcon();
-  }
-
-  private loadSpawnFlagIcon() {
-    this.spawnFlagIcon = new Image();
-    this.spawnFlagIcon.src = "/images/RedFlagIcon.svg";
-    this.spawnFlagIcon.onload = () => {
-      console.log("Spawn flag icon loaded successfully");
-    };
-    this.spawnFlagIcon.onerror = () => {
-      console.error("Failed to load spawn flag icon");
-    };
+    this.spawnFlagIconImage = new Image();
+    this.spawnFlagIconImage.src = spawnFlagIcon;
   }
 
   shouldTransform(): boolean {
@@ -208,12 +199,19 @@ export class TerritoryLayer implements Layer {
         }
       }
 
-      if (this.spawnFlagIcon && this.spawnFlagIcon.complete && this.highlightContext) {
+      // draw spawn flag for the local player
+      if (
+        myPlayer !== null &&
+        human === myPlayer &&
+        this.spawnFlagIconImage &&
+        this.spawnFlagIconImage.complete &&
+        this.highlightContext
+      ) {
         const iconSize = 32;
         const offsetX = center.x - iconSize / 5;
         const offsetY = center.y - iconSize;
         this.highlightContext.drawImage(
-          this.spawnFlagIcon,
+          this.spawnFlagIconImage,
           offsetX,
           offsetY,
           iconSize,


### PR DESCRIPTION
## Description:
Issue: https://github.com/openfrontio/OpenFrontIO/issues/1941

Creates a red flag svg and places it above the user's spawn point when they choose their starting location

UI:
<img width="1449" height="1082" alt="image" src="https://github.com/user-attachments/assets/4565da42-0166-4a63-b0e4-f18a3ac3c6a7" />

Discord: leviathanlaw
