### PR TITLE
Fix empty Leaderboard on Teams replay

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -117,9 +117,8 @@ export class Leaderboard extends LitElement implements Layer {
         troops: renderNumber(troops),
         isMyPlayer: player === myPlayer,
         isOnSameTeam:
-          player === myPlayer || myPlayer !== null
-            ? player.isOnSameTeam(myPlayer)
-            : false,
+          myPlayer !== null &&
+          (player === myPlayer || player.isOnSameTeam(myPlayer)),
         player: player,
       };
     });


### PR DESCRIPTION
## Description:

Fixes https://github.com/openfrontio/OpenFrontIO/issues/2356

Leaderboard was empty on replay of Team games. This fixes it.

For v26, since the bug was introduced in v26. Set main as target branch though.

**BEFORE**
<img width="1918" height="1075" alt="508510056-b5ec5c7e-33a7-4bae-92f8-103e6cc1f165" src="https://github.com/user-attachments/assets/f8c7d029-1c8b-4bbe-8288-e73829f1c239" />

**AFTER**
<img width="1065" height="567" alt="image" src="https://github.com/user-attachments/assets/f29fb7ef-78df-414e-8ea8-e1f86433b4c6" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
