### PR TITLE
FIX/IMPROVE Clan Identification

### DIFF
--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -408,7 +408,7 @@ export class PlayerInfo {
     if (!name.startsWith("[") || !name.includes("]")) {
       this.clan = null;
     } else {
-      const clanMatch = name.match(/^\[([a-zA-Z]{2,5})\]/);
+      const clanMatch = name.match(/\[([a-zA-Z0-9]{2,5})\]/);
       this.clan = clanMatch ? clanMatch[1] : null;
     }
   }


### PR DESCRIPTION
Removed the "^" from the clan identification to ensure [?????] is identified anywhere in the username. Also added 0-9 in the character detect to allow integers in the clan name. 

This is consistent with the above logic: `clan = null` is assigned when `!name.startsWith("[") || !name.contains("]")`. Therefore, it stands to reason from the second part of that if statement that if `]` is found within the player name, it *could* be identified as a clan tag. 

This change to Clan identification matching will improve that functionality.

## Description:

Updates to the clan identification RegEx logic. The original inclusion of `^` within the RegEx limited clan identification to the start of a username, inconsistent with the prior logic of setting a clan = null when brackets are not detected. 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

GlacialDrift (GlacialDrift_)
