### PR TITLE
Small refactor/cleanup: RadialMenuElements and PlayerImpl

### DIFF
--- a/src/client/graphics/layers/RadialMenuElements.ts
+++ b/src/client/graphics/layers/RadialMenuElements.ts
@@ -1,5 +1,10 @@
 import { Config } from "../../../core/configuration/Config";
-import { AllPlayers, PlayerActions, UnitType } from "../../../core/game/Game";
+import {
+  AllPlayers,
+  PlayerActions,
+  StructureTypes,
+  UnitType,
+} from "../../../core/game/Game";
 import { TileRef } from "../../../core/game/GameMap";
 import { GameView, PlayerView } from "../../../core/game/GameView";
 import { Emoji, flattenedEmojiTable } from "../../../core/Util";
@@ -338,29 +343,24 @@ export const infoMenuElement: MenuElement = {
 };
 
 function getAllEnabledUnits(myPlayer: boolean, config: Config): Set<UnitType> {
-  const Units: Set<UnitType> = new Set<UnitType>();
+  const units: Set<UnitType> = new Set<UnitType>();
 
-  const addStructureIfEnabled = (unitType: UnitType) => {
+  const addIfEnabled = (unitType: UnitType) => {
     if (!config.isUnitDisabled(unitType)) {
-      Units.add(unitType);
+      units.add(unitType);
     }
   };
 
   if (myPlayer) {
-    addStructureIfEnabled(UnitType.City);
-    addStructureIfEnabled(UnitType.DefensePost);
-    addStructureIfEnabled(UnitType.Port);
-    addStructureIfEnabled(UnitType.MissileSilo);
-    addStructureIfEnabled(UnitType.SAMLauncher);
-    addStructureIfEnabled(UnitType.Factory);
+    StructureTypes.forEach(addIfEnabled);
   } else {
-    addStructureIfEnabled(UnitType.Warship);
-    addStructureIfEnabled(UnitType.HydrogenBomb);
-    addStructureIfEnabled(UnitType.MIRV);
-    addStructureIfEnabled(UnitType.AtomBomb);
+    addIfEnabled(UnitType.Warship);
+    addIfEnabled(UnitType.HydrogenBomb);
+    addIfEnabled(UnitType.MIRV);
+    addIfEnabled(UnitType.AtomBomb);
   }
 
-  return Units;
+  return units;
 }
 
 const ATTACK_UNIT_TYPES: UnitType[] = [

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -997,7 +997,7 @@ export class PlayerImpl implements Player {
             canBuild !== false
               ? this.mg.railNetwork().computeGhostRailPaths(u, canBuild)
               : [],
-        } as BuildableUnit;
+        };
       });
   }
 


### PR DESCRIPTION
## Description:

PR 7/x in effort to break up PR #3220. Follows on already merged #3238.

Please see if these can be merged for v30.

-**RadialMenuElements**: 
- _getAllEnabledUnits_: use camelCase instead of PascalCase so change Units into units. 
- _getAllEnabledUnits_: use StructureTypes to loop through instead of having 6 individual lines of code to check if a structure is enabled. StructureTypes contains and will keep containing the same structures as those that are checked here. PR 3220 will later on also replace the individual lines for the attack type units into a loop with a newly introduced Types array, in the same way as we do in this PR with StructureTypes.
- _getAllEnabledUnits_: rename the long named const addStructureIfEnabled to just addIfEnabled, which is clear enough from the context it is used in.

-**PlayerImpl**
- _buildableUnits_: removed unnecessary "as BuildableUnit" after the in-loop return; the function itself already says it returns BuildableUnit[].

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33