### PR TITLE
use pull_request_target for auto-assign

### DIFF
--- a/.github/workflows/pr-author.yml
+++ b/.github/workflows/pr-author.yml
@@ -1,10 +1,8 @@
 name: 🧼 PR
 
 on:
-  pull_request:
-    types:
-      - edited
-      - opened
+  pull_request_target:
+    types: [opened, reopened]
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Description:

With pull_request, the default GITHUB_TOKEN has read-only permissions on forked PRs.
As a result, the auto-assign action (toshimaru/auto-author-assign) failed with:

```
Error: Resource not accessible by integration.
```

Using pull_request_target allows the workflow to run with write permissions on the base repository, enabling author assignment even for PRs opened from forks

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
