### PR TITLE
Fix team stats owned percentage 100%

### DIFF
--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -247,6 +247,5 @@ export class TeamStats extends LitElement implements Layer {
 function formatPercentage(value: number): string {
   const perc = value * 100;
   if (Number.isNaN(perc)) return "0%";
-  if (perc === 100) return "100%";
-  return perc.toPrecision(2) + "%";
+  return perc.toFixed(1) + "%";
 }


### PR DESCRIPTION
Resolves #2837

## Description:

This PR aligns the "Owned" percentage format in TeamStats to the same data in Leaderboard, fixing the issue that currently happens when team reaches 100%, and the percentage is displayed as "1.0e+2%".

Previous implementation to avoid this problem involved checking for the "100" value, but we all know how floating point arithmetic works in JS...

Before:

<img width="912" height="450" alt="image" src="https://github.com/user-attachments/assets/a3ce03ab-53c6-4b7b-b3fd-7073a6095252" />

After:

<img width="441" height="233" alt="image" src="https://github.com/user-attachments/assets/21b07834-e3ec-44c3-bd6f-3d5a5d6c851c" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

deshack_82603
