### PR TITLE
update readme, remove duplicate licensing section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -678,5 +678,5 @@ but may not use "OpenFront" as the primary title or imply official
 status.
 
 Trademark Notice:
-"OpenFront" is a registered trademark. Use of the trademark must 
+"OpenFront" is a trademark. Use of the trademark must 
 comply with applicable trademark law.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,13 @@ This is a fork/rewrite of WarFront.io. Credit to https://github.com/WarFrontIO.
 
 ## License
 
-OpenFront is licensed under the **GNU Affero General Public License v3.0** with additional attribution requirements:
+OpenFront source code is licensed under the **GNU Affero General Public License v3.0** with additional attribution requirements:
 
-- Any forks must display attribution (e.g., "Based on OpenFront") prominently on the main menu
+- Any forks or derivative works must display attribution (e.g., "Based on OpenFront", "Derived from OpenFront", "Powered by OpenFront", or "Fork of OpenFront") prominently on the main menu/UI screen
+- Forks must not use "OpenFront" as the primary title or imply official endorsement
+- "OpenFront" is a trademark and must be used in compliance with applicable trademark law
 
-See the [LICENSE](LICENSE) file for full details.
+See [LICENSE](LICENSE), [LICENSE-ASSETS](LICENSE-ASSETS), and [LICENSING.md](LICENSING.md) for full details.
 
 ## 🌟 Features
 
@@ -131,10 +133,6 @@ npm run dev:prod
 - `/src/core` - Shared game logic
 - `/src/server` - Backend game server
 - `/resources` - Static assets (images, maps, etc.)
-
-## 📝 License
-
-This project is licensed under the terms found in the [LICENSE](LICENSE) file.
 
 ## 🤝 Contributing
 


### PR DESCRIPTION
## Description:

Make links to license files more clear and remove duplicate license section.
Change "registered trademark" => "trademark" because registration is in progress.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
