### PR TITLE
Allow attacking allies or teammates if player is disconnected

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -669,6 +669,10 @@ export class DefaultConfig implements Config {
     }
 
     if (attacker.isPlayer() && defender.isPlayer()) {
+      if (defender.isDisconnected() && attacker.isOnSameTeam(defender)) {
+        // No troop loss if defender is disconnected.
+        mag = 0;
+      }
       if (
         attacker.type() === PlayerType.Human &&
         defender.type() === PlayerType.Bot

--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -100,13 +100,6 @@ export class AttackExecution implements Execution {
         this.active = false;
         return;
       }
-      if (this._owner.isOnSameTeam(this.target)) {
-        console.warn(
-          `${this._owner.displayName()} cannot attack ${this.target.displayName()} because they are on the same team`,
-        );
-        this.active = false;
-        return;
-      }
     }
 
     this.startTroops ??= this.mg

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -746,6 +746,9 @@ export class PlayerImpl implements Player {
   }
 
   isFriendly(other: Player): boolean {
+    if (other.isDisconnected()) {
+      return false;
+    }
     return this.isOnSameTeam(other) || this.isAlliedWith(other);
   }
 


### PR DESCRIPTION
## Description:

This will allow players to conquer land from afk teammates in team games.

No troop loss if attacking afk teammate.

Also remove the team check in attack execution because we already do an isFriendly check.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
