### PR TITLE
"Spectate" instead of "Keep playing" after loss

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -495,7 +495,7 @@
     "you_won": "You Won!",
     "other_won": "{player} has won!",
     "exit": "Exit Game",
-    "keep": "Keep Playing",
+    "spectate": "Spectate",
     "wishlist": "Wishlist on Steam!"
   },
   "leaderboard": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -495,6 +495,7 @@
     "you_won": "You Won!",
     "other_won": "{player} has won!",
     "exit": "Exit Game",
+    "keep": "Keep Playing",
     "spectate": "Spectate",
     "wishlist": "Wishlist on Steam!"
   },

--- a/src/client/graphics/layers/WinModal.ts
+++ b/src/client/graphics/layers/WinModal.ts
@@ -29,6 +29,9 @@ export class WinModal extends LitElement implements Layer {
   showButtons = false;
 
   @state()
+  private isWin = false;
+
+  @state()
   private patternContent: TemplateResult | null = null;
 
   private _title: string;
@@ -68,7 +71,9 @@ export class WinModal extends LitElement implements Layer {
             @click=${this.hide}
             class="flex-1 px-3 py-3 text-base cursor-pointer bg-blue-500/60 text-white border-0 rounded transition-all duration-200 hover:bg-blue-500/80 hover:-translate-y-px active:translate-y-px"
           >
-            ${translateText("win_modal.spectate")}
+            ${this.isWin
+              ? translateText("win_modal.keep")
+              : translateText("win_modal.spectate")}
           </button>
         </div>
       </div>
@@ -230,10 +235,12 @@ export class WinModal extends LitElement implements Layer {
         this.eventBus.emit(new SendWinnerEvent(wu.winner, wu.allPlayersStats));
         if (wu.winner[1] === this.game.myPlayer()?.team()) {
           this._title = translateText("win_modal.your_team");
+          this.isWin = true;
         } else {
           this._title = translateText("win_modal.other_team", {
             team: wu.winner[1],
           });
+          this.isWin = false;
         }
         this.show();
       } else {
@@ -250,10 +257,12 @@ export class WinModal extends LitElement implements Layer {
           winnerClient === this.game.myPlayer()?.clientID()
         ) {
           this._title = translateText("win_modal.you_won");
+          this.isWin = true;
         } else {
           this._title = translateText("win_modal.other_won", {
             player: winner.name(),
           });
+          this.isWin = false;
         }
         this.show();
       }

--- a/src/client/graphics/layers/WinModal.ts
+++ b/src/client/graphics/layers/WinModal.ts
@@ -68,7 +68,7 @@ export class WinModal extends LitElement implements Layer {
             @click=${this.hide}
             class="flex-1 px-3 py-3 text-base cursor-pointer bg-blue-500/60 text-white border-0 rounded transition-all duration-200 hover:bg-blue-500/80 hover:-translate-y-px active:translate-y-px"
           >
-            ${translateText("win_modal.keep")}
+            ${translateText("win_modal.spectate")}
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Description:

Fixes #2149

Losing a game now causes the "Keep playing" button to say "Spectate" instead.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
