### PR TITLE
Change public game difficulty to Easy 📊

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -93,7 +93,7 @@ export class MapPlaylist {
       maxPlayers: config.lobbyMaxPlayers(map, mode, playerTeams),
       gameType: GameType.Public,
       gameMapSize: GameMapSize.Normal,
-      difficulty: Difficulty.Medium,
+      difficulty: Difficulty.Easy,
       infiniteGold: false,
       infiniteTroops: false,
       maxTimerValue: undefined,


### PR DESCRIPTION
## Description:

Multiple people in the game-feedback dc channel are complaining that nations are too strong. To make the FFAs feel more like `PvP` instead of `PvPvE`, switch to the easy difficulty. 

Unlike humans, the easy nations cannot execute parallel bot attacks at all, making them expand much slower.
Also their `maxTroops`, `troopIncreaseRate` and `startManpower` configs are lower than the human ones.
They are easier to ally, etc...
And I have some dumbing-down ideas ready.

**Proposal:** We could introduce "modifiers" to public games in the future: Higher difficulty nations (for people who like PvPvE), random spawn, compact map, MIRVs disabled, ...

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin