### PR TITLE
Hotfix: Max troops instead of troops for team stats 📊

### DIFF
--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -134,45 +134,45 @@ export class TeamStats extends LitElement implements Layer {
         >
           <!-- Header -->
           <div class="contents font-bold bg-slate-700/50">
-            <div class="py-1.5 md:py-2.5 text-center border-b border-slate-500">
+            <div class="p-1.5 md:p-2.5 text-center border-b border-slate-500">
               ${translateText("leaderboard.team")}
             </div>
             ${this.showUnits
               ? html`
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.launchers")}
                   </div>
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.sams")}
                   </div>
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.warships")}
                   </div>
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.cities")}
                   </div>
                 `
               : html`
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.owned")}
                   </div>
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.gold")}
                   </div>
                   <div
-                    class="py-1.5 md:py-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
                   >
                     ${translateText("leaderboard.maxtroops")}
                   </div>


### PR DESCRIPTION
## Description:

Missing i18n key because I forgot to add maxTroops to the team leaderboard...
I completely forgot that troops are also shown on the team leaderboard

Before:

<img width="905" height="309" alt="Screenshot 2025-12-17 022043" src="https://github.com/user-attachments/assets/c2f95c0b-86a5-4447-bbfc-1925d70005f6" />

After:

<img width="778" height="309" alt="Screenshot 2025-12-17 025028" src="https://github.com/user-attachments/assets/fe6c968a-7867-4be9-8ee1-65f2baa26190" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
