### PR TITLE
Fix for Keyboard Shortcuts Not Respecting Keyboard Layout [Issue #1071]

### DIFF
--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -2,6 +2,7 @@ import "./components/baseComponents/setting/SettingKeybind";
 import "./components/baseComponents/setting/SettingNumber";
 import "./components/baseComponents/setting/SettingSlider";
 import "./components/baseComponents/setting/SettingToggle";
+import { Action, ActionKeybindMapDefaults } from "./utilities/InputMap";
 import { LitElement, html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { SettingKeybind } from "./components/baseComponents/setting/SettingKeybind";
@@ -422,7 +423,7 @@ export class UserSettingModal extends LitElement {
         action="toggleView"
         label=${translateText("user_setting.toggle_view")}
         description=${translateText("user_setting.toggle_view_desc")}
-        defaultKey="Space"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.TOGGLE_VIEW)}"
         .value=${this.keybinds["toggleView"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -435,7 +436,7 @@ export class UserSettingModal extends LitElement {
         action="attackRatioDown"
         label=${translateText("user_setting.attack_ratio_down")}
         description=${translateText("user_setting.attack_ratio_down_desc")}
-        defaultKey="Digit1"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.ATTACK_RATIO_DOWN)}"
         .value=${this.keybinds["attackRatioDown"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -444,7 +445,7 @@ export class UserSettingModal extends LitElement {
         action="attackRatioUp"
         label=${translateText("user_setting.attack_ratio_up")}
         description=${translateText("user_setting.attack_ratio_up_desc")}
-        defaultKey="Digit2"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.ATTACK_RATIO_UP)}"
         .value=${this.keybinds["attackRatioUp"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -457,7 +458,7 @@ export class UserSettingModal extends LitElement {
         action="boatAttack"
         label=${translateText("user_setting.boat_attack")}
         description=${translateText("user_setting.boat_attack_desc")}
-        defaultKey="KeyB"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.BOAT_ATTACK)}"
         .value=${this.keybinds["boatAttack"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -466,7 +467,7 @@ export class UserSettingModal extends LitElement {
         action="groundAttack"
         label=${translateText("user_setting.ground_attack")}
         description=${translateText("user_setting.ground_attack_desc")}
-        defaultKey="KeyG"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.GROUND_ATTACK)}"
         .value=${this.keybinds["groundAttack"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -479,7 +480,7 @@ export class UserSettingModal extends LitElement {
         action="zoomOut"
         label=${translateText("user_setting.zoom_out")}
         description=${translateText("user_setting.zoom_out_desc")}
-        defaultKey="KeyQ"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.ZOOM_OUT)}"
         .value=${this.keybinds["zoomOut"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -488,7 +489,7 @@ export class UserSettingModal extends LitElement {
         action="zoomIn"
         label=${translateText("user_setting.zoom_in")}
         description=${translateText("user_setting.zoom_in_desc")}
-        defaultKey="KeyE"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.ZOOM_IN)}"
         .value=${this.keybinds["zoomIn"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -501,7 +502,7 @@ export class UserSettingModal extends LitElement {
         action="centerCamera"
         label=${translateText("user_setting.center_camera")}
         description=${translateText("user_setting.center_camera_desc")}
-        defaultKey="KeyC"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.CENTER_CAMERA)}"
         .value=${this.keybinds["centerCamera"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -510,7 +511,7 @@ export class UserSettingModal extends LitElement {
         action="moveUp"
         label=${translateText("user_setting.move_up")}
         description=${translateText("user_setting.move_up_desc")}
-        defaultKey="KeyW"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.MOVE_UP)}"
         .value=${this.keybinds["moveUp"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -519,7 +520,7 @@ export class UserSettingModal extends LitElement {
         action="moveLeft"
         label=${translateText("user_setting.move_left")}
         description=${translateText("user_setting.move_left_desc")}
-        defaultKey="KeyA"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.MOVE_LEFT)}"
         .value=${this.keybinds["moveLeft"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -528,7 +529,7 @@ export class UserSettingModal extends LitElement {
         action="moveDown"
         label=${translateText("user_setting.move_down")}
         description=${translateText("user_setting.move_down_desc")}
-        defaultKey="KeyS"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.MOVE_DOWN)}"
         .value=${this.keybinds["moveDown"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>
@@ -537,7 +538,7 @@ export class UserSettingModal extends LitElement {
         action="moveRight"
         label=${translateText("user_setting.move_right")}
         description=${translateText("user_setting.move_right_desc")}
-        defaultKey="KeyD"
+        defaultKey="${ActionKeybindMapDefaults.get(Action.MOVE_RIGHT)}"
         .value=${this.keybinds["moveRight"] ?? ""}
         @change=${this.handleKeybindChange}
       ></setting-keybind>

--- a/src/client/components/baseComponents/setting/SettingKeybind.ts
+++ b/src/client/components/baseComponents/setting/SettingKeybind.ts
@@ -74,13 +74,13 @@ export class SettingKeybind extends LitElement {
     if (!this.listening) return;
     e.preventDefault();
 
-    const { code } = e;
+    const { key } = e;
 
-    this.value = code;
+    this.value = key;
 
     this.dispatchEvent(
       new CustomEvent("change", {
-        detail: { action: this.action, value: code },
+        detail: { action: this.action, value: key },
         bubbles: true,
         composed: true,
       }),

--- a/src/client/utilities/InputMap.ts
+++ b/src/client/utilities/InputMap.ts
@@ -1,0 +1,42 @@
+export enum Action {
+  // View and camera controls
+  TOGGLE_VIEW,
+  CENTER_CAMERA,
+
+  // Movement controls
+  MOVE_UP,
+  MOVE_DOWN,
+  MOVE_LEFT,
+  MOVE_RIGHT,
+
+  // Zoom controls
+  ZOOM_OUT,
+  ZOOM_IN,
+
+  // Attack controls
+  ATTACK_RATIO_DOWN,
+  ATTACK_RATIO_UP,
+  BOAT_ATTACK,
+  GROUND_ATTACK,
+
+  // Modifier keys
+  MODIFIER_KEY,
+  ALT_KEY
+}
+
+export const ActionKeybindMapDefaults = new Map<Action, string>([
+  [Action.TOGGLE_VIEW, " "],
+  [Action.CENTER_CAMERA, "c"],
+  [Action.MOVE_UP, "w"],
+  [Action.MOVE_DOWN, "s"],
+  [Action.MOVE_LEFT, "a"],
+  [Action.MOVE_RIGHT, "d"],
+  [Action.ZOOM_OUT, "q"],
+  [Action.ZOOM_IN, "e"],
+  [Action.ATTACK_RATIO_DOWN, "1"],
+  [Action.ATTACK_RATIO_UP, "2"],
+  [Action.BOAT_ATTACK, "b"],
+  [Action.GROUND_ATTACK, "g"],
+  [Action.MODIFIER_KEY, "ControlLeft"],
+  [Action.ALT_KEY, "AltLeft"],
+]);


### PR DESCRIPTION
…ffects keybind related actions. Actions such as Escape and Performance overlay remain as physical key presses.

## Description:

This PR fixes #1071 in which the physical key code was used over the key itself. The previous behavior resulted in issues when using keyboard layouts outside of the standard such as AZERTY.

The ideal fix would utilize a command pattern and some central manager that would route key presses. This PR is a half step towards that methodology as a quick fix for the issue described.

This approach should also respect user keybinds already in production -- converting their 'physical keys' to 'digital.'

All tests pass:
<img width="290" height="120" alt="image" src="https://github.com/user-attachments/assets/d9914e92-54a7-4106-af34-15c85a12922e" />

Manually tested behavior on local build, behaves as expected using QWERTY and AZERTY.

## Please complete the following:

- [x ] I have added screenshots for all UI updates
- [x ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x ] I have added relevant tests to the test directory
- [x ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Mikesteam1234
