### PR TITLE
Feature: Elo now displayed on the main menu (#3029)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -968,6 +968,7 @@
   },
   "matchmaking_button": {
     "play_ranked": "1v1 Ranked Matchmaking",
+    "elo": "Current elo: ",
     "description": "(ALPHA)",
     "login_required": "Login to play ranked!",
     "must_login": "You must be logged in to play ranked matchmaking."

--- a/src/client/components/PlayPage.ts
+++ b/src/client/components/PlayPage.ts
@@ -1,8 +1,32 @@
 import { LitElement, html } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
+import { UserMeResponse } from "../../core/ApiSchemas";
 
 @customElement("play-page")
 export class PlayPage extends LitElement {
+  @state() private elo: string = "...";
+  private _onUserMeResponse: (e: Event) => void;
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    this._onUserMeResponse = (e: Event): void => {
+      const event = e as CustomEvent<UserMeResponse | false>;
+
+      if (!event.detail) {
+        this.elo = "...";
+        return;      }
+
+      this.elo = event.detail?.player?.leaderboard?.oneVone?.elo?.toString() ?? "...";
+    };
+
+    document.addEventListener("userMeResponse", this._onUserMeResponse);
+  }
+
+  disconnectedCallback() {
+    document.removeEventListener("userMeResponse", this._onUserMeResponse)
+  }
+
   createRenderRoot() {
     return this;
   }
@@ -159,6 +183,14 @@ export class PlayPage extends LitElement {
                 class="relative z-10 text-2xl"
                 data-i18n="matchmaking_button.play_ranked"
               ></span>
+              <span>
+                <span
+                  class="relative z-10 text-xs font-medium text-purple-100 opacity-90 group-hover:opacity-100 transition-opacity"
+                  data-i18n="matchmaking_button.elo"
+                ></span>
+                <span class="relative z-10 text-xs font-medium text-purple-100 opacity-90 group-hover:opacity-100 transition-opacity"
+                >${ this.elo }</span>
+              </span>
               <span
                 class="relative z-10 text-xs font-medium text-purple-100 opacity-90 group-hover:opacity-100 transition-opacity"
                 data-i18n="matchmaking_button.description"


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #3029

## Description:

Your elo is now being displayed in the main menu.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

@xtonai

## UI changes

<img width="737" height="88" alt="image" src="https://github.com/user-attachments/assets/de3480ea-3665-4e52-abab-e28c469c6974" />
<img width="738" height="90" alt="image" src="https://github.com/user-attachments/assets/942827b8-a5be-4128-89bd-d3bde6668468" />
