### PR TITLE
Player names are hidden when zoomed in too much

### DIFF
--- a/src/client/graphics/layers/NameLayer.ts
+++ b/src/client/graphics/layers/NameLayer.ts
@@ -139,8 +139,14 @@ export class NameLayer implements Layer {
     const isOnScreen = render.location
       ? this.transformHandler.isOnScreen(render.location)
       : false;
+    const maxZoomScale = 17;
 
-    if (!this.isVisible || size < 7 || !isOnScreen) {
+    if (
+      !this.isVisible ||
+      size < 7 ||
+      (this.transformHandler.scale > maxZoomScale && size > 100) ||
+      !isOnScreen
+    ) {
       render.element.style.display = "none";
     } else {
       render.element.style.display = "flex";


### PR DESCRIPTION
## Description:
Player names are hidden, except small sized fonts, when zoomed in too much(near max), improving user experience by allowing users to see structures clearly without the obstruction of text

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file(no need)
- [x] I have added relevant tests to the test directory(n/a)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Video
[video](https://streamable.com/e/mlrfqo?)

## Please put your Discord username so you can be contacted if a bug or regression is found:
_federalagent
