### PR TITLE
Add missing translation keys for performance overlay enabled/disabled

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -316,6 +316,8 @@
     "territory_patterns_desc": "Choose whether to display territory pattern designs in game",
     "performance_overlay_label": "Performance Overlay",
     "performance_overlay_desc": "Toggle the performance overlay. When enabled, the performance overlay will be displayed. Press shift-D during game to toggle.",
+    "performance_overlay_enabled": "Performance overlay enabled",
+    "performance_overlay_disabled": "Performance overlay disabled",
     "easter_writing_speed_label": "Writing Speed Multiplier",
     "easter_writing_speed_desc": "Adjust how fast you pretend to code (x1–x100)",
     "easter_bug_count_label": "Bug Count",


### PR DESCRIPTION
## Description:

This PR adds the missing translation keys
(performance_overlay_enabled and performance_overlay_disabled)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
