### PR TITLE
fix: Input text fields no longer have transparent backgrounds after tailwind update

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -16,6 +16,13 @@
     border-color: var(--color-gray-200, currentColor);
   }
 
+  input,
+  textarea,
+  select {
+    background-color: #fff;
+    color: #000;
+  }
+
   input::placeholder,
   textarea::placeholder {
     color: var(--color-gray-400);


### PR DESCRIPTION
## Description:

Woah 🚨🚨 massive PR alert!!! Kidding, this is a really small fix that adds back the white background on text input fields since (I believe) the tailwind updates made recently reset the styles here. This just adds it back via CSS. 

### Before
<img width="1317" height="724" alt="image" src="https://github.com/user-attachments/assets/8ecaed7e-2808-4e36-8348-c9f8da7804ca" />
<img width="1135" height="629" alt="image" src="https://github.com/user-attachments/assets/713d0aae-5209-474f-b48e-1623fb8f513d" />

## After
<img width="1330" height="812" alt="image" src="https://github.com/user-attachments/assets/afe5c392-0555-47d7-a5b2-a068561efdb2" />
<img width="1219" height="834" alt="image" src="https://github.com/user-attachments/assets/6bf51124-55e2-4bc3-b475-75f931a4ee84" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

bijx
