### PR TITLE
Small perf: find() instead of filter() for retreat

### DIFF
--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -366,20 +366,20 @@ export class PlayerImpl implements Player {
     this.mg.conquer(this, tile);
   }
   orderRetreat(id: string) {
-    const attack = this._outgoingAttacks.filter((attack) => attack.id() === id);
-    if (!attack || !attack[0]) {
+    const attack = this._outgoingAttacks.find((attack) => attack.id() === id);
+    if (!attack) {
       console.warn(`Didn't find outgoing attack with id ${id}`);
       return;
     }
-    attack[0].orderRetreat();
+    attack.orderRetreat();
   }
   executeRetreat(id: string): void {
-    const attack = this._outgoingAttacks.filter((attack) => attack.id() === id);
+    const attack = this._outgoingAttacks.find((attack) => attack.id() === id);
     // Execution is delayed so it's not an error that the attack does not exist.
-    if (!attack || !attack[0]) {
+    if (!attack) {
       return;
     }
-    attack[0].executeRetreat();
+    attack.executeRetreat();
   }
   relinquish(tile: TileRef) {
     if (this.mg.owner(tile) !== this) {


### PR DESCRIPTION
## Description:

Only need find() instead of filter() in orderRetreat and executeRetreat, since we just need the first hit. Small perf win.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33