### PR TITLE
Update map-generator readme (output files & tile count)

### DIFF
--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -113,11 +113,15 @@ Using the `name` from your json:
 
 ## Notes
 
-- Maps with over 3 million land tiles are not recommended for performance reasons.
-- Average land tile count is around 1 - 2 million.
 - Islands smaller than 30 tiles (pixels) are automatically removed by the script.
 - Bodies of water smaller than 200 tiles (pixels) are also removed.
 - The map generator normalizes dimensions to multiples of 4. Any pixels beyond `Width - (Width % 4)` or `Height - (Height % 4)` are cropped.
+
+For Performance Reasons:
+
+- Maps should be between 2 - 3 million pixels square (area).
+- Maps with over 3 million land tiles are not recommended.
+- Average land tile count is around 1 - 2 million.
 
 ## 🛠️ Development Tools
 


### PR DESCRIPTION
## Description:

- clarify the map generator readme size recommendation is for land tile count, not px size (and that it is for performance, not a hard limit).  Add note about average map land tile count to provide more context.
- Add output files list to provide reference for where to find land tile count (for some reason the script doesn't output it, will probably open a new PR to add it to the output of the generator)

I must have missed some context when first documenting this, oops!

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tidwell
