### PR TITLE
Remove border around in game time

### DIFF
--- a/src/client/graphics/layers/GameRightSidebar.ts
+++ b/src/client/graphics/layers/GameRightSidebar.ts
@@ -148,7 +148,7 @@ export class GameRightSidebar extends LitElement implements Layer {
         <!-- Timer display below buttons -->
         <div class="flex justify-center items-center mt-2">
           <div
-            class="w-[70px] h-8 lg:w-24 lg:h-10 border border-slate-400 p-0.5 text-xs md:text-sm lg:text-base flex items-center justify-center text-white px-1"
+            class="w-[70px] h-8 lg:w-24 lg:h-10 p-0.5 text-xs md:text-sm lg:text-base flex items-center justify-center text-white px-1"
             style="${this.game.config().gameConfig().maxTimerValue !==
               undefined && this.timer < 60
               ? "color: #ff8080;"


### PR DESCRIPTION
## Description:

Removes the border around the in game time because it looks better this way. Sorry my screenshots are a bit washed out, windows doesn't like my HDR monitor...

Before:
<img width="201" height="145" alt="image" src="https://github.com/user-attachments/assets/ef399dcd-72bc-4ee7-ac67-42a0e4b2b793" />

After:
<img width="213" height="143" alt="image" src="https://github.com/user-attachments/assets/bdb211af-d2c6-4b5e-8946-1cb88bf707c2" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

rovi.
