### PR TITLE
Fix spacing in player team label display

### DIFF
--- a/src/client/graphics/layers/GameLeftSidebar.ts
+++ b/src/client/graphics/layers/GameLeftSidebar.ts
@@ -99,7 +99,7 @@ export class GameLeftSidebar extends LitElement implements Layer {
               >
                 ${translateText("help_modal.ui_your_team")}
                 <span style="color: ${this.playerColor.toRgbString()}">
-                  ${this.getTranslatedPlayerTeamLabel()} &#10687;
+                  &nbsp;${this.getTranslatedPlayerTeamLabel()} &#10687;
                 </span>
               </div>
             `


### PR DESCRIPTION
## Description:

Add a space after "Your team:"

Before:
<img width="237" height="117" alt="image" src="https://github.com/user-attachments/assets/60c0821f-a188-44bc-bcd5-e810a741b297" />

After:
<img width="243" height="122" alt="image" src="https://github.com/user-attachments/assets/99b3ff5a-167d-4bae-b8f6-b1b199d4946a" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
