### PR TITLE
Add dev feature flags to disable external services during local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,7 @@ resources/.DS_Store
 .clinic/
 CLAUDE.md
 .idea/
+.claude/
+
+# Local configuration
+config.json

--- a/config.example.json
+++ b/config.example.json
@@ -1,0 +1,8 @@
+{
+  "features": {
+    "analytics": false,
+    "publicLobbies": false,
+    "cloudflare": false,
+    "ads": false
+  }
+}

--- a/src/client/DevConfig.ts
+++ b/src/client/DevConfig.ts
@@ -1,0 +1,83 @@
+// Development configuration for disabling external services
+// Create a config.json in the project root to override these defaults
+
+export interface DevFeatureConfig {
+  features: {
+    analytics: boolean;
+    publicLobbies: boolean;
+    cloudflare: boolean;
+    ads: boolean;
+  };
+}
+
+const defaultConfig: DevFeatureConfig = {
+  features: {
+    analytics: true,
+    publicLobbies: true,
+    cloudflare: true,
+    ads: true,
+  },
+};
+
+let cachedConfig: DevFeatureConfig | null = null;
+
+/**
+ * Load development configuration from config.json
+ * Falls back to default config if file doesn't exist
+ */
+async function loadConfig(): Promise<DevFeatureConfig> {
+  try {
+    const response = await fetch("/config.json");
+    if (response.ok) {
+      const config = await response.json();
+
+      // Validate basic structure
+      if (
+        !config ||
+        typeof config !== "object" ||
+        (config.features && typeof config.features !== "object")
+      ) {
+        console.warn("Invalid config.json structure, using defaults");
+        cachedConfig = defaultConfig;
+        return defaultConfig;
+      }
+
+      const mergedConfig: DevFeatureConfig = {
+        features: { ...defaultConfig.features, ...config.features },
+      };
+      cachedConfig = mergedConfig;
+      return mergedConfig;
+    }
+  } catch {
+    // config.json not found, use defaults
+  }
+
+  cachedConfig = defaultConfig;
+  return defaultConfig;
+}
+
+// Auto-load config at module initialization
+const configPromise: Promise<DevFeatureConfig> = loadConfig();
+
+/**
+ * Wait for dev config to be loaded (use in async contexts)
+ */
+export async function waitForDevConfig(): Promise<DevFeatureConfig> {
+  return configPromise;
+}
+
+/**
+ * Get configuration synchronously (may return defaults if not yet loaded)
+ */
+export function getDevConfig(): DevFeatureConfig {
+  return cachedConfig ?? defaultConfig;
+}
+
+/**
+ * Check if a feature is enabled
+ */
+export function isDevFeatureEnabled(
+  feature: keyof DevFeatureConfig["features"],
+): boolean {
+  return getDevConfig().features[feature];
+}

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -15,6 +15,7 @@ import { fetchCosmetics } from "./Cosmetics";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import "./DarkModeButton";
 import { DarkModeButton } from "./DarkModeButton";
+import { isDevFeatureEnabled, waitForDevConfig } from "./DevConfig";
 import "./FlagInput";
 import { FlagInput } from "./FlagInput";
 import { FlagInputModal } from "./FlagInputModal";
