### PR TITLE
Prevent keyboard shortcuts from firing while typing in quick chat search

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -290,6 +290,15 @@ export class InputHandler {
     }, 1);
 
     window.addEventListener("keydown", (e) => {
+      const target = e.target as HTMLElement | null;
+      const isTextInput =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable;
+      if (isTextInput && e.code !== "Escape") {
+        return;
+      }
+
       if (e.code === this.keybinds.toggleView) {
         e.preventDefault();
         if (!this.alternateView) {
@@ -331,6 +340,15 @@ export class InputHandler {
       }
     });
     window.addEventListener("keyup", (e) => {
+      const target = e.target as HTMLElement | null;
+      const isTextInput =
+        target?.tagName === "INPUT" ||
+        target?.tagName === "TEXTAREA" ||
+        target?.isContentEditable;
+      if (isTextInput && !this.activeKeys.has(e.code)) {
+        return;
+      }
+
       if (e.code === this.keybinds.toggleView) {
         e.preventDefault();
         this.alternateView = false;


### PR DESCRIPTION
## Description:

Guard global keydown/keyup handlers to ignore events from text/textarea/contenteditable targets (except Escape/active keys) so
    gameplay shortcuts don’t trigger while typing in the quick chat player search.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri