### PR TITLE
Fix obvious typos

### DIFF
--- a/API.md
+++ b/API.md
@@ -176,7 +176,7 @@ GET https://openfront.io/public/clan/:clanTag
 **Query Parameters:**
 
 - `start` (optional): ISO 8601 timestamp
-- `end` (optonal): ISO 8601 timestamp
+- `end` (optional): ISO 8601 timestamp
 
 **Example**
 
@@ -198,7 +198,7 @@ GET https://api.openfront.io/public/clan/:clanTag/sessions
 **Query Parameters:**
 
 - `start` (optional): ISO 8601 timestamp
-- `end` (optonal): ISO 8601 timestamp
+- `end` (optional): ISO 8601 timestamp
 
 **Example**
 

--- a/resources/changelog.md
+++ b/resources/changelog.md
@@ -161,12 +161,12 @@
 - Revert tradeship path caching by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/927
 - Meta Adjustments from [UN] clan test by @1brucben in https://github.com/openfrontio/OpenFrontIO/pull/932
 - fix alternate view regression by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/937
-- fix warship targetting range by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/938
+- fix warship targeting range by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/938
 - Add instructional overlay message during spawn phase by @spicydll in https://github.com/openfrontio/OpenFrontIO/pull/934
 - Add test coverage script by @aqw42 in https://github.com/openfrontio/OpenFrontIO/pull/929
 - Added two checkboxes to the default pull request template by @aqw42 in https://github.com/openfrontio/OpenFrontIO/pull/930
 - Fix slow singleplayer timer by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/943
-- improved perfomance of PseudoRandom by @falcolnic in https://github.com/openfrontio/OpenFrontIO/pull/933
+- improved performance of PseudoRandom by @falcolnic in https://github.com/openfrontio/OpenFrontIO/pull/933
 - Change deploy concurrency group by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/944
 - Set singleplayer gitCommit in the client by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/945
 - Simplify bots retaliation logic by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/946
@@ -202,7 +202,7 @@
 - Use bigint for gold by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/1000
 - Fix : Donation when max pop already reached by @aqw42 in https://github.com/openfrontio/OpenFrontIO/pull/904
 - Validate incoming API data with zod by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/891
-- this is a fix for the "possibly null" error. dosent seem to cause runtime issues but does cause the compiler to throw an error by @Jerryslang in https://github.com/openfrontio/OpenFrontIO/pull/1005
+- this is a fix for the "possibly null" error. doesn't seem to cause runtime issues but does cause the compiler to throw an error by @Jerryslang in https://github.com/openfrontio/OpenFrontIO/pull/1005
 - Fixnukeboatbug by @rldtech in https://github.com/openfrontio/OpenFrontIO/pull/1011
 - added ratio controls by @falcolnic in https://github.com/openfrontio/OpenFrontIO/pull/963
 - Add a status check for the milestone field by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/1029
@@ -333,7 +333,7 @@
 - improve astar perf by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/1268
 - Log public id by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/1278
 - clarify license by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/1277
-- Fix sam targetting everything by @jrouillard in https://github.com/openfrontio/OpenFrontIO/pull/1280
+- Fix sam targeting everything by @jrouillard in https://github.com/openfrontio/OpenFrontIO/pull/1280
 - Add Creative Commons License to resources/non-commercial by @evanpelle in https://github.com/openfrontio/OpenFrontIO/pull/1284
 - Sword pattern by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/1283
 - Display OFM25 ad in WinModal by @scottanderson in https://github.com/openfrontio/OpenFrontIO/pull/1281

