### PR TITLE
Clarify team and timer labels in pulbic lobbies

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -362,17 +362,18 @@
     "disabled_units": "Disabled Units"
   },
   "public_lobby": {
+    "starts_in": "Starts in {s}",
     "join": "Join next Game",
     "waiting": "players waiting",
-    "teams_Duos": "{team_count} teams of 2 (Duos)",
-    "teams_Trios": "{team_count} teams of 3 (Trios)",
-    "teams_Quads": "{team_count} teams of 4 (Quads)",
+    "teams_Duos": "{team_count} teams (Duos)",
+    "teams_Trios": "{team_count} teams (Trios)",
+    "teams_Quads": "{team_count} teams (Quads)",
     "waiting_for_players": "Waiting for players",
     "starting_game": "Starting game…",
     "teams_hvn": "Humans vs Nations",
     "teams_hvn_detailed": "{num} Humans vs {num} Nations",
     "teams": "{num} teams",
-    "players_per_team": "of {num}",
+    "players_per_team": "({num} each)",
     "started": "Started"
   },
   "matchmaking_modal": {

--- a/src/client/PublicLobby.ts
+++ b/src/client/PublicLobby.ts
@@ -82,7 +82,9 @@ export class PublicLobby extends LitElement {
     const start = this.lobbyIDToStart.get(lobby.gameID) ?? 0;
     const timeRemaining = Math.max(0, Math.floor((start - Date.now()) / 1000));
     const isStarting = timeRemaining <= 2;
-    const timeDisplay = renderDuration(timeRemaining);
+    const timeDisplay = translateText("public_lobby.starts_in", {
+      s: renderDuration(timeRemaining),
+    });
 
     const teamCount =
       lobby.gameConfig.gameMode === GameMode.Team


### PR DESCRIPTION
## Description:
Update labels for clarity:

- 2 TEAMS (30 EACH) (instead of 2 TEAMS OF 30)
- Starts in 37s (instead of just 37s)

<img width="537" height="454" alt="Screenshot 2026-01-30 202825" src="https://github.com/user-attachments/assets/a25d1ff4-1913-4b6a-bf86-2d087431cdd8" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

abodcraft1