@@ -118,9 +119,13 @@ class Client {
 
   async initialize(): Promise<void> {
     crazyGamesSDK.maybeInit();
+    // Load dev config to set up feature flags
+    await waitForDevConfig();
     // Prefetch turnstile token so it is available when
-    // the user joins a lobby.
-    this.turnstileTokenPromise = getTurnstileToken();
+    // the user joins a lobby (skip if cloudflare is disabled).
+    if (isDevFeatureEnabled("cloudflare")) {
+      this.turnstileTokenPromise = getTurnstileToken();
+    }
 
     const gameVersion = document.getElementById(
       "game-version",

--- a/src/client/PublicLobby.ts
+++ b/src/client/PublicLobby.ts
@@ -11,6 +11,7 @@ import {
 } from "../core/game/Game";
 import { GameID, GameInfo } from "../core/Schemas";
 import { generateID } from "../core/Util";
+import { isDevFeatureEnabled } from "./DevConfig";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 
@@ -35,6 +36,16 @@ export class PublicLobby extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    // Skip fetching public lobbies if disabled in dev config
+    // Check window.__devConfig first (set synchronously in index.html),
+    // then fall back to async-loaded config
+    const devConfig = (window as any).__devConfig;
+    if (devConfig?.features?.publicLobbies === false) {
+      return;
+    }
+    if (!isDevFeatureEnabled("publicLobbies")) {
+      return;
+    }
     this.fetchAndUpdateLobbies();
     this.lobbiesInterval = window.setInterval(
       () => this.fetchAndUpdateLobbies(),

--- a/src/client/index.html
+++ b/src/client/index.html
@@ -136,54 +136,77 @@
       async
     ></script>
 
-    <!-- Cloudflare Turnstile -->
-    <script
-      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
-      async
-      defer
-    ></script>
-
-    <!-- Publift/Fuse ads -->
-    <script
-      async
-      src="https://cdn.fuseplatform.net/publift/tags/2/4121/fuse.js"
-    ></script>
-
+    <!-- Dev config check - blocks external scripts in dev mode -->
     <script>
-      window.googletag = window.googletag || { cmd: [] };
-      googletag.cmd.push(function () {
-        googletag.pubads().set("page_url", "http://openfront.io ");
-      });
+      (function () {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", "/config.json", false); // Synchronous request
+        try {
+          xhr.send();
+          if (xhr.status === 200) {
+            window.__devConfig = JSON.parse(xhr.responseText);
+          }
+        } catch (e) {
+          // No config.json, use production defaults
+        }
+      })();
     </script>
 
-    <!-- Analytics -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=AW-16702609763"
-    ></script>
+    <!-- Cloudflare Turnstile (conditionally loaded) -->
     <script>
-      window.dataLayer = window.dataLayer || [];
-
-      function gtag() {
-        dataLayer.push(arguments);
+      if (
+        !window.__devConfig ||
+        window.__devConfig.features?.cloudflare !== false
+      ) {
+        var s = document.createElement("script");
+        s.src = "https://challenges.cloudflare.com/turnstile/v0/api.js";
+        s.async = true;
+        s.defer = true;
+        document.head.appendChild(s);
       }
-
-      gtag("js", new Date());
-      gtag("config", "AW-16702609763");
     </script>
-    <!-- Google tag (gtag.js) -->
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-WQGQQ8RDN4"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag() {
-        dataLayer.push(arguments);
-      }
-      gtag("js", new Date());
 
-      gtag("config", "G-WQGQQ8RDN4");
+    <!-- Publift/Fuse ads (conditionally loaded) -->
+    <script>
+      if (!window.__devConfig || window.__devConfig.features?.ads !== false) {
+        var s = document.createElement("script");
+        s.src = "https://cdn.fuseplatform.net/publift/tags/2/4121/fuse.js";
+        s.async = true;
+        document.head.appendChild(s);
+
+        window.googletag = window.googletag || { cmd: [] };
+        googletag.cmd.push(function () {
+          googletag.pubads().set("page_url", "https://openfront.io");
+        });
+      }
+    </script>
+
+    <!-- Analytics (conditionally loaded) -->
+    <script>
+      if (
+        !window.__devConfig ||
+        window.__devConfig.features?.analytics !== false
+      ) {
+        // Google Ads
+        var s1 = document.createElement("script");
+        s1.src = "https://www.googletagmanager.com/gtag/js?id=AW-16702609763";
+        s1.async = true;
+        document.head.appendChild(s1);
+
+        // Google Analytics
+        var s2 = document.createElement("script");
+        s2.src = "https://www.googletagmanager.com/gtag/js?id=G-WQGQQ8RDN4";
+        s2.async = true;
+        document.head.appendChild(s2);
+
+        window.dataLayer = window.dataLayer || [];
+        function gtag() {
+          dataLayer.push(arguments);
+        }
+        gtag("js", new Date());
+        gtag("config", "AW-16702609763");
+        gtag("config", "G-WQGQQ8RDN4");
+      }
     </script>
   </head>
 
@@ -505,11 +528,18 @@
       });
     </script>
 
-    <!-- Analytics -->
-    <script
-      defer
-      src="https://static.cloudflareinsights.com/beacon.min.js"
-      data-cf-beacon='{"token": "03d93e6fefb349c28ee69b408fa25a13"}'
-    ></script>
+    <!-- Cloudflare Analytics (conditionally loaded) -->
+    <script>
+      if (
+        !window.__devConfig ||
+        window.__devConfig.features?.analytics !== false
+      ) {
+        var s = document.createElement("script");
+        s.src = "https://static.cloudflareinsights.com/beacon.min.js";
+        s.defer = true;
+        s.dataset.cfBeacon = '{"token": "03d93e6fefb349c28ee69b408fa25a13"}';
+        document.body.appendChild(s);
+      }
+    </script>
   </body>
 </html>

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -142,7 +142,13 @@ export async function startMaster() {
     );
   });
 
