### PR TITLE
bugfix: singleplayer not starting

### DIFF
--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -41,16 +41,25 @@ export class LocalServer {
   private turnStartTime = 0;
 
   private turnCheckInterval: NodeJS.Timeout;
+  private clientConnect: () => void;
+  private clientMessage: (message: ServerMessage) => void;
 
   constructor(
     private lobbyConfig: LobbyConfig,
-    private clientConnect: () => void,
-    private clientMessage: (message: ServerMessage) => void,
     private isReplay: boolean,
     private eventBus: EventBus,
   ) {}
 
+  public updateCallback(
+    clientConnect: () => void,
+    clientMessage: (message: ServerMessage) => void,
+  ) {
+    this.clientConnect = clientConnect;
+    this.clientMessage = clientMessage;
+  }
+
   start() {
+    console.log("local server starting");
     this.turnCheckInterval = setInterval(() => {
       const turnIntervalMs =
         this.lobbyConfig.serverConfig.turnIntervalMs() *
@@ -97,6 +106,14 @@ export class LocalServer {
   }
 
   onMessage(clientMsg: ClientMessage) {
+    if (clientMsg.type === "rejoin") {
+      this.clientMessage({
+        type: "start",
+        gameStartInfo: this.lobbyConfig.gameStartInfo!,
+        turns: this.turns,
+        lobbyCreatedAt: this.lobbyConfig.gameStartInfo!.lobbyCreatedAt,
+      } satisfies ServerStartGameMessage);
+    }
     if (clientMsg.type === "intent") {
       if (this.lobbyConfig.gameRecord) {
         // If we are replaying a game, we don't want to process intents

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -292,8 +292,12 @@ export class Transport {
     onconnect: () => void,
     onmessage: (message: ServerMessage) => void,
   ) {
-    this.onconnect = onconnect;
-    this.onmessage = onmessage;
+    if (this.isLocal) {
+      this.localServer.updateCallback(onconnect, onmessage);
+    } else {
+      this.onconnect = onconnect;
+      this.onmessage = onmessage;
+    }
   }
 
   private connectLocal(
@@ -302,11 +306,10 @@ export class Transport {
   ) {
     this.localServer = new LocalServer(
       this.lobbyConfig,
-      onconnect,
-      onmessage,
       this.lobbyConfig.gameRecord !== undefined,
       this.eventBus,
     );
+    this.localServer.updateCallback(onconnect, onmessage);
     this.localServer.start();
   }
 


### PR DESCRIPTION
#075c232 introduced a bug that prevented singplayer games from starting.

The `updateCallback` was not set for localserver, and local server didn't send a start message when client sent a "rejoin".

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
