### PR TITLE
Add translate="no" to <html>

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en" class="h-full">
+<html lang="en" class="h-full" translate="no">
   <head>
     <meta charset="UTF-8" />
     <meta


### PR DESCRIPTION
## Description:

This PR prevents automatic browser translation (e.g., in Chrome) from triggering immediately upon page load.
This approach is somewhat of a workaround, so it would be better if another fix could be found.

Please refer to the following issue for the rationale: #2052

Fixes #2052

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Aotumuri