### PR TITLE
Add Leaderboard refresh time

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -230,6 +230,7 @@
     "title": "Leaderboard",
     "ranked_tab": "1v1 Ranked",
     "clans_tab": "Clans",
+    "refresh_time": "Refreshed every 1 hour",
     "loading": "Loading...",
     "error": "Error loading leaderboard",
     "no_stats": "No stats available",

--- a/src/client/LeaderboardModal.ts
+++ b/src/client/LeaderboardModal.ts
@@ -76,6 +76,10 @@ export class LeaderboardModal extends BaseModal {
         >(${start} - ${end})</span
       >`;
     }
+    const refreshTime = html`<span
+        class="text-sm font-normal text-white/40 ml-2 wrap-break-words italic"
+        >(${translateText("leaderboard_modal.refresh_time")})</span
+      >`;
 
     const content = html`
       <div
@@ -92,6 +96,7 @@ export class LeaderboardModal extends BaseModal {
                 ${translateText("leaderboard_modal.title")}
               </span>
               ${this.activeTab === "clans" ? dateRange : ""}
+              ${this.activeTab === "players" ? refreshTime : ""}
             </div>
           `,
           onBack: this.close,

--- a/src/client/LeaderboardModal.ts
+++ b/src/client/LeaderboardModal.ts
@@ -77,9 +77,9 @@ export class LeaderboardModal extends BaseModal {
       >`;
     }
     const refreshTime = html`<span
-        class="text-sm font-normal text-white/40 ml-2 wrap-break-words italic"
-        >(${translateText("leaderboard_modal.refresh_time")})</span
-      >`;
+      class="text-sm font-normal text-white/40 ml-2 wrap-break-words italic"
+      >(${translateText("leaderboard_modal.refresh_time")})</span
+    >`;
 
     const content = html`
       <div

--- a/tests/client/LeaderboardModal.test.ts
+++ b/tests/client/LeaderboardModal.test.ts
@@ -17,6 +17,7 @@ vi.mock("../../src/client/Utils", () => ({
       "leaderboard_modal.title": "Leaderboard",
       "leaderboard_modal.ranked_tab": "Ranked",
       "leaderboard_modal.clans_tab": "Clans",
+      "leaderboard_modal.refresh_time": "Refreshed every 1 hour",
       "leaderboard_modal.error": "Something went wrong",
       "leaderboard_modal.rank": "Rank",
       "leaderboard_modal.clan": "Clan",


### PR DESCRIPTION
## Description:

I added a small refresh time text (see screenshots below).

> I play ranked a lot since it's been added and I just reached the top 100 (yay !!), I was wondering what was the refresh time so after I found it in the code, I wanted to add a small text for easier understanding :)





<details>
  <summary><h2>Open Screenshots "players" here</h2></summary>

Before "players" :
<img width="622" height="645" alt="image" src="https://github.com/user-attachments/assets/d3335954-8e16-4465-b09f-89d03defe643" />

After "players" :

<img width="628" height="637" alt="image" src="https://github.com/user-attachments/assets/fd89df53-0942-4869-bfb5-9c7e7497af38" />

</details>


This can be edited as you want but I did not added the text in the "clans" section.

I did not added any test in the tests files since this is a minor UI improvement, but I can if needed, And I do tested everything locally myself to take the screenshots :)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

@noleet
