### PR TITLE
add credits link to starting modal

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -1,0 +1,28 @@
+# Credits
+
+## Code
+
+OpenFront is licensed under AGPL-3.0.  
+See [Contributors](https://github.com/openfrontio/OpenFrontIO/graphs/contributors) for code contributors.
+
+## Map Data
+
+### OpenStreetMap
+
+© [OpenStreetMap contributors](https://www.openstreetmap.org/copyright)  
+Licensed under ODbL
+
+### Natural Earth
+
+[Natural Earth](https://www.naturalearthdata.com/)  
+Public Domain
+
+### Bedmap3 Antarctica Dataset
+
+Pritchard, H.D., Fretwell, P.T., Fremand, A.C. et al. Bedmap3 updated ice bed, surface and thickness gridded datasets for Antarctica. _Sci Data_ 12, 109 (2025).  
+[https://doi.org/10.1038/s41597-025-04672-y](https://doi.org/10.1038/s41597-025-04672-y)  
+Licensed under [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/)
+
+## Icons
+
+Icons from [The Noun Project](https://thenounproject.com/)

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -262,8 +262,8 @@
   },
   "game_starting_modal": {
     "title": "Game is Starting...",
-    "code_license": "Code licensed under AGPL-3.0",
-    "desc": "Preparing for the lobby to start. Please wait."
+    "credits": "Credits",
+    "code_license": "Code licensed under AGPL-3.0"
   },
   "difficulty": {
     "difficulty": "Difficulty",

--- a/src/client/GameStartingModal.ts
+++ b/src/client/GameStartingModal.ts
@@ -51,6 +51,13 @@ export class GameStartingModal extends LitElement {
     }
 
     .modal p {
+      margin: 2px 0;
+      font-size: 14px;
+    }
+
+    .modal .loading {
+      font-size: 16px;
+      margin-top: 20px;
       margin-bottom: 20px;
       background-color: rgba(0, 0, 0, 0.3);
       padding: 10px;
@@ -88,7 +95,23 @@ export class GameStartingModal extends LitElement {
     .copyright {
       font-size: 32px;
       margin-top: 20px;
+      margin-bottom: 10px;
       opacity: 1;
+    }
+
+    .modal a {
+      display: block;
+      margin-top: 10px;
+      margin-bottom: 15px;
+      font-size: 20px;
+      color: #4a9eff;
+      text-decoration: none;
+      transition: color 0.2s ease;
+    }
+
+    .modal a:hover {
+      color: #6bb0ff;
+      text-decoration: underline;
     }
   `;
 
@@ -96,8 +119,14 @@ export class GameStartingModal extends LitElement {
     return html`
       <div class="modal ${this.isVisible ? "visible" : ""}">
         <div class="copyright">© OpenFront</div>
-        <h5>${translateText("game_starting_modal.code_license")}</h5>
-        <p>${translateText("game_starting_modal.title")}</p>
+        <a
+          href="https://github.com/openfrontio/OpenFrontIO/blob/main/CREDITS.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          >${translateText("game_starting_modal.credits")}</a
+        >
+        <p>${translateText("game_starting_modal.code_license")}</p>
+        <p class="loading">${translateText("game_starting_modal.title")}</p>
       </div>
     `;
   }


### PR DESCRIPTION
## Description:

* Create CREDITS.md
* add all link to it on loading page

<img width="338" height="254" alt="Screenshot 2025-10-30 at 6 24 07 PM" src="https://github.com/user-attachments/assets/5e89c846-f672-44e1-9add-3d03608c849e" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
