### PR TITLE
Fix: less console warn spam on each attack-click

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -654,8 +654,7 @@ export class ClientGameRunner {
     }
 
     this.myPlayer.actions(tile).then((actions) => {
-      const canBoat = this.canBoatAttack(actions);
-      if (canBoat === false) {
+      if (this.canBoatAttack(actions) === false) {
         console.warn(
           "Boat attack triggered but can't send Transport Ship to tile",
         );


### PR DESCRIPTION
## Description:

Rabbit suggestion to move console warn for not being able to send boat to doBoatAttackUnderCursor and remove it from canBoatAttack. 

On each attack-click on land, if that land is own land or ally and canAttack is false, it will check canAutoBoat. Even if user had no intention to attack, there would be a warning that no boat could be send. Now only do that warning when user actually intended to send a boat using hotkey G which calls doBoatAttackUnderCursor.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33