### PR TITLE
Fix bots no longer attacking humans 🤖

### DIFF
--- a/src/core/execution/utils/AiAttackBehavior.ts
+++ b/src/core/execution/utils/AiAttackBehavior.ts
@@ -432,11 +432,12 @@ export class AiAttackBehavior {
   }
 
   shouldAttack(other: Player | TerraNullius): boolean {
-    // Always attack Terra Nullius, non-humans and traitors
+    // Always attack Terra Nullius, non-humans and traitors (or if we are a bot)
     if (
       other.isPlayer() === false ||
       other.type() !== PlayerType.Human ||
-      other.isTraitor()
+      other.isTraitor() ||
+      this.player.type() === PlayerType.Bot
     ) {
       return true;
     }


### PR DESCRIPTION
## Description:

A small number of people are complaining that bots no longer attack them and that "This has broken the factory farming strat".
In the old #2550 I somehow added that bots on easy difficulty don't attack humans and nations anymore. 
And public games are on easy difficulty now.
But I think the difficulty should actually only change nation behavior, not bot behavior. Their attacks are harmless anyways.
So lets remove that little check.
Also let `shouldAttack()` return true for bots.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin