### PR TITLE
fix donation not set on singleplayer

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -130,9 +130,7 @@
     "disable_nations": "Disable Nations",
     "instant_build": "Instant build",
     "infinite_gold": "Infinite gold",
-    "donate_gold": "Donate gold",
     "infinite_troops": "Infinite troops",
-    "donate_troops": "Donate troops",
     "disable_nukes": "Disable Nukes",
     "enables_title": "Enable Settings",
     "start": "Start Game"

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -33,9 +33,7 @@ export class SinglePlayerModal extends LitElement {
   @state() private disableNPCs: boolean = false;
   @state() private bots: number = 400;
   @state() private infiniteGold: boolean = false;
-  @state() private donateGold: boolean = false;
   @state() private infiniteTroops: boolean = false;
-  @state() private donateTroops: boolean = false;
   @state() private instantBuild: boolean = false;
   @state() private useRandomMap: boolean = false;
   @state() private gameMode: GameMode = GameMode.FFA;
@@ -454,9 +452,9 @@ export class SinglePlayerModal extends LitElement {
               disableNPCs: this.disableNPCs,
               bots: this.bots,
               infiniteGold: this.infiniteGold,
-              donateGold: this.donateGold,
+              donateGold: true,
+              donateTroops: true,
               infiniteTroops: this.infiniteTroops,
-              donateTroops: this.donateTroops,
               instantBuild: this.instantBuild,
               disabledUnits: this.disabledUnits
                 .map((u) => Object.values(UnitType).find((ut) => ut === u))

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -145,8 +145,8 @@ export type TeamCountConfig = z.infer<typeof TeamCountConfigSchema>;
 export const GameConfigSchema = z.object({
   gameMap: z.enum(GameMapType),
   difficulty: z.enum(Difficulty),
-  donateGold: z.boolean(),
-  donateTroops: z.boolean(),
+  donateGold: z.boolean(), // Configures donations to humans only
+  donateTroops: z.boolean(), // Configures donations to humans only
   gameType: z.enum(GameType),
   gameMode: z.enum(GameMode),
   disableNPCs: z.boolean(),

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -21,8 +21,6 @@ import {
   ColoredTeams,
   Embargo,
   EmojiMessage,
-  GameMode,
-  GameType,
   Gold,
   MessageType,
   MutableAlliance,
@@ -578,12 +576,8 @@ export class PlayerImpl implements Player {
     }
     if (
       recipient.type() === PlayerType.Human &&
-      this.mg.config().gameConfig().gameMode === GameMode.FFA &&
-      this.mg.config().gameConfig().gameType === GameType.Public
+      this.mg.config().donateGold() === false
     ) {
-      return false;
-    }
-    if (this.mg.config().donateGold() === false) {
       return false;
     }
     for (const donation of this.sentDonations) {
@@ -605,12 +599,8 @@ export class PlayerImpl implements Player {
     }
     if (
       recipient.type() === PlayerType.Human &&
-      this.mg.config().gameConfig().gameMode === GameMode.FFA &&
-      this.mg.config().gameConfig().gameType === GameType.Public
+      this.mg.config().donateTroops() === false
     ) {
-      return false;
-    }
-    if (this.mg.config().donateTroops() === false) {
       return false;
     }
     for (const donation of this.sentDonations) {

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -77,8 +77,8 @@ export class MapPlaylist {
 
     // Create the default public game config (from your GameManager)
     return {
-      donateGold: true,
-      donateTroops: true,
+      donateGold: false,
+      donateTroops: false,
       gameMap: map,
       maxPlayers: config.lobbyMaxPlayers(map, mode, playerTeams),
       gameType: GameType.Public,


### PR DESCRIPTION
## Description:
Bug: Donation to nations was not allowed in single player mode.

Always allow donation to Nations. Simplify the donation check logic.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
