### PR TITLE
Made leaderboard entries bold for teammates

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -14,6 +14,7 @@ interface Entry {
   gold: string;
   troops: string;
   isMyPlayer: boolean;
+  isOnSameTeam: boolean;
   player: PlayerView;
 }
 
@@ -115,6 +116,7 @@ export class Leaderboard extends LitElement implements Layer {
         gold: renderNumber(player.gold()),
         troops: renderNumber(troops),
         isMyPlayer: player === myPlayer,
+        isOnSameTeam: player === myPlayer || player.isOnSameTeam(myPlayer!),
         player: player,
       };
     });
@@ -143,6 +145,7 @@ export class Leaderboard extends LitElement implements Layer {
           gold: renderNumber(myPlayer.gold()),
           troops: renderNumber(myPlayerTroops),
           isMyPlayer: true,
+          isOnSameTeam: true,
           player: myPlayer,
         });
       }
@@ -225,7 +228,7 @@ export class Leaderboard extends LitElement implements Layer {
             (p) => p.player.id(),
             (player) => html`
               <div
-                class="contents hover:bg-slate-600/60 ${player.isMyPlayer
+                class="contents hover:bg-slate-600/60 ${player.isOnSameTeam
                   ? "font-bold"
                   : ""} cursor-pointer"
                 @click=${() => this.handleRowClickPlayer(player.player)}


### PR DESCRIPTION
## Description:
Closes #2185.
Made leaderboard entries **bold** all your for **teamates**. Before it was only bold for your player.
_Your player should still be bold even when is undefined._

Didn't add any tests - not sure if there is any testing for these type of things.

### collapsed leaderboard list
<img width="1920" height="1080" alt="Snímek obrazovky 2025-10-22 182432" src="https://github.com/user-attachments/assets/6241fda7-6e1e-47c0-a6a0-7eaf4b95e8b8" />

### expanded leaderboard
<img width="1920" height="1008" alt="Snímek obrazovky 2025-10-22 182539" src="https://github.com/user-attachments/assets/22d1089f-62ae-4fb3-8ff1-e7ddc75c100e" />

### player not yet spawned
<img width="1920" height="1008" alt="Snímek obrazovky 2025-10-22 183858" src="https://github.com/user-attachments/assets/2e7f3856-a084-4043-8e65-cf0653a901e5" />



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
michal7952

