### PR TITLE
Cleanup: remove unused code from four files

### DIFF
--- a/src/client/graphics/layers/PlayerActionHandler.ts
+++ b/src/client/graphics/layers/PlayerActionHandler.ts
@@ -1,5 +1,4 @@
 import { EventBus } from "../../../core/EventBus";
-import { PlayerActions } from "../../../core/game/Game";
 import { TileRef } from "../../../core/game/GameMap";
 import { PlayerView } from "../../../core/game/GameView";
 import {
@@ -22,13 +21,6 @@ export class PlayerActionHandler {
     private eventBus: EventBus,
     private uiState: UIState,
   ) {}
-
-  async getPlayerActions(
-    player: PlayerView,
-    tile: TileRef,
-  ): Promise<PlayerActions> {
-    return await player.actions(tile);
-  }
 
   handleAttack(player: PlayerView, targetId: string | null) {
     this.eventBus.emit(

--- a/src/client/graphics/layers/StructureIconsLayer.ts
+++ b/src/client/graphics/layers/StructureIconsLayer.ts
@@ -8,7 +8,6 @@ import { wouldNukeBreakAlliance } from "../../../core/execution/Util";
 import {
   BuildableUnit,
   Cell,
-  PlayerActions,
   PlayerID,
   UnitType,
 } from "../../../core/game/Game";
@@ -74,7 +73,6 @@ export class StructureIconsLayer implements Layer {
   private ghostStage: PIXI.Container;
   private levelsStage: PIXI.Container;
   private rootStage: PIXI.Container = new PIXI.Container();
-  public playerActions: PlayerActions | null = null;
   private dotsStage: PIXI.Container;
   private readonly theme: Theme;
   private renderer: PIXI.Renderer | null = null;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -360,7 +360,6 @@ export class DefaultConfig implements Config {
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
           upgradable: true,
-          canBuildTrainStation: true,
         };
       case UnitType.AtomBomb:
         return {
@@ -429,7 +428,6 @@ export class DefaultConfig implements Config {
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
           upgradable: true,
-          canBuildTrainStation: true,
         };
       case UnitType.Factory:
         return {
@@ -441,15 +439,12 @@ export class DefaultConfig implements Config {
           ),
           territoryBound: true,
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
-          canBuildTrainStation: true,
-          experimental: true,
           upgradable: true,
         };
       case UnitType.Train:
         return {
           cost: () => 0n,
           territoryBound: false,
-          experimental: true,
         };
       default:
         assertNever(type);

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -233,8 +233,6 @@ export interface UnitInfo {
   damage?: number;
   constructionDuration?: number;
   upgradable?: boolean;
-  canBuildTrainStation?: boolean;
-  experimental?: boolean;
 }
 
 export enum UnitType {


### PR DESCRIPTION
## Description:

PR 2/x in effort to break up PR https://github.com/openfrontio/OpenFrontIO/pull/3220. Follows on https://github.com/openfrontio/OpenFrontIO/pull/3233. Precedes https://github.com/openfrontio/OpenFrontIO/pull/3235.

Please see if these can be merged for v30.

Removes unused code and properties.

- **Game.ts** and **DefaultConfig** unitInfo: removed _canBuildTrainStation_ and _expirimental_ properties, as they weren't used anywhere anymore.

- **PlayerActionHandler**: remove unused getPlayerActions, the only potential caller MainRadialMenu already just calls myPlayer.actions via GameView directly.

- **StructureIconsLayer**: remove unused PlayerActions

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33