### PR TITLE
Tint territory borders based on player relationships.

### DIFF
--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -367,9 +367,7 @@ export class PlayerView {
     const y = this.game.y(tile);
     const lightTile =
       (x % 2 === 0 && y % 2 === 0) || (y % 2 === 1 && x % 2 === 1);
-    return lightTile 
-    ? defendedColors.light 
-    : defendedColors.dark;
+    return lightTile ? defendedColors.light : defendedColors.dark;
   }
 
   /**


### PR DESCRIPTION
## Description:

Add visual indicators to territory borders that reflect diplomatic relationships between players, making it easier to identify relations at a glance.

### Problem Statement

Currently, players must check diplomatic status through other UI elements. There's no immediate visual feedback on the map showing which borders represent embargo or friendly relationships.

### Benefits

1. **Improved Gameplay Clarity**: Quickly identify diplomatic relationships without opening menus
2. **Strategic Awareness**: Visual feedback helps make tactical decisions about border defense

### Proposed Solution

Tint territory borders based on neighbor relationships: embargo red, friendly green


### Implementation Details
- Border variants are based on this._borderColor (theme/style handling unchanged) computed in the constructor and stored in userSettings UnitView
- Apply tinting to checkerboard for defended borders
- borderColor()  checks all neighbors to determine the worst relationship status
- Embargos take priority.


<img width="1193" height="601" alt="image" src="https://github.com/user-attachments/assets/cb516402-4f4b-473c-a31b-02397fee9203" />
<img width="959" height="682" alt="image" src="https://github.com/user-attachments/assets/de01a4b9-0fd4-44b2-895d-96705b6cf30b" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced