### PR TITLE
Fix trailing space in attack ratio troop count.

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -201,8 +201,7 @@ export class ControlPanel extends LitElement implements Layer {
               <span>
                 (${renderTroops(
                   (this.game?.myPlayer()?.troops() ?? 0) * this.attackRatio,
-                )}
-                )
+                )})
               </span>
             </span>
           </label>


### PR DESCRIPTION
## Description:

Fixes a trailing space in the attack ratio troop count.

**Before**
<img width="257" height="96" alt="Screenshot from 2026-01-19 20-36-57" src="https://github.com/user-attachments/assets/0941c160-97dd-43a5-a111-cc3238ebbdb0" />

**After**
<img width="257" height="96" alt="Screenshot from 2026-01-19 20-29-45" src="https://github.com/user-attachments/assets/cac06654-e13c-4831-a0f7-61ba1951338a" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

n/a
