### PR TITLE
Add missing English keybind text for MIRV action

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -354,6 +354,8 @@
     "build_atom_bomb_desc": "Build an Atom Bomb under your cursor.",
     "build_hydrogen_bomb": "Build Hydrogen Bomb",
     "build_hydrogen_bomb_desc": "Build a Hydrogen Bomb under your cursor.",
+    "build_mirv": "Build MIRV",
+    "build_mirv_desc": "Build a MIRV under your cursor.",
     "attack_ratio_controls": "Attack Ratio Controls",
     "attack_ratio_up": "Increase Attack Ratio",
     "attack_ratio_up_desc": "Increase attack ratio by 10%",

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -523,8 +523,8 @@ export class UserSettingModal extends LitElement {
 
       <setting-keybind
         action="buildMIRV"
-        label=${translateText("user_setting.build_MIRV")}
-        description=${translateText("user_setting.build_MIRV_desc")}
+        label=${translateText("user_setting.build_mirv")}
+        description=${translateText("user_setting.build_mirv_desc")}
         defaultKey="Digit0"
         .value=${this.keybinds["buildMIRV"]?.key ?? ""}
         @change=${this.handleKeybindChange}


### PR DESCRIPTION
## Description:

This PR adds the missing string for the MIRV keybind action in the User Settings menu.
<img width="383" height="137" alt="スクリーンショット 2025-10-25 16 03 21" src="https://github.com/user-attachments/assets/1a436fff-76a3-428a-bf14-c836ef9faf40" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri