### PR TITLE
Fix: console error stemming from WinModal

### DIFF
--- a/src/client/graphics/layers/WinModal.ts
+++ b/src/client/graphics/layers/WinModal.ts
@@ -93,7 +93,7 @@ export class WinModal extends LitElement implements Layer {
             @click=${this.hide}
             class="flex-1 px-3 py-3 text-base cursor-pointer bg-blue-500/60 text-white border-0 rounded-sm transition-all duration-200 hover:bg-blue-500/80 hover:-translate-y-px active:translate-y-px"
           >
-            ${this.game.myPlayer()?.isAlive()
+            ${this.game?.myPlayer()?.isAlive()
               ? translateText("win_modal.keep")
               : translateText("win_modal.spectate")}
           </button>


### PR DESCRIPTION
## Description:

Fix console error triggered by this.game being undefined but WinModal render() still tries to get this.game.myPlayer?.

There is no guard needed in tick() or show() (the latter only called by tick). Because when this.game is undefined tick() won't be called anyway.

![undefined in WinModal reading myPlayer in console at game start](https://github.com/user-attachments/assets/0c399516-f6a1-418d-916b-2633413eb241)

![undefined in WinModal reading myPlayer in console at game start B](https://github.com/user-attachments/assets/28986383-596a-4a64-bc26-b00f28828bb7)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33