### PR TITLE
Added afterEach cleanup to call inputHandler.destroy(), which clears the setInterval before jsdom tears down and removes window.

### DIFF
--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -40,6 +40,10 @@ describe("InputHandler AutoUpgrade", () => {
     );
   });
 
+  afterEach(() => {
+    inputHandler.destroy();
+  });
+
   describe("Middle Mouse Button Handling", () => {
     test("should emit AutoUpgradeEvent on middle mouse button press", () => {
       const mockEmit = vi.spyOn(eventBus, "emit");


### PR DESCRIPTION
## Description:

Fixes the failing test:coverage ci.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
