### PR TITLE
Remove duplicate CSS rules to improve maintainability

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -77,19 +77,6 @@
   margin: 24px 0;
 }
 
-.options-section {
-  background: rgba(0, 0, 0, 0.2);
-  padding: 12px 24px 24px 24px;
-  border-radius: 12px;
-}
-
-.option-title {
-  margin: 0 0 16px 0;
-  font-size: 20px;
-  color: #fff;
-  text-align: center;
-}
-
 .option-cards {
   display: flex;
   flex-direction: row;
@@ -203,14 +190,6 @@ label.option-card:hover {
   color: #4caf50;
 }
 
-.lobby-id-box {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 10px;
-  margin: 8px 0px 0px 0px;
-}
-
 #lobbyIdInput {
   font-family: monospace;
   font-weight: 600;
@@ -240,14 +219,6 @@ label.option-card:hover {
   text-align: center;
   font-family: monospace;
   font-weight: 600;
-}
-
-.players-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  justify-content: center;
-  padding: 0 16px;
 }
 
 .player-tag {

--- a/src/client/styles/modal/chat.css
+++ b/src/client/styles/modal/chat.css
@@ -7,13 +7,6 @@
   overflow-x: auto;
 }
 
-.chat-column {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-  min-width: 120px;
-}
-
 .column-title {
   font-weight: bold;
   margin-bottom: 4px;


### PR DESCRIPTION
## Description:

This PR removes duplicate CSS rule definitions.

.lobby-id-box - Removed duplicate definition, keeping the version with appropriate margin
.options-section - Consolidated identical duplicate definitions
.option-title - Merged duplicate rules with same styling
.players-list - Removed redundant duplicate definition
.chat-column - Kept the updated version with min-width: 140px

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri