### PR TITLE
Fix: remove duplicate setting of _troops from ControlPanel

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -85,7 +85,6 @@ export class ControlPanel extends LitElement implements Layer {
       this.updateTroopIncrease();
     }
 
-    this._troops = player.troops();
     this._maxTroops = this.game.config().maxTroops(player);
     this._gold = player.gold();
     this._troops = player.troops();


### PR DESCRIPTION
## Description:

PR https://github.com/openfrontio/OpenFrontIO/pull/1676 introduced a duplicate line of code in ControlPanel. Resulting in _troops being set twice in a row. Remove one to keep only the oldest one.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
