### PR TITLE
Improve transport ship spawn tile selection

### DIFF
--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -113,15 +113,25 @@ export class TransportShipExecution implements Execution {
       return;
     }
 
-    const closestTileSrc = this.attacker.canBuild(
-      UnitType.TransportShip,
-      this.dst,
-    );
-    if (closestTileSrc === false) {
-      console.warn(`can't build transport ship`);
-      this.active = false;
-      return;
-    }
+  	const candidateTiles = this.attacker.transportShipSpawnTiles();
+  	let bestSrc: TileRef | null = null;
+  	let lowestCost = Infinity;
+  
+  	for (const tile of candidateTiles) {
+  	  const cost = this.pathFinder.estimateCost(tile, this.dst);
+  	  if (cost < lowestCost) {
+  		lowestCost = cost;
+  		bestSrc = tile;
+  	  }
+  	}
+  
+  	if (!bestSrc) {
+  	  console.warn(`can't find valid transport ship spawn`);
+  	  this.active = false;
+  	  return;
+  	}
+  
+  	this.src = bestSrc;
 
     if (this.src === null) {
       // Only update the src if it's not already set


### PR DESCRIPTION
Currently, when sending a transport ship to a target territory, the game selects the spawn tile that is closest to the target in straight-line distance from the player's territory. This can result in transport ships taking longer water routes, causing troops to arrive later than necessary.

This PR refactors the transport ship spawning logic to select the source tile that allows the ship to reach the target in the shortest estimated travel time over water, using the pathfinder to estimate routes.

Key points:

Evaluates all eligible shore tiles controlled by the player.

Estimates the path length or travel time from each tile to the destination.

Chooses the tile that minimizes the expected arrival time of the transport ship.

This ensures transport ships are sent efficiently and troops arrive at the target faster, even if the chosen tile is not the geographically closest territory.

Checklist:

 I have added screenshots for all UI updates (not applicable here)

 I process any text displayed to the user through translateText() and I've added it to the en.json file (not applicable)

 I have added relevant tests to the test directory (No)

 I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

Discord contact: exudiz