### PR TITLE
Fix: 'Mini Map' to 'Compact Map' for Private Lobby Modal

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -268,7 +268,7 @@
     "donate_gold": "Donate gold",
     "infinite_troops": "Infinite troops",
     "donate_troops": "Donate troops",
-    "compact_map": "Mini Map",
+    "compact_map": "Compact Map",
     "automatic_difficulty": "Automatic Difficulty",
     "enables_title": "Enable Settings",
     "player": "Player",


### PR DESCRIPTION
## Description:

Fix for v27.

In commit https://github.com/openfrontio/OpenFrontIO/commit/91ff1c0e538b80825fd4374b936763923905cb1d, the name of Mini Map was changed to Compact Map. But it was only done for the Single Player modal by mistake. This PR also changes it for the Host Lobby Modal.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