--- a/src/client/graphics/layers/FxLayer.ts
+++ b/src/client/graphics/layers/FxLayer.ts
@@ -129,7 +129,7 @@ export class FxLayer implements Layer {
     if (gold > 0) {
       const shortened = renderNumber(gold, 0);
       this.addTextFx(`+ ${shortened}`, x, y);
-      y += 10; // increase y so the next popup starts bellow
+      y += 10; // increase y so the next popup starts below
     }
 
     if (troops > 0) {

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -376,7 +376,7 @@ export class UnitLayer implements Layer {
     );
   }
 
-  // interception missle from SAM
+  // interception missile from SAM
   private handleMissileEvent(unit: UnitView) {
     this.drawSprite(unit);
   }

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -82,7 +82,7 @@ export class NukeExecution implements Execution {
         this.nuke.type() !== UnitType.MIRVWarhead
       ) {
         // Resolves exploit of alliance breaking in which a pending alliance request
-        // was accepeted in the middle of an missle attack.
+        // was accepted in the middle of a missile attack.
         const allianceRequest = attackedPlayer
           .incomingAllianceRequests()
           .find((ar) => ar.requestor() === this.player);

--- a/src/core/execution/utils/BotNames.ts
+++ b/src/core/execution/utils/BotNames.ts
@@ -274,7 +274,7 @@ export const COMMUNITY_FULL_ELF_NAMES = [
   "Lumiin the YT Elf",
   "youngfentanyl OFM Elf",
   "Remorse the Wiki Elf",
-  "Lonely Millenial Twitch Elf",
+  "Lonely Millennial Twitch Elf",
   "Kaizeron OFM Elf",
   "Zilka OFM Elf",
   "JIZK Caster Elf",

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -398,7 +398,7 @@ export class PlayerImpl implements Player {
     if (this.isDisconnected() || other.isDisconnected()) {
       // Disconnected players are marked as not-friendly even if they are allies,
       // so we need to return early if either player is disconnected.
-      // Otherise we could end up sending an alliance request to someone
+      // Otherwise we could end up sending an alliance request to someone
       // we are already allied with.
       return false;
     }

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -75,7 +75,7 @@ export class UserSettings {
 
   focusLocked() {
     return false;
-    // TODO: renable when performance issues are fixed.
+    // TODO: re-enable when performance issues are fixed.
     this.get("settings.focusLocked", true);
   }
 

--- a/src/core/pathfinding/MiniAStar.ts
+++ b/src/core/pathfinding/MiniAStar.ts
@@ -104,7 +104,7 @@ function fixExtremes(upscaled: Cell[], cellDst: Cell, cellSrc?: Cell): Cell[] {
   if (cellSrc !== undefined) {
     const srcIndex = findCell(upscaled, cellSrc);
     if (srcIndex === -1) {
-      // didnt find the start tile in the path
+      // didn't find the start tile in the path
       upscaled.unshift(cellSrc);
     } else if (srcIndex !== 0) {
       // found start tile but not at the start
@@ -115,7 +115,7 @@ function fixExtremes(upscaled: Cell[], cellDst: Cell, cellSrc?: Cell): Cell[] {
 
   const dstIndex = findCell(upscaled, cellDst);
   if (dstIndex === -1) {
-    // didnt find the dst tile in the path
+    // didn't find the dst tile in the path
     upscaled.push(cellDst);
   } else if (dstIndex !== upscaled.length - 1) {
     // found dst tile but not at the end

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -54,7 +54,7 @@ export function isProfaneUsername(username: string): boolean {
  *
  * Removing bad clan tags won't hurt existing clans nor cause desyncs:
  * - full name including clan tag was overwritten in the past, if any part of name was bad
- * - only each seperate local player name with a profane clan tag will remain, no clan team assignment
+ * - only each separate local player name with a profane clan tag will remain, no clan team assignment
  *
  * Examples:
  * - "GoodName" -> "GoodName"

--- a/tests/AllianceRequestExecution.test.ts
+++ b/tests/AllianceRequestExecution.test.ts
@@ -87,7 +87,7 @@ describe("AllianceRequestExecution", () => {
     expect(player1.outgoingAllianceRequests().length).toBe(1);
     expect(player2.incomingAllianceRequests().length).toBe(1);
 
-    // Player 1 Builds a silo & launches a missle at player 2.
+    // Player 1 Builds a silo & launches a missile at player 2.
     constructionExecution(game, player1, 0, 0, UnitType.MissileSilo);
     game.addExecution(
       new NukeExecution(UnitType.AtomBomb, player1, game.ref(0, 1), null),

--- a/tests/MissileSilo.test.ts
+++ b/tests/MissileSilo.test.ts
@@ -74,7 +74,7 @@ describe("MissileSilo", () => {
 
   test("missilesilo should cooldown as long as configured", async () => {
     expect(attacker.units(UnitType.MissileSilo)[0].isInCooldown()).toBeFalsy();
-    // send the nuke far enough away so it doesnt destroy the silo
+    // send the nuke far enough away so it doesn't destroy the silo
     attackerBuildsNuke(null, game.ref(50, 50));
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(1);
 

--- a/tests/client/graphics/UILayer.test.ts
+++ b/tests/client/graphics/UILayer.test.ts
@@ -70,12 +70,12 @@ describe("UILayer", () => {
     ui.drawHealthBar(unit);
     expect(ui["allHealthBars"].has(1)).toBe(true);
 
-    // a full hp unit doesnt have a health bar
+    // a full hp unit doesn't have a health bar
     unit.health = () => 10;
     ui.drawHealthBar(unit);
     expect(ui["allHealthBars"].has(1)).toBe(false);
 
-    // a dead unit doesnt have a health bar
+    // a dead unit doesn't have a health bar
     unit.health = () => 5;
     ui.drawHealthBar(unit);
     expect(ui["allHealthBars"].has(1)).toBe(true);
@@ -98,7 +98,7 @@ describe("UILayer", () => {
     ui.drawHealthBar(unit);
     expect(ui["allHealthBars"].has(1)).toBe(true);
 
-    // an inactive unit doesnt have a health bar
+    // an inactive unit doesn't have a health bar
     unit.isActive = () => false;
     ui.drawHealthBar(unit);
     expect(ui["allHealthBars"].has(1)).toBe(false);


### PR DESCRIPTION
## Summary
- fix obvious spelling typos flagged by codespell across docs, tests, comments
- no functional changes

## Testing
- pre-commit hooks (eslint/prettier) ran during commit