### PR TITLE
Fix: Nuking an Ally that is Disconnected shows a Red background ghost. Shouldn't be Red as not a Betrayal

### DIFF
--- a/src/client/graphics/layers/StructureIconsLayer.ts
+++ b/src/client/graphics/layers/StructureIconsLayer.ts
@@ -270,8 +270,8 @@ export class StructureIconsLayer implements Layer {
       myPlayer &&
       (nukeType === UnitType.AtomBomb || nukeType === UnitType.HydrogenBomb)
     ) {
-      // Only check if player has allies
-      const allies = myPlayer.allies();
+      // Only check connected allies - nuking disconnected allies doesn't cause a traitor debuff
+      const allies = myPlayer.allies().filter((a) => !a.isDisconnected());
       if (allies.length > 0) {
         targetingAlly = wouldNukeBreakAlliance({
           game: this.game,


### PR DESCRIPTION
## Description:

Previous behavior: https://youtu.be/Lv0RuBYh9qw?t=1359

New behavior:

https://github.com/user-attachments/assets/acfcc4f0-157e-44a0-be28-802927a3c787

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
