### PR TITLE
Fix for v29: Increase chance of starting gold in random game modifiers from 3% to 5% 🙂

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -201,7 +201,7 @@ export class MapPlaylist {
     return {
       isRandomSpawn: Math.random() < 0.1, // 10% chance
       isCompact: Math.random() < 0.05, // 5% chance
-      startingGold: Math.random() < 0.03 ? 5_000_000 : undefined, // 3% chance
+      startingGold: Math.random() < 0.05 ? 5_000_000 : undefined, // 5% chance
     };
   }
 


### PR DESCRIPTION
## Description:

While looking at the game rotation on my localhost page I noticed that the cool new starting gold modifier came up veeeery rarely.
Every 33th game is just too rare, lets do "Every 20th game" 🙂

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin