### PR TITLE
fix failing nationNameLength test

### DIFF
--- a/tests/NationNameLength.test.ts
+++ b/tests/NationNameLength.test.ts
@@ -1,6 +1,5 @@
 import fs from "fs";
 import { globSync } from "glob";
-import path from "path";
 
 type Nation = {
   name?: string;


### PR DESCRIPTION
## Description:

Fixes the failing nationNameLength.test by usinbg the proper absolute path glob syntax

Also switches to fast-glob because I don't see a reason to not use it.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Lavodan