### PR TITLE
make TerrainLayer opaque (alpha:false) 

### DIFF
--- a/src/client/graphics/layers/TerrainLayer.ts
+++ b/src/client/graphics/layers/TerrainLayer.ts
@@ -32,7 +32,7 @@ export class TerrainLayer implements Layer {
     this.canvas.width = this.game.width();
     this.canvas.height = this.game.height();
 
-    const context = this.canvas.getContext("2d");
+    const context = this.canvas.getContext("2d", { alpha: false });
     if (context === null) throw new Error("2d context not supported");
     this.context = context;
 
@@ -55,7 +55,7 @@ export class TerrainLayer implements Layer {
       this.imageData.data[offset] = terrainColor.rgba.r;
       this.imageData.data[offset + 1] = terrainColor.rgba.g;
       this.imageData.data[offset + 2] = terrainColor.rgba.b;
-      this.imageData.data[offset + 3] = (terrainColor.rgba.a * 255) | 0;
+      this.imageData.data[offset + 3] = 255;
     });
   }
 


### PR DESCRIPTION
## Description:

Make the terrain backing canvas explicitly opaque by requesting a 2D context with alpha: false.
Remove confusing latent alpha support in TerrainLayer

Current themes always generate opaque terrain colors, but the code previously looked like it supported per-tile alpha (via terrainColor.rgba.a), which is misleading.
Being explicit about opacity can avoid unnecessary alpha compositing work and clarifies intent.

No visual change expected with current themes (terrain was already effectively opaque).

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
