### PR TITLE
Fix for v29: Add nation count loading for JoinPrivateLobbyModal; change HvN difficulty

### DIFF
--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -13,6 +13,7 @@ import {
   Team,
   Trios,
 } from "../../core/game/Game";
+import { getCompactMapNationCount } from "../../core/game/NationCreation";
 import { assignTeamsLobbyPreview } from "../../core/game/TeamAssignment";
 import { ClientInfo, TeamCountConfig } from "../../core/Schemas";
 import { translateText } from "../Utils";
@@ -22,7 +23,7 @@ export interface TeamPreviewData {
   players: ClientInfo[];
 }
 
-@customElement("lobby-team-view")
+@customElement("lobby-player-view")
 export class LobbyTeamView extends LitElement {
   @property({ type: String }) gameMode: GameMode = GameMode.FFA;
   @property({ type: Array }) clients: ClientInfo[] = [];
@@ -32,6 +33,8 @@ export class LobbyTeamView extends LitElement {
   @property({ attribute: "team-count" }) teamCount: TeamCountConfig = 2;
   @property({ type: Function }) onKickPlayer?: (clientID: string) => void;
   @property({ type: Number }) nationCount: number = 0;
+  @property({ type: Boolean }) disableNations: boolean = false;
+  @property({ type: Boolean }) isCompactMap: boolean = false;
 
   private theme: PastelTheme = new PastelTheme();
   @state() private showTeamColors: boolean = false;
@@ -52,11 +55,32 @@ export class LobbyTeamView extends LitElement {
   }
 
   render() {
-    return html`<div class="players-list">
-      ${this.gameMode === GameMode.Team
-        ? this.renderTeamMode()
-        : this.renderFreeForAll()}
-    </div>`;
+    return html`
+      <div class="border-t border-white/10 pt-6">
+        <div class="flex justify-between items-center mb-4">
+          <div
+            class="text-xs font-bold text-white/40 uppercase tracking-widest"
+          >
+            ${this.clients.length}
+            ${this.clients.length === 1
+              ? translateText("host_modal.player")
+              : translateText("host_modal.players")}
+            <span style="margin: 0 8px;">•</span>
+            ${this.getEffectiveNationCount()}
+            ${this.getEffectiveNationCount() === 1
+              ? translateText("host_modal.nation_player")
+              : translateText("host_modal.nation_players")}
+          </div>
+        </div>
+        <div
+          class="players-list block rounded-lg border border-white/10 bg-white/5 p-2"
+        >
+          ${this.gameMode === GameMode.Team
+            ? this.renderTeamMode()
+            : this.renderFreeForAll()}
+        </div>
+      </div>
+    `;
   }
 
   createRenderRoot() {
@@ -148,14 +172,15 @@ export class LobbyTeamView extends LitElement {
   }
 
   private renderTeamCard(preview: TeamPreviewData, isEmpty: boolean = false) {
+    const effectiveNationCount = this.getEffectiveNationCount();
     const displayCount =
       preview.team === ColoredTeams.Nations
-        ? this.nationCount
+        ? effectiveNationCount
         : preview.players.length;
 
     const maxTeamSize =
       preview.team === ColoredTeams.Nations
-        ? this.nationCount
+        ? effectiveNationCount
         : this.teamMaxSize;
 
     return html`
@@ -307,5 +332,21 @@ export class LobbyTeamView extends LitElement {
       team: t,
       players: buckets.get(t) ?? [],
     }));
+  }
+
+  /**
+   * Returns the effective nation count for display purposes.
+   * In HumansVsNations mode, this equals the number of human players.
+   * For compact maps, only 25% of nations are used.
+   * Otherwise, it uses the manifest nation count (or 0 if nations are disabled).
+   */
+  private getEffectiveNationCount(): number {
+    if (this.disableNations) {
+      return 0;
+    }
+    if (this.gameMode === GameMode.Team && this.teamCount === HumansVsNations) {
+      return this.clients.length;
+    }
+    return getCompactMapNationCount(this.nationCount, this.isCompactMap);
   }
 }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -546,7 +546,6 @@ label.option-card:hover {
   flex-wrap: wrap;
   gap: 8px;
   justify-content: center;
-  padding: 0 16px;
 }
 
 /* News Button Notification */

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -127,9 +127,7 @@ export class MapPlaylist {
       publicGameModifiers: { isCompact, isRandomSpawn, startingGold },
       startingGold,
       difficulty:
-        playerTeams === HumansVsNations
-          ? Difficulty.Impossible
-          : Difficulty.Easy,
+        playerTeams === HumansVsNations ? Difficulty.Hard : Difficulty.Easy,
       infiniteGold: false,
       infiniteTroops: false,
       maxTimerValue: undefined,


### PR DESCRIPTION
## Description:

1. In JoinPrivateLobbyModal the nation count loading was missing. That caused the team preview UI to show different player counts compared to the HostLobbyModal. For example it showed 0/0 nations for the HumansVsNations team mode (instead of 2/2):

<img width="726" height="217" alt="Screenshot 2026-01-16 211337" src="https://github.com/user-attachments/assets/8b4219de-e2b2-46ff-a600-c86915e5bdb3" />

2. Turn down HvN difficulty from Impossible to Hard. 
We steamrolled over Hard nations in the playtest (at least in two of the three games) because we donated lots of troops to each other.
But after some API data research I noticed that only 33% of players in public team games ever use the donate functionality.
And we probably have less skilled players in public games than in the playtest.
So its probably better to use the Hard difficulty to ensure balanced gameplay.
I know, I'm overthinking this 😂

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
