### PR TITLE
Fix slow radial menu animation for mobile players (#2201)

### DIFF
--- a/src/client/graphics/layers/RadialMenu.ts
+++ b/src/client/graphics/layers/RadialMenu.ts
@@ -149,10 +149,6 @@ export class RadialMenu implements Layer {
       .style("position", "absolute")
       .style("top", "50%")
       .style("left", "50%")
-      .style(
-        "transition",
-        `top ${this.config.menuTransitionDuration}ms ease, left ${this.config.menuTransitionDuration}ms ease`,
-      )
       .style("transform", "translate(-50%, -50%)")
       .style("pointer-events", "all")
       .on("click", (event) => this.hideRadialMenu());


### PR DESCRIPTION
## Description:

Closes #2201

Remove CSS transition from SVG element that was causing the radial menu to animate from its previous position to the new clicked position. This was creating delays of up to 2 seconds for mobile players, making the game unplayable on mobile devices.

The viewport clamping functionality (from PR #1817) is preserved - the menu now appears instantly at the correct clamped position instead of animating to it.

I wasn't sure if this should only apply for mobile players, but making it so sounded too much trouble for what it's worth so its removed entirely

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

stackk.
