### PR TITLE
fix: align leaderboard modal background with other modals

### DIFF
--- a/src/client/LeaderboardModal.ts
+++ b/src/client/LeaderboardModal.ts
@@ -79,7 +79,9 @@ export class LeaderboardModal extends BaseModal {
 
     const content = html`
       <div
-        class="h-full flex flex-col bg-black/80 backdrop-blur-xl rounded-2xl border border-white/10 overflow-hidden shadow-2xl"
+        class="h-full flex flex-col overflow-hidden ${this.inline
+          ? "bg-black/60 backdrop-blur-md rounded-2xl border border-white/10"
+          : ""}"
       >
         ${modalHeader({
           titleContent: html`


### PR DESCRIPTION
## Description:
Aligned the LeaderboardModal background styling with other modals (e.g., HelpModal). Uses the same inline background/blur/border treatment to improve visual consistency.

before
leaderboard
<img width="848" height="657" alt="スクリーンショット 2026-02-03 22 07 58" src="https://github.com/user-attachments/assets/b31c0754-00e0-4248-9e2d-97869df99acb" />
other
<img width="921" height="686" alt="スクリーンショット 2026-02-03 22 08 07" src="https://github.com/user-attachments/assets/e84ab4e0-64b1-490f-8d93-d745f4eabbbb" />

after 
leaderboard
<img width="852" height="650" alt="スクリーンショット 2026-02-03 22 08 20" src="https://github.com/user-attachments/assets/6f4a4073-4d6e-4ca8-8ef1-fb08240a5e6b" />
other
<img width="857" height="685" alt="スクリーンショット 2026-02-03 22 08 35" src="https://github.com/user-attachments/assets/367607f7-f665-4e1e-9c34-4566d2b68570" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri