### PR TITLE
Fix: Ally won't conquer last tiles of so-called dead defender

### DIFF
--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -371,7 +371,11 @@ export class AttackExecution implements Execution {
         } else {
           for (const neighbor of this.mg.neighbors(tile)) {
             const no = this.mg.owner(neighbor);
-            if (no.isPlayer() && no !== this.target  && !no.isFriendly(this.target)) {
+            if (
+              no.isPlayer() &&
+              no !== this.target &&
+              !no.isFriendly(this.target)
+            ) {
               this.mg.player(no.id()).conquer(tile);
               break;
             }


### PR DESCRIPTION
## Description:

When a player is conquered (has less than 100 tiles left) their gold is transfered to the conqueror. And after that the conqueror gets the last tiles. But if some of those last tiles are not bordered by the conqueror, they are given to their neighbour player. However that neighbour player can be an ally. It is percieved as a bug if an ally conquers/annexes tiles.

This PR fixes that by adding an isFriendly check to `handleDeadDefender` in `AttackExecution`.

Now, there are already scenarios possible currently, where a player survives being conquered. If they have some tiles on a small island for example. Going from that, there should be no unexpected bugs following this change. A player can be conquered twice in a game already in the stats too. https://discord.com/channels/1359946986937258015/1359946989046989063/1462595261204533248

Example of this happening in an Enzo vid (with his surprised reaction) and explanation posted here: https://discord.com/channels/1359946986937258015/1359946989046989063/1460483209308536925

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33