-  const PORT = 3000;
+  const portEnv = process.env.OPENFRONT_SERVER_PORT ?? "3000";
+  const PORT = parseInt(portEnv, 10);
+  if (isNaN(PORT) || PORT < 1 || PORT > 65535) {
+    throw new Error(
+      `Invalid OPENFRONT_SERVER_PORT: "${portEnv}". Must be a number between 1 and 65535.`,
+    );
+  }
   server.listen(PORT, () => {
     log.info(`Master HTTP server listening on port ${PORT}`);
   });

--- a/tests/DevConfig.test.ts
+++ b/tests/DevConfig.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Tests for DevConfig module
+ * Tests the development feature flag configuration system
+ */
+
+// Store original fetch for restoration
+const originalFetch = global.fetch;
+
+describe("DevConfig", () => {
+  beforeEach(() => {
+    // Reset modules before each test to clear cached config
+    jest.resetModules();
+    // Reset fetch mock
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("default configuration", () => {
+    it("should have all features enabled by default", async () => {
+      // Mock fetch to simulate missing config.json (404)
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: false,
+        status: 404,
+      });
+
+      const { getDevConfig, waitForDevConfig } = await import(
+        "../src/client/DevConfig"
+      );
+      await waitForDevConfig();
+
+      const config = getDevConfig();
+      expect(config.features.analytics).toBe(true);
+      expect(config.features.publicLobbies).toBe(true);
+      expect(config.features.cloudflare).toBe(true);
+      expect(config.features.ads).toBe(true);
+    });
+  });
+
+  describe("config loading", () => {
+    it("should load and merge config from config.json", async () => {
+      const mockConfig = {
+        features: {
+          analytics: false,
+          publicLobbies: false,
+        },
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfig),
+      });
+
+      const { getDevConfig, waitForDevConfig } = await import(
+        "../src/client/DevConfig"
+      );
+      await waitForDevConfig();
+
+      const config = getDevConfig();
+      // Explicitly set values
+      expect(config.features.analytics).toBe(false);
+      expect(config.features.publicLobbies).toBe(false);
+      // Default values for unspecified features
+      expect(config.features.cloudflare).toBe(true);
+      expect(config.features.ads).toBe(true);
+    });
+
+    it("should handle fetch network errors gracefully", async () => {
+      (global.fetch as jest.Mock).mockRejectedValue(new Error("Network error"));
+
+      const { getDevConfig, waitForDevConfig } = await import(
+        "../src/client/DevConfig"
+      );
+      await waitForDevConfig();
+
+      // Should fall back to defaults
+      const config = getDevConfig();
+      expect(config.features.analytics).toBe(true);
+      expect(config.features.publicLobbies).toBe(true);
+      expect(config.features.cloudflare).toBe(true);
+      expect(config.features.ads).toBe(true);
+    });
+
+    it("should handle invalid JSON structure gracefully", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      // Invalid structure: features is not an object
+      const mockConfig = {
+        features: "invalid",
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfig),
+      });
+
+      const { getDevConfig, waitForDevConfig } = await import(
+        "../src/client/DevConfig"
+      );
+      await waitForDevConfig();
+
+      // Should fall back to defaults
+      const config = getDevConfig();
+      expect(config.features.analytics).toBe(true);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Invalid config.json structure, using defaults",
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should handle null config gracefully", async () => {
+      const consoleSpy = jest
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(null),
+      });
+
+      const { getDevConfig, waitForDevConfig } = await import(
+        "../src/client/DevConfig"
+      );
+      await waitForDevConfig();
+
+      const config = getDevConfig();
+      expect(config.features.analytics).toBe(true);
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "Invalid config.json structure, using defaults",
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("isDevFeatureEnabled", () => {
+    it("should return correct value for each feature", async () => {
+      const mockConfig = {
+        features: {
+          analytics: false,
+          publicLobbies: true,
+          cloudflare: false,
+          ads: true,
+        },
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfig),
+      });
+
+      const { isDevFeatureEnabled, waitForDevConfig } = await import(
+        "../src/client/DevConfig"
+      );
+      await waitForDevConfig();
+
+      expect(isDevFeatureEnabled("analytics")).toBe(false);
+      expect(isDevFeatureEnabled("publicLobbies")).toBe(true);
+      expect(isDevFeatureEnabled("cloudflare")).toBe(false);
+      expect(isDevFeatureEnabled("ads")).toBe(true);
+    });
+  });
+
+  describe("getDevConfig synchronous behavior", () => {
+    it("should return defaults before async config loads", async () => {
+      // Create a fetch that never resolves
+      let resolvePromise: (value: any) => void;
+      const pendingPromise = new Promise((resolve) => {
+        resolvePromise = resolve;
+      });
+
+      (global.fetch as jest.Mock).mockReturnValue(pendingPromise);
+
+      const { getDevConfig } = await import("../src/client/DevConfig");
+
+      // Before config loads, should return defaults
+      const config = getDevConfig();
+      expect(config.features.analytics).toBe(true);
+      expect(config.features.publicLobbies).toBe(true);
+
+      // Cleanup: resolve the pending promise
+      resolvePromise!({
+        ok: false,
+        status: 404,
+      });
+    });
+  });
+
+  describe("waitForDevConfig", () => {
+    it("should return the loaded config", async () => {
+      const mockConfig = {
+        features: {
+          analytics: false,
+          ads: false,
+        },
+      };
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(mockConfig),
+      });
+
+      const { waitForDevConfig } = await import("../src/client/DevConfig");
+      const config = await waitForDevConfig();
+
+      expect(config.features.analytics).toBe(false);
+      expect(config.features.ads).toBe(false);
+      expect(config.features.publicLobbies).toBe(true); // default
+      expect(config.features.cloudflare).toBe(true); // default
+    });
+
+    it("should be idempotent - multiple calls return same config", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ features: { analytics: false } }),
+      });
+
+      const { waitForDevConfig } = await import("../src/client/DevConfig");
+
+      const config1 = await waitForDevConfig();
+      const config2 = await waitForDevConfig();
+
+      // Both calls should return the same cached config object
+      expect(config1).toBe(config2);
+      expect(config1.features.analytics).toBe(false);
+    });
+  });
+});

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,15 @@ import webpack from "webpack";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Client dev server port (default: 9000)
+const clientPortEnv = process.env.OPENFRONT_CLIENT_PORT ?? "9000";
+const clientPort = parseInt(clientPortEnv, 10);
+if (isNaN(clientPort) || clientPort < 1 || clientPort > 65535) {
+  throw new Error(
+    `Invalid OPENFRONT_CLIENT_PORT: "${clientPortEnv}". Must be a number between 1 and 65535.`,
+  );
+}
+
 const gitCommit =
   process.env.GIT_COMMIT ?? execSync("git rev-parse HEAD").toString().trim();
 
