### PR TITLE
Split out & reuse logic in Host/Join/Solo modals

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -4,15 +4,11 @@ import { copyToClipboard, translateText } from "../client/Utils";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import {
   Difficulty,
-  Duos,
   GameMapSize,
   GameMapType,
   GameMode,
   HumansVsNations,
-  Quads,
-  Trios,
   UnitType,
-  mapCategories,
 } from "../core/game/Game";
 import { getCompactMapNationCount } from "../core/game/NationCreation";
 import { UserSettings } from "../core/game/UserSettings";
@@ -30,12 +26,20 @@ import "./components/Difficulties";
 import "./components/FluentSlider";
 import "./components/LobbyTeamView";
 import "./components/Maps";
-import { modalHeader } from "./components/ui/ModalHeader";
+import { renderDifficultySection } from "./components/ui/DifficultySection";
+import { renderGameModeSection } from "./components/ui/GameModeSection";
+import { renderGameOptionsSection } from "./components/ui/GameOptionsSection";
+import { renderLobbyIdBox } from "./components/ui/LobbyIdBox";
+import {
+  lobbyModalShell,
+  renderLobbyFooterButton,
+} from "./components/ui/LobbyModalShell";
+import { renderLobbyPlayerList } from "./components/ui/LobbyPlayerList";
+import { renderMapSelection } from "./components/ui/MapSelection";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
-import { renderUnitTypeOptions } from "./utilities/RenderUnitTypeOptions";
-import randomMap from "/images/RandomMap.webp?url";
+import { renderUnitTypeSection } from "./utilities/RenderUnitTypeOptions";
 @customElement("host-lobby-modal")
 export class HostLobbyModal extends BaseModal {
   @state() private selectedMap: GameMapType = GameMapType.World;
@@ -76,31 +80,144 @@ export class HostLobbyModal extends BaseModal {
   private userSettings: UserSettings = new UserSettings();
   private mapLoader = terrainMapFileLoader;
 
-  private leaveLobbyOnClose = true;
-
-  private renderOptionToggle(
-    labelKey: string,
-    checked: boolean,
-    onChange: (val: boolean) => void,
-    hidden: boolean = false,
-  ): TemplateResult {
-    if (hidden) return html``;
+  private renderMaxTimerCard(): TemplateResult {
+    const { click, keydown } = this.createToggleHandlers(
+      () => this.maxTimer,
+      (val) => (this.maxTimer = val),
+      () => this.maxTimerValue,
+      (val) => (this.maxTimerValue = val),
+      30,
+    );
+    const cardClass = this.maxTimer
+      ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
+      : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80";
+    const checkClass = this.maxTimer
+      ? "bg-blue-500 border-blue-500"
+      : "border-white/20 bg-white/5";
+    const labelClass = this.maxTimer ? "text-white" : "text-white/60";
 
     return html`
-      <button
-        class="relative p-4 rounded-xl border transition-all duration-200 flex flex-col items-center justify-center gap-2 h-full min-h-[100px] w-full cursor-pointer ${checked
-          ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-          : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-        @click=${() => onChange(!checked)}
+      <div
+        role="button"
+        tabindex="0"
+        @click=${click}
+        @keydown=${keydown}
+        class="relative p-3 rounded-xl border transition-all duration-200 flex flex-col items-center justify-between gap-2 h-full cursor-pointer min-h-[100px] ${cardClass}"
       >
-        <div
-          class="text-xs uppercase font-bold tracking-wider text-center w-full leading-tight break-words hyphens-auto ${checked
-            ? "text-white"
-            : "text-white/60"}"
-        >
-          ${translateText(labelKey)}
+        <div class="flex items-center justify-center w-full mt-1">
+          <div
+            class="w-5 h-5 rounded border flex items-center justify-center transition-colors ${checkClass}"
+          >
+            ${this.maxTimer
+              ? html`<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-3 w-3 text-white"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clip-rule="evenodd"
+                  />
+                </svg>`
+              : ""}
+          </div>
         </div>
-      </button>
+
+        ${this.maxTimer
+          ? html`
+              <input
+                type="number"
+                min="0"
+                max="120"
+                .value=${String(this.maxTimerValue ?? 0)}
+                class="w-full text-center rounded bg-black/60 text-white text-sm font-bold border border-white/20 focus:outline-none focus:border-blue-500 p-1 my-1"
+                @click=${(e: Event) => e.stopPropagation()}
+                @input=${this.handleMaxTimerValueChanges}
+                @keydown=${this.handleMaxTimerValueKeyDown}
+                placeholder=${translateText("host_modal.mins_placeholder")}
+              />
+            `
+          : html`<div class="h-[2px] w-4 bg-white/10 rounded my-3"></div>`}
+
+        <div
+          class="text-[10px] uppercase font-bold tracking-wider text-center w-full leading-tight ${labelClass}"
+        >
+          ${translateText("host_modal.max_timer")}
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSpawnImmunityCard(): TemplateResult {
+    const { click, keydown } = this.createToggleHandlers(
+      () => this.spawnImmunity,
+      (val) => (this.spawnImmunity = val),
+      () => this.spawnImmunityDurationMinutes,
+      (val) => (this.spawnImmunityDurationMinutes = val),
+      5,
+    );
+    const cardClass = this.spawnImmunity
+      ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
+      : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80";
+    const checkClass = this.spawnImmunity
+      ? "bg-blue-500 border-blue-500"
+      : "border-white/20 bg-white/5";
+    const labelClass = this.spawnImmunity ? "text-white" : "text-white/60";
+
+    return html`
+      <div
+        role="button"
+        tabindex="0"
+        @click=${click}
+        @keydown=${keydown}
+        class="relative p-3 rounded-xl border transition-all duration-200 flex flex-col items-center justify-between gap-2 h-full cursor-pointer min-h-[100px] ${cardClass}"
+      >
+        <div class="flex items-center justify-center w-full mt-1">
+          <div
+            class="w-5 h-5 rounded border flex items-center justify-center transition-colors ${checkClass}"
+          >
+            ${this.spawnImmunity
+              ? html`<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-3 w-3 text-white"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path
+                    fill-rule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clip-rule="evenodd"
+                  />
+                </svg>`
+              : ""}
+          </div>
+        </div>
+
+        ${this.spawnImmunity
+          ? html`
+              <input
+                type="number"
+                min="0"
+                max="120"
+                step="1"
+                .value=${String(this.spawnImmunityDurationMinutes ?? 0)}
+                class="w-full text-center rounded bg-black/60 text-white text-sm font-bold border border-white/20 focus:outline-none focus:border-blue-500 p-1 my-1"
+                @click=${(e: Event) => e.stopPropagation()}
+                @input=${this.handleSpawnImmunityDurationInput}
+                @keydown=${this.handleSpawnImmunityDurationKeyDown}
+                placeholder=${translateText("host_modal.mins_placeholder")}
+              />
+            `
+          : html`<div class="h-[2px] w-4 bg-white/10 rounded my-3"></div>`}
+
+        <div
+          class="text-[10px] uppercase font-bold tracking-wider text-center w-full leading-tight ${labelClass}"
+        >
+          ${translateText("host_modal.player_immunity_duration")}
+        </div>
+      </div>
     `;
   }
 
@@ -127,716 +244,163 @@ export class HostLobbyModal extends BaseModal {
   }
 
   render() {
+    const isHumanVsNations =
+      this.gameMode === GameMode.Team && this.teamCount === HumansVsNations;
+    const maxTimerCard = this.renderMaxTimerCard();
+    const spawnImmunityCard = this.renderSpawnImmunityCard();
+    const playerCount = this.clients.length;
+    const nationCount = this.getEffectiveNationCount();
+    const canStart = playerCount >= 2;
+
     const content = html`
-      <div
-        class="h-full flex flex-col bg-black/60 backdrop-blur-md rounded-2xl border border-white/10 overflow-hidden select-none"
-      >
-        <!-- Header -->
-        ${modalHeader({
-          title: translateText("host_modal.title"),
-          onBack: () => {
-            this.leaveLobbyOnClose = true;
-            this.close();
-          },
-          ariaLabel: translateText("common.back"),
-          rightContent: html`
-            <!-- Lobby ID Box -->
-            <div
-              class="flex items-center gap-0.5 bg-white/5 rounded-lg px-2 py-1 border border-white/10 max-w-[220px] flex-nowrap"
-            >
-              <button
-                @click=${() => {
-                  this.lobbyIdVisible = !this.lobbyIdVisible;
-                  this.requestUpdate();
-                }}
-                class="p-1.5 rounded-md hover:bg-white/10 text-white/60 hover:text-white transition-colors"
-                title="${translateText("user_setting.toggle_visibility")}"
-              >
-                ${this.lobbyIdVisible
-                  ? html`<svg
-                      viewBox="0 0 512 512"
-                      height="16px"
-                      width="16px"
-                      fill="currentColor"
-                    >
-                      <path
-                        d="M256 105c-101.8 0-188.4 62.7-224 151 35.6 88.3 122.2 151 224 151s188.4-62.7 224-151c-35.6-88.3-122.2-151-224-151zm0 251.7c-56 0-101.7-45.7-101.7-101.7S200 153.3 256 153.3 357.7 199 357.7 255 312 356.7 256 356.7zm0-161.1c-33 0-59.4 26.4-59.4 59.4s26.4 59.4 59.4 59.4 59.4-26.4 59.4-59.4-26.4-59.4-59.4-59.4z"
-                      ></path>
-                    </svg>`
-                  : html`<svg
-                      viewBox="0 0 512 512"
-                      height="16px"
-                      width="16px"
-                      fill="currentColor"
-                    >
-                      <path
-                        d="M448 256s-64-128-192-128S64 256 64 256c32 64 96 128 192 128s160-64 192-128z"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="32"
-                      ></path>
-                      <path
-                        d="M144 256l224 0"
-                        fill="none"
-                        stroke="currentColor"
-                        stroke-width="32"
-                        stroke-linecap="round"
-                      ></path>
-                    </svg>`}
-              </button>
-              <button
-                @click=${this.copyToClipboard}
-                @dblclick=${(e: Event) => {
-                  (e.currentTarget as HTMLElement).classList.add("select-all");
-                }}
-                @mouseleave=${(e: Event) => {
-                  (e.currentTarget as HTMLElement).classList.remove(
-                    "select-all",
-                  );
-                }}
-                class="font-mono text-xs font-bold text-white px-2 cursor-pointer select-none min-w-[80px] text-center truncate tracking-wider bg-transparent border-0"
-                title="${translateText("common.click_to_copy")}"
-                aria-label="${translateText("common.click_to_copy")}"
-                type="button"
-              >
-                ${this.copySuccess
-                  ? translateText("common.copied")
-                  : this.lobbyIdVisible
-                    ? this.lobbyId
-                    : "••••••••"}
-              </button>
-              <button
-                @click=${this.copyToClipboard}
-                class="p-1.5 rounded-md hover:bg-white/10 text-white/60 hover:text-white transition-colors"
-                title="${translateText("common.click_to_copy")}"
-                aria-label="${translateText("common.click_to_copy")}"
-                type="button"
-              >
-                <svg
-                  viewBox="0 0 24 24"
-                  height="16px"
-                  width="16px"
-                  fill="currentColor"
-                  aria-hidden="true"
-                >
-                  <path
-                    d="M16 1H4c-1.1 0-2 .9-2 2v12h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
-                  />
-                </svg>
-              </button>
-            </div>
-          `,
+      <div class="max-w-5xl mx-auto space-y-10">
+        <!-- Map Selection -->
+        ${renderMapSelection({
+          selectedMap: this.selectedMap,
+          useRandomMap: this.useRandomMap,
+          onSelectMap: (map) => this.handleMapSelection(map),
+          onSelectRandomMap: this.handleSelectRandomMap,
+          specialSectionClassName: "w-full pt-4 border-t border-white/5",
         })}
 
-        <!-- Scrollable Content -->
-        <div class="flex-1 overflow-y-auto custom-scrollbar p-6 mr-1">
-          <div class="max-w-5xl mx-auto space-y-10">
-            <!-- Map Selection -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-blue-500/20 flex items-center justify-center text-blue-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      d="M21.731 2.269a2.625 2.625 0 00-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 000-3.712zM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 00-1.32 2.214l-.8 2.685a.75.75 0 00.933.933l2.685-.8a5.25 5.25 0 002.214-1.32L19.513 8.2z"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("map.map")}
-                </h3>
-              </div>
-              <div class="space-y-8">
-                <!-- Use the imported mapCategories -->
-                ${Object.entries(mapCategories).map(
-                  ([categoryKey, maps]) => html`
-                    <div class="w-full">
-                      <h4
-                        class="text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2"
-                      >
-                        ${translateText(`map_categories.${categoryKey}`)}
-                      </h4>
-                      <div
-                        class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
-                      >
-                        ${maps.map((mapValue) => {
-                          const mapKey = Object.entries(GameMapType).find(
-                            ([, v]) => v === mapValue,
-                          )?.[0];
-                          return html`
-                            <div
-                              @click=${() => this.handleMapSelection(mapValue)}
-                              class="cursor-pointer transition-transform duration-200 active:scale-95"
-                            >
-                              <map-display
-                                .mapKey=${mapKey}
-                                .selected=${!this.useRandomMap &&
-                                this.selectedMap === mapValue}
-                                .translation=${translateText(
-                                  `map.${mapKey?.toLowerCase()}`,
-                                )}
-                              ></map-display>
-                            </div>
-                          `;
-                        })}
-                      </div>
-                    </div>
-                  `,
-                )}
-                <!-- Random Map Card -->
-                <div class="w-full pt-4 border-t border-white/5">
-                  <h4
-                    class="text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2"
-                  >
-                    ${translateText("map_categories.special")}
-                  </h4>
-                  <div
-                    class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
-                  >
-                    <button
-                      class="relative group rounded-xl border transition-all duration-200 overflow-hidden flex flex-col items-stretch ${this
-                        .useRandomMap
-                        ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.3)]"
-                        : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                      @click=${this.handleSelectRandomMap}
-                    >
-                      <div
-                        class="aspect-[2/1] w-full relative overflow-hidden bg-black/20"
-                      >
-                        <img
-                          src=${randomMap}
-                          alt=${translateText("map.random")}
-                          class="w-full h-full object-cover opacity-60 group-hover:opacity-100 transition-opacity"
-                        />
-                      </div>
-                      <div class="p-3 text-center border-t border-white/5">
-                        <div
-                          class="text-xs font-bold text-white uppercase tracking-wider break-words hyphens-auto"
-                        >
-                          ${translateText("map.random")}
-                        </div>
-                      </div>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
+        <!-- Difficulty Selection -->
+        ${renderDifficultySection({
+          selectedDifficulty: this.selectedDifficulty,
+          disableNations: this.disableNations,
+          onSelectDifficulty: (difficulty) =>
+            this.handleDifficultySelection(difficulty),
+        })}
 
-            <!-- Difficulty Selection -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-green-500/20 flex items-center justify-center text-green-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M12.97 3.97a.75.75 0 011.06 0l7.5 7.5a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 11-1.06-1.06l6.22-6.22H3a.75.75 0 010-1.5h16.19l-6.22-6.22a.75.75 0 010-1.06z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("difficulty.difficulty")}
-                </h3>
-              </div>
+        <!-- Game Mode -->
+        ${renderGameModeSection({
+          gameMode: this.gameMode,
+          teamCount: this.teamCount,
+          onSelectMode: (mode) => this.handleGameModeSelection(mode),
+          onSelectTeamCount: (count) => this.handleTeamCountSelection(count),
+        })}
 
-              <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                ${Object.entries(Difficulty)
-                  .filter(([key]) => isNaN(Number(key)))
-                  .map(([key, value]) => {
-                    const isSelected = this.selectedDifficulty === value;
-                    const isDisabled = this.disableNations;
-                    return html`
-                      <button
-                        ?disabled=${isDisabled}
-                        @click=${() =>
-                          !isDisabled && this.handleDifficultySelection(value)}
-                        class="relative group rounded-xl border transition-all duration-200 w-full overflow-hidden flex flex-col items-center p-4 gap-3 ${isDisabled
-                          ? "opacity-30 grayscale cursor-not-allowed bg-white/5 border-white/5"
-                          : isSelected
-                            ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                            : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                      >
-                        <difficulty-display
-                          .difficultyKey=${key}
-                          class="transform scale-125 origin-center ${isDisabled
-                            ? "pointer-events-none"
-                            : ""}"
-                        ></difficulty-display>
-                        <div
-                          class="text-xs font-bold text-white uppercase tracking-wider text-center w-full mt-1 break-words hyphens-auto"
-                        >
-                          ${translateText(`difficulty.${key.toLowerCase()}`)}
-                        </div>
-                      </button>
-                    `;
-                  })}
-              </div>
-            </div>
+        <!-- Game Options -->
+        ${renderGameOptionsSection({
+          titleKey: "host_modal.options_title",
+          botsValue: this.bots,
+          botsMin: 0,
+          botsMax: 400,
+          botsStep: 1,
+          botsLabelKey: "host_modal.bots",
+          botsDisabledKey: "host_modal.bots_disabled",
+          onBotsChange: this.handleBotsChange,
+          toggles: [
+            {
+              labelKey: "host_modal.disable_nations",
+              checked: this.disableNations,
+              onToggle: this.handleDisableNationsChange,
+              hidden: isHumanVsNations,
+            },
+            {
+              labelKey: "host_modal.instant_build",
+              checked: this.instantBuild,
+              onToggle: this.handleInstantBuildChange,
+            },
+            {
+              labelKey: "host_modal.random_spawn",
+              checked: this.randomSpawn,
+              onToggle: this.handleRandomSpawnChange,
+            },
+            {
+              labelKey: "host_modal.donate_gold",
+              checked: this.donateGold,
+              onToggle: this.handleDonateGoldChange,
+            },
+            {
+              labelKey: "host_modal.donate_troops",
+              checked: this.donateTroops,
+              onToggle: this.handleDonateTroopsChange,
+            },
+            {
+              labelKey: "host_modal.infinite_gold",
+              checked: this.infiniteGold,
+              onToggle: this.handleInfiniteGoldChange,
+            },
+            {
+              labelKey: "host_modal.infinite_troops",
+              checked: this.infiniteTroops,
+              onToggle: this.handleInfiniteTroopsChange,
+            },
+            {
+              labelKey: "host_modal.compact_map",
+              checked: this.compactMap,
+              onToggle: this.handleCompactMapChange,
+            },
+          ],
+          extraCards: [maxTimerCard, spawnImmunityCard],
+        })}
 
-            <!-- Game Mode -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-purple-500/20 flex items-center justify-center text-purple-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      d="M11.25 4.533A9.707 9.707 0 006 3a9.735 9.735 0 00-3.25.555.75.75 0 00-.5.707v14.25a.75.75 0 001 .707A8.237 8.237 0 016 18.75c1.995 0 3.823.707 5.25 1.886V4.533zM12.75 20.636A8.214 8.214 0 0118 18.75c.966 0 1.89.166 2.75.47a.75.75 0 001-.708V4.262a.75.75 0 00-.5-.707A9.735 9.735 0 0018 3a9.707 9.707 0 00-5.25 1.533v16.103z"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("host_modal.mode")}
-                </h3>
-              </div>
-              <div class="grid grid-cols-2 gap-4">
-                ${[GameMode.FFA, GameMode.Team].map((mode) => {
-                  const isSelected = this.gameMode === mode;
-                  return html`
-                    <button
-                      class="w-full py-6 rounded-xl border transition-all duration-200 flex flex-col items-center justify-center gap-3 ${isSelected
-                        ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                        : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                      @click=${() => this.handleGameModeSelection(mode)}
-                    >
-                      <span
-                        class="text-sm font-bold text-white uppercase tracking-widest break-words hyphens-auto"
-                      >
-                        ${mode === GameMode.FFA
-                          ? translateText("game_mode.ffa")
-                          : translateText("game_mode.teams")}
-                      </span>
-                    </button>
-                  `;
-                })}
-              </div>
-            </div>
+        <!-- Enabled Items -->
+        ${renderUnitTypeSection({
+          titleKey: "host_modal.enables_title",
+          disabledUnits: this.disabledUnits,
+          toggleUnit: this.toggleUnit.bind(this),
+        })}
 
-            ${this.gameMode === GameMode.FFA
-              ? ""
-              : html`
-                  <!-- Team Count -->
-                  <div class="space-y-6">
-                    <div
-                      class="text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2"
-                    >
-                      ${translateText("host_modal.team_count")}
-                    </div>
-                    <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
-                      ${[
-                        2,
-                        3,
-                        4,
-                        5,
-                        6,
-                        7,
-                        Quads,
-                        Trios,
-                        Duos,
-                        HumansVsNations,
-                      ].map((o) => {
-                        const isSelected = this.teamCount === o;
-                        return html`
-                          <button
-                            @click=${() => this.handleTeamCountSelection(o)}
-                            class="w-full px-4 py-3 rounded-xl border transition-all duration-200 flex items-center justify-center ${isSelected
-                              ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                              : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                          >
-                            <span
-                              class="text-xs font-bold uppercase tracking-wider text-center text-white break-words hyphens-auto"
-                            >
-                              ${typeof o === "string"
-                                ? o === HumansVsNations
-                                  ? translateText("public_lobby.teams_hvn")
-                                  : translateText(`host_modal.teams_${o}`)
-                                : translateText("public_lobby.teams", {
-                                    num: o,
-                                  })}
-                            </span>
-                          </button>
-                        `;
-                      })}
-                    </div>
-                  </div>
-                `}
-
-            <!-- Game Options -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-orange-500/20 flex items-center justify-center text-orange-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.922-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("host_modal.options_title")}
-                </h3>
-              </div>
-              <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
-                <!-- Bots Slider -->
-                <div
-                  class="col-span-2 rounded-xl p-4 flex flex-col justify-center min-h-[100px] border transition-all duration-200 ${this
-                    .bots > 0
-                    ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                    : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-                >
-                  <fluent-slider
-                    min="0"
-                    max="400"
-                    step="1"
-                    .value=${this.bots}
-                    labelKey="host_modal.bots"
-                    disabledKey="host_modal.bots_disabled"
-                    @value-changed=${this.handleBotsChange}
-                  ></fluent-slider>
-                </div>
-
-                ${!(
-                  this.gameMode === GameMode.Team &&
-                  this.teamCount === HumansVsNations
-                )
-                  ? this.renderOptionToggle(
-                      "host_modal.disable_nations",
-                      this.disableNations,
-                      this.handleDisableNationsChange,
-                    )
-                  : ""}
-                ${this.renderOptionToggle(
-                  "host_modal.instant_build",
-                  this.instantBuild,
-                  this.handleInstantBuildChange,
-                )}
-                ${this.renderOptionToggle(
-                  "host_modal.random_spawn",
-                  this.randomSpawn,
-                  this.handleRandomSpawnChange,
-                )}
-                ${this.renderOptionToggle(
-                  "host_modal.donate_gold",
-                  this.donateGold,
-                  this.handleDonateGoldChange,
-                )}
-                ${this.renderOptionToggle(
-                  "host_modal.donate_troops",
-                  this.donateTroops,
-                  this.handleDonateTroopsChange,
-                )}
-                ${this.renderOptionToggle(
-                  "host_modal.infinite_gold",
-                  this.infiniteGold,
-                  this.handleInfiniteGoldChange,
-                )}
-                ${this.renderOptionToggle(
-                  "host_modal.infinite_troops",
-                  this.infiniteTroops,
-                  this.handleInfiniteTroopsChange,
-                )}
-                ${this.renderOptionToggle(
-                  "host_modal.compact_map",
-                  this.compactMap,
-                  this.handleCompactMapChange,
-                )}
-
-                <!-- Max Timer -->
-                <div
-                  role="button"
-                  tabindex="0"
-                  @click=${this.createToggleHandlers(
-                    () => this.maxTimer,
-                    (val) => (this.maxTimer = val),
-                    () => this.maxTimerValue,
-                    (val) => (this.maxTimerValue = val),
-                    30,
-                  ).click}
-                  @keydown=${this.createToggleHandlers(
-                    () => this.maxTimer,
-                    (val) => (this.maxTimer = val),
-                    () => this.maxTimerValue,
-                    (val) => (this.maxTimerValue = val),
-                    30,
-                  ).keydown}
-                  class="relative p-3 rounded-xl border transition-all duration-200 flex flex-col items-center justify-between gap-2 h-full cursor-pointer min-h-[100px] ${this
-                    .maxTimer
-                    ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                    : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-                >
-                  <div class="flex items-center justify-center w-full mt-1">
-                    <div
-                      class="w-5 h-5 rounded border flex items-center justify-center transition-colors ${this
-                        .maxTimer
-                        ? "bg-blue-500 border-blue-500"
-                        : "border-white/20 bg-white/5"}"
-                    >
-                      ${this.maxTimer
-                        ? html`<svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-3 w-3 text-white"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>`
-                        : ""}
-                    </div>
-                  </div>
-
-                  ${this.maxTimer
-                    ? html`
-                        <input
-                          type="number"
-                          min="0"
-                          max="120"
-                          .value=${String(this.maxTimerValue ?? 0)}
-                          class="w-full text-center rounded bg-black/60 text-white text-sm font-bold border border-white/20 focus:outline-none focus:border-blue-500 p-1 my-1"
-                          @click=${(e: Event) => e.stopPropagation()}
-                          @input=${this.handleMaxTimerValueChanges}
-                          @keydown=${this.handleMaxTimerValueKeyDown}
-                          placeholder=${translateText(
-                            "host_modal.mins_placeholder",
-                          )}
-                        />
-                      `
-                    : html`<div
-                        class="h-[2px] w-4 bg-white/10 rounded my-3"
-                      ></div>`}
-
-                  <div
-                    class="text-[10px] uppercase font-bold tracking-wider text-center w-full leading-tight ${this
-                      .maxTimer
-                      ? "text-white"
-                      : "text-white/60"}"
-                  >
-                    ${translateText("host_modal.max_timer")}
-                  </div>
-                </div>
-
-                <!-- Spawn Immunity -->
-                <div
-                  role="button"
-                  tabindex="0"
-                  @click=${this.createToggleHandlers(
-                    () => this.spawnImmunity,
-                    (val) => (this.spawnImmunity = val),
-                    () => this.spawnImmunityDurationMinutes,
-                    (val) => (this.spawnImmunityDurationMinutes = val),
-                    5,
-                  ).click}
-                  @keydown=${this.createToggleHandlers(
-                    () => this.spawnImmunity,
-                    (val) => (this.spawnImmunity = val),
-                    () => this.spawnImmunityDurationMinutes,
-                    (val) => (this.spawnImmunityDurationMinutes = val),
-                    5,
-                  ).keydown}
-                  class="relative p-3 rounded-xl border transition-all duration-200 flex flex-col items-center justify-between gap-2 h-full cursor-pointer min-h-[100px] ${this
-                    .spawnImmunity
-                    ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                    : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-                >
-                  <div class="flex items-center justify-center w-full mt-1">
-                    <div
-                      class="w-5 h-5 rounded border flex items-center justify-center transition-colors ${this
-                        .spawnImmunity
-                        ? "bg-blue-500 border-blue-500"
-                        : "border-white/20 bg-white/5"}"
-                    >
-                      ${this.spawnImmunity
-                        ? html`<svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-3 w-3 text-white"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>`
-                        : ""}
-                    </div>
-                  </div>
-
-                  ${this.spawnImmunity
-                    ? html`
-                        <input
-                          type="number"
-                          min="0"
-                          max="120"
-                          step="1"
-                          .value=${String(
-                            this.spawnImmunityDurationMinutes ?? 0,
-                          )}
-                          class="w-full text-center rounded bg-black/60 text-white text-sm font-bold border border-white/20 focus:outline-none focus:border-blue-500 p-1 my-1"
-                          @click=${(e: Event) => e.stopPropagation()}
-                          @input=${this.handleSpawnImmunityDurationInput}
-                          @keydown=${this.handleSpawnImmunityDurationKeyDown}
-                          placeholder=${translateText(
-                            "host_modal.mins_placeholder",
-                          )}
-                        />
-                      `
-                    : html`<div
-                        class="h-[2px] w-4 bg-white/10 rounded my-3"
-                      ></div>`}
-
-                  <div
-                    class="text-[10px] uppercase font-bold tracking-wider text-center w-full leading-tight ${this
-                      .spawnImmunity
-                      ? "text-white"
-                      : "text-white/60"}"
-                  >
-                    ${translateText("host_modal.player_immunity_duration")}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Enabled Items -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-teal-500/20 flex items-center justify-center text-teal-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm0 8.625a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25zM15.375 12a1.125 1.125 0 112.25 0 1.125 1.125 0 01-2.25 0zM7.5 10.875a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("host_modal.enables_title")}
-                </h3>
-              </div>
-              <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-                ${renderUnitTypeOptions({
-                  disabledUnits: this.disabledUnits,
-                  toggleUnit: this.toggleUnit.bind(this),
-                })}
-              </div>
-            </div>
-
-            <!-- Player List -->
-            <div class="border-t border-white/10 pt-6">
-              <div class="flex justify-between items-center mb-4">
-                <div
-                  class="text-xs font-bold text-white/40 uppercase tracking-widest"
-                >
-                  ${this.clients.length}
-                  ${this.clients.length === 1
-                    ? translateText("host_modal.player")
-                    : translateText("host_modal.players")}
-                  <span style="margin: 0 8px;">•</span>
-                  ${this.getEffectiveNationCount()}
-                  ${this.getEffectiveNationCount() === 1
-                    ? translateText("host_modal.nation_player")
-                    : translateText("host_modal.nation_players")}
-                </div>
-              </div>
-
-              <lobby-team-view
-                class="block rounded-lg border border-white/10 bg-white/5 p-2"
-                .gameMode=${this.gameMode}
-                .clients=${this.clients}
-                .lobbyCreatorClientID=${this.lobbyCreatorClientID}
-                .teamCount=${this.teamCount}
-                .nationCount=${this.getEffectiveNationCount()}
-                .onKickPlayer=${(clientID: string) => this.kickPlayer(clientID)}
-              ></lobby-team-view>
-            </div>
-          </div>
-        </div>
-
-        <!-- Player List / footer -->
-        <div class="p-6 pt-4 border-t border-white/10 bg-black/20 shrink-0">
-          <button
-            class="w-full py-4 text-sm font-bold text-white uppercase tracking-widest bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed rounded-xl transition-all shadow-lg shadow-blue-900/20 hover:shadow-blue-900/40 hover:-translate-y-0.5 active:translate-y-0 disabled:transform-none"
-            @click=${this.startGame}
-            ?disabled=${this.clients.length < 2}
-          >
-            ${this.clients.length === 1
-              ? translateText("host_modal.waiting")
-              : translateText("host_modal.start")}
-          </button>
-        </div>
+        <!-- Player List -->
+        ${renderLobbyPlayerList({
+          count: {
+            value: playerCount,
+            singularKey: "host_modal.player",
+            pluralKey: "host_modal.players",
+          },
+          secondary: {
+            value: nationCount,
+            singularKey: "host_modal.nation_player",
+            pluralKey: "host_modal.nation_players",
+          },
+          teamList: {
+            gameMode: this.gameMode,
+            clients: this.clients,
+            lobbyCreatorClientID: this.lobbyCreatorClientID,
+            teamCount: this.teamCount,
+            nationCount,
+            onKickPlayer: (clientID) => this.kickPlayer(clientID),
+          },
+        })}
       </div>
     `;
 
-    if (this.inline) {
-      return content;
-    }
+    const footer = renderLobbyFooterButton({
+      label:
+        playerCount === 1
+          ? translateText("host_modal.waiting")
+          : translateText("host_modal.start"),
+      disabled: !canStart,
+      onClick: this.startGame,
+    });
 
-    return html`
-      <o-modal
-        title=""
-        ?hideCloseButton=${true}
-        ?inline=${this.inline}
-        hideHeader
-      >
-        ${content}
-      </o-modal>
-    `;
+    return lobbyModalShell({
+      header: {
+        title: translateText("host_modal.title"),
+        onBack: () => {
+          this.leaveLobbyOnClose = true;
+          this.close();
+        },
+        ariaLabel: translateText("common.back"),
+        rightContent: renderLobbyIdBox({
+          lobbyId: this.lobbyId,
+          isVisible: this.lobbyIdVisible,
+          copySuccess: this.copySuccess,
+          onToggleVisibility: () => {
+            this.lobbyIdVisible = !this.lobbyIdVisible;
+            this.requestUpdate();
+          },
+          onCopy: this.copyToClipboard,
+          toggleTitle: translateText("user_setting.toggle_visibility"),
+          copyTitle: translateText("common.click_to_copy"),
+          copiedLabel: translateText("common.copied"),
+        }),
+      },
+      content,
+      footer,
+      inline: this.inline,
+    });
   }
 
   protected onOpen(): void {
@@ -1159,10 +723,10 @@ export class HostLobbyModal extends BaseModal {
     );
   }
 
-  private toggleUnit(unit: UnitType, checked: boolean): void {
-    this.disabledUnits = checked
-      ? [...this.disabledUnits, unit]
-      : this.disabledUnits.filter((u) => u !== unit);
+  private toggleUnit(unit: UnitType, enabled: boolean): void {
+    this.disabledUnits = enabled
+      ? this.disabledUnits.filter((u) => u !== unit)
+      : [...this.disabledUnits, unit];
 
     this.putGameConfig();
   }

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -4,16 +4,12 @@ import { translateText } from "../client/Utils";
 import { UserMeResponse } from "../core/ApiSchemas";
 import {
   Difficulty,
-  Duos,
   GameMapSize,
   GameMapType,
   GameMode,
   GameType,
   HumansVsNations,
-  Quads,
-  Trios,
   UnitType,
-  mapCategories,
 } from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import { TeamCountConfig } from "../core/Schemas";
@@ -25,13 +21,16 @@ import { BaseModal } from "./components/BaseModal";
 import "./components/Difficulties";
 import "./components/FluentSlider";
 import "./components/Maps";
-import { modalHeader } from "./components/ui/ModalHeader";
+import { renderDifficultySection } from "./components/ui/DifficultySection";
+import { renderGameModeSection } from "./components/ui/GameModeSection";
+import { renderGameOptionsSection } from "./components/ui/GameOptionsSection";
+import { lobbyModalShell } from "./components/ui/LobbyModalShell";
+import { renderMapSelection } from "./components/ui/MapSelection";
 import { fetchCosmetics } from "./Cosmetics";
 import { FlagInput } from "./FlagInput";
 import { JoinLobbyEvent } from "./Main";
 import { UsernameInput } from "./UsernameInput";
-import { renderUnitTypeOptions } from "./utilities/RenderUnitTypeOptions";
-import randomMap from "/images/RandomMap.webp?url";
+import { renderUnitTypeSection } from "./utilities/RenderUnitTypeOptions";
 
 @customElement("single-player-modal")
 export class SinglePlayerModal extends BaseModal {
@@ -127,574 +126,241 @@ export class SinglePlayerModal extends BaseModal {
     this.mapWins = winsMap;
   }
 
-  render() {
-    const content = html`
+  private renderMaxTimerCard(): TemplateResult {
+    const cardClass = this.maxTimer
+      ? "bg-blue-500/20 border-blue-500/50"
+      : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20";
+    const checkClass = this.maxTimer
+      ? "bg-blue-500 border-blue-500"
+      : "border-white/20 bg-white/5";
+    const labelClass = this.maxTimer ? "text-white" : "text-white/60";
+
+    const toggleMaxTimer = () => {
+      this.maxTimer = !this.maxTimer;
+      if (!this.maxTimer) {
+        this.maxTimerValue = undefined;
+        return;
+      }
+      if (!this.maxTimerValue || this.maxTimerValue <= 0) {
+        this.maxTimerValue = 30;
+      }
+      setTimeout(() => {
+        const input = this.getEndTimerInput();
+        if (input) {
+          input.focus();
+          input.select();
+        }
+      }, 0);
+    };
+
+    const handleToggleClick = (e: Event) => {
+      if ((e.target as HTMLElement).tagName.toLowerCase() === "input") {
+        return;
+      }
+      toggleMaxTimer();
+    };
+
+    const handleToggleKeyDown = (e: KeyboardEvent) => {
+      if ((e.target as HTMLElement).tagName.toLowerCase() === "input") {
+        return;
+      }
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        toggleMaxTimer();
+      }
+    };
+
+    return html`
       <div
-        class="h-full flex flex-col bg-black/60 backdrop-blur-md rounded-2xl border border-white/10 overflow-hidden"
+        role="button"
+        tabindex="0"
+        class="relative p-3 rounded-xl border transition-all duration-200 flex flex-col items-center justify-between gap-2 h-full cursor-pointer min-h-[100px] ${cardClass}"
+        @click=${handleToggleClick}
+        @keydown=${handleToggleKeyDown}
       >
-        <!-- Header -->
-        ${modalHeader({
-          title: translateText("main.solo") || "Solo",
-          onBack: this.close,
-          ariaLabel: translateText("common.back"),
-          rightContent: hasLinkedAccount(this.userMeResponse)
-            ? html`<button
-                @click=${this.toggleAchievements}
-                class="flex items-center gap-2 px-3 py-2 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 transition-all shrink-0 ${this
-                  .showAchievements
-                  ? "bg-yellow-500/10 border-yellow-500/30 text-yellow-400"
-                  : "text-white/60"}"
-              >
-                <img
-                  src="/images/MedalIconWhite.svg"
-                  class="w-4 h-4 opacity-80 shrink-0"
-                  style="${this.showAchievements
-                    ? ""
-                    : "filter: grayscale(1);"}"
-                />
-                <span
-                  class="text-xs font-bold uppercase tracking-wider whitespace-nowrap"
-                  >${translateText("single_modal.toggle_achievements")}</span
+        <div class="flex items-center justify-center w-full mt-1">
+          <div
+            class="w-5 h-5 rounded border flex items-center justify-center transition-colors ${checkClass}"
+          >
+            ${this.maxTimer
+              ? html`<svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  class="h-3 w-3 text-white"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
                 >
-              </button>`
-            : this.renderNotLoggedInBanner(),
-        })}
-
-        <!-- Scrollable Content -->
-        <div class="flex-1 overflow-y-auto custom-scrollbar px-6 pb-6 mr-1">
-          <div class="max-w-5xl mx-auto space-y-6 pt-4">
-            <!-- Map Selection -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-blue-500/20 flex items-center justify-center text-blue-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      d="M21.731 2.269a2.625 2.625 0 00-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 000-3.712zM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 00-1.32 2.214l-.8 2.685a.75.75 0 00.933.933l2.685-.8a5.25 5.25 0 002.214-1.32L19.513 8.2z"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("map.map")}
-                </h3>
-              </div>
-
-              <div class="space-y-8">
-                ${Object.entries(mapCategories).map(
-                  ([categoryKey, maps]) => html`
-                    <div class="w-full">
-                      <h4
-                        class="text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2"
-                      >
-                        ${translateText(`map_categories.${categoryKey}`)}
-                      </h4>
-                      <div
-                        class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
-                      >
-                        ${maps.map((mapValue) => {
-                          const mapKey = Object.keys(GameMapType).find(
-                            (key) =>
-                              GameMapType[key as keyof typeof GameMapType] ===
-                              mapValue,
-                          );
-                          return html`
-                            <div
-                              @click=${() => this.handleMapSelection(mapValue)}
-                              class="cursor-pointer transition-transform duration-200 active:scale-95"
-                            >
-                              <map-display
-                                .mapKey=${mapKey}
-                                .selected=${!this.useRandomMap &&
-                                this.selectedMap === mapValue}
-                                .showMedals=${this.showAchievements}
-                                .wins=${this.mapWins.get(mapValue) ?? new Set()}
-                                .translation=${translateText(
-                                  `map.${mapKey?.toLowerCase()}`,
-                                )}
-                              ></map-display>
-                            </div>
-                          `;
-                        })}
-                      </div>
-                    </div>
-                  `,
-                )}
-
-                <!-- Random Map Card -->
-                <div class="w-full">
-                  <h4
-                    class="text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2"
-                  >
-                    ${translateText("map_categories.special")}
-                  </h4>
-                  <div
-                    class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4"
-                  >
-                    <button
-                      class="relative group rounded-xl border transition-all duration-200 overflow-hidden flex flex-col items-stretch ${this
-                        .useRandomMap
-                        ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.3)]"
-                        : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                      @click=${this.handleSelectRandomMap}
-                    >
-                      <div
-                        class="aspect-[2/1] w-full relative overflow-hidden bg-black/20"
-                      >
-                        <img
-                          src=${randomMap}
-                          alt=${translateText("map.random")}
-                          class="w-full h-full object-cover opacity-60 group-hover:opacity-100 transition-opacity"
-                        />
-                      </div>
-                      <div class="p-3 text-center border-t border-white/5">
-                        <div
-                          class="text-xs font-bold text-white uppercase tracking-wider break-words hyphens-auto"
-                        >
-                          ${translateText("map.random")}
-                        </div>
-                      </div>
-                    </button>
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Difficulty Selection -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-green-500/20 flex items-center justify-center text-green-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M12.97 3.97a.75.75 0 011.06 0l7.5 7.5a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 11-1.06-1.06l6.22-6.22H3a.75.75 0 010-1.5h16.19l-6.22-6.22a.75.75 0 010-1.06z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("difficulty.difficulty")}
-                </h3>
-              </div>
-
-              <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
-                ${Object.entries(Difficulty)
-                  .filter(([key]) => isNaN(Number(key)))
-                  .map(
-                    ([key, value]) => html`
-                      <button
-                        class="relative group rounded-xl border transition-all duration-200 w-full overflow-hidden flex flex-col items-center p-4 gap-3 ${this
-                          .selectedDifficulty === value
-                          ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                          : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"} ${this
-                          .disableNations
-                          ? "opacity-30 cursor-not-allowed grayscale"
-                          : ""}"
-                        @click=${() =>
-                          !this.disableNations &&
-                          this.handleDifficultySelection(value)}
-                      >
-                        <difficulty-display
-                          class="${this.disableNations
-                            ? "pointer-events-none"
-                            : ""} transform scale-125"
-                          .difficultyKey=${key}
-                        ></difficulty-display>
-                        <div
-                          class="text-xs font-bold text-white uppercase tracking-wider text-center w-full mt-1 break-words hyphens-auto"
-                        >
-                          ${translateText(`difficulty.${key.toLowerCase()}`)}
-                        </div>
-                      </button>
-                    `,
-                  )}
-              </div>
-            </div>
-
-            <!-- Game Mode Selection -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-purple-500/20 flex items-center justify-center text-purple-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      d="M11.25 4.533A9.707 9.707 0 006 3a9.735 9.735 0 00-3.25.555.75.75 0 00-.5.707v14.25a.75.75 0 001 .707A8.237 8.237 0 016 18.75c1.995 0 3.823.707 5.25 1.886V4.533zM12.75 20.636A8.214 8.214 0 0118 18.75c.966 0 1.89.166 2.75.47a.75.75 0 001-.708V4.262a.75.75 0 00-.5-.707A9.735 9.735 0 0018 3a9.707 9.707 0 00-5.25 1.533v16.103z"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("host_modal.mode")}
-                </h3>
-              </div>
-
-              <div class="grid grid-cols-2 gap-4">
-                ${[GameMode.FFA, GameMode.Team].map((mode) => {
-                  const isSelected = this.gameMode === mode;
-                  const label =
-                    mode === GameMode.FFA
-                      ? translateText("game_mode.ffa")
-                      : translateText("game_mode.teams");
-
-                  return html`
-                    <button
-                      class="w-full py-6 rounded-xl border transition-all duration-200 flex flex-col items-center justify-center gap-3 ${isSelected
-                        ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                        : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                      @click=${() => this.handleGameModeSelection(mode)}
-                    >
-                      <div
-                        class="text-sm font-bold text-white uppercase tracking-widest break-words hyphens-auto"
-                      >
-                        ${label}
-                      </div>
-                    </button>
-                  `;
-                })}
-              </div>
-            </div>
-
-            ${this.gameMode === GameMode.FFA
-              ? ""
-              : html`
-                  <!-- Team Count Selection -->
-                  <div class="space-y-6">
-                    <div
-                      class="text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2"
-                    >
-                      ${translateText("host_modal.team_count")}
-                    </div>
-                    <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
-                      ${[
-                        2,
-                        3,
-                        4,
-                        5,
-                        6,
-                        7,
-                        Quads,
-                        Trios,
-                        Duos,
-                        HumansVsNations,
-                      ].map(
-                        (o) => html`
-                          <button
-                            class="w-full px-4 py-3 rounded-xl border transition-all duration-200 flex items-center justify-center ${this
-                              .teamCount === o
-                              ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                              : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                            @click=${() => this.handleTeamCountSelection(o)}
-                          >
-                            <div
-                              class="text-xs font-bold text-white uppercase tracking-wider text-center break-words hyphens-auto"
-                            >
-                              ${typeof o === "string"
-                                ? o === HumansVsNations
-                                  ? translateText("public_lobby.teams_hvn")
-                                  : translateText(`host_modal.teams_${o}`)
-                                : translateText(`public_lobby.teams`, {
-                                    num: o,
-                                  })}
-                            </div>
-                          </button>
-                        `,
-                      )}
-                    </div>
-                  </div>
-                `}
-
-            <!-- Game Options -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-orange-500/20 flex items-center justify-center text-orange-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.922-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("single_modal.options_title")}
-                </h3>
-              </div>
-
-              <div class="grid grid-cols-2 lg:grid-cols-4 gap-4">
-                <!-- Bot Slider Card -->
-                <div
-                  class="col-span-2 rounded-xl p-4 flex flex-col justify-center min-h-[100px] border transition-all duration-200 ${this
-                    .bots > 0
-                    ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-                    : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-                >
-                  <fluent-slider
-                    min="0"
-                    max="400"
-                    step="1"
-                    .value=${this.bots}
-                    labelKey="single_modal.bots"
-                    disabledKey="single_modal.bots_disabled"
-                    @value-changed=${this.handleBotsChange}
-                  ></fluent-slider>
-                </div>
-
-                ${this.renderOptionToggle(
-                  "single_modal.disable_nations",
-                  this.disableNations,
-                  (val) => (this.disableNations = val),
-                  this.gameMode === GameMode.Team &&
-                    this.teamCount === HumansVsNations,
-                )}
-                ${this.renderOptionToggle(
-                  "single_modal.instant_build",
-                  this.instantBuild,
-                  (val) => (this.instantBuild = val),
-                )}
-                ${this.renderOptionToggle(
-                  "single_modal.random_spawn",
-                  this.randomSpawn,
-                  (val) => (this.randomSpawn = val),
-                )}
-                ${this.renderOptionToggle(
-                  "single_modal.infinite_gold",
-                  this.infiniteGold,
-                  (val) => (this.infiniteGold = val),
-                )}
-                ${this.renderOptionToggle(
-                  "single_modal.infinite_troops",
-                  this.infiniteTroops,
-                  (val) => (this.infiniteTroops = val),
-                )}
-                ${this.renderOptionToggle(
-                  "single_modal.compact_map",
-                  this.compactMap,
-                  (val) => {
-                    this.compactMap = val;
-                    if (val && this.bots === 400) {
-                      this.bots = 100;
-                    } else if (!val && this.bots === 100) {
-                      this.bots = 400;
-                    }
-                  },
-                )}
-
-                <!-- Toggle with input support for Max Timer -->
-                <div
-                  class="relative p-3 rounded-xl border transition-all duration-200 flex flex-col items-center justify-between gap-2 h-full cursor-pointer min-h-[100px] ${this
-                    .maxTimer
-                    ? "bg-blue-500/20 border-blue-500/50"
-                    : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20"}"
-                  @click=${(e: Event) => {
-                    // Prevent toggling when clicking the input
-                    if (
-                      (e.target as HTMLElement).tagName.toLowerCase() ===
-                      "input"
-                    )
-                      return;
-                    this.maxTimer = !this.maxTimer;
-                    if (!this.maxTimer) {
-                      this.maxTimerValue = undefined;
-                    } else {
-                      // Set default value when enabling if not already set or invalid
-                      if (!this.maxTimerValue || this.maxTimerValue <= 0) {
-                        this.maxTimerValue = 30;
-                      }
-                      // Focus the input after render
-                      setTimeout(() => {
-                        const input = this.getEndTimerInput();
-                        if (input) {
-                          input.focus();
-                          input.select();
-                        }
-                      }, 0);
-                    }
-                  }}
-                >
-                  <div class="flex items-center justify-center w-full mt-1">
-                    <div
-                      class="w-5 h-5 rounded border flex items-center justify-center transition-colors ${this
-                        .maxTimer
-                        ? "bg-blue-500 border-blue-500"
-                        : "border-white/20 bg-white/5"}"
-                    >
-                      ${this.maxTimer
-                        ? html`<svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            class="h-3 w-3 text-white"
-                            viewBox="0 0 20 20"
-                            fill="currentColor"
-                          >
-                            <path
-                              fill-rule="evenodd"
-                              d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
-                              clip-rule="evenodd"
-                            />
-                          </svg>`
-                        : ""}
-                    </div>
-                  </div>
-
-                  ${this.maxTimer
-                    ? html`<input
-                        type="number"
-                        id="end-timer-value"
-                        min="1"
-                        max="120"
-                        .value=${String(this.maxTimerValue ?? "")}
-                        class="w-full text-center rounded bg-black/60 text-white text-sm font-bold border border-white/20 focus:outline-none focus:border-blue-500 p-1 my-1"
-                        aria-label=${translateText("single_modal.max_timer")}
-                        @input=${this.handleMaxTimerValueChanges}
-                        @keydown=${this.handleMaxTimerValueKeyDown}
-                        placeholder=${translateText(
-                          "single_modal.max_timer_placeholder",
-                        )}
-                      />`
-                    : html`<div
-                        class="h-[2px] w-4 bg-white/10 rounded my-3"
-                      ></div>`}
-                  <!-- Spacer/Icon placeholder -->
-
-                  <div
-                    class="text-[10px] uppercase font-bold text-white/60 tracking-wider text-center w-full leading-tight break-words hyphens-auto"
-                  >
-                    ${translateText("single_modal.max_timer")}
-                  </div>
-                </div>
-              </div>
-            </div>
-
-            <!-- Enable Settings -->
-            <div class="space-y-6">
-              <div
-                class="flex items-center gap-4 pb-2 border-b border-white/10"
-              >
-                <div
-                  class="w-8 h-8 rounded-lg bg-teal-500/20 flex items-center justify-center text-teal-400"
-                >
-                  <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    viewBox="0 0 24 24"
-                    fill="currentColor"
-                    class="w-5 h-5"
-                  >
-                    <path
-                      fill-rule="evenodd"
-                      d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm0 8.625a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25zM15.375 12a1.125 1.125 0 112.25 0 1.125 1.125 0 01-2.25 0zM7.5 10.875a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25z"
-                      clip-rule="evenodd"
-                    />
-                  </svg>
-                </div>
-                <h3
-                  class="text-lg font-bold text-white uppercase tracking-wider"
-                >
-                  ${translateText("single_modal.enables_title")}
-                </h3>
-              </div>
-              <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
-                ${renderUnitTypeOptions({
-                  disabledUnits: this.disabledUnits,
-                  toggleUnit: this.toggleUnit.bind(this),
-                })}
-              </div>
-            </div>
+                  <path
+                    fill-rule="evenodd"
+                    d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                    clip-rule="evenodd"
+                  />
+                </svg>`
+              : ""}
           </div>
         </div>
 
-        <!-- Footer Action -->
-        <div class="p-6 pt-4 border-t border-white/10 bg-black/20">
-          <button
-            @click=${this.startGame}
-            class="w-full py-4 text-sm font-bold text-white uppercase tracking-widest bg-blue-600 hover:bg-blue-500 rounded-xl transition-all shadow-lg shadow-blue-900/20 hover:shadow-blue-900/40 hover:-translate-y-0.5 active:translate-y-0"
-          >
-            ${translateText("single_modal.start")}
-          </button>
+        ${this.maxTimer
+          ? html`<input
+              type="number"
+              id="end-timer-value"
+              min="1"
+              max="120"
+              .value=${String(this.maxTimerValue ?? "")}
+              class="w-full text-center rounded bg-black/60 text-white text-sm font-bold border border-white/20 focus:outline-none focus:border-blue-500 p-1 my-1"
+              aria-label=${translateText("single_modal.max_timer")}
+              @click=${(e: Event) => e.stopPropagation()}
+              @input=${this.handleMaxTimerValueChanges}
+              @keydown=${this.handleMaxTimerValueKeyDown}
+              placeholder=${translateText("single_modal.max_timer_placeholder")}
+            />`
+          : html`<div class="h-[2px] w-4 bg-white/10 rounded my-3"></div>`}
+
+        <div
+          class="text-[10px] uppercase font-bold tracking-wider text-center w-full leading-tight ${labelClass}"
+        >
+          ${translateText("single_modal.max_timer")}
         </div>
       </div>
     `;
