### PR TITLE
Fix nation warship edge-case issue ⛴️

### DIFF
--- a/src/core/execution/nation/NationWarshipBehavior.ts
+++ b/src/core/execution/nation/NationWarshipBehavior.ts
@@ -75,6 +75,11 @@ export class NationWarshipBehavior {
   }
 
   private maybeRetaliateWithWarship(tile: TileRef, enemy: Player): void {
+    // Don't send too many warships
+    if (this.player.units(UnitType.Warship).length >= 10) {
+      return;
+    }
+
     const { difficulty } = this.game.config().gameConfig();
     // In Easy never retaliate. In Medium retaliate with 15% chance. Hard with 50%, Impossible with 80%.
     if (


### PR DESCRIPTION
## Description:

On the world map, if two teams of nations are fighting each other (left side vs. right side), there is a possibility that an extreme warship battle involving nearly 200 warships could occur. This PR helps resolve that edge-case issue a bit.

<img width="623" height="647" alt="Screenshot 2025-12-31 155924" src="https://github.com/user-attachments/assets/993c0b08-eccc-491f-aae9-7ea4fd8943f3" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
