### PR TITLE
FIX: Revert Spawn Highlight Color for DUOS, TRIOS, QUADS

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -175,6 +175,7 @@ export class TerritoryLayer implements Layer {
       .filter((p) => p.type() === PlayerType.Human);
 
     const focusedPlayer = this.game.focusedPlayer();
+    const teamColors = Object.values(ColoredTeams);
     for (const human of humans) {
       if (human === focusedPlayer) {
         continue;
@@ -197,7 +198,6 @@ export class TerritoryLayer implements Layer {
         // Optionally, this could be broken down to teammate or enemy and simplified to green and red, respectively
         const team = human.team();
         if (team !== null) {
-          const teamColors = Object.values(ColoredTeams);
           if (teamColors.includes(team)) {
             color = this.theme.teamColor(team);
           } else {


### PR DESCRIPTION
## Description:

This PR addresses issue #2297 - Spawn Color Overload in DUOS, TRIOS, and QUADS game modes. This PR reverts the spawn highlight color behavior for these game modes so that the player can identify their teammates more easily in these modes. 

See below for example fix. The "self" player and their teammate in this DUOS mode game are the same `light blue` color as shown in issue #2297 and their opponent is still the same `brown` color as shown in that issue. 

However, now the player's teammate has a green spawn highlight color (same as v0.26.7 and earlier) and the players on other teams have a yellow spawn highlight color (same as v0.26.7 and earlier).  

<img width="605" height="657" alt="Duos Teammate ID Resolution" src="https://github.com/user-attachments/assets/6e62830a-31bb-4d3d-ae5a-34b809ea4e13" />

The "self" player's spawn highlight color remains a breathing white ring, consistent with other game modes. 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

GlacialDrift
