### PR TITLE
Ignore subtick intents, except if whitelisted

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -76,6 +76,16 @@ export class GameServer {
 
   private _hasEnded = false;
 
+  private whitelistedIntents = new Set<Intent['type']>([
+    'emoji',
+    'spawn',
+    'mark_disconnected',
+    'update_game_config',
+    'cancel_attack',
+    'kick_player',
+    'cancel_boat',
+  ]);
+
   public desyncCount = 0;
 
   constructor(
@@ -585,7 +595,13 @@ export class GameServer {
   }
 
   private addIntent(intent: Intent) {
-    this.intents.push(intent);
+    const isWhitelisted = this.whitelistedIntents.has(intent.type);
+    const existing = this.intents.some(i => i.clientID === intent.clientID)
+    if (existing && !isWhitelisted) {
+      this.log.warn(`Ignoring duplicate intent from ${intent.clientID}. Maybe using an auto-clicker?`);
+    } else {
+      this.intents.push(intent);
+    }
   }
 
   private sendStartGameMsg(ws: WebSocket, lastTurn: number) {

--- a/tests/server/GameLifecycle.test.ts
+++ b/tests/server/GameLifecycle.test.ts
@@ -25,6 +25,7 @@ vi.mock("../../src/core/Schemas", async () => {
   };
 });
 
+import { Intent } from "src/core/Schemas";
 import { GameEnv } from "../../src/core/configuration/Config";
 import { GameType } from "../../src/core/game/Game";
 import { GameServer } from "../../src/server/GameServer";
@@ -117,5 +118,63 @@ describe("GameLifecycle", () => {
     // Should not throw or crash
     await expect(game.end()).resolves.toBeUndefined();
     expect((game as any)._hasEnded).toBe(true);
+  });
+
+  it("should should block duplicate intents if they are not whitelisted", async () => {
+    const game = new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      mockConfig,
+      { gameType: GameType.Private } as any,
+    ) as any;
+
+    const clientId = "client-1";
+    const intent1: Intent = {
+      clientID: clientId,
+      type: "attack",
+      targetID: null,
+      troops: null
+    };
+    const intent2: Intent = {
+      clientID: clientId,
+      type: "attack",
+      targetID: null,
+      troops: null
+    };
+
+    game.addIntent(intent1);
+    game.addIntent(intent2);
+
+    expect(game.intents.length).toBe(1);
+  });
+
+  it("should should allow duplicate intents if they are whitelisted", async () => {
+    const game = new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      mockConfig,
+      { gameType: GameType.Private } as any,
+    ) as any;
+
+    const clientId = "client-1";
+    const intent1: Intent = {
+      clientID: clientId,
+      type: "emoji",
+      recipient: "some",
+      emoji: 1,
+    };
+    const intent2: Intent = {
+      clientID: clientId,
+      type: "emoji",
+      recipient: "some",
+      emoji: 2,
+    };
+
+    game.addIntent(intent1);
+    game.addIntent(intent2);
+
+    expect(game.intents.length).toBe(2);
   });
 });


### PR DESCRIPTION
Resolves #2993

## Description:

I added a guard to the `addIntent` method that checks if the user trying to push an intent already has one in this turn. If so, only allow it if it's a "spammable" intent like leaving, sending emojis, etc.
The list of whitelisted intents might not be needed, but my logic was: If a user sends an intent and then disconnects we don't want to miss the disconnect intent.
This feature has automated tests.

---

I tested manually by playing a game as I usually with bots. Nothing out of the ordinary occured, but as its my first contribution I would love if someone else could also test it.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

name.loading
