### PR TITLE
Amended renderNumber to display numbers in the billions range

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -48,7 +48,7 @@ export function renderNumber(
   } else if (num >= 1_000_000_000) {
     const value = Math.floor(num / 10000000) / 100;
     return value.toFixed(fixedPoints ?? 2) + "B";
-  }else if (num >= 10_000_000) {
+  } else if (num >= 10_000_000) {
     const value = Math.floor(num / 100000) / 10;
     return value.toFixed(fixedPoints ?? 1) + "M";
   } else if (num >= 1_000_000) {


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves [#2910](https://github.com/openfrontio/OpenFrontIO/issues/2910)

## Description:

When any number is rendered using the Utils.ts renderNumber() function that is greater than 999,999,999, the display uses 1001M instead of 1B.

Similar to existing logic, I expand the if statements to check if the number is greater than a threshold in the billions, and format it accordingly if so.

Screenshots:
<img width="1268" height="370" alt="image" src="https://github.com/user-attachments/assets/e4edf28b-94bd-4ec6-a4e6-083b9a2fd4fb" />
<img width="271" height="238" alt="img1" src="https://github.com/user-attachments/assets/bc259f4d-68e8-4b6a-831b-34f02cf56750" />


## Please complete the following:

- [YES] I have added screenshots for all UI updates
- [YES ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [YES] I have added relevant tests to the test directory
- [YES] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

visneh
