### PR TITLE
Allow full language names

### DIFF
--- a/src/client/LanguageModal.ts
+++ b/src/client/LanguageModal.ts
@@ -75,13 +75,13 @@ export class LanguageModal extends BaseModal {
                   />
                   <div class="flex flex-col items-start min-w-0">
                     <span
-                      class="text-sm font-bold uppercase tracking-wider truncate w-full text-left ${isActive
+                      class="text-sm font-bold uppercase tracking-wider whitespace-normal break-words w-full text-left ${isActive
                         ? "text-white"
                         : "text-gray-200 group-hover:text-white"}"
                       >${lang.native}</span
                     >
                     <span
-                      class="text-xs text-white/40 uppercase tracking-widest group-hover:text-white/60 transition-colors truncate w-full text-left"
+                      class="text-xs text-white/40 uppercase tracking-widest group-hover:text-white/60 transition-colors whitespace-normal break-words w-full text-left"
                       >${lang.en}</span
                     >
                   </div>


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #(issue number)

## Description:

Remove truncation so long language names wrap instead of ellipsizing

before
<img width="194" height="147" alt="スクリーンショット 2026-01-21 20 47 27" src="https://github.com/user-attachments/assets/551edf13-9896-41ab-984f-aa6dab1ec2b0" />

after
<img width="406" height="305" alt="スクリーンショット 2026-01-21 20 47 50" src="https://github.com/user-attachments/assets/bbd0657a-44ca-4623-8cfc-efb76ceda0c5" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri