### PR TITLE
Fix: don't show "Join discord" for discord users

### DIFF
--- a/src/client/graphics/layers/WinModal.ts
+++ b/src/client/graphics/layers/WinModal.ts
@@ -40,6 +40,9 @@ export class WinModal extends LitElement implements Layer {
   @state()
   private patternContent: TemplateResult | null = null;
 
+  @state()
+  private hasDiscord = false;
+
   private _title: string;
 
   private rand = Math.random();
@@ -116,7 +119,10 @@ export class WinModal extends LitElement implements Layer {
     if (this.rand < 0.25) {
       return this.steamWishlist();
     } else if (this.rand < 0.5) {
-      return this.discordDisplay();
+      // If user already has Discord, don't show the "join Discord" promo
+      return this.hasDiscord
+        ? this.renderPatternButton()
+        : this.discordDisplay();
     } else {
       return this.renderPatternButton();
     }
@@ -160,6 +166,7 @@ export class WinModal extends LitElement implements Layer {
   async loadPatternContent() {
     const me = await getUserMe();
     const patterns = await fetchCosmetics();
+    this.hasDiscord = me !== false && me.user.discord !== undefined;
 
     const purchasablePatterns: {
       pattern: Pattern;


### PR DESCRIPTION
Resolves #3093

## Description:

If the user is logged in with Discord, then don't promote it at the end of a match.

## Please complete the following:

- [x] I have added screenshots for all UI updates  
  > This doesn't change anything that I can show in screenshots.

- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file  
  > I didn't change any display text.

- [x] I have added relevant tests to the test directory  
  > No tests required.

- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced  
  > Yes I did.

## Please put your Discord username so you can be contacted if a bug or regression is found:

internet_addict_
