### PR TITLE
Empty map

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -148,6 +148,7 @@
     "max_timer": "Game length (minutes)",
     "disable_nukes": "Disable Nukes",
     "automatic_difficulty": "Automatic Difficulty",
+    "empty_map": "Empty Map",
     "enables_title": "Enable Settings",
     "start": "Start Game"
   },

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -44,6 +44,7 @@ export class SinglePlayerModal extends LitElement {
   @state() private maxTimer: boolean = false;
   @state() private maxTimerValue: number | undefined = undefined;
   @state() private instantBuild: boolean = false;
+  @state() private emptyMap: boolean = false;
   @state() private useRandomMap: boolean = false;
   @state() private gameMode: GameMode = GameMode.FFA;
   @state() private teamCount: TeamCountConfig = 2;
@@ -340,6 +341,21 @@ export class SinglePlayerModal extends LitElement {
                 </div>
               </label>
               <label
+                for="singleplayer-modal-empty-map"
+                class="option-card ${this.emptyMap ? "selected" : ""}"
+              >
+                <div class="checkbox-icon"></div>
+                <input
+                  type="checkbox"
+                  id="singleplayer-modal-empty-map"
+                  @change=${this.handleEmptyMapChange}
+                  .checked=${this.emptyMap}
+                />
+                <div class="option-card-title">
+                  ${translateText("single_modal.empty_map")}
+                </div>
+              </label>
+              <label
                 for="end-timer"
                 class="option-card ${this.maxTimer ? "selected" : ""}"
               >
@@ -452,6 +468,10 @@ export class SinglePlayerModal extends LitElement {
     this.compactMap = Boolean((e.target as HTMLInputElement).checked);
   }
 
+  private handleEmptyMapChange(e: Event) {
+    this.emptyMap = Boolean((e.target as HTMLInputElement).checked);
+  }
+
   private handleMaxTimerValueKeyDown(e: KeyboardEvent) {
     if (["-", "+", "e"].includes(e.key)) {
       e.preventDefault();
@@ -557,7 +577,7 @@ export class SinglePlayerModal extends LitElement {
               playerTeams: this.teamCount,
               difficulty: this.selectedDifficulty,
               maxTimerValue: this.maxTimer ? this.maxTimerValue : undefined,
-              bots: this.bots,
+              bots: this.emptyMap ? 0 : this.bots,
               infiniteGold: this.infiniteGold,
               donateGold: true,
               donateTroops: true,
@@ -572,7 +592,7 @@ export class SinglePlayerModal extends LitElement {
                     disableNPCs: false,
                   }
                 : {
-                    disableNPCs: this.disableNPCs,
+                    disableNPCs: this.emptyMap ? true : this.disableNPCs,
                   }),
             },
           },


### PR DESCRIPTION
This adds a button in singleplayer that allows you to play in an empty map, meaning no other nations, nor bots. This could be used for multiple things like wanting to own the entire world without needing to fight bots, or to see how maps look without bots. If this gets added i'll update it overtime with also being able to add bots mid-match nd more. 

Changes:
- Added 'emptyMap' state variable to SinglePlayerModal component
- Added checkbox UI element that matches the existing option style
- Added translation string 'empty_map' to en.json
- Implemented logic to set bots=0 and disableNPCs=true when emptyMap is enabled
- The option appears alongside other options like Infinite Troops, Instant Build, etc.
- 
<img width="2549" height="1341" alt="Screenshot 2025-11-03 141817" src="https://github.com/user-attachments/assets/f2b9ad90-f480-40be-a338-32d54a50f08a" />


DISCORD_USERNAME
naamliegtwssniet
