### PR TITLE
Fix transport ships not adding back troops for wilderness

### DIFF
--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -220,28 +220,18 @@ export class TransportShipExecution implements Execution {
     const result = this.pathFinder.nextTile(this.boat.tile(), this.dst);
     switch (result.type) {
       case PathFindResultType.Completed:
-        if (this.mg.owner(this.dst) === this.attacker) {
-          this.attacker.addTroops(this.boat.troops());
-          this.boat.delete(false);
-          this.active = false;
-
-          // Record stats
-          this.mg
-            .stats()
-            .boatArriveTroops(this.attacker, this.target, this.boat.troops());
-          return;
-        }
-        this.attacker.conquer(this.dst);
-        if (this.target.isPlayer() && this.attacker.isFriendly(this.target)) {
-          this.attacker.addTroops(this.boat.troops());
-        } else {
+        this.attacker.addTroops(this.boat.troops());
+        if (
+          this.mg.owner(this.dst) !== this.attacker &&
+          (!this.target.isPlayer() || !this.attacker.isFriendly(this.target))
+        ) {
+          this.attacker.conquer(this.dst);
           this.mg.addExecution(
             new AttackExecution(
               this.boat.troops(),
               this.attacker,
               this.targetID,
               this.dst,
-              false,
             ),
           );
         }


### PR DESCRIPTION
## Description:

Fixes a problem introduced in 0.26.14 by a check for removeTroops bool in AttackExecution, where transport ships going into wilderness would not return the left troops.
In the process, the PR also simplifies and unifies the logic for TransportShip PathFindResultType.Completed by condendsing it into a single if statement.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Lavodan
