### PR TITLE
Fix boat pathfinding to allow shore tiles only at endpoints

### DIFF
--- a/src/core/pathfinding/MiniAStar.ts
+++ b/src/core/pathfinding/MiniAStar.ts
@@ -38,7 +38,8 @@ export class GameMapAdapter implements GraphAdapter<TileRef> {
       // Allow shore tiles ONLY at source/destination endpoints (not intermediate waypoints)
       // This prevents boats from visually appearing to travel on land
       const isDestination = this.dst !== undefined && to === this.dst;
-      const isSource = this.src !== undefined &&
+      const isSource =
+        this.src !== undefined &&
         (Array.isArray(this.src) ? this.src.includes(to) : to === this.src);
 
       if ((isSource || isDestination) && this.gameMap.isShore(to)) {


### PR DESCRIPTION
## Description:
disclaimer: AI used for this pull. 

Fixes a bug where boats could only traverse pure water tiles, preventing pathfinding from working correctly since boats spawn on shore tiles and need to reach shore destinations.

Previously, boats could take very long routes instead of using nearby water borders 2-3 pixels away because the traversability check blocked all shore tiles.

closes #2242 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

stackk.