@@ -150,6 +159,11 @@ export default async (env, argv) => {
             to: path.resolve(__dirname, "static"),
             noErrorOnMissing: true,
           },
+          {
+            from: path.resolve(__dirname, "config.json"),
+            to: path.resolve(__dirname, "static/config.json"),
+            noErrorOnMissing: true,
+          },
         ],
         options: { concurrency: 100 },
       }),
@@ -179,7 +193,7 @@ export default async (env, argv) => {
           },
           historyApiFallback: true,
           compress: true,
-          port: 9000,
+          port: clientPort,
           proxy: [
             // WebSocket proxies
             {


### PR DESCRIPTION
## Description:

Add dev feature flags to disable external services during local development, plus configurable port support.

**Features:**
- Dev feature flags via `config.json` (analytics, publicLobbies, cloudflare, ads)
- Configurable ports via `.env` (`OPENFRONT_SERVER_PORT`, `OPENFRONT_CLIENT_PORT`)
- Comprehensive test suite for DevConfig module (9 tests)

**Motivation:**
When developing locally, external service calls can cause:
- 504 errors from public lobbies API
- Turnstile loading errors after timeout
- Unnecessary analytics/ad network requests

**How to use:**
1. Copy `config.example.json` to `config.json` and set features to `false`
2. Optionally set custom ports in `.env`

**Files Changed:**
| File | Change |
|------|--------|
| `config.example.json` | New - example dev configuration |
| `src/client/DevConfig.ts` | New - dev feature flag module |
| `tests/DevConfig.test.ts` | New - 9 unit tests |
| `src/client/Main.ts` | Modified - conditional Turnstile loading |
| `src/client/PublicLobby.ts` | Modified - check dev config before API calls |
| `src/client/index.html` | Modified - conditional script injection, fix page_url to HTTPS |
| `src/server/Master.ts` | Modified - configurable PORT with validation |
| `webpack.config.js` | Modified - copy config.json, configurable client port |
| `.gitignore` | Modified - ignore config.json |

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

nodeGarden

🤖 Generated with [Claude Code](https://claude.com/claude-code)