### PR TITLE
Fix: Filter out in construction buildings for totalunitlevels

### DIFF
--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -382,6 +382,7 @@ export class PlayerView {
 
   totalUnitLevels(type: UnitType): number {
     return this.units(type)
+      .filter((unit) => !unit.isUnderConstruction())
       .map((unit) => unit.level())
       .reduce((a, b) => a + b, 0);
   }


### PR DESCRIPTION
## Description:

Fix for v28.

After PR #2378 changes, unit type Construction doesn't exist anymore. Resulting in totalUnitLevels counting in construction buildings towards total units in TeamStats, old and new Build Menu and Player Info Overlay. To fix this we now need to filter out the construction phase.

totalUnitLevels is only used for displaying total count purposes, it doesn't affect other logic.

Before PR 2378 changes:
https://github.com/user-attachments/assets/7748092a-8b7b-41bb-bc68-439ba922b479

After PR 2378 changes:
https://github.com/user-attachments/assets/bc77d7c2-be02-487a-b46a-c02367ae5ad8

After fix in this PR it is back to what is was before:
https://github.com/user-attachments/assets/8d7d14b6-7b6b-4ddb-96d1-17a0a45727f3

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
