### PR TITLE
Anonymized/hidden names on lobby preview

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -653,6 +653,7 @@ export class HostLobbyModal extends BaseModal {
               .gameMode=${this.gameMode}
               .clients=${this.clients}
               .lobbyCreatorClientID=${this.lobbyCreatorClientID}
+              .currentClientID=${this.lobbyCreatorClientID}
               .teamCount=${this.teamCount}
               .nationCount=${this.nationCount}
               .disableNations=${this.disableNations}

--- a/src/client/JoinPrivateLobbyModal.ts
+++ b/src/client/JoinPrivateLobbyModal.ts
@@ -28,6 +28,7 @@ export class JoinPrivateLobbyModal extends BaseModal {
   @state() private gameConfig: GameConfig | null = null;
   @state() private lobbyCreatorClientID: string | null = null;
   @state() private currentLobbyId: string = "";
+  @state() private currentClientID: string = "";
   @state() private nationCount: number = 0;
 
   private playersInterval: NodeJS.Timeout | null = null;
@@ -101,6 +102,7 @@ export class JoinPrivateLobbyModal extends BaseModal {
                   .gameMode=${this.gameConfig?.gameMode ?? GameMode.FFA}
                   .clients=${this.players}
                   .lobbyCreatorClientID=${this.lobbyCreatorClientID}
+                  .currentClientID=${this.currentClientID}
                   .teamCount=${this.gameConfig?.playerTeams ?? 2}
                   .nationCount=${this.nationCount}
                   .disableNations=${this.gameConfig?.disableNations ?? false}
@@ -290,6 +292,7 @@ export class JoinPrivateLobbyModal extends BaseModal {
     this.hasJoined = false;
     this.message = "";
     this.currentLobbyId = "";
+    this.currentClientID = "";
     this.nationCount = 0;
 
     this.leaveLobbyOnClose = true;
@@ -418,6 +421,7 @@ export class JoinPrivateLobbyModal extends BaseModal {
       this.showMessage(translateText("private_lobby.joined_waiting"));
       this.message = "";
       this.hasJoined = true;
+      this.currentClientID = generateID();
 
       // If the modal closes as part of joining the game, do not leave the lobby
       this.leaveLobbyOnClose = false;
@@ -426,7 +430,7 @@ export class JoinPrivateLobbyModal extends BaseModal {
         new CustomEvent("join-lobby", {
           detail: {
             gameID: lobbyId,
-            clientID: generateID(),
+            clientID: this.currentClientID,
           } as JoinLobbyEvent,
           bubbles: true,
           composed: true,
@@ -477,12 +481,13 @@ export class JoinPrivateLobbyModal extends BaseModal {
       return "version_mismatch";
     }
 
+    this.currentClientID = generateID();
     this.dispatchEvent(
       new CustomEvent("join-lobby", {
         detail: {
           gameID: lobbyId,
           gameRecord: parsed.data,
-          clientID: generateID(),
+          clientID: this.currentClientID,
         } as JoinLobbyEvent,
         bubbles: true,
         composed: true,


### PR DESCRIPTION
Resolves #2962

## Description:

Anonymize lobby preview player names when “Hidden names” is enabled, using the same deterministic mapping as in-game.

<img width="864" height="618" alt="スクリーンショット 2026-01-20 21 13 19" src="https://github.com/user-attachments/assets/30ebe155-c66e-49a5-8957-f8ec0a1ccd76" />

<img width="668" height="341" alt="スクリーンショット 2026-01-20 21 13 27" src="https://github.com/user-attachments/assets/6ef74d98-ea2f-4156-a321-306acf012672" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri