### PR TITLE
Add glowing red dot on store when skins change

### DIFF
--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -30,6 +30,18 @@ export async function handlePurchase(
 }
 
 let __cosmetics: Promise<Cosmetics | null> | null = null;
+let __cosmeticsHash: string | null = null;
+
+function simpleHash(str: string): string {
+  let hash = 0;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash;
+  }
+  return hash.toString(36);
+}
+
 export async function fetchCosmetics(): Promise<Cosmetics | null> {
   if (__cosmetics !== null) {
     return __cosmetics;
@@ -46,6 +58,11 @@ export async function fetchCosmetics(): Promise<Cosmetics | null> {
         console.error(`Invalid cosmetics: ${result.error.message}`);
         return null;
       }
+      const patternKeys = Object.keys(result.data.patterns).sort();
+      const hashInput = patternKeys
+        .map((k) => k + (result.data.patterns[k].product ? "sale" : ""))
+        .join(",");
+      __cosmeticsHash = simpleHash(hashInput);
       return result.data;
     } catch (error) {
       console.error("Error getting cosmetics:", error);
@@ -53,6 +70,11 @@ export async function fetchCosmetics(): Promise<Cosmetics | null> {
     }
   })();
   return __cosmetics;
+}
+
+export async function getCosmeticsHash(): Promise<string | null> {
+  await fetchCosmetics();
+  return __cosmeticsHash;
 }
 
 export function patternRelationship(


### PR DESCRIPTION
## Description:

Hash the pattern + is for sale and store it in local storage. then check if the new cosmetics hash is different from the one we last saw. If it's different, add a glowing red dot on the store. After user clicks it, then update the hash and remove the dot.
<img width="1030" height="143" alt="Screenshot 2026-01-29 at 3 54 46 PM" src="https://github.com/user-attachments/assets/e5727764-40e4-45e1-b651-65816e657067" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
