### PR TITLE
Update tradeship spawn & gold meta

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -126,11 +126,10 @@ export interface Config {
   defaultDonationAmount(sender: Player): number;
   unitInfo(type: UnitType): UnitInfo;
   tradeShipShortRangeDebuff(): number;
-  tradeShipGold(dist: number, numPorts: number): Gold;
+  tradeShipGold(dist: number): Gold;
   tradeShipSpawnRate(
+    tradeShipSpawnRejections: number,
     numTradeShips: number,
-    numPlayerPorts: number,
-    numPlayerTradeShips: number,
   ): number;
   trainGold(rel: "self" | "team" | "ally" | "other"): Gold;
   trainSpawnRate(numPlayerFactories: number): number;

--- a/src/core/execution/PortExecution.ts
+++ b/src/core/execution/PortExecution.ts
@@ -9,6 +9,7 @@ export class PortExecution implements Execution {
   private port: Unit;
   private random: PseudoRandom;
   private checkOffset: number;
+  private tradeShipSpawnRejections = 0;
 
   constructor(port: Unit) {
     this.port = port;
@@ -69,17 +70,15 @@ export class PortExecution implements Execution {
 
   shouldSpawnTradeShip(): boolean {
     const numTradeShips = this.mg.unitCount(UnitType.TradeShip);
-    const numPlayerPorts = this.port!.owner().unitCount(UnitType.Port);
-    const numPlayerTradeShips = this.port!.owner().unitCount(
-      UnitType.TradeShip,
-    );
     const spawnRate = this.mg
       .config()
-      .tradeShipSpawnRate(numTradeShips, numPlayerPorts, numPlayerTradeShips);
+      .tradeShipSpawnRate(this.tradeShipSpawnRejections, numTradeShips);
     for (let i = 0; i < this.port!.level(); i++) {
       if (this.random.chance(spawnRate)) {
+        this.tradeShipSpawnRejections = 0;
         return true;
       }
+      this.tradeShipSpawnRejections++;
     }
     return false;
   }

--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -133,12 +133,7 @@ export class TradeShipExecution implements Execution {
   private complete() {
     this.active = false;
     this.tradeShip!.delete(false);
-    const gold = this.mg
-      .config()
-      .tradeShipGold(
-        this.tilesTraveled,
-        this.tradeShip!.owner().unitCount(UnitType.Port),
-      );
+    const gold = this.mg.config().tradeShipGold(this.tilesTraveled);
 
     if (this.wasCaptured) {
       this.tradeShip!.owner().addGold(gold, this._dstPort.tile());


### PR DESCRIPTION
## Description:

Now that pathfinding is much more efficient with hpa*, we can add more trade ships.

This PR does the following:

1. No gold bonus for additional ports, keeps the meta simple
2. cut the gold per trade ship roughly in half.
3. Use a "pity bonus", the more times a port has failed to spawn a tradeship, the higher the likelyhood it will spawn one
4. Increase the sigmoid so the mid-point is 200, with a half life of 50. In tests about ~400 trade ships max.

It's pretty difficult to balance on singleplayer so I'm sure the values will be adjusted after playtests.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
