### PR TITLE
Fixed events panel scroll position not staying at the bottom 🛠️

### DIFF
--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -100,7 +100,7 @@ export class EventsDisplay extends LitElement implements Layer {
   ]);
 
   @query(".events-container")
-  private _eventsContainer: HTMLDivElement;
+  private _eventsContainer?: HTMLDivElement;
   private _shouldScrollToBottom = true;
 
   updated(changed: Map<string, unknown>) {


### PR DESCRIPTION
## Description:

Common issue reported by several people (many times by Enzo) now finally fixed.
If you scroll to the bottom of the events panel the scroll position now always stays there.
This behavior was previously implemented with CSS only, which apparently did not work properly. Now we use javascript.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
