### PR TITLE
perf(ui): switch UI layers to wall-time tick intervals

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -39,6 +39,10 @@ export class ControlPanel extends LitElement implements Layer {
 
   private _lastTroopIncreaseRate: number;
 
+  getTickIntervalMs() {
+    return 100;
+  }
+
   init() {
     this.attackRatio = Number(
       localStorage.getItem("settings.attackRatio") ?? "0.2",
@@ -81,9 +85,7 @@ export class ControlPanel extends LitElement implements Layer {
       return;
     }
 
-    if (this.game.ticks() % 5 === 0) {
-      this.updateTroopIncrease();
-    }
+    this.updateTroopIncrease();
 
     this._maxTroops = this.game.config().maxTroops(player);
     this._gold = player.gold();

--- a/src/client/graphics/layers/Layer.ts
+++ b/src/client/graphics/layers/Layer.ts
@@ -1,6 +1,9 @@
 export interface Layer {
   init?: () => void;
   tick?: () => void;
+  // Optional hint to throttle expensive ticks by wall-clock.
+  // If omitted or <= 0, the layer ticks whenever GameRenderer ticks.
+  getTickIntervalMs?: () => number;
   renderLayer?: (context: CanvasRenderingContext2D) => void;
   shouldTransform?: () => boolean;
   redraw?: () => void;

--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -55,12 +55,14 @@ export class Leaderboard extends LitElement implements Layer {
 
   init() {}
 
+  getTickIntervalMs() {
+    return 1000;
+  }
+
   tick() {
     if (this.game === null) throw new Error("Not initialized");
     if (!this.visible) return;
-    if (this.game.ticks() % 10 === 0) {
-      this.updateLeaderboard();
-    }
+    this.updateLeaderboard();
   }
 
   private setSort(key: "tiles" | "gold" | "maxtroops") {

--- a/src/client/graphics/layers/MainRadialMenu.ts
+++ b/src/client/graphics/layers/MainRadialMenu.ts
@@ -33,6 +33,10 @@ export class MainRadialMenu extends LitElement implements Layer {
 
   private clickedTile: TileRef | null = null;
 
+  getTickIntervalMs() {
+    return 500;
+  }
+
   constructor(
     private eventBus: EventBus,
     private game: GameView,
@@ -156,18 +160,16 @@ export class MainRadialMenu extends LitElement implements Layer {
 
   async tick() {
     if (!this.radialMenu.isMenuVisible() || this.clickedTile === null) return;
-    if (this.game.ticks() % 5 === 0) {
-      this.game
-        .myPlayer()!
-        .actions(this.clickedTile)
-        .then((actions) => {
-          this.updatePlayerActions(
-            this.game.myPlayer()!,
-            actions,
-            this.clickedTile!,
-          );
-        });
-    }
+    this.game
+      .myPlayer()!
+      .actions(this.clickedTile)
+      .then((actions) => {
+        this.updatePlayerActions(
+          this.game.myPlayer()!,
+          actions,
+          this.clickedTile!,
+        );
+      });
   }
 
   renderLayer(context: CanvasRenderingContext2D) {

--- a/src/client/graphics/layers/NameLayer.ts
+++ b/src/client/graphics/layers/NameLayer.ts
@@ -133,11 +133,11 @@ export class NameLayer implements Layer {
     }
   }
 
-  public tick() {
-    if (this.game.ticks() % 10 !== 0) {
-      return;
-    }
+  getTickIntervalMs() {
+    return 1000;
+  }
 
+  public tick() {
     // Precompute the first-place player for performance
     this.firstPlace = getFirstPlacePlayer(this.game);
 

--- a/src/client/graphics/layers/ReplayPanel.ts
+++ b/src/client/graphics/layers/ReplayPanel.ts
@@ -44,11 +44,13 @@ export class ReplayPanel extends LitElement implements Layer {
     }
   }
 
+  getTickIntervalMs() {
+    return 1000;
+  }
+
   tick() {
     if (!this.visible) return;
-    if (this.game!.ticks() % 10 === 0) {
-      this.requestUpdate();
-    }
+    this.requestUpdate();
   }
 
   onReplaySpeedChange(value: ReplaySpeedMultiplier) {

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -42,6 +42,10 @@ export class TeamStats extends LitElement implements Layer {
 
   init() {}
 
+  getTickIntervalMs() {
+    return 1000;
+  }
+
   tick() {
     if (this.game.config().gameConfig().gameMode !== GameMode.Team) return;
 
@@ -52,9 +56,7 @@ export class TeamStats extends LitElement implements Layer {
 
     if (!this.visible) return;
 
-    if (this.game.ticks() % 10 === 0) {
-      this.updateTeamStats();
-    }
+    this.updateTeamStats();
   }
 
   private updateTeamStats() {


### PR DESCRIPTION
## Description:

Preparatory change for the upcoming “unbounded worker” work: 
decouple expensive UI layer updates from game tick frequency by moving UI ticking to wall-clock intervals. This reduces redundant UI work when the simulation runs faster than real time (notably replays / singleplayer at speed > 1) while keeping the UI responsive and predictable.

## Changes:

- Add optional `Layer.getTickIntervalMs()` and enforce it in `GameRenderer.tick()` using wall-clock time.
- Convert key UI layers from tick-modulus gating to fixed intervals:
  - `ControlPanel`: 100ms
  - `GameRightSidebar`: 250ms
  - `MainRadialMenu`: 500ms
  - `Leaderboard`, `NameLayer`, `ReplayPanel`, `TeamStats`: 1000ms


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
