### PR TITLE
fix: display flags in local language

### DIFF
--- a/resources/lang/flags/ru.json
+++ b/resources/lang/flags/ru.json
@@ -1,0 +1,6 @@
+{
+    "None": "Без флага",
+    "Abbasid Caliphate": "Аббасидский халифат",
+    "Achaemenid Empire": "Империя Ахеменидов",
+    "United Arab Emirates": "Объединенные Арабские Эмираты"
+}

--- a/src/client/FlagInputModal.ts
+++ b/src/client/FlagInputModal.ts
@@ -63,7 +63,7 @@ export class FlagInputModal extends LitElement {
                         }
                       }}
                     />
-                    <span class="country-name">${country.name}</span>
+                    <span class="country-name">${translateText(country.name)}</span>
                   </button>
                 `,
               )

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -37,6 +37,8 @@ import tr from "../../resources/lang/tr.json";
 import uk from "../../resources/lang/uk.json";
 import zh_CN from "../../resources/lang/zh-CN.json";
 
+import ru_flags from "../../resources/lang/flags/ru.json";
+
 @customElement("lang-selector")
 export class LangSelector extends LitElement {
   @state() public translations: Record<string, string> | undefined;
@@ -83,6 +85,10 @@ export class LangSelector extends LitElement {
     gl,
     sl,
     sk,
+  };
+
+  private flagsLanguageMap: Record<string, any> = {
+    "ru": ru_flags
   };
 
   createRenderRoot() {
@@ -135,8 +141,10 @@ export class LangSelector extends LitElement {
 
   private loadLanguage(lang: string): Record<string, string> {
     const language = this.languageMap[lang] ?? {};
-    const flat = flattenTranslations(language);
-    return flat;
+    const flagsLanguage = this.flagsLanguageMap[lang] ?? {};
+    const flatLanguage = flattenTranslations(language);
+    const flagFlagsLanguage = flattenTranslations(flagsLanguage);
+    return {...flatLanguage, ...flagFlagsLanguage};
   }
 
   private async loadLanguageList() {


### PR DESCRIPTION
Resolves #1043

## Description:

This commit translates the flag names into users selected language. The translations are in /lang/flags/*.json files. This commits includes a ru.json demo file with a few translations to test out

Before:
<img width="747" height="481" alt="Screenshot_20260101_015026" src="https://github.com/user-attachments/assets/1919d613-dee5-4b9b-94a8-58940ff7f1ef" />
After:
<img width="747" height="481" alt="Screenshot_20260101_014850" src="https://github.com/user-attachments/assets/14020fc6-cd1e-4e6c-9383-c99c61c53a81" />



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

agrofx