-
-    if (this.inline) {
-      return content;
-    }
-
-    return html`
-      <o-modal
-        id="singlePlayerModal"
-        title="${translateText("main.solo") || "Solo"}"
-        ?inline=${this.inline}
-        hideHeader
-        hideCloseButton
-      >
-        ${content}
-      </o-modal>
-    `;
   }
 
-  // Helper for consistent option buttons
-  private renderOptionToggle(
-    labelKey: string,
-    checked: boolean,
-    onChange: (val: boolean) => void,
-    hidden: boolean = false,
-  ): TemplateResult {
-    if (hidden) return html``;
+  render() {
+    const isHumanVsNations =
+      this.gameMode === GameMode.Team && this.teamCount === HumansVsNations;
+    const maxTimerCard = this.renderMaxTimerCard();
+    const hasAccount = hasLinkedAccount(this.userMeResponse);
 
-    return html`
+    const content = html`
+      <div class="max-w-5xl mx-auto space-y-10">
+        <!-- Map Selection -->
+        ${renderMapSelection({
+          selectedMap: this.selectedMap,
+          useRandomMap: this.useRandomMap,
+          onSelectMap: (map) => this.handleMapSelection(map),
+          onSelectRandomMap: this.handleSelectRandomMap,
+          showMedals: this.showAchievements,
+          winsByMap: this.mapWins,
+          specialSectionClassName: "w-full pt-4 border-t border-white/5",
+        })}
+
+        <!-- Difficulty Selection -->
+        ${renderDifficultySection({
+          selectedDifficulty: this.selectedDifficulty,
+          disableNations: this.disableNations,
+          onSelectDifficulty: (difficulty) =>
+            this.handleDifficultySelection(difficulty),
+        })}
+
+        <!-- Game Mode Selection -->
+        ${renderGameModeSection({
+          gameMode: this.gameMode,
+          teamCount: this.teamCount,
+          onSelectMode: (mode) => this.handleGameModeSelection(mode),
+          onSelectTeamCount: (count) => this.handleTeamCountSelection(count),
+        })}
+
+        <!-- Game Options -->
+        ${renderGameOptionsSection({
+          titleKey: "single_modal.options_title",
+          botsValue: this.bots,
+          botsMin: 0,
+          botsMax: 400,
+          botsStep: 1,
+          botsLabelKey: "single_modal.bots",
+          botsDisabledKey: "single_modal.bots_disabled",
+          onBotsChange: this.handleBotsChange,
+          toggles: [
+            {
+              labelKey: "single_modal.disable_nations",
+              checked: this.disableNations,
+              onToggle: (val) => (this.disableNations = val),
+              hidden: isHumanVsNations,
+            },
+            {
+              labelKey: "single_modal.instant_build",
+              checked: this.instantBuild,
+              onToggle: (val) => (this.instantBuild = val),
+            },
+            {
+              labelKey: "single_modal.random_spawn",
+              checked: this.randomSpawn,
+              onToggle: (val) => (this.randomSpawn = val),
+            },
+            {
+              labelKey: "single_modal.infinite_gold",
+              checked: this.infiniteGold,
+              onToggle: (val) => (this.infiniteGold = val),
+            },
+            {
+              labelKey: "single_modal.infinite_troops",
+              checked: this.infiniteTroops,
+              onToggle: (val) => (this.infiniteTroops = val),
+            },
+            {
+              labelKey: "single_modal.compact_map",
+              checked: this.compactMap,
+              onToggle: (val) => {
+                this.compactMap = val;
+                if (val && this.bots === 400) {
+                  this.bots = 100;
+                } else if (!val && this.bots === 100) {
+                  this.bots = 400;
+                }
+              },
+            },
+          ],
+          extraCards: [maxTimerCard],
+        })}
+
+        <!-- Enable Settings -->
+        ${renderUnitTypeSection({
+          titleKey: "single_modal.enables_title",
+          disabledUnits: this.disabledUnits,
+          toggleUnit: this.toggleUnit.bind(this),
+        })}
+      </div>
+    `;
+
+    const footer = html`
       <button
-        class="relative p-4 rounded-xl border transition-all duration-200 flex flex-col items-center justify-center gap-2 h-full min-h-[100px] w-full cursor-pointer ${checked
-          ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-          : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-        @click=${() => onChange(!checked)}
+        @click=${this.startGame}
+        class="w-full py-4 text-sm font-bold text-white uppercase tracking-widest bg-blue-600 hover:bg-blue-500 rounded-xl transition-all shadow-lg shadow-blue-900/20 hover:shadow-blue-900/40 hover:-translate-y-0.5 active:translate-y-0"
       >
-        <div
-          class="text-xs uppercase font-bold tracking-wider text-center w-full leading-tight break-words hyphens-auto ${checked
-            ? "text-white"
-            : "text-white/60"}"
-        >
-          ${translateText(labelKey)}
-        </div>
+        ${translateText("single_modal.start")}
       </button>
     `;
+
+    return lobbyModalShell({
+      header: {
+        title: translateText("main.solo") || "Solo",
+        onBack: this.close,
+        ariaLabel: translateText("common.back"),
+        rightContent: hasAccount
+          ? html`<button
+              @click=${this.toggleAchievements}
+              class="flex items-center gap-2 px-3 py-2 rounded-xl border border-white/10 bg-white/5 hover:bg-white/10 transition-all shrink-0 ${this
+                .showAchievements
+                ? "bg-yellow-500/10 border-yellow-500/30 text-yellow-400"
+                : "text-white/60"}"
+            >
+              <img
+                src="/images/MedalIconWhite.svg"
+                class="w-4 h-4 opacity-80 shrink-0"
+                style="${this.showAchievements ? "" : "filter: grayscale(1);"}"
+              />
+              <span
+                class="text-xs font-bold uppercase tracking-wider whitespace-nowrap"
+                >${translateText("single_modal.toggle_achievements")}</span
+              >
+            </button>`
+          : this.renderNotLoggedInBanner(),
+      },
+      content,
+      footer,
+      inline: this.inline,
+      modalId: "singlePlayerModal",
+      modalTitle: translateText("main.solo") || "Solo",
+    });
   }
 
   protected onClose(): void {
@@ -781,10 +447,10 @@ export class SinglePlayerModal extends BaseModal {
     return maps[randIdx] as GameMapType;
   }
 
-  private toggleUnit(unit: UnitType, checked: boolean): void {
-    this.disabledUnits = checked
-      ? [...this.disabledUnits, unit]
-      : this.disabledUnits.filter((u) => u !== unit);
+  private toggleUnit(unit: UnitType, enabled: boolean): void {
+    this.disabledUnits = enabled
+      ? this.disabledUnits.filter((u) => u !== unit)
+      : [...this.disabledUnits, unit];
   }
 
   private async startGame() {

--- a/src/client/components/ui/DifficultySection.ts
+++ b/src/client/components/ui/DifficultySection.ts
@@ -1,0 +1,83 @@
+import { TemplateResult, html } from "lit";
+import { Difficulty } from "../../../core/game/Game";
+import { translateText } from "../../Utils";
+import { renderSectionHeader } from "./LobbyModalShell";
+
+export interface DifficultySectionProps {
+  selectedDifficulty: Difficulty;
+  disableNations: boolean;
+  onSelectDifficulty: (difficulty: Difficulty) => void;
+}
+
+const DIFFICULTY_GRID_CLASS = "grid grid-cols-2 md:grid-cols-4 gap-4";
+const BUTTON_CLASS_BASE =
+  "relative group rounded-xl border transition-all duration-200 w-full " +
+  "overflow-hidden flex flex-col items-center p-4 gap-3";
+const BUTTON_CLASS_DISABLED =
+  "opacity-30 grayscale cursor-not-allowed bg-white/5 border-white/5";
+const BUTTON_CLASS_SELECTED =
+  "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]";
+const BUTTON_CLASS_IDLE =
+  "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20";
+const LABEL_CLASS =
+  "text-xs font-bold text-white uppercase tracking-wider text-center w-full " +
+  "mt-1 break-words hyphens-auto";
+
+const DIFFICULTY_OPTIONS = Object.entries(Difficulty).filter(([key]) =>
+  isNaN(Number(key)),
+) as Array<[string, Difficulty]>;
+
+export const renderDifficultySection = ({
+  selectedDifficulty,
+  disableNations,
+  onSelectDifficulty,
+}: DifficultySectionProps): TemplateResult => html`
+  <div class="space-y-6">
+    ${renderSectionHeader({
+      titleKey: "difficulty.difficulty",
+      iconClassName: "bg-green-500/20 text-green-400",
+      icon: html`
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-5 h-5"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M12.97 3.97a.75.75 0 011.06 0l7.5 7.5a.75.75 0 010 1.06l-7.5 7.5a.75.75 0 11-1.06-1.06l6.22-6.22H3a.75.75 0 010-1.5h16.19l-6.22-6.22a.75.75 0 010-1.06z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      `,
+    })}
+
+    <div class="${DIFFICULTY_GRID_CLASS}">
+      ${DIFFICULTY_OPTIONS.map(([key, value]) => {
+        const isSelected = selectedDifficulty === value;
+        const isDisabled = disableNations;
+        return html`
+          <button
+            ?disabled=${isDisabled}
+            @click=${() => !isDisabled && onSelectDifficulty(value)}
+            class="${BUTTON_CLASS_BASE} ${isDisabled
+              ? BUTTON_CLASS_DISABLED
+              : isSelected
+                ? BUTTON_CLASS_SELECTED
+                : BUTTON_CLASS_IDLE}"
+          >
+            <difficulty-display
+              .difficultyKey=${key}
+              class="transform scale-125 origin-center ${isDisabled
+                ? "pointer-events-none"
+                : ""}"
+            ></difficulty-display>
+            <div class="${LABEL_CLASS}">
+              ${translateText(`difficulty.${key.toLowerCase()}`)}
+            </div>
+          </button>
+        `;
+      })}
+    </div>
+  </div>
+`;

--- a/src/client/components/ui/GameModeSection.ts
+++ b/src/client/components/ui/GameModeSection.ts
@@ -1,0 +1,135 @@
+import { TemplateResult, html } from "lit";
+import {
+  Duos,
+  GameMode,
+  HumansVsNations,
+  Quads,
+  Trios,
+} from "../../../core/game/Game";
+import { TeamCountConfig } from "../../../core/Schemas";
+import { translateText } from "../../Utils";
+import { renderSectionHeader } from "./LobbyModalShell";
+
+export interface GameModeSectionProps {
+  gameMode: GameMode;
+  teamCount: TeamCountConfig;
+  onSelectMode: (mode: GameMode) => void;
+  onSelectTeamCount: (count: TeamCountConfig) => void;
+}
+
+const MODE_GRID_CLASS = "grid grid-cols-2 gap-4";
+const MODE_BUTTON_CLASS_BASE =
+  "w-full py-6 rounded-xl border transition-all duration-200 flex flex-col " +
+  "items-center justify-center gap-3";
+const MODE_BUTTON_CLASS_ACTIVE =
+  "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]";
+const MODE_BUTTON_CLASS_IDLE =
+  "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20";
+const MODE_LABEL_CLASS =
+  "text-sm font-bold text-white uppercase tracking-widest break-words hyphens-auto";
+const TEAM_TITLE_CLASS =
+  "text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2";
+const TEAM_GRID_CLASS = "grid grid-cols-2 md:grid-cols-5 gap-3";
+const TEAM_BUTTON_CLASS_BASE =
+  "w-full px-4 py-3 rounded-xl border transition-all duration-200 flex " +
+  "items-center justify-center";
+const TEAM_BUTTON_CLASS_ACTIVE =
+  "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]";
+const TEAM_BUTTON_CLASS_IDLE =
+  "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20";
+const TEAM_LABEL_CLASS =
+  "text-xs font-bold uppercase tracking-wider text-center text-white " +
+  "break-words hyphens-auto";
+
+const TEAM_OPTIONS: TeamCountConfig[] = [
+  2,
+  3,
+  4,
+  5,
+  6,
+  7,
+  Quads,
+  Trios,
+  Duos,
+  HumansVsNations,
+];
+
+const getModeLabel = (mode: GameMode) =>
+  mode === GameMode.FFA
+    ? translateText("game_mode.ffa")
+    : translateText("game_mode.teams");
+
+const getTeamLabel = (option: TeamCountConfig) =>
+  typeof option === "string"
+    ? option === HumansVsNations
+      ? translateText("public_lobby.teams_hvn")
+      : translateText(`host_modal.teams_${option}`)
+    : translateText("public_lobby.teams", { num: option });
+
+export const renderGameModeSection = ({
+  gameMode,
+  teamCount,
+  onSelectMode,
+  onSelectTeamCount,
+}: GameModeSectionProps): TemplateResult => html`
+  <div class="space-y-6">
+    ${renderSectionHeader({
+      titleKey: "host_modal.mode",
+      iconClassName: "bg-purple-500/20 text-purple-400",
+      icon: html`
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          viewBox="0 0 24 24"
+          fill="currentColor"
+          class="w-5 h-5"
+        >
+          <path
+            d="M11.25 4.533A9.707 9.707 0 006 3a9.735 9.735 0 00-3.25.555.75.75 0 00-.5.707v14.25a.75.75 0 001 .707A8.237 8.237 0 016 18.75c1.995 0 3.823.707 5.25 1.886V4.533zM12.75 20.636A8.214 8.214 0 0118 18.75c.966 0 1.89.166 2.75.47a.75.75 0 001-.708V4.262a.75.75 0 00-.5-.707A9.735 9.735 0 0018 3a9.707 9.707 0 00-5.25 1.533v16.103z"
+          />
+        </svg>
+      `,
+    })}
+
+    <div class="${MODE_GRID_CLASS}">
+      ${[GameMode.FFA, GameMode.Team].map((mode) => {
+        const isSelected = gameMode === mode;
+        return html`
+          <button
+            class="${MODE_BUTTON_CLASS_BASE} ${isSelected
+              ? MODE_BUTTON_CLASS_ACTIVE
+              : MODE_BUTTON_CLASS_IDLE}"
+            @click=${() => onSelectMode(mode)}
+          >
+            <span class="${MODE_LABEL_CLASS}">${getModeLabel(mode)}</span>
+          </button>
+        `;
+      })}
+    </div>
+  </div>
+  ${gameMode === GameMode.FFA
+    ? html``
+    : html`
+        <div class="space-y-6">
+          <div class="${TEAM_TITLE_CLASS}">
+            ${translateText("host_modal.team_count")}
+          </div>
+          <div class="${TEAM_GRID_CLASS}">
+            ${TEAM_OPTIONS.map((option) => {
+              const isSelected = teamCount === option;
+              return html`
+                <button
+                  @click=${() => onSelectTeamCount(option)}
+                  class="${TEAM_BUTTON_CLASS_BASE} ${isSelected
+                    ? TEAM_BUTTON_CLASS_ACTIVE
+                    : TEAM_BUTTON_CLASS_IDLE}"
+                >
+                  <span class="${TEAM_LABEL_CLASS}">
+                    ${getTeamLabel(option)}
+                  </span>
+                </button>
+              `;
+            })}
+          </div>
+        </div>
+      `}
+`;

--- a/src/client/components/ui/GameOptionsSection.ts
+++ b/src/client/components/ui/GameOptionsSection.ts
@@ -1,0 +1,92 @@
+import { TemplateResult, html } from "lit";
+import { renderSectionHeader } from "./LobbyModalShell";
+import { renderOptionToggle } from "./OptionToggle";
+
+export interface GameOptionsToggle {
+  labelKey: string;
+  checked: boolean;
+  hidden?: boolean;
+  onToggle: (checked: boolean) => void;
+}
+
+export interface GameOptionsSectionProps {
+  titleKey: string;
+  botsValue: number;
+  botsMin: number;
+  botsMax: number;
+  botsStep: number;
+  botsLabelKey: string;
+  botsDisabledKey: string;
+  onBotsChange: (event: Event) => void;
+  toggles: GameOptionsToggle[];
+  extraCards?: TemplateResult[];
+}
+
+const BOT_CARD_CLASS_BASE =
+  "col-span-2 rounded-xl p-4 flex flex-col justify-center min-h-[100px] " +
+  "border transition-all duration-200";
+const BOT_CARD_CLASS_ACTIVE =
+  "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]";
+const BOT_CARD_CLASS_IDLE =
+  "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80";
+const GRID_CLASS = "grid grid-cols-2 lg:grid-cols-4 gap-4";
+
+export const renderGameOptionsSection = ({
+  titleKey,
+  botsValue,
+  botsMin,
+  botsMax,
+  botsStep,
+  botsLabelKey,
+  botsDisabledKey,
+  onBotsChange,
+  toggles,
+  extraCards,
+}: GameOptionsSectionProps): TemplateResult => {
+  const botsCardClass =
+    botsValue > 0 ? BOT_CARD_CLASS_ACTIVE : BOT_CARD_CLASS_IDLE;
+  const cards = [
+    html`
+      <div class="${BOT_CARD_CLASS_BASE} ${botsCardClass}">
+        <fluent-slider
+          min=${String(botsMin)}
+          max=${String(botsMax)}
+          step=${String(botsStep)}
+          .value=${botsValue}
+          labelKey=${botsLabelKey}
+          disabledKey=${botsDisabledKey}
+          @value-changed=${onBotsChange}
+        ></fluent-slider>
+      </div>
+    `,
+    ...toggles.map(({ labelKey, checked, onToggle, hidden }) =>
+      renderOptionToggle({ labelKey, checked, onToggle, hidden }),
+    ),
+    ...(extraCards ?? []),
+  ];
+
+  return html`
+    <div class="space-y-6">
+      ${renderSectionHeader({
+        titleKey,
+        iconClassName: "bg-orange-500/20 text-orange-400",
+        icon: html`
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M11.078 2.25c-.917 0-1.699.663-1.85 1.567L9.05 4.889c-.02.12-.115.26-.297.348a7.493 7.493 0 00-.986.57c-.166.115-.334.126-.45.083L6.3 5.508a1.875 1.875 0 00-2.282.819l-.922 1.597a1.875 1.875 0 00.432 2.385l.84.692c.095.078.17.229.154.43a7.598 7.598 0 000 1.139c.015.2-.059.352-.153.43l-.841.692a1.875 1.875 0 00-.432 2.385l.922 1.597a1.875 1.875 0 002.282.818l1.019-.382c.115-.043.283-.031.45.082.312.214.641.405.985.57.182.088.277.228.297.35l.178 1.071c.151.904.933 1.567 1.85 1.567h1.844c.916 0 1.699-.663 1.85-1.567l.178-1.072c.02-.12.114-.26.297-.349.344-.165.673-.356.985-.57.167-.114.335-.125.45-.082l1.02.382a1.875 1.875 0 002.28-.819l.922-1.597a1.875 1.875 0 00-.432-2.385l-.84-.692c-.095-.078-.17-.229-.154-.43a7.614 7.614 0 000-1.139c-.016-.2.059-.352.153-.43l.84-.692c.708-.582.891-1.59.433-2.385l-.922-1.597a1.875 1.875 0 00-2.282-.818l-1.02.382c-.114.043-.282.031-.449-.083a7.49 7.49 0 00-.985-.57c-.183-.087-.277-.227-.297-.348l-.179-1.072a1.875 1.875 0 00-1.85-1.567h-1.843zM12 15.75a3.75 3.75 0 100-7.5 3.75 3.75 0 000 7.5z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        `,
+      })}
+
+      <div class="${GRID_CLASS}">${cards}</div>
+    </div>
+  `;
+};

--- a/src/client/components/ui/LobbyIdBox.ts
+++ b/src/client/components/ui/LobbyIdBox.ts
@@ -1,0 +1,106 @@
+import { TemplateResult, html } from "lit";
+
+export interface LobbyIdBoxProps {
+  lobbyId: string;
+  isVisible: boolean;
+  copySuccess: boolean;
+  onToggleVisibility: () => void;
+  onCopy: () => void;
+  toggleTitle: string;
+  copyTitle: string;
+  copiedLabel: string;
+}
+
+const WRAPPER_CLASS =
+  "flex items-center gap-0.5 bg-white/5 rounded-lg px-2 py-1 border " +
+  "border-white/10 max-w-[220px] flex-nowrap";
+const ICON_BUTTON_CLASS =
+  "p-1.5 rounded-md hover:bg-white/10 text-white/60 hover:text-white " +
+  "transition-colors";
+const VALUE_BUTTON_CLASS =
+  "font-mono text-xs font-bold text-white px-2 cursor-pointer select-none " +
+  "min-w-[80px] text-center truncate tracking-wider bg-transparent border-0";
+
+const ICON_VISIBLE = html`
+  <svg viewBox="0 0 512 512" height="16px" width="16px" fill="currentColor">
+    <path
+      d="M256 105c-101.8 0-188.4 62.7-224 151 35.6 88.3 122.2 151 224 151s188.4-62.7 224-151c-35.6-88.3-122.2-151-224-151zm0 251.7c-56 0-101.7-45.7-101.7-101.7S200 153.3 256 153.3 357.7 199 357.7 255 312 356.7 256 356.7zm0-161.1c-33 0-59.4 26.4-59.4 59.4s26.4 59.4 59.4 59.4 59.4-26.4 59.4-59.4-26.4-59.4-59.4-59.4z"
+    ></path>
+  </svg>
+`;
+const ICON_HIDDEN = html`
+  <svg viewBox="0 0 512 512" height="16px" width="16px" fill="currentColor">
+    <path
+      d="M448 256s-64-128-192-128S64 256 64 256c32 64 96 128 192 128s160-64 192-128z"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="32"
+    ></path>
+    <path
+      d="M144 256l224 0"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="32"
+      stroke-linecap="round"
+    ></path>
+  </svg>
+`;
+const ICON_COPY = html`
+  <svg
+    viewBox="0 0 24 24"
+    height="16px"
+    width="16px"
+    fill="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      d="M16 1H4c-1.1 0-2 .9-2 2v12h2V3h12V1zm3 4H8c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h11c1.1 0 2-.9 2-2V7c0-1.1-.9-2-2-2zm0 16H8V7h11v14z"
+    />
+  </svg>
+`;
+
+export const renderLobbyIdBox = ({
+  lobbyId,
+  isVisible,
+  copySuccess,
+  onToggleVisibility,
+  onCopy,
+  toggleTitle,
+  copyTitle,
+  copiedLabel,
+}: LobbyIdBoxProps): TemplateResult => html`
+  <div class="${WRAPPER_CLASS}">
+    <button
+      @click=${onToggleVisibility}
+      class="${ICON_BUTTON_CLASS}"
+      title="${toggleTitle}"
+      type="button"
+    >
+      ${isVisible ? ICON_VISIBLE : ICON_HIDDEN}
+    </button>
+    <button
+      @click=${onCopy}
+      @dblclick=${(e: Event) => {
+        (e.currentTarget as HTMLElement).classList.add("select-all");
+      }}
+      @mouseleave=${(e: Event) => {
+        (e.currentTarget as HTMLElement).classList.remove("select-all");
+      }}
+      class="${VALUE_BUTTON_CLASS}"
+      title="${copyTitle}"
+      aria-label="${copyTitle}"
+      type="button"
+    >
+      ${copySuccess ? copiedLabel : isVisible ? lobbyId : "••••••••"}
+    </button>
+    <button
+      @click=${onCopy}
+      class="${ICON_BUTTON_CLASS}"
+      title="${copyTitle}"
+      aria-label="${copyTitle}"
+      type="button"
+    >
+      ${ICON_COPY}
+    </button>
+  </div>
+`;

--- a/src/client/components/ui/LobbyModalShell.ts
+++ b/src/client/components/ui/LobbyModalShell.ts
@@ -1,0 +1,107 @@
+import { TemplateResult, html } from "lit";
+import { translateText } from "../../Utils";
+import { ModalHeaderProps, modalHeader } from "./ModalHeader";
+
+export interface LobbyModalShellProps {
+  header: ModalHeaderProps;
+  content: TemplateResult;
+  footer?: TemplateResult;
+  inline?: boolean;
+  contentClassName?: string;
+  modalId?: string;
+  modalTitle?: string;
+}
+
+export interface LobbyFooterButtonProps {
+  label: string | TemplateResult;
+  disabled?: boolean;
+  onClick?: () => void;
+}
+
+export interface SectionHeaderProps {
+  titleKey: string;
+  icon: TemplateResult;
+  iconClassName: string;
+}
+
+const SHELL_CLASS =
+  "h-full flex flex-col bg-black/60 backdrop-blur-md rounded-2xl border " +
+  "border-white/10 overflow-hidden select-none";
+const CONTENT_CLASS_BASE = "flex-1 overflow-y-auto custom-scrollbar p-6 mr-1";
+const FOOTER_CLASS = "p-6 pt-4 border-t border-white/10 bg-black/20 shrink-0";
+const FOOTER_BUTTON_CLASS =
+  "w-full py-4 text-sm font-bold text-white uppercase tracking-widest " +
+  "bg-blue-600 hover:bg-blue-500 disabled:opacity-50 disabled:cursor-not-allowed " +
+  "rounded-xl transition-all shadow-lg shadow-blue-900/20 hover:shadow-blue-900/40 " +
+  "hover:-translate-y-0.5 active:translate-y-0 disabled:transform-none";
+
+const withClasses = (...classes: Array<string | undefined>) =>
+  classes.filter(Boolean).join(" ");
+
+export const lobbyModalShell = ({
+  header,
+  content,
+  footer,
+  inline,
+  contentClassName,
+  modalId,
+  modalTitle,
+}: LobbyModalShellProps): TemplateResult => {
+  const body = html`
+    <div class="${SHELL_CLASS}">
+      ${modalHeader(header)}
+      <div class="${withClasses(CONTENT_CLASS_BASE, contentClassName)}">
+        ${content}
+      </div>
+      ${footer ? html`<div class="${FOOTER_CLASS}">${footer}</div>` : ""}
+    </div>
+  `;
+
+  if (inline) {
+    return body;
+  }
+
+  return html`
+    <o-modal
+      ?hideHeader=${true}
+      ?hideCloseButton=${true}
+      ?inline=${inline}
+      id=${modalId ?? ""}
+      title=${modalTitle ?? ""}
+    >
+      ${body}
+    </o-modal>
+  `;
+};
+
+export const renderLobbyFooterButton = ({
+  label,
+  disabled,
+  onClick,
+}: LobbyFooterButtonProps): TemplateResult => html`
+  <button
+    class="${FOOTER_BUTTON_CLASS}"
+    ?disabled=${disabled ?? false}
+    @click=${onClick}
+    type="button"
+  >
+    ${label}
+  </button>
+`;
+
+export const renderSectionHeader = ({
+  titleKey,
+  icon,
+  iconClassName,
+}: SectionHeaderProps): TemplateResult => html`
+  <div class="flex items-center gap-4 pb-2 border-b border-white/10">
+    <div
+      class="w-8 h-8 rounded-lg flex items-center justify-center ${iconClassName}"
+    >
+      ${icon}
+    </div>
+    <h3 class="text-lg font-bold text-white uppercase tracking-wider">
+      ${translateText(titleKey)}
+    </h3>
+  </div>
+`;

--- a/src/client/components/ui/LobbyPlayerList.ts
+++ b/src/client/components/ui/LobbyPlayerList.ts
@@ -1,0 +1,85 @@
+import { TemplateResult, html } from "lit";
+import { GameMode } from "../../../core/game/Game";
+import { ClientInfo, TeamCountConfig } from "../../../core/Schemas";
+import { translateText } from "../../Utils";
+
+interface CountLabel {
+  value: number;
+  singularKey: string;
+  pluralKey: string;
+}
+
+export interface LobbyPlayerListProps {
+  count: CountLabel;
+  secondary?: CountLabel;
+  teamList: LobbyTeamListProps;
+  wrapperClassName?: string;
+}
+
+export interface LobbyTeamListProps {
+  gameMode: GameMode;
+  clients: ClientInfo[];
+  lobbyCreatorClientID?: string | null;
+  teamCount: TeamCountConfig;
+  nationCount?: number;
+  onKickPlayer?: (clientID: string) => void;
+  className?: string;
+}
+
+const DEFAULT_WRAPPER_CLASS = "border-t border-white/10 pt-6";
+const HEADER_CLASS =
+  "text-xs font-bold text-white/40 uppercase tracking-widest";
+const DEFAULT_TEAM_LIST_CLASS =
+  "block rounded-lg border border-white/10 bg-white/5 p-2";
+
+const renderCountLabel = ({
+  value,
+  singularKey,
+  pluralKey,
+}: CountLabel) => html`
+  ${value}
+  ${value === 1 ? translateText(singularKey) : translateText(pluralKey)}
+`;
+
+export const renderLobbyPlayerList = ({
+  count,
+  secondary,
+  teamList,
+  wrapperClassName,
+}: LobbyPlayerListProps): TemplateResult => html`
+  <div class="${wrapperClassName ?? DEFAULT_WRAPPER_CLASS}">
+    <div class="flex justify-between items-center mb-4">
+      <div class="${HEADER_CLASS}">
+        ${renderCountLabel(count)}
+        ${secondary
+          ? html`
+              <span class="mx-2">•</span>
+              ${renderCountLabel(secondary)}
+            `
+          : ""}
+      </div>
+    </div>
+
+    ${renderLobbyTeamList(teamList)}
+  </div>
+`;
+
+export const renderLobbyTeamList = ({
+  gameMode,
+  clients,
+  lobbyCreatorClientID,
+  teamCount,
+  nationCount,
+  onKickPlayer,
+  className,
+}: LobbyTeamListProps): TemplateResult => html`
+  <lobby-team-view
+    class="${className ?? DEFAULT_TEAM_LIST_CLASS}"
+    .gameMode=${gameMode}
+    .clients=${clients}
+    .lobbyCreatorClientID=${lobbyCreatorClientID ?? ""}
+    .teamCount=${teamCount}
+    .nationCount=${nationCount ?? 0}
+    .onKickPlayer=${onKickPlayer}
+  ></lobby-team-view>
+`;

--- a/src/client/components/ui/MapSelection.ts
+++ b/src/client/components/ui/MapSelection.ts
@@ -1,0 +1,137 @@
+import { TemplateResult, html } from "lit";
+import {
+  Difficulty,
+  GameMapType,
+  mapCategories,
+} from "../../../core/game/Game";
+import { translateText } from "../../Utils";
+import {
+  MAP_CARD_CLASS_BASE,
+  MAP_CARD_CLASS_IDLE,
+  MAP_CARD_CLASS_SELECTED,
+  MAP_CARD_IMAGE_CLASS_BASE,
+  MAP_CARD_IMAGE_WRAPPER_CLASS,
+  MAP_CARD_LABEL_CLASS,
+} from "../Maps";
+import { renderSectionHeader } from "./LobbyModalShell";
+import randomMap from "/images/RandomMap.webp?url";
+
+export interface MapSelectionProps {
+  selectedMap: GameMapType;
+  useRandomMap: boolean;
+  onSelectMap: (map: GameMapType) => void;
+  onSelectRandomMap: () => void;
+  showMedals?: boolean;
+  winsByMap?: Map<GameMapType, Set<Difficulty>>;
+  specialSectionClassName?: string;
+}
+
+const DEFAULT_SPECIAL_SECTION_CLASS = "w-full";
+const CATEGORY_TITLE_CLASS =
+  "text-xs font-bold text-white/40 uppercase tracking-widest mb-4 pl-2";
+const MAP_GRID_CLASS = "grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4";
+const MAP_IMAGE_WRAPPER_CLASS = MAP_CARD_IMAGE_WRAPPER_CLASS;
+const MAP_TITLE_CLASS = MAP_CARD_LABEL_CLASS;
+const MAP_IMAGE_CLASS_BASE = MAP_CARD_IMAGE_CLASS_BASE;
+
+export const renderMapSelection = ({
+  selectedMap,
+  useRandomMap,
+  onSelectMap,
+  onSelectRandomMap,
+  showMedals,
+  winsByMap,
+  specialSectionClassName,
+}: MapSelectionProps): TemplateResult => {
+  const specialSectionClass =
+    specialSectionClassName ?? DEFAULT_SPECIAL_SECTION_CLASS;
+  const showMedalsValue = showMedals ?? false;
+  const emptyWins = new Set<Difficulty>();
+  const randomLabel = translateText("map.random");
+
+  const getMapKey = (mapValue: GameMapType) =>
+    Object.entries(GameMapType).find(([, value]) => value === mapValue)?.[0];
+
+  const renderMapCard = (mapValue: GameMapType) => {
+    const mapKey = getMapKey(mapValue);
+    return html`
+      <map-display
+        @click=${() => onSelectMap(mapValue)}
+        .mapKey=${mapKey}
+        .selected=${!useRandomMap && selectedMap === mapValue}
+        .showMedals=${showMedalsValue}
+        .wins=${winsByMap?.get(mapValue) ?? emptyWins}
+        .translation=${translateText(`map.${mapKey?.toLowerCase()}`)}
+      ></map-display>
+    `;
+  };
+
+  const renderCategorySection = (
+    categoryKey: string,
+    maps: GameMapType[],
+  ) => html`
+    <div class="w-full">
+      <h4 class="${CATEGORY_TITLE_CLASS}">
+        ${translateText(`map_categories.${categoryKey}`)}
+      </h4>
+      <div class="${MAP_GRID_CLASS}">${maps.map(renderMapCard)}</div>
+    </div>
+  `;
+
+  const renderRandomMapCard = () => html`
+    <button
+      type="button"
+      aria-pressed=${useRandomMap}
+      aria-label=${randomLabel}
+      class="${MAP_CARD_CLASS_BASE} ${useRandomMap
+        ? MAP_CARD_CLASS_SELECTED
+        : MAP_CARD_CLASS_IDLE}"
+      @click=${onSelectRandomMap}
+    >
+      <div class="${MAP_IMAGE_WRAPPER_CLASS}">
+        <img
+          src=${randomMap}
+          alt=${randomLabel}
+          class="${MAP_IMAGE_CLASS_BASE} ${useRandomMap
+            ? "opacity-100"
+            : "opacity-80"}"
+        />
+      </div>
+      <div class="${MAP_TITLE_CLASS}">${randomLabel}</div>
+    </button>
+  `;
+
+  return html`
+    <div class="space-y-6">
+      ${renderSectionHeader({
+        titleKey: "map.map",
+        iconClassName: "bg-blue-500/20 text-blue-400",
+        icon: html`
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              d="M21.731 2.269a2.625 2.625 0 00-3.712 0l-1.157 1.157 3.712 3.712 1.157-1.157a2.625 2.625 0 000-3.712zM19.513 8.199l-3.712-3.712-12.15 12.15a5.25 5.25 0 00-1.32 2.214l-.8 2.685a.75.75 0 00.933.933l2.685-.8a5.25 5.25 0 002.214-1.32L19.513 8.2z"
+            />
+          </svg>
+        `,
+      })}
+
+      <div class="space-y-8">
+        ${Object.entries(mapCategories).map(([categoryKey, maps]) =>
+          renderCategorySection(categoryKey, maps),
+        )}
+
+        <div class="${specialSectionClass}">
+          <h4 class="${CATEGORY_TITLE_CLASS}">
+            ${translateText("map_categories.special")}
+          </h4>
+          <div class="${MAP_GRID_CLASS}">${renderRandomMapCard()}</div>
+        </div>
+      </div>
+    </div>
+  `;
+};

--- a/src/client/components/ui/OptionToggle.ts
+++ b/src/client/components/ui/OptionToggle.ts
@@ -1,0 +1,52 @@
+import { TemplateResult, html } from "lit";
+import { translateText } from "../../Utils";
+
+export interface OptionToggleProps {
+  labelKey: string;
+  checked: boolean;
+  onToggle: (checked: boolean) => void;
+  hidden?: boolean;
+}
+
+const BUTTON_CLASS_BASE =
+  "relative p-4 rounded-xl border transition-all duration-200 flex flex-col " +
+  "items-center justify-center gap-2 h-full min-h-[100px] w-full cursor-pointer";
+const BUTTON_CLASS_ACTIVE =
+  "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]";
+const BUTTON_CLASS_IDLE =
+  "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80";
+const LABEL_CLASS_BASE =
+  "text-xs uppercase font-bold tracking-wider text-center w-full leading-tight " +
+  "break-words hyphens-auto";
+const LABEL_CLASS_ACTIVE = "text-white";
+const LABEL_CLASS_IDLE = "text-white/60";
+
+export const renderOptionToggle = ({
+  labelKey,
+  checked,
+  onToggle,
+  hidden,
+}: OptionToggleProps): TemplateResult => {
+  if (hidden) {
+    return html``;
+  }
+
+  return html`
+    <button
+      class="${BUTTON_CLASS_BASE} ${checked
+        ? BUTTON_CLASS_ACTIVE
+        : BUTTON_CLASS_IDLE}"
+      type="button"
+      aria-pressed=${checked}
+      @click=${() => onToggle(!checked)}
+    >
+      <div
+        class="${LABEL_CLASS_BASE} ${checked
+          ? LABEL_CLASS_ACTIVE
+          : LABEL_CLASS_IDLE}"
+      >
+        ${translateText(labelKey)}
+      </div>
+    </button>
+  `;
+};

--- a/src/client/utilities/RenderUnitTypeOptions.ts
+++ b/src/client/utilities/RenderUnitTypeOptions.ts
@@ -1,10 +1,15 @@
 import { html, TemplateResult } from "lit";
 import { UnitType } from "../../core/game/Game";
-import { translateText } from "../Utils";
+import { renderSectionHeader } from "../components/ui/LobbyModalShell";
+import { renderOptionToggle } from "../components/ui/OptionToggle";
 
 export interface UnitTypeRenderContext {
   disabledUnits: UnitType[];
-  toggleUnit: (unit: UnitType, checked: boolean) => void;
+  toggleUnit: (unit: UnitType, enabled: boolean) => void;
+}
+
+export interface UnitTypeSectionProps extends UnitTypeRenderContext {
+  titleKey: string;
 }
 
 const unitOptions: { type: UnitType; translationKey: string }[] = [
@@ -24,24 +29,45 @@ export function renderUnitTypeOptions({
   disabledUnits,
   toggleUnit,
 }: UnitTypeRenderContext): TemplateResult[] {
+  const disabledSet = new Set(disabledUnits);
   return unitOptions.map(({ type, translationKey }) => {
-    const isEnabled = !disabledUnits.includes(type);
-    return html`
-      <button
-        class="relative p-4 rounded-xl border transition-all duration-200 flex flex-col items-center justify-center gap-2 min-h-[100px] w-full cursor-pointer ${isEnabled
-          ? "bg-blue-500/20 border-blue-500/50 shadow-[0_0_15px_rgba(59,130,246,0.2)]"
-          : "bg-white/5 border-white/10 hover:bg-white/10 hover:border-white/20 opacity-80"}"
-        aria-pressed="${isEnabled}"
-        @click=${() => toggleUnit(type, isEnabled)}
-      >
-        <div
-          class="text-xs uppercase font-bold tracking-wider text-center w-full leading-tight break-words hyphens-auto ${isEnabled
-            ? "text-white"
-            : "text-white/60"}"
-        >
-          ${translateText(translationKey)}
-        </div>
-      </button>
-    `;
+    const isEnabled = !disabledSet.has(type);
+    return renderOptionToggle({
+      labelKey: translationKey,
+      checked: isEnabled,
+      onToggle: (nextEnabled) => toggleUnit(type, nextEnabled),
+    });
   });
+}
+
+export function renderUnitTypeSection({
+  titleKey,
+  disabledUnits,
+  toggleUnit,
+}: UnitTypeSectionProps): TemplateResult {
+  return html`
+    <div class="space-y-6">
+      ${renderSectionHeader({
+        titleKey,
+        iconClassName: "bg-teal-500/20 text-teal-400",
+        icon: html`
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            class="w-5 h-5"
+          >
+            <path
+              fill-rule="evenodd"
+              d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm0 8.625a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25zM15.375 12a1.125 1.125 0 112.25 0 1.125 1.125 0 01-2.25 0zM7.5 10.875a1.125 1.125 0 100 2.25 1.125 1.125 0 000-2.25z"
+              clip-rule="evenodd"
+            />
+          </svg>
+        `,
+      })}
+      <div class="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-4">
+        ${renderUnitTypeOptions({ disabledUnits, toggleUnit })}
+      </div>
+    </div>
+  `;
 }


### PR DESCRIPTION
## Description:

There's a lot of repeat functionality between host/join/solo player modals, this is an attempt to break everything up and reuse them e.g. the copy button, the difficulty section, the map selection etc.

Reduced the size of HostLobby by ~450 lines and Solo by ~350 ish and moved it into separate ui components, should be more maintainable now for future refinements.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
