### PR TITLE
Remove redundant function from FakeHumanExecution

### DIFF
--- a/src/core/execution/FakeHumanExecution.ts
+++ b/src/core/execution/FakeHumanExecution.ts
@@ -186,29 +186,6 @@ export class FakeHumanExecution implements Execution {
     this.maybeAttack();
   }
 
-  /**
-   * TODO: Implement strategic betrayal logic
-   * Currently this just breaks alliances without strategic consideration.
-   * Future implementation should consider:
-   * - Relative strength (troop count, territory size) compared to target
-   * - Risk vs reward of betrayal
-   * - Potential impact on relations with other players
-   * - Timing (don't betray when already fighting other enemies)
-   * - Strategic value of target's territory
-   * - If target is distracted
-   */
-  private maybeConsiderBetrayal(target: Player): boolean {
-    if (this.player === null) throw new Error("not initialized");
-
-    const alliance = this.player.allianceWith(target);
-
-    if (!alliance) return false;
-
-    this.player.breakAlliance(alliance);
-
-    return true;
-  }
-
   private maybeAttack() {
     if (this.player === null || this.behavior === null) {
       throw new Error("not initialized");


### PR DESCRIPTION
## Description:

Removed unused code.

PR https://github.com/openfrontio/OpenFrontIO/pull/2044 introduced function "maybeConsiderBetrayal" in FakeHumanExecution. It was later replaced by "betray" in BotBehavior, called in a chain of functions resulting in the behavior that "maybeConsiderBetrayal" originally intended: https://github.com/openfrontio/OpenFrontIO/commit/b03f9778dbcada54e0f47232af4cd511a8629980. 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33