### PR TITLE
Fix: Bots NEVER attacked someone if they had water access

### DIFF
--- a/src/core/execution/BotExecution.ts
+++ b/src/core/execution/BotExecution.ts
@@ -101,7 +101,7 @@ export class BotExecution implements Execution {
     }
 
     if (this.neighborsTerraNullius) {
-      if (this.bot.sharesBorderWith(this.mg.terraNullius())) {
+      if (this.bot.neighbors().some((n) => !n.isPlayer())) {
         this.attackBehavior.sendAttack(this.mg.terraNullius());
         return;
       }


### PR DESCRIPTION
## Description:

Bots always attacked Terra Nullius if they shared a border with Terra Nullius.
But water is Terra Nullius...
So I changed that condition to `this.bot.neighbors().some((n) => !n.isPlayer())`.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin