### PR TITLE
Prevent self-retaliation crash when own nuke destroys own ship 🔧

### DIFF
--- a/src/core/execution/nation/NationWarshipBehavior.ts
+++ b/src/core/execution/nation/NationWarshipBehavior.ts
@@ -136,6 +136,11 @@ export class NationWarshipBehavior {
     enemy: Player,
     reason: "trade" | "transport",
   ): void {
+    // Don't retaliate against ourselves (e.g. own nuke destroyed own ship)
+    if (enemy === this.player) {
+      return;
+    }
+
     // Don't send too many warships
     if (this.player.units(UnitType.Warship).length >= 10) {
       return;


### PR DESCRIPTION
## Description:

Noticed this in two singleplayer games:

When a nation's nuke destroys its own transport/trade ship in the blast radius, `NationWarshipBehavior` incorrectly tries to retaliate against itself, calling `updateRelation(self)` which throws (GameRunner tick error).

Added a self-check in `maybeRetaliateWithWarship` to skip retaliation when the destroyer is the player itself.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin