### PR TITLE
Use http/2 instead of QUIC for cf tunnels

### DIFF
--- a/src/server/Cloudflare.ts
+++ b/src/server/Cloudflare.ts
@@ -237,7 +237,20 @@ export class Cloudflare {
   public async startCloudflared() {
     const cloudflared = spawn(
       "cloudflared",
-      ["tunnel", "--config", this.configPath, "--loglevel", "error", "run"],
+      [
+        "tunnel",
+        "--config",
+        this.configPath,
+        "--loglevel",
+        "error",
+        "--protocol",
+        "http2",
+        "--retries",
+        "15",
+        "--no-autoupdate",
+        "run",
+      ],
+
       {
         detached: true,
         stdio: ["ignore", "pipe", "pipe"],


### PR DESCRIPTION
## Description:

The cf tunnel drops all connections once every week lately. Using http/2 instead of QUIC will hopefully make it more stable. Also increase retry count and disable auto update.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
