### PR TITLE
bugfix: sending alliance to afk crashes game

### DIFF
--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -390,6 +390,13 @@ export class PlayerImpl implements Player {
     if (other === this) {
       return false;
     }
+    if (this.isDisconnected() || other.isDisconnected()) {
+      // Disconnected players are marked as not-friendly even if they are allies,
+      // so we need to return early if either player is disconnected.
+      // Otherise we could end up sending an alliance request to someone
+      // we are already allied with.
+      return false;
+    }
     if (this.isFriendly(other) || !this.isAlive()) {
       return false;
     }


### PR DESCRIPTION
## Description:

Afk players are marked as not friendly, the canSendAllianceRequest was returning true even if already allied because isFriendly was false. This was allowing  alliance requests to people we were already allied with.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
