### PR TITLE
Fix: Temporarily disable factory upgrades

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -543,7 +543,8 @@ export class DefaultConfig implements Config {
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
           canBuildTrainStation: true,
           experimental: true,
-          upgradable: true,
+          // TODO change upgradeable to true once upgrade implementation is added
+          upgradable: false,
         };
       case UnitType.Construction:
         return {


### PR DESCRIPTION
Temporarily addresses #1949 

## Description:

Stops factories from being able to be upgraded.

Until an actual implementation of a solution for #1949 is made, this at least stops players from wasting gold on a useless upgrade, which they might not know is a thing.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Lavodan
