### PR TITLE
Fix 100% owned in team stats

### DIFF
--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -221,5 +221,6 @@ export class TeamStats extends LitElement implements Layer {
 function formatPercentage(value: number): string {
   const perc = value * 100;
   if (Number.isNaN(perc)) return "0%";
+  if (perc === 100) return "100%";
   return perc.toPrecision(2) + "%";
 }


### PR DESCRIPTION
## Description:

When a team owns 100% of the land, it would show "1.0e2%" because of toPrecision(2). Fix this by keeping the same precision as for other numbers, but just returning 100 for 100%. 

It probably wasn't really noticed before since full land ownership doesn't occur much. Chances of 100% in team stats are a bit higher since fallout is now taken into account.

Only a picture of the before situation:
<img width="725" height="84" alt="100 percent" src="https://github.com/user-attachments/assets/f45edbc5-e740-4157-8a0b-cdc2981ced24" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33