### PR TITLE
Adjust styling for attack ratio popup and event display button ✨

### DIFF
--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -324,7 +324,7 @@ export class ControlPanel extends LitElement implements Layer {
         ${this._touchDragging
           ? html`
               <div
-                class="absolute bottom-full right-0 flex flex-col items-center pointer-events-auto z-[10000] bg-gray-800/80 backdrop-blur-sm rounded-l-lg sm:rounded-lg p-2 w-12"
+                class="absolute bottom-full right-0 flex flex-col items-center pointer-events-auto z-[10000] bg-gray-800/70 backdrop-blur-xs rounded-tl-lg sm:rounded-lg p-2 w-12"
                 style="height: 50vh;"
                 @touchstart=${(e: TouchEvent) => this.handleBarTouch(e)}
               >

--- a/src/client/graphics/layers/EventsDisplay.ts
+++ b/src/client/graphics/layers/EventsDisplay.ts
@@ -799,7 +799,7 @@ export class EventsDisplay extends LitElement implements Layer {
                 `,
                 onClick: this.toggleHidden,
                 className:
-                  "text-white cursor-pointer pointer-events-auto w-fit p-2 lg:p-3 min-[1200px]:rounded-lg sm:rounded-tl-lg bg-gray-800/70 backdrop-blur-xs",
+                  "text-white cursor-pointer pointer-events-auto w-fit p-2 lg:p-3 min-[1200px]:rounded-lg max-sm:rounded-tr-lg sm:rounded-tl-lg bg-gray-800/70 backdrop-blur-xs",
               })}
             </div>
           `


### PR DESCRIPTION
## Description:

Before:

<img width="445" height="501" alt="Screenshot 2026-02-16 205903" src="https://github.com/user-attachments/assets/3add2b1c-f108-4138-9066-ce16ce9fb76d" />

After:

<img width="484" height="515" alt="Screenshot 2026-02-16 210819" src="https://github.com/user-attachments/assets/cb7ba559-535e-4e87-a4b2-4bf744b98e6e" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
