### PR TITLE
Game creation rate: 1 minute -> 2 minutes 🔧

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -119,7 +119,7 @@ export abstract class DefaultServerConfig implements ServerConfig {
     return 100;
   }
   gameCreationRate(): number {
-    return 60 * 1000;
+    return 2 * 60 * 1000;
   }
 
   workerIndex(gameID: GameID): number {


### PR DESCRIPTION
## Description:

Can we maintain a one-minute game creation rate with three times as many lobbies?

I don’t think so - we should allow more time for players to join.

It still shouldn’t bore players, since they can also join the special mix lobby. That lobby includes both FFA and team games and fills more quickly due to the higher frequency of compact-map matches (the Wonder PR https://github.com/openfrontio/OpenFrontIO/pull/3224 needs to be merged for that).

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin