### PR TITLE
feat: additional tag added to build.sh + `latest` tag added on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
           RELEASE_BODY: ${{ github.event.release.body }}
           RELEASE_NAME: ${{ github.event.release.name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
+          ADDITIONAL_VERSION_TAG: ${{ github.event.action == 'published' && 'latest' || '' }}
         run: |
           set -euxo pipefail
           cat <<EOF >> $GITHUB_STEP_SUMMARY

--- a/build.sh
+++ b/build.sh
@@ -64,6 +64,12 @@ fi
 
 DOCKER_IMAGE="${DOCKER_USERNAME}/${DOCKER_REPO}:${VERSION_TAG}"
 
+# If ADDITIONAL_VERSION_TAG is provided ADDITIONAL_DOCKER_IMAGE will be set
+# example usage: adding latest tag
+if [ -n "$ADDITIONAL_VERSION_TAG" ]; then
+    ADDITIONAL_DOCKER_IMAGE="${DOCKER_USERNAME}/${DOCKER_REPO}:${ADDITIONAL_VERSION_TAG}"
+fi
+
 # Build and upload Docker image to Docker Hub
 echo "Environment: ${DEPLOY_ENV}"
 echo "Using version tag: $VERSION_TAG"
@@ -86,6 +92,7 @@ docker buildx build \
     --build-arg GIT_COMMIT=$GIT_COMMIT \
     --metadata-file $METADATA_FILE \
     -t $DOCKER_IMAGE \
+    ${ADDITIONAL_DOCKER_IMAGE:+-t "$ADDITIONAL_DOCKER_IMAGE"} \
     --push \
     .
 


### PR DESCRIPTION
## Description:

Added the possibility to have an additional docker version tag in the `build.sh` script
Added `latest` as an additional version tag when building and publishing a docker image for a new release

The conditional in the github action is taken as is from the original docs example:
https://docs.github.com/en/actions/reference/workflows-and-actions/expressions#example

The conditional bash expression has been tested locally with mock data using a partial `test.sh` script containing only the affected lines and necessary variables for testing without the `--push` option. I confirm that the produced result is as expected with or without the new option provided

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

[fedot_compot](https://discord.com/users/298153303341137922)
