### PR TITLE
Clarify connection label in account modal

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -208,7 +208,7 @@
   },
   "account_modal": {
     "title": "Account",
-    "connected_as": "Connected with the following Discord account",
+    "connected_as": "Connected with the following account",
     "stats_overview": "Stats Overview",
     "link_discord": "Link Discord Account",
     "log_out": "Log Out",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -208,7 +208,7 @@
   },
   "account_modal": {
     "title": "Account",
-    "connected_as": "Connected as",
+    "connected_as": "Connected with the following Discord account",
     "stats_overview": "Stats Overview",
     "link_discord": "Link Discord Account",
     "log_out": "Log Out",


### PR DESCRIPTION
Resolves https://discord.com/channels/1359544954044551290/1359544954803847210/1475490032046444544

## Description:
Replaced the `connected_as` label in the account modal
from: Connected as
to: Connected with the following account

Reason: https://discord.com/channels/1359544954044551290/1359544954803847210/1475490032046444544

before 
<img width="275" height="221" alt="スクリーンショット 2026-02-24 21 13 59" src="https://github.com/user-attachments/assets/aeb8bac1-59df-4b6d-8edb-abd1283e88d6" />

after 
<img width="424" height="215" alt="スクリーンショット 2026-02-24 21 15 12" src="https://github.com/user-attachments/assets/fb1dd385-640f-45e9-8a3e-51dd0d7871bc" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri