### PR TITLE
Optimize team game frequency

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -71,18 +71,18 @@ interface MapWithMode {
   mode: GameMode;
 }
 
-const TEAM_COUNTS = [
-  2,
-  3,
-  4,
-  5,
-  6,
-  7,
-  Duos,
-  Trios,
-  Quads,
-  HumansVsNations,
-] as const satisfies TeamCountConfig[];
+const TEAM_WEIGHTS: { config: TeamCountConfig; weight: number }[] = [
+  { config: 2, weight: 10 },
+  { config: 3, weight: 10 },
+  { config: 4, weight: 10 },
+  { config: 5, weight: 10 },
+  { config: 6, weight: 10 },
+  { config: 7, weight: 10 },
+  { config: Duos, weight: 5 },
+  { config: Trios, weight: 7.5 },
+  { config: Quads, weight: 7.5 },
+  { config: HumansVsNations, weight: 20 },
+];
 
 export class MapPlaylist {
   private mapsPlaylist: MapWithMode[] = [];
@@ -193,7 +193,17 @@ export class MapPlaylist {
   }
 
   private getTeamCount(): TeamCountConfig {
-    return TEAM_COUNTS[Math.floor(Math.random() * TEAM_COUNTS.length)];
+    const totalWeight = TEAM_WEIGHTS.reduce((sum, w) => sum + w.weight, 0);
+    const roll = Math.random() * totalWeight;
+
+    let cumulativeWeight = 0;
+    for (const { config, weight } of TEAM_WEIGHTS) {
+      cumulativeWeight += weight;
+      if (roll < cumulativeWeight) {
+        return config;
+      }
+    }
+    return TEAM_WEIGHTS[0].config;
   }
 
   private getRandomPublicGameModifiers(): PublicGameModifiers {


### PR DESCRIPTION
## Description:

I analyzed the avg fill time of team games (past 30 days) and was able to confirm what people in the main discord said: Duos / Trios / Quads fill slower. 
Might be something for v29.

| Game Mode | Games | Avg Fill Time |
|-----------|-------|---------------|
| **FFA** (Excluding ranked) | 53,654 | **29s** |
| Team: 2 teams | 3,379 | 33s |
| Team: 3 teams | 3,291 | 32s |
| Team: 4 teams | 3,242 | 31s |
| Team: 5 teams | 3,364 | 32s |
| Team: 6 teams | 3,381 | 31s |
| Team: 7 teams | 3,227 | 31s |
| Team: Duos | 3,295 | **43s** |
| Team: Trios | 3,300 | 39s |
| Team: Quads | 3,299 | 37s |
| Team: Humans Vs Nations | 101 | **24s** |

Therefore I propose to decrease the chance of Duos, Trios and Quads (especially Duos).
Also, increase the chance of HumansVsNations because its special and unlike all the other team modes.

| Team Config | Previous | New |
|-------------|----------|-----|
| 2 teams | 10% | 10% |
| 3 teams | 10% | 10% |
| 4 teams | 10% | 10% |
| 5 teams | 10% | 10% |
| 6 teams | 10% | 10% |
| 7 teams | 10% | 10% |
| **Duos** | 10% | **5%** ↓ |
| **Trios** | 10% | **7.5%** ↓ |
| **Quads** | 10% | **7.5%** ↓ |
| **HumansVsNations** | 10% | **20%** ↑ |

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
