### PR TITLE
feat(PlayerExecution): destroy defense posts on capture

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -34,7 +34,8 @@ export class PlayerExecution implements Execution {
       if (u.info().territoryBound) {
         if (tileOwner?.isPlayer()) {
           if (tileOwner !== this.player) {
-            this.mg?.player(tileOwner.id()).captureUnit(u);
+            if (u.type() === UnitType.DefensePost) u.delete(true, tileOwner);
+            else this.mg?.player(tileOwner.id()).captureUnit(u);
           }
         } else {
           u.delete();

--- a/tests/core/executions/PlayerExecution.test.ts
+++ b/tests/core/executions/PlayerExecution.test.ts
@@ -1,0 +1,71 @@
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../../../src/core/game/Game";
+import { PlayerExecution } from "../../../src/core/execution/PlayerExecution";
+import { executeTicks } from "../../util/utils";
+import { setup } from "../../util/Setup";
+
+let game: Game;
+let player: Player;
+let otherPlayer: Player;
+
+describe("PlayerExecution", () => {
+  beforeEach(async () => {
+    game = await setup(
+      "big_plains",
+      {
+        infiniteGold: true,
+        instantBuild: true,
+      },
+      [
+        new PlayerInfo("player", PlayerType.Human, "client_id1", "player_id"),
+        new PlayerInfo("other", PlayerType.Human, "client_id2", "other_id"),
+      ],
+    );
+
+    while (game.inSpawnPhase()) {
+      game.executeNextTick();
+    }
+
+    player = game.player("player_id");
+    otherPlayer = game.player("other_id");
+
+    game.addExecution(new PlayerExecution(player));
+    game.addExecution(new PlayerExecution(otherPlayer));
+  });
+  test("DefensePost is destroyed, not captured, when tile owner changes", () => {
+    const tile = game.ref(50, 50);
+    player.conquer(tile);
+    const defensePost = player.buildUnit(UnitType.DefensePost, tile, {});
+
+    expect(defensePost.isActive()).toBe(true);
+    expect(defensePost.owner()).toBe(player);
+
+    otherPlayer.conquer(tile);
+    executeTicks(game, 2);
+
+    expect(defensePost.isActive()).toBe(false);
+    expect(player.units(UnitType.DefensePost)).toHaveLength(0); // Neither player owns the now inactive DefensePost
+    expect(otherPlayer.units(UnitType.DefensePost)).toHaveLength(0);
+  });
+
+  test("City is captured (transferred), not destroyed, when tile owner changes", () => {
+    const tile = game.ref(50, 50);
+    player.conquer(tile);
+    const city = player.buildUnit(UnitType.City, tile, {});
+
+    expect(city.owner()).toBe(player);
+
+    otherPlayer.conquer(tile);
+    executeTicks(game, 2);
+
+    expect(city.isActive()).toBe(true);
+    expect(city.owner()).toBe(otherPlayer);
+    expect(player.units(UnitType.City)).toHaveLength(0);
+    expect(otherPlayer.units(UnitType.City)).toHaveLength(1); // City transferred
+  });
+});


### PR DESCRIPTION
## Description:

On capture, defense posts will now be destroyed instead of transferred.

Continuation of the stale PR, https://github.com/openfrontio/OpenFrontIO/pull/1622. Closes https://github.com/openfrontio/OpenFrontIO/pull/1622.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Discord username: `seekerreturns`
