### PR TITLE
Add Reddit link to footer on homepage

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -34,7 +34,8 @@
     "advertise": "Advertise",
     "wiki": "Wiki",
     "privacy_policy": "Privacy Policy",
-    "terms_of_service": "Terms of Service"
+    "terms_of_service": "Terms of Service",
+    "reddit": "Reddit"
   },
   "news": {
     "see_all_releases": "See all releases",

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -333,7 +333,6 @@
             target="_blank"
             href="https://www.reddit.com/r/Openfront/"
             class="t-link"
-            target="_blank"
           >
             <span data-i18n="main.reddit"> Reddit </span>
           </a>

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -314,7 +314,7 @@
       <div class="l-footer__content">
         <div class="l-footer__col">
           <a
-            href="https://youtu.be/fRP48Dl3Cnw?si=Wc6Fh0SBr1kdMxk5"
+            href="https://youtu.be/jvHEvbko3uw?si=znspkP84P76B1w5I"
             data-i18n="main.how_to_play"
             class="t-link"
             target="_blank"
@@ -328,6 +328,14 @@
             target="_blank"
           >
             Wiki
+          </a>
+          <a
+            target="_blank"
+            href="https://www.reddit.com/r/Openfront/"
+            class="t-link"
+            target="_blank"
+          >
+            <span data-i18n="main.reddit"> Reddit </span>
           </a>
           <a
             target="_blank"

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -312,7 +312,7 @@
     <!-- Footer section -->
     <footer class="l-footer">
       <div class="l-footer__content">
-        <div class="l-footer__col">
+        <div class="l-footer__col t-text-white">
           <a
             href="https://youtu.be/jvHEvbko3uw?si=znspkP84P76B1w5I"
             data-i18n="main.how_to_play"
@@ -344,7 +344,7 @@
             <span data-i18n="main.join_discord"> Join the Discord! </span>
           </a>
         </div>
-        <div class="l-footer__col t-text-white">
+        <div class="l-footer__col t-text-white space-x-4">
           <a
             href="https://github.com/openfrontio/OpenFrontIO"
             class="t-link inline-flex items-center space-x-2"
@@ -356,7 +356,7 @@
               alt="GitHub"
               width="20"
               height="20"
-              class="ml-2 mr-4"
+              class="ml-2"
             />
           </a>
           <a


### PR DESCRIPTION
## Description:

Add Reddit link to the footer on the homepage. Left of _Join the Discord!_ and to the right of _Wiki_.

Before:
<img width="1917" height="342" alt="image" src="https://github.com/user-attachments/assets/d5a105eb-d284-45ab-af6b-431967d293bb" />

After:
<img width="1915" height="372" alt="image" src="https://github.com/user-attachments/assets/e4bb505b-ce5b-4880-adb2-bb66cd4bdc3a" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
