### PR TITLE
fix(replay): change text to 'replay speed' when watching a replay #2357

### DIFF
--- a/src/client/graphics/layers/ReplayPanel.ts
+++ b/src/client/graphics/layers/ReplayPanel.ts
@@ -70,9 +70,9 @@ export class ReplayPanel extends LitElement implements Layer {
         @contextmenu=${(e: Event) => e.preventDefault()}
       >
         <label class="block mb-1 text-white" translate="no">
-          ${!this.game?.config()?.isReplay()
-            ? translateText("replay_panel.game_speed")
-            : translateText("replay_panel.replay_speed")}
+          ${this.game?.config()?.isReplay()
+            ? translateText("replay_panel.replay_speed")
+            : translateText("replay_panel.game_speed")}
         </label>
         <div class="grid grid-cols-2 gap-1">
           ${this.renderSpeedButton(ReplaySpeedMultiplier.slow, "×0.5")}


### PR DESCRIPTION
Before, the condition was "if it's not singleplayer", but replays are counted as singleplayer game for some reason (will need to fix the underlying issue) so it wasn't robust enough Now the condition is based on are we in replay or not,.

## Description:

Related to issue https://github.com/openfrontio/OpenFrontIO/issues/2357

I cannot get to replay games locally for some reason (client just throws an error that it cannot load the lobby), so I made sure that the singleplayer text did not change (at least no regression) cf screenshot:

<img width="1920" height="963" alt="Screenshot 2025-11-02 at 17 46 57" src="https://github.com/user-attachments/assets/27e055a8-3813-46bd-a8ae-0c463a94d1a8" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

sorikairo