### PR TITLE
Standardize difficulty translation keys to easy/medium/hard/impossible

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -338,10 +338,10 @@
   },
   "difficulty": {
     "difficulty": "Difficulty",
-    "Easy": "Relaxed",
-    "Medium": "Balanced",
-    "Hard": "Intense",
-    "Impossible": "Impossible"
+    "easy": "Easy",
+    "medium": "Medium",
+    "hard": "Hard",
+    "impossible": "Impossible"
   },
   "game_mode": {
     "ffa": "Free for All",

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -248,7 +248,7 @@ export class HostLobbyModal extends LitElement {
                         .difficultyKey=${key}
                       ></difficulty-display>
                       <p class="option-card-title">
-                        ${translateText(`difficulty.${key}`)}
+                        ${translateText(`difficulty.${key.toLowerCase()}`)}
                       </p>
                     </div>
                   `,

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -153,7 +153,7 @@ export class SinglePlayerModal extends LitElement {
                         .difficultyKey=${key}
                       ></difficulty-display>
                       <p class="option-card-title">
-                        ${translateText(`difficulty.${key}`)}
+                        ${translateText(`difficulty.${key.toLowerCase()}`)}
                       </p>
                     </div>
                   `,


### PR DESCRIPTION
Resolves #2673

## Description:

- This PR unifies difficulty naming by switching all difficulty identifiers to a single lowercase set of keys (`easy`, `medium`, `hard`, `impossible`) and aligning UI + translation keys (`en.json`) to match. 
- The old UI labels (`"Relaxed"`, `"Balanced"`, `"Intense"`) have been removed and replaced with the standardized difficulty terms (`Easy`, `Medium`, `Hard`).

<img width="1312" height="306" alt="image" src="https://github.com/user-attachments/assets/a59c5fae-f435-427d-b851-eef179a1e94f" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

assessin.
