### PR TITLE
Fix owned % in Teams stats

### DIFF
--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -83,7 +83,9 @@ export class TeamStats extends LitElement implements Layer {
           }
         }
 
-        const totalScorePercent = totalScoreSort / this.game.numLandTiles();
+        const numTilesWithoutFallout =
+          this.game.numLandTiles() - this.game.numTilesWithFallout();
+        const totalScorePercent = totalScoreSort / numTilesWithoutFallout;
 
         return {
           teamName: teamStr,


### PR DESCRIPTION
## Description:

In Teams games, the Leaderboard for individual players shows a different Owned % than the Team stats next to it. This is because Leaderboard correctly takes fallout/nuked territory into account (lines 99 and 113). But Team stats doesn't. 

It's only visual because the win condition for 95% of the land is also already calculated correctly in WinCheckCondition (lines 78-80).

There is still a difference where Leaderbord uses toFixed(1) and TeamStats does toPrecision(2). Didn't touch that because i don't know the reason for it.

BEFORE:
<img width="699" height="206" alt="Team stats owned not taking fallout into consideration" src="https://github.com/user-attachments/assets/3bd03671-e32a-4c7a-b097-cfd8201c4299" />

AFTER:
<img width="892" height="453" alt="image" src="https://github.com/user-attachments/assets/10c3eae8-8292-404f-83d5-820d10279367" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
