### PR TITLE
Fix: Optimize nation random boat targeting by skipping unreachable players 🚢

### DIFF
--- a/src/core/execution/NationExecution.ts
+++ b/src/core/execution/NationExecution.ts
@@ -15,6 +15,7 @@ import {
   UnitType,
 } from "../game/Game";
 import { TileRef, euclDistFN } from "../game/GameMap";
+import { canBuildTransportShip } from "../game/TransportShipUtils";
 import { PseudoRandom } from "../PseudoRandom";
 import { GameID } from "../Schemas";
 import { boundingBoxTiles, calculateBoundingBox, simpleHash } from "../Util";
@@ -529,6 +530,7 @@ export class NationExecution implements Execution {
     if (this.player === null) throw new Error("not initialized");
     const x = this.mg.x(tile);
     const y = this.mg.y(tile);
+    const unreachablePlayers = new Set<PlayerID>();
     for (let i = 0; i < 500; i++) {
       const randX = this.random.nextInt(x - 150, x + 150);
       const randY = this.random.nextInt(y - 150, y + 150);
@@ -543,6 +545,10 @@ export class NationExecution implements Execution {
       if (owner === this.player) {
         continue;
       }
+      // Skip players we already know are unreachable (Performance optimization)
+      if (owner.isPlayer() && unreachablePlayers.has(owner.id())) {
+        continue;
+      }
       // Don't send boats to players with which we share a border, that usually looks stupid
       if (owner.isPlayer() && borderingEnemies.includes(owner)) {
         continue;
@@ -551,17 +557,28 @@ export class NationExecution implements Execution {
       if (owner.isPlayer() && owner.troops() > this.player.troops() * 2) {
         continue;
       }
-      // High-interest targeting: prioritize unowned tiles or tiles owned by bots
+
+      let matchesCriteria = false;
       if (highInterestOnly) {
-        if (!owner.isPlayer() || owner.type() === PlayerType.Bot) {
-          return randTile;
-        }
+        // High-interest targeting: prioritize unowned tiles or tiles owned by bots
+        matchesCriteria = !owner.isPlayer() || owner.type() === PlayerType.Bot;
       } else {
         // Normal targeting: return unowned tiles or tiles owned by non-friendly players
-        if (!owner.isPlayer() || !owner.isFriendly(this.player)) {
-          return randTile;
-        }
+        matchesCriteria = !owner.isPlayer() || !owner.isFriendly(this.player);
       }
+      if (!matchesCriteria) {
+        continue;
+      }
+
+      // Validate that we can actually build a transport ship to this target
+      if (canBuildTransportShip(this.mg, this.player, randTile) === false) {
+        if (owner.isPlayer()) {
+          unreachablePlayers.add(owner.id());
+        }
+        continue;
+      }
+
+      return randTile;
     }
     return null;
   }


### PR DESCRIPTION
## Description:

Saw lots of `"cannot send ship to Player"` warnings in the console.
It was caused by `randomBoatTarget` not checking if the target is reachable by boat.
It also caused the for loop in `randomBoatTarget` to exit too early (=> no boat sent).
So I added a `canBuildTransportShip` check. Because this runs expensive (?) pathfinding I added a `unreachablePlayers` Set to optimize performance.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin