### PR TITLE
Fix shortcut keys being blocked by quick chat guard on attack rate bar

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -290,11 +290,7 @@ export class InputHandler {
     }, 1);
 
     window.addEventListener("keydown", (e) => {
-      const target = e.target as HTMLElement | null;
-      const isTextInput =
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.isContentEditable;
+      const isTextInput = this.isTextInputTarget(e.target);
       if (isTextInput && e.code !== "Escape") {
         return;
       }
@@ -340,11 +336,7 @@ export class InputHandler {
       }
     });
     window.addEventListener("keyup", (e) => {
-      const target = e.target as HTMLElement | null;
-      const isTextInput =
-        target?.tagName === "INPUT" ||
-        target?.tagName === "TEXTAREA" ||
-        target?.isContentEditable;
+      const isTextInput = this.isTextInputTarget(e.target);
       if (isTextInput && !this.activeKeys.has(e.code)) {
         return;
       }
@@ -597,6 +589,22 @@ export class InputHandler {
       x: (pointerEvents[0].clientX + pointerEvents[1].clientX) / 2,
       y: (pointerEvents[0].clientY + pointerEvents[1].clientY) / 2,
     };
+  }
+
+  private isTextInputTarget(target: EventTarget | null): boolean {
+    const element = target as HTMLElement | null;
+    if (!element) return false;
+    if (element.tagName === "TEXTAREA" || element.isContentEditable) {
+      return true;
+    }
+    if (element.tagName === "INPUT") {
+      const input = element as HTMLInputElement;
+      if (input.id === "attack-ratio" && input.type === "range") {
+        return false;
+      }
+      return true;
+    }
+    return false;
   }
 
   destroy() {


### PR DESCRIPTION
Resolves #2702

## Description:

This fixes the issue reported in #2702 where certain shortcut keys stopped working.

The root cause was the shortcut-guard logic introduced in #2528 to prevent accidental shortcut activation while the quick chat is open.
That logic was also being applied to the attack rate bar unintentionally, causing shortcuts to be blocked there as well.

This PR excludes the attack rate bar from the quick chat guard so shortcuts behave correctly again.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
