### PR TITLE
add openfront copyright to loading screen

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -249,6 +249,7 @@
   },
   "game_starting_modal": {
     "title": "Game is Starting...",
+    "code_license": "Code licensed under AGPL-3.0",
     "desc": "Preparing for the lobby to start. Please wait."
   },
   "difficulty": {

--- a/src/client/GameStartingModal.ts
+++ b/src/client/GameStartingModal.ts
@@ -84,13 +84,20 @@ export class GameStartingModal extends LitElement {
     .modal button:active {
       transform: translateY(1px);
     }
+
+    .copyright {
+      font-size: 32px;
+      margin-top: 20px;
+      opacity: 1;
+    }
   `;
 
   render() {
     return html`
       <div class="modal ${this.isVisible ? "visible" : ""}">
-        <h2>${translateText("game_starting_modal.title")}</h2>
-        <p>${translateText("game_starting_modal.desc")}</p>
+        <div class="copyright">© OpenFront</div>
+        <h5>${translateText("game_starting_modal.code_license")}</h5>
+        <p>${translateText("game_starting_modal.title")}</p>
       </div>
     `;
   }


### PR DESCRIPTION
## Description:

This will make the copyright notice more clear.


<img width="369" height="242" alt="Screenshot 2025-10-07 at 6 03 44 PM" src="https://github.com/user-attachments/assets/53925a24-bf1a-437e-84c1-3d146d598bfd" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
