### PR TITLE
fix: allies cannot annex your clusters

### DIFF
--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -114,27 +114,6 @@ export function inscribed(
   );
 }
 
-export function getMode(list: Set<number>): number {
-  // Count occurrences
-  const counts = new Map<number, number>();
-  for (const item of list) {
-    counts.set(item, (counts.get(item) ?? 0) + 1);
-  }
-
-  // Find the item with the highest count
-  let mode = 0;
-  let maxCount = 0;
-
-  for (const [item, count] of counts) {
-    if (count > maxCount) {
-      maxCount = count;
-      mode = item;
-    }
-  }
-
-  return mode;
-}
-
 export function sanitize(name: string): string {
   return Array.from(name)
     .join("")

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -2,7 +2,7 @@ import { Config } from "../configuration/Config";
 import { Execution, Game, Player, UnitType } from "../game/Game";
 import { GameImpl } from "../game/GameImpl";
 import { GameMap, TileRef } from "../game/GameMap";
-import { calculateBoundingBox, getMode, inscribed, simpleHash } from "../Util";
+import { calculateBoundingBox, inscribed, simpleHash } from "../Util";
 
 export class PlayerExecution implements Execution {
   private readonly ticksPerClusterCalc = 20;
@@ -222,14 +222,12 @@ export class PlayerExecution implements Execution {
     }
 
     // Filter out friendly and non-player candidates
-    const neighborsIDs = new Set<number>();
     const neighbors = new Set<Player>();
     for (const id of candidatesIDs) {
       const neighbor = this.mg.playerBySmallID(id);
       if (!neighbor.isPlayer() || neighbor.isFriendly(this.player)) {
         continue;
       }
-      neighborsIDs.add(id);
       neighbors.add(neighbor);
     }
 
@@ -251,17 +249,10 @@ export class PlayerExecution implements Execution {
         }
       }
     }
-    if (largestNeighborAttack !== null) {
-      return largestNeighborAttack;
-    }
 
-    // Fall back to getting mode if no attacks
-    const mode = getMode(neighborsIDs);
-    const capturing = this.mg.playerBySmallID(mode);
-    if (!capturing.isPlayer()) {
-      return null;
-    }
-    return capturing;
+    // Return the largest neighbor attack
+    // If there is no largest neighbor attack, this will return null
+    return largestNeighborAttack;
   }
 
   private calculateClusters(): Set<TileRef>[] {


### PR DESCRIPTION
## Description:

Fixes #1685
Continuation from #1924, which was auto-closed after the upstream repo force-pushed main and I synced my fork.

This change ensures that allies are excluded from the `getMode()` call made by `getCapturingPlayer()` inside `removeCluster()`.

 - Previously, friendly neighbors were treated as candidates for capturing, leading to incorrect annexations in certain edge cases.
 - Added a small efficiency improvement by filtering out non-player and friendly neighbors up front to reduce total computations down-the-line.
 - Important: we can’t simply check if the `getMode(neighborsIDs)` result is a friendly. Doing so would cause the territory to go to nobody until the user is attacked. I believe the expected behavior is the largest neighboring enemy should take it automatically.

Here's an example of the new behavior in an extreme edge case:
<img width="622" height="422" alt="Screenshot 2025-08-24 at 4 56 46 PM" src="https://github.com/user-attachments/assets/c5dd9c0d-0a3c-4657-8154-e114fa920689" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

nottirb
