### PR TITLE
fix: show full flag names in selector

### DIFF
--- a/src/client/FlagInputModal.ts
+++ b/src/client/FlagInputModal.ts
@@ -73,7 +73,7 @@ export class FlagInputModal extends BaseModal {
                     }}
                   />
                   <span
-                    class="text-xs font-bold text-gray-300 group-hover:text-white text-center leading-tight w-full truncate"
+                    class="text-xs font-bold text-gray-300 group-hover:text-white text-center leading-tight w-full whitespace-normal break-words"
                     >${country.name}</span
                   >
                 </button>


### PR DESCRIPTION
## Description:

Flag selector country names no longer truncate with ellipses; they wrap normally for readability.

before
<img width="561" height="182" alt="スクリーンショット 2026-02-03 22 21 01" src="https://github.com/user-attachments/assets/965ab93e-e10f-42a0-8771-84f042c31e22" />
after
<img width="582" height="217" alt="スクリーンショット 2026-02-03 22 21 11" src="https://github.com/user-attachments/assets/9c6aa840-5af7-46a7-9f54-58d78e021304" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri