### PR TITLE
Fix: show 0 Nations in Lobby Team Preview when disableNPCs is true

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -556,7 +556,7 @@ export class HostLobbyModal extends LitElement {
                 : translateText("host_modal.players")
             }
             <span style="margin: 0 8px;">•</span>
-            ${this.nationCount}
+            ${this.disableNPCs ? 0 : this.nationCount}
             ${
               this.nationCount === 1
                 ? translateText("host_modal.nation_player")


### PR DESCRIPTION
## Description:

Fix for v28: show 0 Nations in Lobby Team Preview when disableNPCs is true. Lobby Team Preview displays the number of Nations on a map, but should diplay "0 Nations" in this case.

After fix:
<img width="1067" height="737" alt="image" src="https://github.com/user-attachments/assets/d89ede3f-e1ca-4614-bf8a-36ad564bf3d2" />

<img width="1072" height="737" alt="image" src="https://github.com/user-attachments/assets/b2b068fd-b0d1-49a8-b284-e64e479f4bab" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
