### PR TITLE
Show troop count of troop transport boats ⛵

### DIFF
--- a/src/client/graphics/layers/PlayerInfoOverlay.ts
+++ b/src/client/graphics/layers/PlayerInfoOverlay.ts
@@ -504,6 +504,14 @@ export class PlayerInfoOverlay extends LitElement implements Layer {
                 </div>
               `
             : ""}
+          ${unit.type() === UnitType.TransportShip
+            ? html`
+                <div class="text-sm">
+                  ${translateText("player_info_overlay.troops")}:
+                  ${renderTroops(unit.troops())}
+                </div>
+              `
+            : ""}
         </div>
       </div>
     `;

--- a/src/core/execution/TransportShipExecution.ts
+++ b/src/core/execution/TransportShipExecution.ts
@@ -114,7 +114,7 @@ export class TransportShipExecution implements Execution {
       mg.displayIncomingUnit(
         this.boat.id(),
         // TODO TranslateText
-        `Naval invasion incoming from ${this.attacker.displayName()}`,
+        `Naval invasion incoming from ${this.attacker.displayName()} (${renderTroops(this.boat.troops())})`,
         MessageType.NAVAL_INVASION_INBOUND,
         this.target.id(),
       );


### PR DESCRIPTION
## Description:

Troop count display for naval invasion message:

<img width="398" height="131" alt="Screenshot 2026-01-28 204213" src="https://github.com/user-attachments/assets/d7ccf2a8-9974-4f12-9901-e603426a8e56" />

On hover, PlayerInfoOverlay shows the troop count now:

<img width="504" height="99" alt="Screenshot 2026-01-28 202916" src="https://github.com/user-attachments/assets/46f7685f-8c0e-4156-8d02-8a68dbcffde0" />


## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin