### PR TITLE
Fix random spawn

### DIFF
--- a/src/client/graphics/layers/RadialMenuElements.ts
+++ b/src/client/graphics/layers/RadialMenuElements.ts
@@ -572,6 +572,9 @@ export const centerButtonElement: CenterButtonElement = {
       return true;
     }
     if (params.game.inSpawnPhase()) {
+      if (params.game.config().isRandomSpawn()) {
+        return true;
+      }
       if (tileOwner.isPlayer()) {
         return true;
       }

--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -42,6 +42,11 @@ export class SpawnExecution implements Execution {
       player = this.mg.addPlayer(this.playerInfo);
     }
 
+    // Security: If random spawn is enabled, prevent players from re-rolling their spawn location
+    if (this.mg.config().isRandomSpawn() && player.hasSpawned()) {
+      return;
+    }
+
     this.tile ??= this.randomSpawnLand();
 
     if (this.tile === undefined) {


### PR DESCRIPTION
## Description:

"You can pick your spawn in random spawn games in v29. You need to open the menu and click on the attack button. That's it."

Thats the fix for this problem.
Radial menu no longer allows to attack (pick a spawn) while random spawn is enabled.
And SpawnExecution got a check so you cannot send malicious intents.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin