### PR TITLE
Fix: display translated messages when deleting units

### DIFF
--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -360,10 +360,8 @@ export class EventsDisplay extends LitElement implements Layer {
     }
 
     let description: string = event.message;
-    if (event.params !== undefined) {
-      if (event.message.startsWith("events_display.")) {
-        description = translateText(event.message, event.params);
-      }
+    if (event.message.startsWith("events_display.")) {
+      description = translateText(event.message, event.params ?? {});
     }
 
     this.addEvent({


### PR DESCRIPTION
## Description:

Close https://github.com/openfrontio/OpenFrontIO/issues/1844

Fix `src/client/graphics/layers/EventsDisplay.ts` translation logic that prevented messages without parameters from being translated.

Now it shows the message correctly:

<img width="383" height="179" alt="image" src="https://github.com/user-attachments/assets/22a4dac5-ae68-40e1-bd11-f0f13e93b5fd" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

yumika8269
