### PR TITLE
Christmas Themed Homepage 2

### DIFF
--- a/src/client/components/Maps.ts
+++ b/src/client/components/Maps.ts
@@ -78,8 +78,8 @@ export class MapDisplay extends LitElement {
     }
 
     .option-card.selected {
-      border-color: #4a9eff;
-      background: rgba(74, 158, 255, 0.1);
+      border-color: var(--primaryColor);
+      background: rgba(229, 57, 53, 0.1);
     }
 
     .option-card-title {


### PR DESCRIPTION
## Description:

A small fix for https://github.com/openfrontio/OpenFrontIO/pull/2608. Give the map buttons in the private lobby and single player modal the same red border and background as the buttons below them.

Before:
<img width="551" height="592" alt="image" src="https://github.com/user-attachments/assets/cd6087ab-d74d-48d7-8093-d4a39fb2e30f" />

After:
<img width="263" height="192" alt="image" src="https://github.com/user-attachments/assets/f47da143-6efd-43f5-b586-d46e6b6df96a" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
