### PR TITLE
bugfix: cosmetics not present during replays

### DIFF
--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -187,6 +187,7 @@ export class LocalServer {
         username: this.lobbyConfig.playerName,
         clientID: this.lobbyConfig.clientID,
         stats: this.allPlayersStats[this.lobbyConfig.clientID],
+        cosmetics: this.lobbyConfig.gameStartInfo?.players[0].cosmetics,
       },
     ];
     if (this.lobbyConfig.gameStartInfo === undefined) {

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -675,6 +675,7 @@ export class GameServer {
           persistentID:
             this.allClients.get(player.clientID)?.persistentID ?? "",
           stats,
+          cosmetics: player.cosmetics,
         } satisfies PlayerRecord;
       },
     );


### PR DESCRIPTION
## Description:

Cosmetics were not being saved into the GameRecord on game completion.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
