### PR TITLE
Fix back button, show join in singleplayer

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -4,7 +4,6 @@ import { EventBus } from "../core/EventBus";
 import { GameRecord, GameStartInfo, ID } from "../core/Schemas";
 import { ServerConfig } from "../core/configuration/Config";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
-import { GameType } from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import "./AccountModal";
 import { joinLobby } from "./ClientGameRunner";
@@ -490,6 +489,9 @@ class Client {
         this.patternsModal.open(affiliateCode);
       }
     }
+    if (decodedHash.startsWith("#refresh")) {
+      window.location.href = "/";
+    }
   }
 
   private async handleJoinLobby(event: CustomEvent<JoinLobbyEvent>) {
@@ -575,9 +577,11 @@ class Client {
           (ad as HTMLElement).style.display = "none";
         });
 
-        if (lobby.gameStartInfo?.config.gameType !== GameType.Singleplayer) {
-          history.pushState(null, "", `#join=${lobby.gameID}`);
+        // Ensure there's a homepage entry in history before adding the lobby entry
+        if (window.location.hash === "" || window.location.hash === "#") {
+          history.pushState(null, "", window.location.origin + "#refresh");
         }
+        history.pushState(null, "", `#join=${lobby.gameID}`);
       },
     );
   }


### PR DESCRIPTION
## Description:

Add #refresh in the history so when back button is pressed the homepage is reloaded

Add the join code in singleplayer because singleplayer games are now replayable

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
