### PR TITLE
Keep Lobby ID bar sticky at top of modal

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -79,7 +79,7 @@ export class HostLobbyModal extends LitElement {
   render() {
     return html`
       <o-modal title=${translateText("host_modal.title")}>
-        <div class="lobby-id-box">
+        <div class="lobby-id-box" style="position: sticky; top: 0; z-index: 50;">
           <button class="lobby-id-button">
             <!-- Visibility toggle icon on the left -->
             ${

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -79,7 +79,7 @@ export class HostLobbyModal extends LitElement {
   render() {
     return html`
       <o-modal title=${translateText("host_modal.title")}>
-        <div class="lobby-id-box" style="position: sticky; top: 0; z-index: 50;">
+        <div class="lobby-id-box">
           <button class="lobby-id-button">
             <!-- Visibility toggle icon on the left -->
             ${

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -565,6 +565,9 @@ label.option-card:hover {
   display: flex;
   align-items: center;
   justify-content: center;
+  position: sticky;
+  top: 0;
+  z-index: 50;
   gap: 10px;
   margin: 40px 0px 0px 0px;
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -220,7 +220,7 @@ label.option-card:hover {
   display: flex;
   align-items: center;
   gap: 8px;
-  background: rgba(0, 0, 0, 0.2);
+  background: rgba(0, 0, 0, 0.6);
   padding: 8px 16px;
   border-radius: 6px;
   border: 1px solid rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
## Description:

This PR adjusts the HostLobbyModal so that the lobby ID bar stays visible at the top of the modal when scrolling.
Fixes #2082 

https://github.com/user-attachments/assets/273b6ebe-3538-4489-b771-67261f7642f8


In this PR, when the ID box became sticky, the background sometimes made the ID hard to read.
To fix this, I made the background color slightly darker for better visibility.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
