### PR TITLE
fix: newsbutton not stretched anymore

### DIFF
--- a/src/client/components/NewsButton.ts
+++ b/src/client/components/NewsButton.ts
@@ -48,7 +48,7 @@ export class NewsButton extends LitElement {
           @click=${this.handleClick}
         >
           <img
-            class="size-[48px] dark:invert max-w-[48px]"
+            class="size-[48px] dark:invert"
             src="${megaphone}"
             alt=${translateText("news.title")}
           />

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -220,9 +220,7 @@
             ></button>
           </territory-patterns-modal>
           <username-input class="relative w-full"></username-input>
-          <news-button
-            class="w-[20%] md:w-[15%] component-hideable"
-          ></news-button>
+          <news-button class="w-[20%] component-hideable"></news-button>
         </div>
         <div></div>
         <div>


### PR DESCRIPTION
## Description:

Resolves #2257

Before:
<img width="644" height="380" alt="Screenshot 2025-11-06 at 21 36 50" src="https://github.com/user-attachments/assets/f2502d17-ef22-4b2e-ab10-22c3b8fc9efc" />


After:

<img width="644" height="380" alt="Screenshot 2025-11-06 at 21 36 40" src="https://github.com/user-attachments/assets/25efe3a2-632f-4a4f-941a-2305705380d5" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
