### PR TITLE
Patterns are now named Skins, change leftover old translation strings

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -330,8 +330,8 @@
     "attack_ratio_label": "⚔️ Attack Ratio",
     "attack_ratio_desc": "What percentage of your troops to send in an attack (1–100%)",
     "troop_ratio_desc": "Adjust the balance between troops (for combat) and workers (for gold production) (1–100%)",
-    "territory_patterns_label": "🏳️ Territory Patterns",
-    "territory_patterns_desc": "Choose whether to display territory pattern designs in game",
+    "territory_patterns_label": "🏳️ Territory Skins",
+    "territory_patterns_desc": "Choose whether to display territory skin designs in game",
     "performance_overlay_label": "Performance Overlay",
     "performance_overlay_desc": "Toggle the performance overlay. When enabled, the performance overlay will be displayed. Press shift-D during game to toggle.",
     "easter_writing_speed_label": "Writing Speed Multiplier",
@@ -665,7 +665,7 @@
     "colors": "Colors",
     "purchase": "Purchase",
     "blocked": {
-      "login": "You must be logged in to access this pattern.",
+      "login": "You must be logged in to access this skin.",
       "purchase": "Purchase this pattern to unlock it."
     },
     "pattern": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -666,7 +666,7 @@
     "purchase": "Purchase",
     "blocked": {
       "login": "You must be logged in to access this skin.",
-      "purchase": "Purchase this pattern to unlock it."
+      "purchase": "Purchase this skin to unlock it."
     },
     "pattern": {
       "default": "Default",


### PR DESCRIPTION
## Description:

On the homepage, the Patterns modal now is titled Skins (territory_pattern > title). This PR changes the other EN translation strings to use the word skins, too.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
