### PR TITLE
Revert "Amended renderNumber to display numbers in the billions range"

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -42,13 +42,7 @@ export function renderNumber(
   num = Number(num);
   num = Math.max(num, 0);
 
-  if (num >= 10_000_000_000) {
-    const value = Math.floor(num / 100000000) / 10;
-    return value.toFixed(fixedPoints ?? 1) + "B";
-  } else if (num >= 1_000_000_000) {
-    const value = Math.floor(num / 10000000) / 100;
-    return value.toFixed(fixedPoints ?? 2) + "B";
-  } else if (num >= 10_000_000) {
+  if (num >= 10_000_000) {
     const value = Math.floor(num / 100000) / 10;
     return value.toFixed(fixedPoints ?? 1) + "M";
   } else if (num >= 1_000_000) {


### PR DESCRIPTION
Reverts openfrontio/OpenFrontIO#2911

## Description:

Reverts confusing "billion"

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n