### PR TITLE
Fix nation relation exploit 🔧

### DIFF
--- a/src/core/execution/DonateGoldExecution.ts
+++ b/src/core/execution/DonateGoldExecution.ts
@@ -6,7 +6,7 @@ import {
   Player,
   PlayerID,
 } from "../game/Game";
-import { toInt } from "../Util";
+import { assertNever, toInt } from "../Util";
 
 export class DonateGoldExecution implements Execution {
   private recipient: Player;
@@ -69,7 +69,7 @@ export class DonateGoldExecution implements Execution {
       case Difficulty.Impossible:
         return 25_000;
       default:
-        return 2_500;
+        assertNever(difficulty);
     }
   }
 

--- a/src/core/execution/DonateTroopExecution.ts
+++ b/src/core/execution/DonateTroopExecution.ts
@@ -1,5 +1,6 @@
 import { Difficulty, Execution, Game, Player, PlayerID } from "../game/Game";
 import { PseudoRandom } from "../PseudoRandom";
+import { assertNever } from "../Util";
 
 export class DonateTroopsExecution implements Execution {
   private recipient: Player;
@@ -84,10 +85,7 @@ export class DonateTroopsExecution implements Execution {
           recipientMaxTroops / 5,
         );
       default:
-        return this.random.nextInt(
-          recipientMaxTroops / 13,
-          recipientMaxTroops / 11,
-        );
+        assertNever(difficulty);
     }
   }
 


### PR DESCRIPTION
## Description:

Saw this in an Enzo video about beating impossible nations:

You can just donate 1% gold / 1% troops to a nation to get a friendly relation with them.

This PR adds randomized minimum donation requirements based on the difficulty.
Randomized in a way that there is a minimum someone has to donate to surely get the relation improvement, but you can also gamble and send less.

For troop donations, the minimum is calculated based on what percentage of their troops the sender donated.

For gold donations, it's fixed values. We cannot use percentages here because “having nearly no gold” is a usual case. Donating 100% of your gold wouldn’t hurt if you just spent all your gold on buildings.

I tried to add tests for this but it's really horrible. Because the test would have to wait until the relation update from the alliance accepting is gone (we need to have an alliance to send stuff), has returned to Neutral, and then changes back to Friendly after the donation.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
