### PR TITLE
Add map-generator --maps flag to process a subset of maps

### DIFF
--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -17,6 +17,16 @@ This is a tool to generate map files for OpenFront.
 5. Run the generator: `go run .`
 6. Find the output folder at `../resources/maps/<map_name>`
 
+By default, this will process all defined maps.
+
+Use `--maps` to process a single map:
+
+`go run . --maps=fourislands`
+
+To process a subset of maps, pass a comma-separated list:
+
+`go run . --maps=northamerica,world`
+
 ## Create image.png
 
 1. [Download world map (warning very large file)](https://drive.google.com/file/d/1W2oMPj1L5zWRyPhh8LfmnY3_kve-FBR2/view?usp=sharing)

--- a/map-generator/main.go
+++ b/map-generator/main.go
@@ -2,12 +2,16 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 )
+
+var mapsFlag string
 
 var maps = []struct {
 	Name   string
@@ -162,13 +166,41 @@ func processMap(name string, isTest bool) error {
 	return nil
 }
 
+func parseMapsFlag() (map[string]bool, error) {
+	if mapsFlag == "" {
+		return nil, nil
+	}
+
+	validNames := make(map[string]bool, len(maps))
+	for _, m := range maps {
+		validNames[m.Name] = true
+	}
+
+	selected := make(map[string]bool)
+	for _, name := range strings.Split(mapsFlag, ",") {
+		if !validNames[name] {
+			return nil, fmt.Errorf("map %q is not defined", name)
+		}
+		selected[name] = true
+	}
+	return selected, nil
+}
+
 func loadTerrainMaps() error {
+	selectedMaps, err := parseMapsFlag()
+	if err != nil {
+		return err
+	}
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(maps))
 
 	// Process maps concurrently
 	for _, mapItem := range maps {
+		if selectedMaps != nil && !selectedMaps[mapItem.Name] {
+			continue
+		}
 		wg.Add(1)
+		mapItem := mapItem
 		go func() {
 			defer wg.Done()
 			if err := processMap(mapItem.Name, mapItem.IsTest); err != nil {
@@ -192,6 +224,9 @@ func loadTerrainMaps() error {
 }
 
 func main() {
+	flag.StringVar(&mapsFlag, "maps", "", "optional comma-separated list of maps to process. ex: --maps=world,eastasia,big_plains")
+	flag.Parse()
+
 	if err := loadTerrainMaps(); err != nil {
 		log.Fatalf("Error generating terrain maps: %v", err)
 	}


### PR DESCRIPTION
Resolves #2594

## Description:

- Added an optional `--maps` flag to the map-generator that allows passing a subset of maps to process.
- Updated `README.md` w/ documentation for using the new flag

Used the [go/flag](https://pkg.go.dev/flag) package.

Running without the flag, or with no arguments matches existing behavior of processing all the maps defined in `main.go`

`go run .`
`go run . --maps=`

New behavior is triggered to process a subset of maps by passing the `--maps` flag.  Multiple maps are defined in a comma-separated list

`go run . --maps=world,africa`

Or a single map (useful for map development)

`go run . --maps=fourislands`

If an invalid map is passed, the process aborts and renders the error

```bash
go run . --maps=invalidmapname
Error generating terrain maps: map "invalidmapname" is not defined
exit status 1
```

By using the default flag package, we get `--help` for free:

```bash
go run . --help
Usage of <path-to-exe>/exe/map-generator:
  -maps string
    	optional comma-separated list of maps to process. ex: --maps=world,eastasia,big_plains
```

I do not write GO often.  Gemini contributed to this syntax.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tidwell
