### PR TITLE
perf: Update myplayer only on tick

### DIFF
--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -443,6 +443,9 @@ export class GameView implements GameMap {
         );
       }
     });
+
+    this._myPlayer ??= this.playerByClientID(this._myClientID);
+
     for (const unit of this._units.values()) {
       unit._wasUpdated = false;
       unit.lastPos = unit.lastPos.slice(-1);
@@ -503,7 +506,6 @@ export class GameView implements GameMap {
   }
 
   myPlayer(): PlayerView | null {
-    this._myPlayer ??= this.playerByClientID(this._myClientID);
     return this._myPlayer;
   }
 


### PR DESCRIPTION
## Description:

During replays, myPlayer() was undefined, causing to search through all clients an each call. Instead just update myPlayer on on tick/update.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
