### PR TITLE
Fix bots no longer attacking humans 🤖 For v28

### DIFF
--- a/src/core/execution/utils/BotBehavior.ts
+++ b/src/core/execution/utils/BotBehavior.ts
@@ -44,13 +44,14 @@ export class BotBehavior {
     this.game.addExecution(new EmojiExecution(this.player, player.id(), emoji));
   }
 
-  // Prevent attacking of humans on lower difficulties
+  // Prevent attacking of humans on lower difficulties (or if we are a bot)
   private shouldAttack(other: Player | TerraNullius): boolean {
     // Always attack Terra Nullius, non-humans and traitors
     if (
       other.isPlayer() === false ||
       other.type() !== PlayerType.Human ||
-      other.isTraitor()
+      other.isTraitor() ||
+      this.player.type() === PlayerType.Bot
     ) {
       return true;
     }
@@ -374,7 +375,6 @@ export class BotBehavior {
     }
 
     // Choose a new enemy randomly
-    const { difficulty } = this.game.config().gameConfig();
     const neighbors = this.player.neighbors();
     for (const neighbor of this.random.shuffleArray(neighbors)) {
       if (!neighbor.isPlayer()) continue;
@@ -383,7 +383,7 @@ export class BotBehavior {
         neighbor.type() === PlayerType.FakeHuman ||
         neighbor.type() === PlayerType.Human
       ) {
-        if (this.random.chance(2) || difficulty === Difficulty.Easy) {
+        if (this.random.chance(2)) {
           continue;
         }
       }


### PR DESCRIPTION
## Description:

A small number of people are complaining that bots no longer attack them and that "This has broken the factory farming strat".
In the old #2550 I somehow added that bots on easy difficulty don't attack humans and nations anymore. 
And public games are on easy difficulty now.
But I think the difficulty should actually only change nation behavior, not bot behavior. Their attacks are harmless anyways.
So lets remove that little check.
Also let `shouldAttack()` return true for bots.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin