### PR TITLE
Change wiki site from miraheze to openfront.wiki

### DIFF
--- a/src/client/index.html
+++ b/src/client/index.html
@@ -329,7 +329,7 @@
             How to Play
           </a>
           <a
-            href="https://openfront.miraheze.org/wiki/Main_Page"
+            href="https://openfront.wiki/Main_Page"
             data-i18n="main.wiki"
             class="t-link"
             target="_blank"


### PR DESCRIPTION
## Description:

Change the wiki site from the inactive openfront.miraheze.org to the new openfront.wiki link. 
Ideally for v27?

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Lavodan
