### PR TITLE
Add Upper and Lower Silesia flags

### DIFF
--- a/resources/countries.json
+++ b/resources/countries.json
@@ -1196,6 +1196,11 @@
     "name": "Louisiana"
   },
   {
+    "code": "Lower Silesia",
+    "continent": "Europe",
+    "name": "Lower Silesia"
+  },
+  {
     "code": "lu",
     "continent": "Europe",
     "name": "Luxembourg"
@@ -2181,6 +2186,11 @@
     "code": "us",
     "continent": "North America",
     "name": "United States of America"
+  },
+  {
+    "code": "Upper Silesia",
+    "continent": "Europe",
+    "name": "Upper Silesia"
   },
   {
     "code": "Urartu",

--- a/resources/flags/Lower Silesia.svg
+++ b/resources/flags/Lower Silesia.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="2560" height="1707">
+<path d="M0 0 C844.8 0 1689.6 0 2560 0 C2560 563.31 2560 1126.62 2560 1707 C1715.2 1707 870.4 1707 0 1707 C0 1143.69 0 580.38 0 0 Z " fill="#FFCE08" transform="translate(0,0)"/>
+<path d="M0 0 C844.8 0 1689.6 0 2560 0 C2560 281.49 2560 562.98 2560 853 C1715.2 853 870.4 853 0 853 C0 571.51 0 290.02 0 0 Z " fill="#FFFFFF" transform="translate(0,0)"/>
+</svg>

--- a/resources/flags/Upper Silesia.svg
+++ b/resources/flags/Upper Silesia.svg
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="250" height="167">
+<path d="M0 0 C82.5 0 165 0 250 0 C250 55.11 250 110.22 250 167 C167.5 167 85 167 0 167 C0 111.89 0 56.78 0 0 Z " fill="#017CC1" transform="translate(0,0)"/>
+<path d="M0 0 C82.5 0 165 0 250 0 C250 27.39 250 54.78 250 83 C167.5 83 85 83 0 83 C0 55.61 0 28.22 0 0 Z " fill="#F8CE00" transform="translate(0,0)"/>
+</svg>


### PR DESCRIPTION
Resolves #2755
https://github.com/openfrontio/OpenFrontIO/issues/2755

## Description:

Add flags of Upper Silesia and Lower Silesia. Added both regions in `resources/countries.json` and both SVG flags.

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

jeunemage333

<img width="609" height="69" alt="image" src="https://github.com/user-attachments/assets/d223642f-f133-4e7b-a811-83a4e6b9cfe5" />
<img width="1910" height="980" alt="image" src="https://github.com/user-attachments/assets/0c7b7a6c-358a-4879-9991-ef540688d790" />
<img width="609" height="69" alt="image" src="https://github.com/user-attachments/assets/4b322b08-96f6-4059-a84c-cddce1eb94b7" />

