### PR TITLE
Rebalance nation configs, they are getting too strong to beat 📊

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -828,7 +828,7 @@ export class DefaultConfig implements Config {
         case Difficulty.Easy:
           return 18_750 * strength;
         case Difficulty.Medium:
-          return 25_000 * strength;
+          return 25_000 * strength; // Like humans
         case Difficulty.Hard:
           return 31_250 * strength;
         case Difficulty.Impossible:
@@ -861,7 +861,7 @@ export class DefaultConfig implements Config {
       case Difficulty.Easy:
         return maxTroops * 0.75;
       case Difficulty.Medium:
-        return maxTroops * 1;
+        return maxTroops * 1; // Like humans
       case Difficulty.Hard:
         return maxTroops * 1.25;
       case Difficulty.Impossible:
@@ -887,7 +887,7 @@ export class DefaultConfig implements Config {
           toAdd *= 0.95;
           break;
         case Difficulty.Medium:
-          toAdd *= 1;
+          toAdd *= 1; // Like humans
           break;
         case Difficulty.Hard:
           toAdd *= 1.05;


### PR DESCRIPTION
Resolves #2599

## Description:

For example in #2599 we can see people already struggling with the higher difficulties.

With my PR #2606 (nation alliance request logic), an alliance request towards an impossible difficulty nation will probably always get rejected. They have `maxTroops * 2`, and because humans have much less troops, the nation of course won't want to ally with them (unless the human somehow manages to get a similar troop count).

This makes them even harder to beat.

So I tuned the `maxTroops`, `troopIncreaseRate` and `startManpower` configs towards the setting for humans, following the goal to make difficulties impact the **SMARTNESS** of nations, instead of just their troop count configs (more varied gameplay 😊).

The biggest change is in `startManpower`. I thought it was weird that easy nations started with much less troops than a bot (2_500 vs 10_000).

Look at this screenshot, a couple of seconds into the game. Bots were bigger than nations. 💀 Turkey in the bottom right corner...

<img width="1536" height="1045" alt="Screenshot 2025-12-14 180823" src="https://github.com/user-attachments/assets/d219e6ce-b579-4b7e-a8bb-effa339507bf" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
