### PR TITLE
Workflows: better message for missing PR Milestone

### DIFF
--- a/.github/workflows/pr-description.yml
+++ b/.github/workflows/pr-description.yml
@@ -73,7 +73,7 @@ jobs:
               // Get the pull request data
               const milestone = context.payload.pull_request.milestone;
               if (!milestone) {
-                core.setFailed('❌ Pull request must have a milestone assigned before merging.');
+                core.setFailed('❌ Reviewer must assign a Milestone to this Pull request before merging.');
                 return;
               }
               console.log(`✅ Milestone found: ${milestone.title}`);


### PR DESCRIPTION
## Description:

Make more clear who's responsible to set the milestone on a PR. The current error message raises questions about who's responsible for this, especially when the PR author doesn't have the access rights to set the Milestone.

**Old message:**
"Pull request must have a milestone assigned before merging."

**New message:**
"Reviewer must assign a Milestone to this Pull request before merging."

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
