### PR TITLE
Fix BoatIcon color to match other icons in HelpModal

### DIFF
--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -597,7 +597,7 @@ export class HelpModal extends BaseModal {
                   </li>
                   <li class="flex items-center gap-3">
                     <img
-                      src="/images/BoatIcon.svg"
+                      src="/images/BoatIconWhite.svg"
                       class="w-8 h-8 scale-75 origin-left"
                     />
                     <span>${translateText("help_modal.radial_boat")}</span>


### PR DESCRIPTION
## Description:

In HelpModal, only the BoatIcon was displayed in black, which was inconsistent with the other icons.
This PR updates its color to white so it matches the rest of the icons.

before
<img width="619" height="235" alt="スクリーンショット 2026-01-10 14 33 44" src="https://github.com/user-attachments/assets/41c10308-7701-40bf-b068-9e14eb78a83a" />

after
<img width="722" height="260" alt="スクリーンショット 2026-01-10 14 35 17" src="https://github.com/user-attachments/assets/2d535ded-83d2-4f3d-990d-49aaa1230642" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri