### PR TITLE
fix(MoveWarshipExecution): remove console.warn when warship not found

### DIFF
--- a/src/core/execution/MoveWarshipExecution.ts
+++ b/src/core/execution/MoveWarshipExecution.ts
@@ -17,7 +17,6 @@ export class MoveWarshipExecution implements Execution {
       .units(UnitType.Warship)
       .find((u) => u.id() === this.unitId);
     if (!warship) {
-      console.warn("MoveWarshipExecution: warship not found");
       return;
     }
     if (!warship.isActive()) {

--- a/tests/Warship.test.ts
+++ b/tests/Warship.test.ts
@@ -242,9 +242,14 @@ describe("Warship", () => {
       game.ref(coastX + 5, 15),
     );
 
+    const consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation();
+
     // Verify that no error is thrown.
     exec.init(game, 0);
 
     expect(exec.isActive()).toBe(false);
+    expect(consoleWarnSpy).not.toHaveBeenCalled();
+
+    consoleWarnSpy.mockRestore();
   });
 });


### PR DESCRIPTION
The `init` method in the `MoveWarshipExecution` class was logging a warning to the console when a warship was not found. This is problematic because the test that checks for this case, `MoveWarshipExecution fails gracefully if warship not found`, was not asserting that the `init` method should not log a warning. This means that the test was passing even though the method was not behaving as expected.

This change modifies the test to assert that the `init` method does not log a warning to the console and removes the `console.warn` statement from the `init` method.

## Description:

Describe the PR.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
