### PR TITLE
Fix: update renderSprites based on user settings in SpriteFactory

### DIFF
--- a/src/client/graphics/layers/StructureDrawingUtils.ts
+++ b/src/client/graphics/layers/StructureDrawingUtils.ts
@@ -148,6 +148,9 @@ export class SpriteFactory {
     const { type, stage } = options;
     const { scale } = this.transformHandler;
 
+    this.renderSprites =
+      this.game.config().userSettings()?.structureSprites() ?? true;
+
     if (type === "icon" || type === "dot") {
       const texture = this.createTexture(
         structureType,


### PR DESCRIPTION
Resolves #2573
 
## Description:
Fixed an issue where structure icons became smaller after upgrading a building.
In StructureDrawingUtils.ts, renderSprites was always set to true and never updated, which caused the code to consistently select the scaled-down icon. This appears to have been the root cause of the problem. Since StructureIconsLayer (the caller of StructureDrawingUtils) updates renderSprites based on settings, I aligned the behavior accordingly.

```ts
    if (type === "icon") {
      const s =
        scale >= ZOOM_THRESHOLD && !this.renderSprites
          ? Math.max(1, scale / ICON_SCALE_FACTOR_ZOOMED_IN)
          : Math.min(1, scale / ICON_SCALE_FACTOR_ZOOMED_OUT);
      parentContainer.scale.set(s);
    }
```

Here is the video demonstrating the behavior after the fix.
Please see the linked issue for the pre-fix behavior.

https://github.com/user-attachments/assets/24c11a39-667e-49eb-adfe-f0c400d91e54

## Please complete the following:
- [x]  I have added screenshots for all UI updates
- [x]  I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x]  I have added relevant tests to the test directory
- [x]  I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri