### PR TITLE
feat: improve team colors with LCH color space

### DIFF
--- a/src/core/configuration/Colors.ts
+++ b/src/core/configuration/Colors.ts
@@ -31,11 +31,9 @@ function generateTeamColors(baseColor: Colord): Colord[] {
   return Array.from({ length: colorCount }, (_, index) => {
     if (index === 0) return baseColor;
 
-    // Golden angle hue distribution clamped to ±12° to preserve team identity
-    const rawHueOffset = (index * goldenAngle) % 360;
-    const hueShift = ((rawHueOffset + 180) % 360) - 180;
-    const clampedShift = Math.max(-12, Math.min(12, hueShift));
-    const h = (lch.h + clampedShift + 360) % 360;
+    // Spread hues evenly across ±12° band using golden angle within that range
+    const hueShift = ((index * goldenAngle) % 24) - 12;
+    const h = (lch.h + hueShift + 360) % 360;
 
     // Chroma oscillates ±10% around the base to add variety without washing out
     const chromaFactor = 1.0 + 0.1 * Math.sin(index * 0.7);


### PR DESCRIPTION
## Summary

Refactor `generateTeamColors()` to use LCH (Lightness-Chroma-Hue) color space instead of HSL for perceptually uniform team color variations.

## Changes

- **`Colors.ts`**: Rewrite `generateTeamColors()` to use LCH color space
  - Golden angle hue distribution clamped to ±12° to preserve team identity
  - Chroma oscillates ±10% around the base to add variety without washing out
  - Lightness alternates ±18 around the base to keep teammates recognizable

## Why LCH?

LCH is a perceptually uniform color space, meaning equal numeric differences correspond to equal perceived differences. This produces team color variations that look more consistent and distinguishable compared to HSL-based generation.

## Notes

- The "skip ally attack confirmation" feature that was previously in this PR has been split into a separate PR as requested by @evanpelle.