### PR TITLE
Rebalance nation difficulty 📊 More oriented towards beginners now

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -727,9 +727,9 @@ export class DefaultConfig implements Config {
         case Difficulty.Easy:
           return 12_500;
         case Difficulty.Medium:
-          return 25_000; // Like humans
+          return 18_750;
         case Difficulty.Hard:
-          return 28_125;
+          return 25_000; // Like humans
         case Difficulty.Impossible:
           return 31_250;
         default:
@@ -762,9 +762,9 @@ export class DefaultConfig implements Config {
       case Difficulty.Easy:
         return maxTroops * 0.5;
       case Difficulty.Medium:
-        return maxTroops * 1; // Like humans
+        return maxTroops * 0.75;
       case Difficulty.Hard:
-        return maxTroops * 1.125;
+        return maxTroops * 1; // Like humans
       case Difficulty.Impossible:
         return maxTroops * 1.25;
       default:
@@ -790,10 +790,10 @@ export class DefaultConfig implements Config {
           toAdd *= 0.9;
           break;
         case Difficulty.Medium:
-          toAdd *= 1; // Like humans
+          toAdd *= 0.95;
           break;
         case Difficulty.Hard:
-          toAdd *= 1.025;
+          toAdd *= 1; // Like humans
           break;
         case Difficulty.Impossible:
           toAdd *= 1.05;

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -150,8 +150,7 @@ export class MapPlaylist {
         startingGold,
       },
       startingGold,
-      difficulty:
-        playerTeams === HumansVsNations ? Difficulty.Medium : Difficulty.Easy,
+      difficulty: Difficulty.Medium,
       infiniteGold: false,
       infiniteTroops: false,
       maxTimerValue: undefined,


### PR DESCRIPTION
## Description:

**3 problems:**

* Nation difficulty steps in `DefaultConfig` don't look good (max troops: 0.5 → 1 → 1.125 → 1.25).
* We previously reduced the difficulty of easy nations for singleplayer, but now they are too easy for public FFAs.
* In Discord we discussed HvN difficulty and concluded that a 50% human win rate (my previous target) is too low; nations should be easier.

This PR addresses all of them:

* Difficulty steps in `DefaultConfig` are now cleaner (max troops: 0.5 → 0.75 → 1 → 1.25).
* Nation difficulty in public-game FFAs is restored to *medium* (0.75 max troops - still weaker than humans, but not too weak).
* HvN difficulty (medium) is now easier.

Regarding singleplayer:
These rebalances make nation difficulties more beginner-friendly, while experts still have their challenge at *Impossible*.


## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
