### PR TITLE
fix: matchmaking race condition

### DIFF
--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -525,12 +525,11 @@ async function startMatchmakingPolling(gm: GameManager) {
 
         if (data.assignment) {
           const gameConfig = playlist.get1v1Config();
-          const game = gm.createGame(gameId, gameConfig);
-          setTimeout(() => {
-            // Wait a few seconds to allow clients to connect.
-            console.log(`Starting game ${gameId}`);
-            game.start();
-          }, 7000);
+          gm.createGame(gameId, gameConfig);
+          log.info(
+            `Created matchmaking game ${gameId}, waiting for players...`,
+          );
+          // Game will be started by GameManager when full.
         }
       } catch (error) {
         log.error(`Error polling lobby:`, error);


### PR DESCRIPTION
The worker blindly waits 7 seconds after creating a game from matchmaking before calling. If clients (especially those with slower connections) fail to connect within 7s, the game starts without them or in an invalid state. This is a major source of "game started empty" bugs.


1. GameServer.ts: Added isReadyToStart() mechanism. Public games now explicitly remain in Lobby phase until the required number of players have joined.

GameManager.ts:

- Refactored the central loop to respect the new Lobby -> Active transition strictly.
- Added "stale lobby" cleanup: Lobbies created > 2 minutes ago that haven't started are now automatically destroyed to prevent memory leaks.

Worker.ts: Removed the blind 7-second setTimeout. Games now wait indefinitely (up to the 2-minute stale limit) for players to join before starting.


This eliminates the race condition where games would start empty or broken if players had slow connections, and ensures resource cleanup for failed matches.


