### PR TITLE
feat(client): Add toggleable troop display mode (absolute vs percentage)

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -176,8 +176,10 @@ export class ControlPanel extends LitElement implements Layer {
               >${translateText("control_panel.troops")}:</span
             >
             <span translate="no">
-              <span
-                class="cursor-pointer"
+              <button
+                type="button"
+                class="cursor-pointer bg-transparent border-none p-0 text-inherit font-inherit text-left"
+                aria-pressed="${this._troopsPercentageMode}"
                 @click=${() => {
                   this._troopsPercentageMode = !this._troopsPercentageMode;
                   localStorage.setItem(
@@ -185,7 +187,8 @@ export class ControlPanel extends LitElement implements Layer {
                     this._troopsPercentageMode ? "percentage" : "absolute",
                   );
                 }}
-                >${this._troopsPercentageMode
+              >
+                ${this._troopsPercentageMode
                   ? (() => {
                       const troopsFillPercent =
                         (this._troops / this._maxTroops) * 100;
@@ -194,8 +197,8 @@ export class ControlPanel extends LitElement implements Layer {
                         : `${Math.round(troopsFillPercent)}%`;
                     })()
                   : renderTroops(this._troops)}
-                / ${renderTroops(this._maxTroops)}</span
-              >
+                / ${renderTroops(this._maxTroops)}
+              </button>
               <span
                 class="${this._troopRateIsIncreasing
                   ? "text-green-500"


### PR DESCRIPTION
## Description:

Added a clickable toggle to the ControlPanel's troop display, allowing users to switch between absolute troop counts and a percentage of max troops. The preference is persisted in localStorage, and the percentage display uses adaptive decimal precision (1 decimal place for values below 5% or above 95%, and whole numbers otherwise).

<img width="329" height="200" alt="SCR-20260109-uacv" src="https://github.com/user-attachments/assets/ceb9d9e7-74a0-40ea-be36-203f7cb294c0" />
<img width="330" height="203" alt="SCR-20260109-ubgi" src="https://github.com/user-attachments/assets/38010cad-dd2b-4b34-9948-a8a290720a3a" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

webdev.js