### PR TITLE
fix: adjust style for plus and minor leaderboard button to match other buttons

### DIFF
--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -265,7 +265,9 @@ export class Leaderboard extends LitElement implements Layer {
       </div>
 
       <button
-        class="mt-1 px-1.5 py-0.5 md:px-2 md:py-0.5 text-xs md:text-xs lg:text-sm border border-white/20 hover:bg-white/10 text-white mx-auto block"
+        class="mt-1 px-1.5 pb-0.5 md:px-2 text-xs md:text-xs lg:text-sm 
+        border rounded-md border-slate-500 transition-colors
+        text-white mx-auto block hover:bg-white/10"
         @click=${() => {
           this.showTopFive = !this.showTopFive;
           this.updateLeaderboard();


### PR DESCRIPTION
## Description:

Changes the leaderboard + / - buttons to follow the styling of other buttons. 
Suggested by @FloPinguin 

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

***
Screenshots:

Example with previous (above) and new style (below):
<img width="539" height="186" alt="image" src="https://github.com/user-attachments/assets/896e3fba-4dfb-4e12-a6bf-f2c363faf485" />

Example with previous (above) and new style (below) with onhover effect:
<img width="555" height="307" alt="image" src="https://github.com/user-attachments/assets/b76aaa80-2839-4e6c-b244-9af6ce569a9a" />

##Discord username: martoi

***
Signed-off-by: MartinIvovIv <https://github.com/martinIvovIv>