### PR TITLE
meta update: use rational function to discourage short trades, buff trains

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -345,7 +345,7 @@ export class DefaultConfig implements Config {
   trainSpawnRate(numPlayerFactories: number): number {
     // hyperbolic decay, midpoint at 10 factories
     // expected number of trains = numPlayerFactories  / trainSpawnRate(numPlayerFactories)
-    return (numPlayerFactories + 10) * 20;
+    return (numPlayerFactories + 10) * 16;
   }
   trainGold(rel: "self" | "team" | "ally" | "other"): Gold {
     switch (rel) {
@@ -370,7 +370,8 @@ export class DefaultConfig implements Config {
   }
 
   tradeShipGold(dist: number, numPorts: number): Gold {
-    const baseGold = Math.floor(100_000 + 100 * dist);
+    // Smooth anti-cheese formula: base reward scales with distance using rational function, heavily penalizing short trades while converging to original rewards at long distances
+    const baseGold = Math.floor(100_000 * (dist / (dist + 50)) + 100 * dist);
     const numPortBonus = numPorts - 1;
     // Hyperbolic decay, midpoint at 5 ports, 3x bonus max.
     const bonus = 1 + 2 * (numPortBonus / (numPortBonus + 5));


### PR DESCRIPTION
## Description:

Use a rational function to strongly nerf short trades. At 50 tiles the reward is halved.

To compensate, increase gold given by trains by 20%.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
