### PR TITLE
Remove confusing characters from game IDs

### DIFF
--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -192,7 +192,7 @@ export function assertNever(x: never): never {
 
 export function generateID(): GameID {
   const nanoid = customAlphabet(
-    "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+    "123456789abcdefghijkmnopqrstuvwxyzABCDEFGHJKLMNPQRSTUVWXYZ",
     8,
   );
   return nanoid();


### PR DESCRIPTION
## Description:

I have often encountered the problem of characters that look alike when typing a private game code, mainly `l` / `I`, and `O` / `0`.

In this PR, I therefore propose removing these 4 characters from ID generation.

The number of possible combinations goes from $$2.2\times10^{14}$$ to $$1.3\times10^{14}$$, which is still the same order of magnitude.

## Please complete the following:

- [ ] ~~I have added screenshots for all UI updates~~
- [ ] ~~I process any text displayed to the user through translateText() and I've added it to the en.json file~~
- [ ] ~~I have added relevant tests to the test directory~~
- [ ] ~~I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced~~

## Please put your Discord username so you can be contacted if a bug or regression is found:

`@dimension`
