### PR TITLE
fix: possibility for negative values in gold and troop donation

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -309,13 +309,13 @@ export const EmbargoAllIntentSchema = BaseIntentSchema.extend({
 export const DonateGoldIntentSchema = BaseIntentSchema.extend({
   type: z.literal("donate_gold"),
   recipient: ID,
-  gold: z.number().nullable(),
+  gold: z.number().nonnegative().nullable(),
 });
 
 export const DonateTroopIntentSchema = BaseIntentSchema.extend({
   type: z.literal("donate_troops"),
   recipient: ID,
-  troops: z.number().nullable(),
+  troops: z.number().nonnegative().nullable(),
 });
 
 export const BuildUnitIntentSchema = BaseIntentSchema.extend({


### PR DESCRIPTION
## Description:

Previously, the zod schemas for troop and gold donation allowed for negative values which could open the game up to vulnerabilities through undefined behavior in the future. We mitigate these vulnerabilities but adding `.nonnegative` to the `DonateGoldIntentSchema` and `DonateTroopIntentShcema` respectively. Today, code exists to prevent this deeper in the codebase, but we should also prevent this earlier if possible during intent validation.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

haticus
