### PR TITLE
Spawn. Fix respawn near the previos spawn

### DIFF
--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -49,6 +49,7 @@ export class SpawnExecution implements Execution {
       return;
     }
 
+    player.tiles().forEach((t) => player.relinquish(t));
     const spawn = this.getSpawn(this.tile);
 
     if (!spawn) {
@@ -56,7 +57,6 @@ export class SpawnExecution implements Execution {
       return;
     }
 
-    player.tiles().forEach((t) => player.relinquish(t));
     spawn.tiles.forEach((t) => {
       player.conquer(t);
     });


### PR DESCRIPTION
## Description:

Because spawning is prohibited on tiles that have an owner, this created a problem when a person tried to spawn near the center of their previous spawn. This was resolved by relinquishing all the tiles conquered by the previous spawn.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

nikolaj_mykola
