### PR TITLE
Add support for colored patterns

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -558,7 +558,7 @@
     "choose_spawn": "Choose a starting location"
   },
   "territory_patterns": {
-    "title": "Select Territory Pattern",
+    "title": "Select Territory Skin",
     "purchase": "Purchase",
     "blocked": {
       "login": "You must be logged in to access this pattern.",

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -5,6 +5,7 @@ import {
   GameID,
   GameRecord,
   GameStartInfo,
+  PlayerPattern,
   PlayerRecord,
   ServerMessage,
 } from "../core/Schemas";
@@ -47,7 +48,7 @@ import { createRenderer, GameRenderer } from "./graphics/GameRenderer";
 
 export interface LobbyConfig {
   serverConfig: ServerConfig;
-  patternName: string | undefined;
+  pattern: PlayerPattern | undefined;
   flag: string;
   playerName: string;
   clientID: ClientID;

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -7,6 +7,7 @@ import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import { UserSettings } from "../core/game/UserSettings";
 import "./AccountModal";
 import { joinLobby } from "./ClientGameRunner";
+import { fetchCosmetics } from "./Cosmetics";
 import "./DarkModeButton";
 import { DarkModeButton } from "./DarkModeButton";
 import "./FlagInput";
@@ -508,7 +509,9 @@ class Client {
       {
         gameID: lobby.gameID,
         serverConfig: config,
-        patternName: this.userSettings.getSelectedPatternName(),
+        pattern:
+          this.userSettings.getSelectedPatternName(await fetchCosmetics()) ??
+          undefined,
         flag:
           this.flagInput === null || this.flagInput.getCurrentFlag() === "xx"
             ? ""

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -21,7 +21,7 @@ import "./components/baseComponents/Modal";
 import "./components/Difficulties";
 import { DifficultyDescription } from "./components/Difficulties";
 import "./components/Maps";
-import { getCosmetics } from "./Cosmetics";
+import { fetchCosmetics } from "./Cosmetics";
 import { FlagInput } from "./FlagInput";
 import { JoinLobbyEvent } from "./Main";
 import { UsernameInput } from "./UsernameInput";
@@ -425,13 +425,12 @@ export class SinglePlayerModal extends LitElement {
     if (!flagInput) {
       console.warn("Flag input element not found");
     }
-    const patternName = this.userSettings.getSelectedPatternName();
-    let pattern: string | undefined = undefined;
-    if (this.userSettings.getDevOnlyPattern()) {
-      pattern = this.userSettings.getDevOnlyPattern();
-    } else if (patternName) {
-      pattern = (await getCosmetics())?.patterns[patternName]?.pattern;
-    }
+    const cosmetics = await fetchCosmetics();
+    let selectedPattern = this.userSettings.getSelectedPatternName(cosmetics);
+    selectedPattern ??= cosmetics
+      ? (this.userSettings.getDevOnlyPattern() ?? null)
+      : null;
+
     this.dispatchEvent(
       new CustomEvent("join-lobby", {
         detail: {
@@ -443,11 +442,13 @@ export class SinglePlayerModal extends LitElement {
               {
                 clientID,
                 username: usernameInput.getCurrentUsername(),
-                flag:
-                  flagInput.getCurrentFlag() === "xx"
-                    ? ""
-                    : flagInput.getCurrentFlag(),
-                pattern: pattern,
+                cosmetics: {
+                  flag:
+                    flagInput.getCurrentFlag() === "xx"
+                      ? ""
+                      : flagInput.getCurrentFlag(),
+                  pattern: selectedPattern ?? undefined,
+                },
               },
             ],
             config: {

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -368,8 +368,11 @@ export class Transport {
       lastTurn: numTurns,
       token: this.lobbyConfig.token,
       username: this.lobbyConfig.playerName,
-      flag: this.lobbyConfig.flag,
-      patternName: this.lobbyConfig.patternName,
+      cosmetics: {
+        flag: this.lobbyConfig.flag,
+        patternName: this.lobbyConfig.pattern?.name,
+        patternColorPaletteName: this.lobbyConfig.pattern?.colorPalette?.name,
+      },
     } satisfies ClientJoinMessage);
   }
 

--- a/src/client/graphics/AnimatedSpriteLoader.ts
+++ b/src/client/graphics/AnimatedSpriteLoader.ts
@@ -188,8 +188,8 @@ export class AnimatedSpriteLoader {
     const baseImage = this.animatedSpriteImageMap.get(fxType);
     const config = ANIMATED_SPRITE_CONFIG[fxType];
     if (!baseImage || !config) return null;
-    const territoryColor = theme.territoryColor(owner);
-    const borderColor = theme.borderColor(owner);
+    const territoryColor = owner.territoryColor();
+    const borderColor = owner.borderColor();
     const spawnHighlightColor = theme.spawnHighlightColor();
     const key = `${fxType}-${owner.id()}`;
     let coloredCanvas: HTMLCanvasElement;

--- a/src/client/graphics/SpriteLoader.ts
+++ b/src/client/graphics/SpriteLoader.ts
@@ -171,10 +171,9 @@ export const getColoredSprite = (
   customTerritoryColor?: Colord,
   customBorderColor?: Colord,
 ): HTMLCanvasElement => {
-  const owner = unit.owner();
   const territoryColor: Colord =
-    customTerritoryColor ?? theme.territoryColor(owner);
-  const borderColor: Colord = customBorderColor ?? theme.borderColor(owner);
+    customTerritoryColor ?? unit.owner().territoryColor();
+  const borderColor: Colord = customBorderColor ?? unit.owner().borderColor();
   const spawnHighlightColor = theme.spawnHighlightColor();
   const key = computeSpriteKey(unit, territoryColor, borderColor);
   if (coloredSpriteCache.has(key)) {

--- a/src/client/graphics/layers/RailroadLayer.ts
+++ b/src/client/graphics/layers/RailroadLayer.ts
@@ -153,7 +153,7 @@ export class RailroadLayer implements Layer {
     const owner = this.game.owner(railRoad.tile);
     const recipient = owner.isPlayer() ? (owner as PlayerView) : null;
     const color = recipient
-      ? this.theme.railroadColor(recipient)
+      ? recipient.borderColor()
       : new Colord({ r: 255, g: 255, b: 255, a: 1 });
     this.context.fillStyle = color.toRgbString();
     this.paintRailRects(x, y, railRoad.railType);

--- a/src/client/graphics/layers/StructureIconsLayer.ts
+++ b/src/client/graphics/layers/StructureIconsLayer.ts
@@ -344,7 +344,7 @@ export class StructureIconsLayer implements Layer {
     const structureType = isConstruction ? constructionType! : unit.type();
     const cacheKey = isConstruction
       ? `construction-${structureType}` + (renderIcon ? "-icon" : "")
-      : `${this.theme.territoryColor(unit.owner()).toRgbString()}-${structureType}` +
+      : `${unit.owner().territoryColor().toRgbString()}-${structureType}` +
         (renderIcon ? "-icon" : "");
     if (this.textureCache.has(cacheKey)) {
       return this.textureCache.get(cacheKey)!;
@@ -386,13 +386,13 @@ export class StructureIconsLayer implements Layer {
       context.fillStyle = "rgb(198, 198, 198)";
       borderColor = "rgb(128, 127, 127)";
     } else {
-      context.fillStyle = this.theme
-        .territoryColor(owner)
+      context.fillStyle = owner
+        .territoryColor()
         .lighten(0.13)
         .alpha(renderIcon ? 0.65 : 1)
         .toRgbString();
-      const darken = this.theme.borderColor(owner).isLight() ? 0.17 : 0.15;
-      borderColor = this.theme.borderColor(owner).darken(darken).toRgbString();
+      const darken = owner.borderColor().isLight() ? 0.17 : 0.15;
+      borderColor = owner.borderColor().darken(darken).toRgbString();
     }
 
     context.strokeStyle = borderColor;

--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -190,7 +190,7 @@ export class StructureLayer implements Layer {
         new Cell(this.game.x(tile), this.game.y(tile)),
         unit.type() === UnitType.Construction
           ? underConstructionColor
-          : this.theme.territoryColor(unit.owner()),
+          : unit.owner().territoryColor(),
         130,
       );
     }
@@ -203,7 +203,7 @@ export class StructureLayer implements Layer {
 
     const config = this.unitConfigs[unitType];
     let icon: HTMLImageElement | undefined;
-    let borderColor = this.theme.borderColor(unit.owner());
+    let borderColor = unit.owner().borderColor();
 
     // Handle cooldown states and special icons
     if (unit.type() === UnitType.Construction) {
@@ -244,7 +244,7 @@ export class StructureLayer implements Layer {
     height: number,
     unit: UnitView,
   ) {
-    let color = this.theme.borderColor(unit.owner());
+    let color = unit.owner().borderColor();
     if (unit.type() === UnitType.Construction) {
       color = underConstructionColor;
     }

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -143,7 +143,7 @@ export class UILayer implements Layer {
     if (this.context === null || this.theme === null) {
       return;
     }
-    const color = this.theme.borderColor(unit.owner());
+    const color = unit.owner().borderColor();
     this.context.fillStyle = color.toRgbString();
     this.context.fillRect(startX, startY, icon.width, icon.height);
     this.context.drawImage(icon, startX, startY);
@@ -208,7 +208,7 @@ export class UILayer implements Layer {
 
     // Get the unit's owner color for the box
     if (this.theme === null) throw new Error("missing theme");
-    const ownerColor = this.theme.territoryColor(unit.owner());
+    const ownerColor = unit.owner().territoryColor();
 
     // Create a brighter version of the owner color for the selection
     const selectionColor = ownerColor.lighten(0.2);

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -201,7 +201,7 @@ export class UnitLayer implements Layer {
           this.game.x(t),
           this.game.y(t),
           this.relationship(unit),
-          this.theme.territoryColor(unit.owner()),
+          unit.owner().territoryColor(),
           150,
           this.unitTrailContext,
         );
@@ -321,14 +321,14 @@ export class UnitLayer implements Layer {
       this.game.x(unit.tile()),
       this.game.y(unit.tile()),
       rel,
-      this.theme.borderColor(unit.owner()),
+      unit.owner().borderColor(),
       255,
     );
     this.paintCell(
       this.game.x(unit.lastTile()),
       this.game.y(unit.lastTile()),
       rel,
-      this.theme.borderColor(unit.owner()),
+      unit.owner().borderColor(),
       255,
     );
   }
@@ -369,7 +369,7 @@ export class UnitLayer implements Layer {
             this.game.x(t),
             this.game.y(t),
             rel,
-            this.theme.territoryColor(other.owner()),
+            other.owner().territoryColor(),
             150,
             this.unitTrailContext,
           );
@@ -410,7 +410,7 @@ export class UnitLayer implements Layer {
 
     this.drawTrail(
       trail.slice(-newTrailSize),
-      this.theme.territoryColor(unit.owner()),
+      unit.owner().territoryColor(),
       rel,
     );
     this.drawSprite(unit);
@@ -430,7 +430,7 @@ export class UnitLayer implements Layer {
         this.game.x(unit.tile()),
         this.game.y(unit.tile()),
         rel,
-        this.theme.borderColor(unit.owner()),
+        unit.owner().borderColor(),
         255,
       );
     }
@@ -454,11 +454,7 @@ export class UnitLayer implements Layer {
     trail.push(unit.lastTile());
 
     // Paint trail
-    this.drawTrail(
-      trail.slice(-1),
-      this.theme.territoryColor(unit.owner()),
-      rel,
-    );
+    this.drawTrail(trail.slice(-1), unit.owner().territoryColor(), rel);
     this.drawSprite(unit);
 
     if (!unit.isActive()) {

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -1,11 +1,14 @@
 import { base64url } from "jose";
 import { z } from "zod/v4";
-import { PatternDecoder } from "./PatternDecoder";
+import { decodePatternData } from "./PatternDecoder";
+import { PlayerPattern } from "./Schemas";
 
 export type Cosmetics = z.infer<typeof CosmeticsSchema>;
-export type Pattern = z.infer<typeof PatternInfoSchema>;
+export type Pattern = z.infer<typeof PatternSchema>;
 export type PatternName = z.infer<typeof PatternNameSchema>;
 export type Product = z.infer<typeof ProductSchema>;
+export type ColorPalette = z.infer<typeof ColorPaletteSchema>;
+export type PatternData = z.infer<typeof PatternDataSchema>;
 
 export const ProductSchema = z.object({
   productId: z.string(),
@@ -18,14 +21,14 @@ export const PatternNameSchema = z
   .regex(/^[a-z0-9_]+$/)
   .max(32);
 
-export const PatternSchema = z
+export const PatternDataSchema = z
   .string()
   .max(1403)
   .base64url()
   .refine(
     (val) => {
       try {
-        new PatternDecoder(val, base64url.decode);
+        decodePatternData(val, base64url.decode);
         return true;
       } catch (e) {
         if (e instanceof Error) {
@@ -41,16 +44,30 @@ export const PatternSchema = z
     },
   );
 
-export const PatternInfoSchema = z.object({
+export const ColorPaletteSchema = z.object({
+  name: z.string(),
+  primaryColor: z.string(),
+  secondaryColor: z.string(),
+});
+
+export const PatternSchema = z.object({
   name: PatternNameSchema,
-  pattern: PatternSchema,
+  pattern: PatternDataSchema,
+  colorPalettes: z
+    .object({
+      name: z.string(),
+      isArchived: z.boolean(),
+    })
+    .array()
+    .optional(),
   affiliateCode: z.string().nullable(),
   product: ProductSchema.nullable(),
 });
 
 // Schema for resources/cosmetics/cosmetics.json
 export const CosmeticsSchema = z.object({
-  patterns: z.record(z.string(), PatternInfoSchema),
+  colorPalettes: z.record(z.string(), ColorPaletteSchema).optional(),
+  patterns: z.record(z.string(), PatternSchema),
   flag: z
     .object({
       layers: z.record(
@@ -71,3 +88,9 @@ export const CosmeticsSchema = z.object({
     })
     .optional(),
 });
+
+export const DefaultPattern = {
+  name: "default",
+  patternData: "AAAAAA",
+  colorPalette: undefined,
+} satisfies PlayerPattern;

--- a/src/core/PatternDecoder.ts
+++ b/src/core/PatternDecoder.ts
@@ -1,3 +1,5 @@
+import { PlayerPattern } from "./Schemas";
+
 export class PatternDecoder {
   private bytes: Uint8Array;
 
@@ -5,37 +7,19 @@ export class PatternDecoder {
   readonly width: number;
   readonly scale: number;
 
-  constructor(base64: string, base64urlDecode: (input: string) => Uint8Array) {
-    this.bytes = base64urlDecode(base64);
-
-    if (this.bytes.length < 3) {
-      throw new Error(
-        "Pattern data is too short to contain required metadata.",
-      );
-    }
-
-    const version = this.bytes[0];
-    if (version !== 0) {
-      throw new Error(`Unrecognized pattern version ${version}.`);
-    }
-
-    const byte1 = this.bytes[1];
-    const byte2 = this.bytes[2];
-    this.scale = byte1 & 0x07;
-
-    this.width = (((byte2 & 0x03) << 5) | ((byte1 >> 3) & 0x1f)) + 2;
-    this.height = ((byte2 >> 2) & 0x3f) + 2;
-
-    const expectedBits = this.width * this.height;
-    const expectedBytes = (expectedBits + 7) >> 3; // Equivalent to: ceil(expectedBits / 8);
-    if (this.bytes.length - 3 < expectedBytes) {
-      throw new Error(
-        "Pattern data is too short for the specified dimensions.",
-      );
-    }
+  constructor(
+    pattern: PlayerPattern,
+    base64urlDecode: (input: string) => Uint8Array,
+  ) {
+    ({
+      height: this.height,
+      width: this.width,
+      scale: this.scale,
+      bytes: this.bytes,
+    } = decodePatternData(pattern.patternData, base64urlDecode));
   }
 
-  isSet(x: number, y: number): boolean {
+  isPrimary(x: number, y: number): boolean {
     const px = (x >> this.scale) % this.width;
     const py = (y >> this.scale) % this.height;
     const idx = py * this.width + px;
@@ -43,7 +27,8 @@ export class PatternDecoder {
     const bitIndex = idx & 7;
     const byte = this.bytes[3 + byteIndex];
     if (byte === undefined) throw new Error("Invalid pattern");
-    return (byte & (1 << bitIndex)) !== 0;
+
+    return (byte & (1 << bitIndex)) === 0;
   }
 
   scaledHeight(): number {
@@ -53,4 +38,35 @@ export class PatternDecoder {
   scaledWidth(): number {
     return this.width << this.scale;
   }
+}
+
+export function decodePatternData(
+  b64: string,
+  base64urlDecode: (input: string) => Uint8Array,
+): { height: number; width: number; scale: number; bytes: Uint8Array } {
+  const bytes = base64urlDecode(b64);
+
+  if (bytes.length < 3) {
+    throw new Error("Pattern data is too short to contain required metadata.");
+  }
+
+  const version = bytes[0];
+  if (version !== 0) {
+    throw new Error(`Unrecognized pattern version ${version}.`);
+  }
+
+  const byte1 = bytes[1];
+  const byte2 = bytes[2];
+  const scale = byte1 & 0x07;
+
+  const width = (((byte2 & 0x03) << 5) | ((byte1 >> 3) & 0x1f)) + 2;
+  const height = ((byte2 >> 2) & 0x3f) + 2;
+
+  const expectedBits = width * height;
+  const expectedBytes = (expectedBits + 7) >> 3; // Equivalent to: ceil(expectedBits / 8);
+  if (bytes.length - 3 < expectedBytes) {
+    throw new Error("Pattern data is too short for the specified dimensions.");
+  }
+
+  return { height, width, scale, bytes };
 }

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -1,7 +1,11 @@
 import { z } from "zod";
 import quickChatData from "../../resources/QuickChat.json" with { type: "json" };
 import countries from "../client/data/countries.json" with { type: "json" };
-import { PatternSchema } from "./CosmeticSchemas";
+import {
+  ColorPaletteSchema,
+  PatternDataSchema,
+  PatternNameSchema,
+} from "./CosmeticSchemas";
 import {
   AllPlayers,
   Difficulty,
@@ -106,6 +110,10 @@ export type ClientHashMessage = z.infer<typeof ClientHashSchema>;
 
 export type AllPlayersStats = z.infer<typeof AllPlayersStatsSchema>;
 export type Player = z.infer<typeof PlayerSchema>;
+export type PlayerCosmetics = z.infer<typeof PlayerCosmeticsSchema>;
+export type PlayerCosmeticRefs = z.infer<typeof PlayerCosmeticRefsSchema>;
+export type PlayerPattern = z.infer<typeof PlayerPatternSchema>;
+export type Flag = z.infer<typeof FlagSchema>;
 export type GameStartInfo = z.infer<typeof GameStartInfoSchema>;
 const PlayerTypeSchema = z.enum(PlayerType);
 
@@ -190,18 +198,6 @@ export const AllPlayersStatsSchema = z.record(ID, PlayerStatsSchema);
 
 export const UsernameSchema = SafeString;
 const countryCodes = countries.filter((c) => !c.restricted).map((c) => c.code);
-export const FlagSchema = z
-  .string()
-  .max(128)
-  .optional()
-  .refine(
-    (val) => {
-      if (val === undefined || val === "") return true;
-      if (val.startsWith("!")) return true;
-      return countryCodes.includes(val);
-    },
-    { message: "Invalid flag: must be a valid country code or start with !" },
-  );
 
 export const QuickChatKeySchema = z.enum(
   Object.entries(quickChatData).flatMap(([category, entries]) =>
@@ -365,11 +361,38 @@ export const TurnSchema = z.object({
   hash: z.number().nullable().optional(),
 });
 
+export const FlagSchema = z
+  .string()
+  .max(128)
+  .optional()
+  .refine(
+    (val) => {
+      if (val === undefined || val === "") return true;
+      if (val.startsWith("!")) return true;
+      return countryCodes.includes(val);
+    },
+    { message: "Invalid flag: must be a valid country code or start with !" },
+  );
+
+export const PlayerCosmeticRefsSchema = z.object({
+  flag: FlagSchema.optional(),
+  patternName: PatternNameSchema.optional(),
+  patternColorPaletteName: z.string().optional(),
+});
+
+export const PlayerPatternSchema = z.object({
+  name: PatternNameSchema,
+  patternData: PatternDataSchema,
+  colorPalette: ColorPaletteSchema.optional(),
+});
+export const PlayerCosmeticsSchema = z.object({
+  flag: FlagSchema.optional(),
+  pattern: PlayerPatternSchema.optional(),
+});
 export const PlayerSchema = z.object({
   clientID: ID,
   username: UsernameSchema,
-  flag: FlagSchema,
-  pattern: PatternSchema.optional(),
+  cosmetics: PlayerCosmeticsSchema.optional(),
 });
 
 export const GameStartInfoSchema = z.object({
@@ -474,8 +497,8 @@ export const ClientJoinMessageSchema = z.object({
   gameID: ID,
   lastTurn: z.number(), // The last turn the client saw.
   username: UsernameSchema,
-  flag: FlagSchema,
-  patternName: z.string().optional(),
+  // Server replaces the refs with the actual cosmetic data.
+  cosmetics: PlayerCosmeticRefsSchema.optional(),
 });
 
 export const ClientMessageSchema = z.discriminatedUnion("type", [

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -177,11 +177,12 @@ export interface Config {
 
 export interface Theme {
   teamColor(team: Team): Colord;
+  // Don't call directly, use PlayerView
   territoryColor(playerInfo: PlayerView): Colord;
-  specialBuildingColor(playerInfo: PlayerView): Colord;
-  railroadColor(playerInfo: PlayerView): Colord;
+  // Don't call directly, use PlayerView
   borderColor(playerInfo: PlayerView): Colord;
-  defendedBorderColors(playerInfo: PlayerView): { light: Colord; dark: Colord };
+  // Don't call directly, use PlayerView
+  defendedBorderColors(territoryColor: Colord): { light: Colord; dark: Colord };
   focusedBorderColor(): Colord;
   terrainColor(gm: GameMap, tile: TileRef): Colord;
   backgroundColor(): Colord;

--- a/src/core/configuration/PastelTheme.ts
+++ b/src/core/configuration/PastelTheme.ts
@@ -54,29 +54,7 @@ export class PastelTheme implements Theme {
     return this.nationColorAllocator.assignColor(player.id());
   }
 
-  textColor(player: PlayerView): string {
-    return player.type() === PlayerType.Human ? "#000000" : "#4D4D4D";
-  }
-
-  specialBuildingColor(player: PlayerView): Colord {
-    const tc = this.territoryColor(player).rgba;
-    return colord({
-      r: Math.max(tc.r - 50, 0),
-      g: Math.max(tc.g - 50, 0),
-      b: Math.max(tc.b - 50, 0),
-    });
-  }
-
-  railroadColor(player: PlayerView): Colord {
-    const tc = this.territoryColor(player).rgba;
-    const color = colord({
-      r: Math.max(tc.r - 10, 0),
-      g: Math.max(tc.g - 10, 0),
-      b: Math.max(tc.b - 10, 0),
-    });
-    return color;
-  }
-
+  // Don't call directly, use PlayerView
   borderColor(player: PlayerView): Colord {
     if (this.borderColorCache.has(player.id())) {
       return this.borderColorCache.get(player.id())!;
@@ -92,15 +70,22 @@ export class PastelTheme implements Theme {
     return color;
   }
 
-  defendedBorderColors(player: PlayerView): { light: Colord; dark: Colord } {
+  defendedBorderColors(territoryColor: Colord): {
+    light: Colord;
+    dark: Colord;
+  } {
     return {
-      light: this.territoryColor(player).darken(0.2),
-      dark: this.territoryColor(player).darken(0.4),
+      light: territoryColor.darken(0.2),
+      dark: territoryColor.darken(0.4),
     };
   }
 
   focusedBorderColor(): Colord {
     return colord({ r: 230, g: 230, b: 230 });
+  }
+
+  textColor(player: PlayerView): string {
+    return player.type() === PlayerType.Human ? "#000000" : "#4D4D4D";
   }
 
   terrainColor(gm: GameMap, tile: TileRef): Colord {

--- a/src/core/configuration/PastelThemeDark.ts
+++ b/src/core/configuration/PastelThemeDark.ts
@@ -1,119 +1,25 @@
 import { Colord, colord } from "colord";
-import { PseudoRandom } from "../PseudoRandom";
-import { PlayerType, Team, TerrainType } from "../game/Game";
+import { TerrainType } from "../game/Game";
 import { GameMap, TileRef } from "../game/GameMap";
-import { PlayerView } from "../game/GameView";
-import { ColorAllocator } from "./ColorAllocator";
-import { botColors, fallbackColors, humanColors, nationColors } from "./Colors";
-import { Theme } from "./Config";
+import { PastelTheme } from "./PastelTheme";
 
-type ColorCache = Map<string, Colord>;
+export class PastelThemeDark extends PastelTheme {
+  private darkShore = colord({ r: 134, g: 133, b: 88 });
 
-export class PastelThemeDark implements Theme {
-  private borderColorCache: ColorCache = new Map<string, Colord>();
-  private rand = new PseudoRandom(123);
-  private humanColorAllocator = new ColorAllocator(humanColors, fallbackColors);
-  private botColorAllocator = new ColorAllocator(botColors, botColors);
-  private teamColorAllocator = new ColorAllocator(humanColors, fallbackColors);
-  private nationColorAllocator = new ColorAllocator(nationColors, nationColors);
-
-  private background = colord({ r: 0, g: 0, b: 0 });
-  private shore = colord({ r: 134, g: 133, b: 88 });
-  private falloutColors = [
-    colord({ r: 120, g: 255, b: 71 }), // Original color
-    colord({ r: 130, g: 255, b: 85 }), // Slightly lighter
-    colord({ r: 110, g: 245, b: 65 }), // Slightly darker
-    colord({ r: 125, g: 255, b: 75 }), // Warmer tint
-    colord({ r: 115, g: 250, b: 68 }), // Cooler tint
-  ];
-  private water = colord({ r: 14, g: 11, b: 30 });
-  private shorelineWater = colord({ r: 50, g: 50, b: 50 });
-
-  private _selfColor = colord({ r: 0, g: 255, b: 0 });
-  private _allyColor = colord({ r: 255, g: 255, b: 0 });
-  private _neutralColor = colord({ r: 128, g: 128, b: 128 });
-  private _enemyColor = colord({ r: 255, g: 0, b: 0 });
-
-  private _spawnHighlightColor = colord({ r: 255, g: 213, b: 79 });
-
-  teamColor(team: Team): Colord {
-    return this.teamColorAllocator.assignTeamColor(team);
-  }
-
-  territoryColor(player: PlayerView): Colord {
-    const team = player.team();
-    if (team !== null) {
-      return this.teamColorAllocator.assignTeamPlayerColor(team, player.id());
-    }
-    if (player.type() === PlayerType.Human) {
-      return this.humanColorAllocator.assignColor(player.id());
-    }
-    if (player.type() === PlayerType.Bot) {
-      return this.botColorAllocator.assignColor(player.id());
-    }
-    return this.nationColorAllocator.assignColor(player.id());
-  }
-
-  textColor(player: PlayerView): string {
-    return player.type() === PlayerType.Human ? "#ffffff" : "#e6e6e6";
-  }
-
-  specialBuildingColor(player: PlayerView): Colord {
-    const tc = this.territoryColor(player).rgba;
-    return colord({
-      r: Math.max(tc.r - 50, 0),
-      g: Math.max(tc.g - 50, 0),
-      b: Math.max(tc.b - 50, 0),
-    });
-  }
-
-  railroadColor(player: PlayerView): Colord {
-    const tc = this.territoryColor(player).rgba;
-    const color = colord({
-      r: Math.max(tc.r - 10, 0),
-      g: Math.max(tc.g - 10, 0),
-      b: Math.max(tc.b - 10, 0),
-    });
-    return color;
-  }
-
-  borderColor(player: PlayerView): Colord {
-    if (this.borderColorCache.has(player.id())) {
-      return this.borderColorCache.get(player.id())!;
-    }
-    const tc = this.territoryColor(player).rgba;
-    const color = colord({
-      r: Math.max(tc.r - 40, 0),
-      g: Math.max(tc.g - 40, 0),
-      b: Math.max(tc.b - 40, 0),
-    });
-
-    this.borderColorCache.set(player.id(), color);
-    return color;
-  }
-
-  defendedBorderColors(player: PlayerView): { light: Colord; dark: Colord } {
-    return {
-      light: this.territoryColor(player).darken(0.2),
-      dark: this.territoryColor(player).darken(0.4),
-    };
-  }
-
-  focusedBorderColor(): Colord {
-    return colord({ r: 255, g: 255, b: 255 });
-  }
+  private darkWater = colord({ r: 14, g: 11, b: 30 });
+  private darkShorelineWater = colord({ r: 50, g: 50, b: 50 });
 
   terrainColor(gm: GameMap, tile: TileRef): Colord {
     const mag = gm.magnitude(tile);
     if (gm.isShore(tile)) {
-      return this.shore;
+      return this.darkShore;
     }
     switch (gm.terrainType(tile)) {
       case TerrainType.Ocean:
       case TerrainType.Lake:
-        const w = this.water.rgba;
+        const w = this.darkWater.rgba;
         if (gm.isShoreline(tile) && gm.isWater(tile)) {
-          return this.shorelineWater;
+          return this.darkShorelineWater;
         }
         if (gm.magnitude(tile) < 10) {
           return colord({
@@ -122,7 +28,7 @@ export class PastelThemeDark implements Theme {
             b: Math.max(w.b + 9 - mag, 0),
           });
         }
-        return this.water;
+        return this.darkWater;
       case TerrainType.Plains:
         return colord({
           r: 140,
@@ -142,34 +48,5 @@ export class PastelThemeDark implements Theme {
           b: 180 + mag / 2,
         });
     }
-  }
-
-  backgroundColor(): Colord {
-    return this.background;
-  }
-
-  falloutColor(): Colord {
-    return this.rand.randElement(this.falloutColors);
-  }
-
-  font(): string {
-    return "Overpass, sans-serif";
-  }
-
-  selfColor(): Colord {
-    return this._selfColor;
-  }
-  allyColor(): Colord {
-    return this._allyColor;
-  }
-  neutralColor(): Colord {
-    return this._neutralColor;
-  }
-  enemyColor(): Colord {
-    return this._enemyColor;
-  }
-
-  spawnHighlightColor(): Colord {
-    return this._spawnHighlightColor;
   }
 }

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -1,7 +1,9 @@
+import { Colord, colord } from "colord";
 import { base64url } from "jose";
 import { Config } from "../configuration/Config";
+import { ColorPalette } from "../CosmeticSchemas";
 import { PatternDecoder } from "../PatternDecoder";
-import { ClientID, GameID, Player } from "../Schemas";
+import { ClientID, GameID, Player, PlayerCosmetics } from "../Schemas";
 import { createRandomName } from "../Util";
 import { WorkerClient } from "../worker/WorkerClient";
 import {
@@ -38,11 +40,6 @@ import { UnitGrid, UnitPredicate } from "./UnitGrid";
 import { UserSettings } from "./UserSettings";
 
 const userSettings: UserSettings = new UserSettings();
-
-interface PlayerCosmetics {
-  pattern?: string | undefined;
-  flag?: string | undefined;
-}
 
 export class UnitView {
   public _wasUpdated = true;
@@ -181,6 +178,10 @@ export class PlayerView {
   public anonymousName: string | null = null;
   private decoder?: PatternDecoder;
 
+  private _territoryColor: Colord;
+  private _borderColor: Colord;
+  private _defendedBorderColors: { light: Colord; dark: Colord };
+
   constructor(
     private game: GameView,
     public data: PlayerUpdate,
@@ -195,14 +196,72 @@ export class PlayerView {
         this.data.playerType,
       );
     }
+
+    const pattern = this.cosmetics.pattern;
+    if (pattern) {
+      const territoryColor = this.game.config().theme().territoryColor(this);
+      pattern.colorPalette ??= {
+        name: "",
+        primaryColor: territoryColor.toHex(),
+        secondaryColor: territoryColor.darken(0.125).toHex(),
+      } satisfies ColorPalette;
+    }
+
+    if (
+      this.team() === null &&
+      this.cosmetics.pattern?.colorPalette?.primaryColor !== undefined
+    ) {
+      this._territoryColor = colord(
+        this.cosmetics.pattern.colorPalette.primaryColor,
+      );
+    } else {
+      this._territoryColor = this.game.config().theme().territoryColor(this);
+    }
+
+    if (this.cosmetics.pattern?.colorPalette?.secondaryColor !== undefined) {
+      this._borderColor = colord(
+        this.cosmetics.pattern.colorPalette.secondaryColor,
+      );
+    } else if (this.game.myClientID() === this.data.clientID) {
+      this._borderColor = this.game.config().theme().focusedBorderColor();
+    } else {
+      this._borderColor = this.game.config().theme().borderColor(this);
+    }
+
+    this._defendedBorderColors = this.game
+      .config()
+      .theme()
+      .defendedBorderColors(this._borderColor);
+
     this.decoder =
       this.cosmetics.pattern === undefined
         ? undefined
         : new PatternDecoder(this.cosmetics.pattern, base64url.decode);
   }
 
-  patternDecoder(): PatternDecoder | undefined {
-    return this.decoder;
+  territoryColor(tile?: TileRef): Colord {
+    if (tile === undefined || this.decoder === undefined) {
+      return this._territoryColor;
+    }
+    const isPrimary = this.decoder.isPrimary(
+      this.game.x(tile),
+      this.game.y(tile),
+    );
+    return isPrimary ? this._territoryColor : this._borderColor;
+  }
+
+  borderColor(tile?: TileRef, isDefended: boolean = false): Colord {
+    if (tile === undefined || !isDefended) {
+      return this._borderColor;
+    }
+
+    const x = this.game.x(tile);
+    const y = this.game.y(tile);
+    const lightTile =
+      (x % 2 === 0 && y % 2 === 0) || (y % 2 === 1 && x % 2 === 1);
+    return lightTile
+      ? this._defendedBorderColors.light
+      : this._defendedBorderColors.dark;
   }
 
   async actions(tile: TileRef): Promise<PlayerActions> {
@@ -387,16 +446,13 @@ export class GameView implements GameMap {
     this.lastUpdate = null;
     this.unitGrid = new UnitGrid(this._map);
     this._cosmetics = new Map(
-      this.humans.map((h) => [
-        h.clientID,
-        { flag: h.flag, pattern: h.pattern } satisfies PlayerCosmetics,
-      ]),
+      this.humans.map((h) => [h.clientID, h.cosmetics ?? {}]),
     );
     for (const nation of this._mapData.manifest.nations) {
       // Nations don't have client ids, so we use their name as the key instead.
       this._cosmetics.set(nation.name, {
         flag: nation.flag,
-      });
+      } satisfies PlayerCosmetics);
     }
   }
 

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -1,3 +1,6 @@
+import { Cosmetics } from "../CosmeticSchemas";
+import { PlayerPattern } from "../Schemas";
+
 const PATTERN_KEY = "territoryPattern";
 
 export class UserSettings {
@@ -112,12 +115,36 @@ export class UserSettings {
   }
 
   // For development only. Used for testing patterns, set in the console manually.
-  getDevOnlyPattern(): string | undefined {
-    return localStorage.getItem("dev-pattern") ?? undefined;
+  getDevOnlyPattern(): PlayerPattern | undefined {
+    const data = localStorage.getItem("dev-pattern") ?? undefined;
+    if (data === undefined) return undefined;
+    return {
+      name: "dev-pattern",
+      patternData: data,
+      colorPalette: {
+        name: "dev-color-palette",
+        primaryColor: localStorage.getItem("dev-primary") ?? "#ffffff",
+        secondaryColor: localStorage.getItem("dev-secondary") ?? "#000000",
+      },
+    } satisfies PlayerPattern;
   }
 
-  getSelectedPatternName(): string | undefined {
-    return localStorage.getItem(PATTERN_KEY) ?? undefined;
+  getSelectedPatternName(cosmetics: Cosmetics | null): PlayerPattern | null {
+    if (cosmetics === null) return null;
+    let data = localStorage.getItem(PATTERN_KEY) ?? null;
+    if (data === null) return null;
+    const patternPrefix = "pattern:";
+    if (data.startsWith(patternPrefix)) {
+      data = data.slice(patternPrefix.length);
+    }
+    const [patternName, colorPalette] = data.split(":");
+    const pattern = cosmetics.patterns[patternName];
+    if (pattern === undefined) return null;
+    return {
+      name: patternName,
+      patternData: pattern.pattern,
+      colorPalette: cosmetics.colorPalettes?.[colorPalette],
+    } satisfies PlayerPattern;
   }
 
   setSelectedPatternName(patternName: string | undefined): void {

--- a/src/server/Client.ts
+++ b/src/server/Client.ts
@@ -1,7 +1,7 @@
 import WebSocket from "ws";
 import { TokenPayload } from "../core/ApiSchemas";
 import { Tick } from "../core/game/Game";
-import { ClientID, Winner } from "../core/Schemas";
+import { ClientID, PlayerCosmetics, Winner } from "../core/Schemas";
 
 export class Client {
   public lastPing: number = Date.now();
@@ -19,7 +19,6 @@ export class Client {
     public readonly ip: string,
     public readonly username: string,
     public readonly ws: WebSocket,
-    public readonly flag: string | undefined,
-    public readonly pattern: string | undefined,
+    public readonly cosmetics: PlayerCosmetics | undefined,
   ) {}
 }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -389,8 +389,7 @@ export class GameServer {
       players: this.activeClients.map((c) => ({
         username: c.username,
         clientID: c.clientID,
-        pattern: c.pattern,
-        flag: c.flag,
+        cosmetics: c.cosmetics,
       })),
     });
     if (!result.success) {


### PR DESCRIPTION
## Description:

Add support for colored territory patterns/skins

* Refactored & updated territory pattern rendering to render colored skins
* rename public from pattern to skin (keep pattern name internally, too difficult to rename)
* Moved all territory color logic to PlayerView
* Updated WinModal to show colored skins
* Refactored decode logic into a separate function: decodePatternData
* Refactored/updated how cosmetics are sent to server. Players now send a PlayerCosmeticRefsSchema in the ClientJoinMessage. PlayerCosmeticRefsSchema just contains names of the cosmetics, and the server replaces the names/references with actual cosmetic data
* Refactored PastelThemeDark: have it extend Pastel theme so duplicate logic can be removed.
* 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
