### PR TITLE
Load env vars before server config init

### DIFF
--- a/src/server/Server.ts
+++ b/src/server/Server.ts
@@ -6,9 +6,9 @@ import { Cloudflare, TunnelConfig } from "./Cloudflare";
 import { startMaster } from "./Master";
 import { startWorker } from "./Worker";
 
-const config = getServerConfigFromServer();
-
+// Load environment variables before we read configuration values derived from them.
 dotenv.config();
+const config = getServerConfigFromServer();
 
 // Main entry point of the application
 async function main() {


### PR DESCRIPTION
## Summary
- load dotenv before constructing the server config so .env values are available
- avoid misconfigured tunnels/host metadata when env vars were previously undefined

## Testing
- npm test -- --runInBand