### PR TITLE
Added Animation of a breathing border around the spawn Cell

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -23,6 +23,7 @@ export class TerritoryLayer implements Layer {
   private context: CanvasRenderingContext2D | undefined;
   private imageData: ImageData | undefined;
   private alternativeImageData: ImageData | undefined;
+  private borderAnimTime = 0;
 
   private cachedTerritoryPatternsEnabled: boolean | undefined;
 
@@ -195,6 +196,35 @@ export class TerritoryLayer implements Layer {
         }
       }
     }
+    // Breathing border animation
+    this.borderAnimTime += 1;
+    const minPadding = 3;
+    const maxPadding = 8;
+    // Range: [minPadding..maxPadding]
+    const breathingPadding = minPadding + (maxPadding - minPadding) * (0.5 + 0.5 * Math.sin(this.borderAnimTime * 0.3));
+
+    if (focusedPlayer) {
+    // Clear previous animated border
+      if(this.highlightContext) {
+        this.highlightContext.clearRect(
+          0,
+          0,
+          this.game.width(),
+          this.game.height(),
+        );
+      }
+
+      const center = focusedPlayer.nameLocation();
+      if (center) {
+        this.drawBreathingRing(
+          center.x,
+          center.y,
+          breathingPadding,
+          this.theme.spawnHighlightColor(),
+        );
+      }
+    }
+
   }
 
   init() {
@@ -565,4 +595,19 @@ export class TerritoryLayer implements Layer {
     if (this.highlightContext === undefined) throw new Error("Not initialized");
     this.highlightContext.clearRect(x, y, 1, 1);
   }
+  private drawBreathingRing(
+    cx: number,
+    cy: number,
+    radius: number,
+    color: Colord,
+  ) {
+    const ctx = this.highlightContext;
+    if (!ctx) return;
+    ctx.beginPath();
+    ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+    ctx.strokeStyle = color.toRgbString();
+    ctx.lineWidth = 2;
+    ctx.stroke();
+  }
+
 }


### PR DESCRIPTION
## Description:

_Lost control of the previous PR (#1951) because of faulty commits , PRing again_

Noticed many people are struggling to see where they choose to spawn or forget where they chose , what leads to confusion.
solved it with this animation around the spawning player cell.

![483088331-938f7dc8-97cb-40d0-8222-9f8ddbc2b21f](https://github.com/user-attachments/assets/da4d7ae2-a775-4464-a6a3-edc1b6667754)

<img width="231" height="265" alt="483088982-22e157a5-301d-4d41-8f2c-21a9dd09a1f6" src="https://github.com/user-attachments/assets/58c0829d-4b8c-4762-b971-cd08ebe64143" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

boostry
