### PR TITLE
Fix nations break alliance too ealry bug 

### DIFF
--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -258,14 +258,14 @@ export class FakeHumanExecution implements Execution {
       return false;
     }
 
-    const canProceed = this.attackChance(other);
+    const shouldAttack = this.attackChance(other);
 
     // Consider betrayal for allies
-    if (canProceed && this.player.isAlliedWith(other)) {
+    if (shouldAttack && this.player.isAlliedWith(other)) {
       return this.maybeConsiderBetrayal(other);
     }
 
-    return canProceed;
+    return shouldAttack;
   }
 
   private attackChance(other: Player): boolean {


### PR DESCRIPTION
## Description:
Betrayal was being considered too early (inside shouldAttack), causing alliances to break before calling attackChance.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

abodcraft1
