### PR TITLE
Feat: Add cost to ghost structure icon when using keyboard shortcuts

### DIFF
--- a/src/client/graphics/layers/StructureDrawingUtils.ts
+++ b/src/client/graphics/layers/StructureDrawingUtils.ts
@@ -147,13 +147,7 @@ export class SpriteFactory {
 
     const priceBg = new PIXI.Graphics();
     priceBg
-      .roundRect(
-        -boxWidth / 2,
-        boxY - boxHeight / 2,
-        boxWidth,
-        boxHeight,
-        4,
-      )
+      .roundRect(-boxWidth / 2, boxY - boxHeight / 2, boxWidth, boxHeight, 4)
       .fill({ color: 0x000000, alpha: 0.65 });
 
     priceText.position.set(0, boxY);

--- a/src/client/graphics/layers/StructureIconsLayer.ts
+++ b/src/client/graphics/layers/StructureIconsLayer.ts
@@ -25,10 +25,10 @@ import {
   BuildUnitIntentEvent,
   SendUpgradeStructureIntentEvent,
 } from "../../Transport";
+import { renderNumber } from "../../Utils";
 import { TransformHandler } from "../TransformHandler";
 import { UIState } from "../UIState";
 import { Layer } from "./Layer";
-import { renderNumber } from "../../Utils";
 import {
   DOTS_ZOOM_THRESHOLD,
   ICON_SCALE_FACTOR_ZOOMED_IN,


### PR DESCRIPTION
## Description:

Introduces a dynamic textbox under the cursor and populates it with price when a keyboard hotkey is pressed. Prices update correctly based on current value of the structure or strike being purchased, even if the value is 0 (during `Infinite Gold` mode). Price value updates live even if the price box is currently being shown (for example, when voluntarily removing a structure causes the price to change. See video below).

### Video Demo 

https://github.com/user-attachments/assets/3f974268-c14b-4129-9629-5a0f7db8b30c


The more in depth demo was too big for GitHub, but I uploaded it on the Discord
https://discord.com/channels/1284581928254701718/1447907175522504704/1451483322260914297

### Live price updates on tooltip

https://github.com/user-attachments/assets/0d98739c-6f24-4fcd-a047-cc304e7e86aa

### Works with `Infinite Gold` mode

https://github.com/user-attachments/assets/25bd2919-77cd-4735-8c3f-043306f53b8f




## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

bijx
