### PR TITLE
Fix transportship target tile on construction

### DIFF
--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -143,7 +143,7 @@ export class TransportShipExecution implements Execution {
 
     this.boat = this.attacker.buildUnit(UnitType.TransportShip, this.src, {
       troops: this.startTroops,
-      targetTile: this.dst,
+      targetTile: this.dst ?? undefined,
     });
 
     // Notify the target player about the incoming naval invasion


### PR DESCRIPTION
## Description:

The recent pathfinding rework broke the naval invasion target.
This change reverts the code to the previous working one.

<img width="232" height="273" alt="image" src="https://github.com/user-attachments/assets/0cc3ed80-bd77-4e7b-886b-0ce5012840ac" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

IngloriousTom
