### PR TITLE
Add missing lang/en.json strings for Build MIRV keybind config

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -355,7 +355,7 @@
     "build_hydrogen_bomb": "Build Hydrogen Bomb",
     "build_hydrogen_bomb_desc": "Build a Hydrogen Bomb under your cursor.",
     "build_MIRV": "Build MIRV",
-    "build_MIRV_desc" : "Build a MIRV under your cursor.",
+    "build_MIRV_desc": "Build a MIRV under your cursor.",
     "attack_ratio_controls": "Attack Ratio Controls",
     "attack_ratio_up": "Increase Attack Ratio",
     "attack_ratio_up_desc": "Increase attack ratio by 10%",


### PR DESCRIPTION
## Description:

Added two key:value pairs into en.json the user config for building a MIRV and its description.

## Please complete the following:

- [x] N/A I have added screenshots for all UI updates
- [x] N/A I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] N/A I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Lavodan
