### PR TITLE
Allow accepting alliance via radial menu during alliance request cooldown

### DIFF
--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -423,6 +423,14 @@ export class PlayerImpl implements Player {
       return false;
     }
 
+    const hasIncoming = this.incomingAllianceRequests().some(
+      (ar) => ar.requestor() === other,
+    );
+
+    if (hasIncoming) {
+      return true;
+    }
+
     const recent = this.pastOutgoingAllianceRequests
       .filter((ar) => ar.recipient() === other)
       .sort((a, b) => b.createdAt() - a.createdAt());


### PR DESCRIPTION
## Description:

Currently, when you send an alliance request to another player and it gets rejected, but the same player sends you an alliance request back during your alliance request cooldown, you cannot accept it via the radial menu, you need to do that via the notification on the bottom right.

This is not consistent with when you receive an alliance request outside of the cooldown.

This PR checks for incoming alliance request for the same player before checking the outgoing request cooldown, therefore allowing you to accept incoming alliance requests via the radial menu button even during cooldown.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

deshack_82603
