### PR TITLE
Fix incorrect display of ability to upgrade enemy units

### DIFF
--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -903,7 +903,7 @@ export class PlayerImpl implements Player {
       return false;
     }
     if (unit.owner() !== this) {
-	  return false;
+      return false;
     }
     return true;
   }


### PR DESCRIPTION
## Description:

Fixes #2135.
Adds an owner check to canUpgradeUnit to prevent enemy units from seemingly being able to be upgraded when Ctrl+clicked on

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Lavodan
