### PR TITLE
Update 1v1 game configuration: Original format 🗡️

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -173,23 +173,24 @@ export class MapPlaylist {
       GameMapType.Asia, // 20%
       GameMapType.EuropeClassic, // 20%
     ];
+    const isCompact = Math.random() < 0.5;
     return {
       donateGold: false,
       donateTroops: false,
       gameMap: maps[Math.floor(Math.random() * maps.length)],
       maxPlayers: 2,
       gameType: GameType.Public,
-      gameMapSize: GameMapSize.Normal,
+      gameMapSize: isCompact ? GameMapSize.Compact : GameMapSize.Normal,
       difficulty: Difficulty.Medium, // Doesn't matter, nations are disabled
       rankedType: RankedType.OneVOne,
       infiniteGold: false,
       infiniteTroops: false,
-      maxTimerValue: 15, // 15 minutes
+      maxTimerValue: isCompact ? 10 : 15,
       instantBuild: false,
       randomSpawn: false,
       disableNations: true,
       gameMode: GameMode.FFA,
-      bots: 400,
+      bots: isCompact ? 100 : 400,
       spawnImmunityDuration: 30 * 10,
       disabledUnits: [],
     } satisfies GameConfig;


### PR DESCRIPTION
## Description:

This PR changes the ranked 1vs1 config to use the original format (tournaments and openfront 1vs1 club): https://discord.com/channels/1359946986937258015/1463178945108246757
(Reasoning in the discord thread)

But I still think we need a **1vs1 "party mode"**. With nations, ALL our small maps, and sometimes compact maps. Maybe even sometimes with 5M starting gold.
- Offering it to all 1vs1 players below a specific ELO count is probably not the best idea: Some people will avoid getting too much ELO, others will hate it until they have enough ELO.
- Offering another matchmaking queue might be an idea, but might cause too much complexity (needs its own ELO system and its own leaderboard).
- A solution could be: Offer 1vs1 party games without ELO in the upcoming new "special" rotation (Collect 20 players and put them into 10 games)

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
