### PR TITLE
chore(dev): automatically open the browser when the server starts in vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ This will:
 
 - Start the webpack dev server for the client
 - Launch the game server with development settings
-- Open the game in your default browser
+- Open the game in your default browser (to disable this behavior, set `SKIP_BROWSER_OPEN=true` in your environment)
 
 ### Client Only
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -97,6 +97,8 @@ export default defineConfig(({ mode }) => {
 
     server: {
       port: 9000,
+      // Automatically open the browser when the server starts
+      open: process.env.SKIP_BROWSER_OPEN !== "true",
       proxy: {
         "/socket": {
           target: "ws://localhost:3000",


### PR DESCRIPTION
## Description:

automatically open the browser when the server starts in vite

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

wraith4081
