### PR TITLE
Fix auth: preserve localStorage persistentID on network errors

### DIFF
--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -155,7 +155,8 @@ async function refreshJwt(): Promise<void> {
     __jwt = jwt;
   } catch (e) {
     console.error("Refresh failed", e);
-    logOut();
+    // if server unreachable, just clear jwt
+    __jwt = null;
     return;
   }
 }


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #(issue number)

## Description:

When refreshJwt() fails due to network errors (auth server unreachable), only clear __jwt instead of calling logOut(). This preserves the player_persistent_id in localStorage for dev mode fallback.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

furo18