### PR TITLE
Fix: GulfOfStLawrence map name not being translated

### DIFF
--- a/src/client/PublicLobby.ts
+++ b/src/client/PublicLobby.ts
@@ -191,7 +191,7 @@ export class PublicLobby extends LitElement {
                 : ""}
               <span
                 >${translateText(
-                  `map.${lobby.gameConfig.gameMap.toLowerCase().replace(/\s+/g, "")}`,
+                  `map.${lobby.gameConfig.gameMap.toLowerCase().replace(/[\s.]+/g, "")}`,
                 )}</span
               >
             </div>


### PR DESCRIPTION
## Description:
The map name was not translated because it contained a . character, which caused the translation key to break.

To prevent this issue, the map name handling now strips . characters when generating translation keys.
With this change, maps that include . in their names will no longer cause translation issues in the future.

Before fix:
<img width="538" height="284" alt="スクリーンショット 2025-12-14 14 26 02" src="https://github.com/user-attachments/assets/a683e3de-09df-4b43-8077-4a00bd5f1272" />

After fix:
<img width="494" height="176" alt="スクリーンショット 2025-12-14 14 27 19" src="https://github.com/user-attachments/assets/f9d27e16-de70-4c43-af31-aaa30287e5cd" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri