### PR TITLE
Fix: can't boat into AFK ally from radial menu

### DIFF
--- a/src/client/graphics/layers/RadialMenuElements.ts
+++ b/src/client/graphics/layers/RadialMenuElements.ts
@@ -630,9 +630,7 @@ export const rootMenuElement: MenuElement = {
       ...(isOwnTerritory
         ? [deleteUnitElement, allyRequestElement, buildMenuElement]
         : [
-            isAllied && !isDisconnected
-              ? allyBreakElement
-              : boatMenuElement,
+            isAllied && !isDisconnected ? allyBreakElement : boatMenuElement,
             allyRequestElement,
             isFriendlyTarget(params) && !isDisconnected
               ? donateGoldRadialElement


### PR DESCRIPTION
## Description:

Fixes issue where you can't boat into an AFK/disconnected ally from the radial menu: https://www.youtube.com/clip/UgkxRXy2Y9BrmCiQRSFJnhVFanR5NRsG9pzu

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33