### PR TITLE
Add mobile flag selector next to territory pattern control

### DIFF
--- a/src/client/components/PlayPage.ts
+++ b/src/client/components/PlayPage.ts
@@ -64,6 +64,11 @@ export class PlayPage extends LitElement {
               show-select-label
               class="aspect-square h-[50px] sm:h-[50px] lg:hidden shrink-0"
             ></pattern-input>
+            <flag-input
+              id="flag-input-mobile"
+              show-select-label
+              class="aspect-square h-[50px] sm:h-[50px] lg:hidden shrink-0"
+            ></flag-input>
           </div>
 
           <!-- Pattern & Flag buttons (Desktop only - separate column) -->


### PR DESCRIPTION
## Description:

Add a flag selection button to the mobile header alongside the territory pattern selector so it remains accessible on narrow screens.

before
<img width="614" height="165" alt="スクリーンショット 2026-01-12 18 13 10" src="https://github.com/user-attachments/assets/5adb1531-1128-4872-8a78-d26881161bbd" />

after
<img width="538" height="111" alt="スクリーンショット 2026-01-12 18 12 23" src="https://github.com/user-attachments/assets/76436944-0e36-4196-b1eb-9ff1089c11c4" />



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
