### PR TITLE
uniformed HeadsUpMessage text

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -743,9 +743,7 @@
   },
   "heads_up_message": {
     "choose_spawn": "Choose a starting location",
-    "random_spawn": "Random spawn is enabled. Selecting starting location for you..."
-  },
-  "pause": {
+    "random_spawn": "Random spawn is enabled. Selecting starting location for you...",
     "singleplayer_game_paused": "Game paused",
     "multiplayer_game_paused": "Game paused by Lobby Creator"
   },

--- a/src/client/graphics/layers/HeadsUpMessage.ts
+++ b/src/client/graphics/layers/HeadsUpMessage.ts
@@ -39,9 +39,9 @@ export class HeadsUpMessage extends LitElement implements Layer {
   private getMessage(): string {
     if (this.isPaused) {
       if (this.game.config().gameConfig().gameType === GameType.Singleplayer) {
-        return translateText("pause.singleplayer_game_paused");
+        return translateText("heads_up_message.singleplayer_game_paused");
       } else {
-        return translateText("pause.multiplayer_game_paused");
+        return translateText("heads_up_message.multiplayer_game_paused");
       }
     }
     return this.game.config().isRandomSpawn()


### PR DESCRIPTION
## Description:

Moves pause-related translation keys from their own object into ```heads_up_message``` to keep all heads-up message text in one place.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

furo18
