### PR TITLE
Add test for nation name length and fix names exceeding 27 chars

### DIFF
--- a/resources/maps/africa/manifest.json
+++ b/resources/maps/africa/manifest.json
@@ -103,7 +103,7 @@
     {
       "coordinates": [1094, 1093],
       "flag": "cd",
-      "name": "Democratic Republic of the Congo",
+      "name": "DR Congo",
       "strength": 2
     },
     {

--- a/resources/maps/europe/manifest.json
+++ b/resources/maps/europe/manifest.json
@@ -169,7 +169,7 @@
     {
       "coordinates": [517, 1483],
       "flag": "dz",
-      "name": "People's Democratic Republic of Algeria",
+      "name": "Algeria",
       "strength": 1
     },
     {

--- a/resources/maps/gatewaytotheatlantic/manifest.json
+++ b/resources/maps/gatewaytotheatlantic/manifest.json
@@ -85,7 +85,7 @@
     {
       "coordinates": [1609, 1837],
       "flag": "dz",
-      "name": "People's Republic of Algeria'",
+      "name": "Algeria",
       "strength": 2
     },
     {

--- a/resources/maps/oceania/manifest.json
+++ b/resources/maps/oceania/manifest.json
@@ -85,7 +85,7 @@
     {
       "coordinates": [143, 37],
       "flag": "la",
-      "name": "Lao People's Democratic Republic",
+      "name": "Lao PDR",
       "strength": 1
     },
     {
@@ -115,7 +115,7 @@
     {
       "coordinates": [834, 215],
       "flag": "fm",
-      "name": "Federated States of Micronesia",
+      "name": "Micronesia",
       "strength": 1
     },
     {

--- a/resources/maps/world/manifest.json
+++ b/resources/maps/world/manifest.json
@@ -253,7 +253,7 @@
     {
       "coordinates": [1074, 508],
       "flag": "cd",
-      "name": "The Democratic Republic of the Congo",
+      "name": "DR Congo",
       "strength": 1
     },
     {

--- a/tests/NationNameLength.test.ts
+++ b/tests/NationNameLength.test.ts
@@ -1,0 +1,55 @@
+import fs from "fs";
+import { globSync } from "glob";
+import path from "path";
+
+type Nation = {
+  name?: string;
+};
+
+type Manifest = {
+  nations?: Nation[];
+};
+
+describe("Map manifests: nation name length constraint", () => {
+  test("All nations' names must be ≤ 27 characters", () => {
+    const manifestPaths = globSync(
+      path.resolve(process.cwd(), "resources/maps/**/manifest.json"),
+    );
+
+    expect(manifestPaths.length).toBeGreaterThan(0);
+
+    const violations: string[] = [];
+
+    for (const manifestPath of manifestPaths) {
+      try {
+        const raw = fs.readFileSync(manifestPath, "utf8");
+        const manifest = JSON.parse(raw) as Manifest;
+
+        (manifest.nations ?? []).forEach((nation, idx) => {
+          const name = nation?.name;
+          if (typeof name !== "string") {
+            violations.push(
+              `✖ ${manifestPath} -> nations[${idx}].name is not a string`,
+            );
+            return;
+          }
+          if (name.length > 27) {
+            violations.push(
+              `✖ ${manifestPath} -> nations[${idx}].name "${name}" has length ${name.length} (> 27)`,
+            );
+          }
+        });
+      } catch (err) {
+        violations.push(
+          `✖ Failed to parse ${manifestPath}: ${(err as Error).message}`,
+        );
+      }
+    }
+
+    if (violations.length > 0) {
+      throw new Error(
+        "Nation name length violations:\n" + violations.join("\n"),
+      );
+    }
+  });
+});

--- a/tests/NationNameLength.test.ts
+++ b/tests/NationNameLength.test.ts
@@ -29,19 +29,19 @@ describe("Map manifests: nation name length constraint", () => {
           const name = nation?.name;
           if (typeof name !== "string") {
             violations.push(
-              `✖ ${manifestPath} -> nations[${idx}].name is not a string`,
+              `${manifestPath} -> nations[${idx}].name is not a string`,
             );
             return;
           }
           if (name.length > 27) {
             violations.push(
-              `✖ ${manifestPath} -> nations[${idx}].name "${name}" has length ${name.length} (> 27)`,
+              `${manifestPath} -> nations[${idx}].name "${name}" has length ${name.length} (> 27)`,
             );
           }
         });
       } catch (err) {
         violations.push(
-          `✖ Failed to parse ${manifestPath}: ${(err as Error).message}`,
+          `Failed to parse ${manifestPath}: ${(err as Error).message}`,
         );
       }
     }


### PR DESCRIPTION
## Description:

Added tests/NationNameLength.test.ts to enforce nation name length ≤27.  
Updated manifest.json files in resources/maps with shorter names to pass the test.
This fix ensures that names will no longer be truncated

Examples of country names that are too long and have their endings cut off
<img width="231" height="331" alt="スクリーンショット 2025-10-01 10 51 40" src="https://github.com/user-attachments/assets/8c4611ab-f97b-4606-9834-7816dbd1ee8d" />

### Changes
- Replaced overly long country names with shorter common forms:
  - "The Democratic Republic of the Congo" -> "DR Congo"
  - "Democratic Republic of the Congo" -> "DR Congo"
  - "Lao People's Democratic Republic" -> "Laos"
  - "Federated States of Micronesia" -> "Micronesia"
  - "People's Democratic Republic of Algeria" -> "Algeria"
  - "People's Republic of Algeria'" -> "Algeria"


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
