### PR TITLE
Fix annex surrounded main cluster disconnected player

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -118,7 +118,7 @@ export class PlayerExecution implements Execution {
     if (main === undefined) throw new Error("No clusters");
     this.player.largestClusterBoundingBox = calculateBoundingBox(this.mg, main);
     const surroundedBy = this.surroundedBySamePlayer(main);
-    if (surroundedBy && !this.player.isFriendly(surroundedBy)) {
+    if (surroundedBy && !surroundedBy.isFriendly(this.player)) {
       this.removeCluster(main);
     }
 


### PR DESCRIPTION
## Description:

When a main cluster is fully surrounded, the surrounding player is able to attack them (based on AttackLogic in DefaultConfig). But so far wasn't able to annex them. 

Fix: turned around an isFriendly check in PlayerExecution. This way if this.player is disconnected, they can get annexed, allied/team mate or not.

This also means that in the edge case of surrounding player going AFK, the enclosed main cluster can attack the disconnected surrounding player and maybe fight it's way out of being enclosed.

Meant as hotfix for v26.

Reported here: https://discord.com/channels/1284581928254701718/1429252618995105923/1429252618995105923

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
