### PR TITLE
Refactor attacker troop loss calculation

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -652,15 +652,23 @@ export class DefaultConfig implements Config {
         largeAttackerSpeedBonus = (100_000 / attacker.numTilesOwned()) ** 0.6;
       }
 
+      const defenderTroopLoss = defender.troops() / defender.numTilesOwned();
+      const traitorMod = defender.isTraitor() ? this.traitorDefenseDebuff() : 1;
+      const currentAttackerLoss =
+        within(defender.troops() / attackTroops, 0.6, 2) *
+        mag *
+        0.8 *
+        largeDefenderAttackDebuff *
+        largeAttackBonus *
+        traitorMod;
+      const altAttackerLoss =
+        1.3 * defenderTroopLoss * (mag / 100) * traitorMod;
+      const attackerTroopLoss =
+        0.5 * currentAttackerLoss + 0.5 * altAttackerLoss;
+
       return {
-        attackerTroopLoss:
-          within(defender.troops() / attackTroops, 0.6, 2) *
-          mag *
-          0.8 *
-          largeDefenderAttackDebuff *
-          largeAttackBonus *
-          (defender.isTraitor() ? this.traitorDefenseDebuff() : 1),
-        defenderTroopLoss: defender.troops() / defender.numTilesOwned(),
+        attackerTroopLoss,
+        defenderTroopLoss,
         tilesPerTickUsed:
           within(defender.troops() / (5 * attackTroops), 0.2, 1.5) *
           speed *


### PR DESCRIPTION

## Description:
This PR fixes (at least partially) the attack loss imbalance. Would recommend adjusting the weighting towards 100% in the long run and then removing redundant code. I haven't tested it at 100% yet, but it might actually be fine to change it now. I don't notice any substantial differences in how the game feels at 50%.


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
