### PR TITLE
Fix bugs causing 403s after refreshing jwt

### DIFF
--- a/src/client/jwt.ts
+++ b/src/client/jwt.ts
@@ -225,6 +225,7 @@ export async function postRefresh(): Promise<boolean> {
     // Refresh the JWT
     const response = await fetch(getApiBase() + "/refresh", {
       method: "POST",
+      credentials: "include",
       headers: {
         authorization: `Bearer ${token}`,
       },
@@ -242,6 +243,9 @@ export async function postRefresh(): Promise<boolean> {
       return false;
     }
     localStorage.setItem("token", result.data.token);
+    // Clear the cached logged in state
+    // so that the next call to isLoggedIn() will refresh the token
+    __isLoggedIn = undefined;
     return true;
   } catch (e) {
     __isLoggedIn = false;


### PR DESCRIPTION
## Description:

Two bugs where causing 403s when trying to connect to a game after refreshing the jwt:

1. __isLoggedIn was not cleared, so the existing, cached, token was used.
2. set "credentials: "include" in the refresh request so we get the token as a cookie. getToken() checks cookie before checking "token" in localstorage. So cookie wasn't being updated and we were using the existing cookie.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
