### PR TITLE
fix: remove incorrect host display in JoinLobbyModal (Public game)

### DIFF
--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -91,6 +91,10 @@ export class JoinLobbyModal extends BaseModal {
           : translateText("public_lobby.started");
     const maxPlayers = this.gameConfig?.maxPlayers ?? 0;
     const playerCount = this.playerCount;
+    const hostClientID =
+      this.gameConfig?.gameType === GameType.Private
+        ? (this.lobbyCreatorClientID ?? "")
+        : "";
     const content = html`
       <div
         class="h-full flex flex-col bg-black/60 backdrop-blur-md rounded-2xl border border-white/10 overflow-hidden select-none"
@@ -129,7 +133,7 @@ export class JoinLobbyModal extends BaseModal {
                         class="mt-6"
                         .gameMode=${this.gameConfig?.gameMode ?? GameMode.FFA}
                         .clients=${this.players}
-                        .lobbyCreatorClientID=${this.lobbyCreatorClientID}
+                        .lobbyCreatorClientID=${hostClientID}
                         .currentClientID=${this.currentClientID}
                         .teamCount=${this.gameConfig?.playerTeams ?? 2}
                         .nationCount=${this.nationCount}
@@ -533,7 +537,6 @@ export class JoinLobbyModal extends BaseModal {
     if (lobby.clients) {
       this.players = lobby.clients;
       this.playerCount = lobby.clients.length;
-      this.lobbyCreatorClientID = lobby.clients[0]?.clientID ?? null;
     } else {
       this.players = [];
       this.playerCount = lobby.numClients ?? 0;
@@ -551,6 +554,11 @@ export class JoinLobbyModal extends BaseModal {
         this.loadNationCount();
       }
     }
+
+    const isPrivate = this.gameConfig?.gameType === GameType.Private;
+    this.lobbyCreatorClientID = isPrivate
+      ? (lobby.clients?.[0]?.clientID ?? null)
+      : null;
   }
 
   private startLobbyUpdates() {

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -557,8 +557,7 @@ export class JoinLobbyModal extends BaseModal {
       }
     }
 
-    const isPrivate = this.isPrivateLobby();
-    this.lobbyCreatorClientID = isPrivate
+    this.lobbyCreatorClientID = this.isPrivateLobby()
       ? (lobby.clients?.[0]?.clientID ?? null)
       : null;
   }

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -55,6 +55,10 @@ export class JoinLobbyModal extends BaseModal {
   private countdownTimerId: number | null = null;
   private handledJoinTimeout = false;
 
+  private isPrivateLobby(): boolean {
+    return this.gameConfig?.gameType === GameType.Private;
+  }
+
   private readonly handleLobbyInfo = (event: LobbyInfoEvent) => {
     const lobby = event.lobby;
     if (!this.currentLobbyId || lobby.gameID !== this.currentLobbyId) {
@@ -91,10 +95,9 @@ export class JoinLobbyModal extends BaseModal {
           : translateText("public_lobby.started");
     const maxPlayers = this.gameConfig?.maxPlayers ?? 0;
     const playerCount = this.playerCount;
-    const hostClientID =
-      this.gameConfig?.gameType === GameType.Private
-        ? (this.lobbyCreatorClientID ?? "")
-        : "";
+    const hostClientID = this.isPrivateLobby()
+      ? (this.lobbyCreatorClientID ?? "")
+      : "";
     const content = html`
       <div
         class="h-full flex flex-col bg-black/60 backdrop-blur-md rounded-2xl border border-white/10 overflow-hidden select-none"
@@ -104,8 +107,7 @@ export class JoinLobbyModal extends BaseModal {
           onBack: () => this.closeAndLeave(),
           ariaLabel: translateText("common.close"),
           rightContent:
-            this.currentLobbyId &&
-            this.gameConfig?.gameType === GameType.Private
+            this.currentLobbyId && this.isPrivateLobby()
               ? html`
                   <copy-button .lobbyId=${this.currentLobbyId}></copy-button>
                 `
@@ -147,7 +149,7 @@ export class JoinLobbyModal extends BaseModal {
               `}
         </div>
 
-        ${this.gameConfig?.gameType === GameType.Private
+        ${this.isPrivateLobby()
           ? html`
               <div
                 class="p-6 pt-4 border-t border-white/10 bg-black/20 shrink-0"
@@ -555,7 +557,7 @@ export class JoinLobbyModal extends BaseModal {
       }
     }
 
-    const isPrivate = this.gameConfig?.gameType === GameType.Private;
+    const isPrivate = this.isPrivateLobby();
     this.lobbyCreatorClientID = isPrivate
       ? (lobby.clients?.[0]?.clientID ?? null)
       : null;


### PR DESCRIPTION
## Description:
Hide the host badge when joining public lobbies

before
<img width="802" height="635" alt="スクリーンショット 2026-02-03 21 45 45" src="https://github.com/user-attachments/assets/2b8bd5a0-3023-4bd3-9042-1bbd0649e499" />

after
<img width="668" height="702" alt="スクリーンショット 2026-02-03 21 44 00" src="https://github.com/user-attachments/assets/65eb9b66-99b0-46ce-a786-55974a443010" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri