### PR TITLE
Add a note to the README explaining the nuances of replaying production games locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ npm run start:server-dev
 
 Sometimes it's useful to connect to production servers when replaying a game, testing user profiles, purchases, or login flow.
 
-> To replay production games, make sure you're on the same commit as the game, check the `gitCommit` property via https://api.openfront.io/game/[gameId].
-> Not finished games can't be replayed on localhost.
+> To replay a production game, make sure you're on the same commit that the game you want to replay was executed on, you can find the `gitCommit` value via `https://api.openfront.io/game/[gameId]`.
+> Unfinished games cannot be replayed on localhost.
 
 To connect to staging api servers:
 


### PR DESCRIPTION
## Description:

Had an issue with replaying games via `npm run dev:prod`. 

Added summary of the [issue discussion](https://discord.com/channels/1359946986937258015/1359946989046989063/1436819549205827697) with @evanpelle into this PR 


## Please put your Discord username so you can be contacted if a bug or regression is found:

nikolaj_mykola
