### PR TITLE
troopIncreateRate calculation: include troops that are on transport ships

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -837,10 +837,14 @@ export class DefaultConfig implements Config {
 
   troopIncreaseRate(player: Player): number {
     const max = this.maxTroops(player);
+    const onShips = player
+      .units(UnitType.TransportShip)
+      .reduce((sum, ship) => sum + ship.troops(), 0);
+    const current = player.troops() + onShips;
 
-    let toAdd = 10 + Math.pow(player.troops(), 0.73) / 4;
+    let toAdd = 10 + Math.pow(current, 0.73) / 4;
 
-    const ratio = 1 - player.troops() / max;
+    const ratio = 1 - current / max;
     toAdd *= ratio;
 
     if (player.type() === PlayerType.Bot) {
@@ -864,7 +868,7 @@ export class DefaultConfig implements Config {
       }
     }
 
-    return Math.min(player.troops() + toAdd, max) - player.troops();
+    return Math.max(0, Math.min(current + toAdd, max) - current);
   }
 
   goldAdditionRate(player: Player): Gold {


### PR DESCRIPTION
## Description:

Simple `DefaultConfig` change with the explicit goal of eliminating the "boat banking" strategy.

This is a gameplay meta change that I think would improve casual public play, especially for players that are not experienced. It's no fun finally having a good game only to be hit by a player from a big clan attacking with 2x their troop cap because they know about the boat strategy.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

newyearnewphil / [CYN] super mario
