### PR TITLE
perf(PerformanceOverlay): reduce per-render overhead

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -852,6 +852,7 @@
     "tps": "TPS:",
     "tps_avg_60s": "Avg:",
     "tick_exec": "Tick Exec:",
+    "max_label": "max:",
     "tick_delay": "Tick Delay:",
     "layers_header": "Render Layers",
     "render_layers_table_header": "avg / max | tick avg",

--- a/src/client/graphics/layers/PerformanceOverlay.ts
+++ b/src/client/graphics/layers/PerformanceOverlay.ts
@@ -153,6 +153,7 @@ export class PerformanceOverlay extends LitElement implements Layer {
     tps: string;
     tpsAvg60s: string;
     tickExec: string;
+    maxLabel: string;
     tickDelay: string;
     layersHeader: string;
     tickLayersHeader: string;
@@ -172,6 +173,7 @@ export class PerformanceOverlay extends LitElement implements Layer {
     tps: "performance_overlay.tps",
     tpsAvg60s: "performance_overlay.tps_avg_60s",
     tickExec: "performance_overlay.tick_exec",
+    maxLabel: "performance_overlay.max_label",
     tickDelay: "performance_overlay.tick_delay",
     layersHeader: "performance_overlay.layers_header",
     tickLayersHeader: "performance_overlay.tick_layers_header",
@@ -215,6 +217,7 @@ export class PerformanceOverlay extends LitElement implements Layer {
       tps: translateText("performance_overlay.tps"),
       tpsAvg60s: translateText("performance_overlay.tps_avg_60s"),
       tickExec: translateText("performance_overlay.tick_exec"),
+      maxLabel: translateText("performance_overlay.max_label"),
       tickDelay: translateText("performance_overlay.tick_delay"),
       layersHeader: translateText("performance_overlay.layers_header"),
       tickLayersHeader: translateText("performance_overlay.tick_layers_header"),
@@ -1169,12 +1172,12 @@ export class PerformanceOverlay extends LitElement implements Layer {
           <div class="performance-line">
             ${this.uiText.tickExec}
             <span>${this.tickExecutionAvg.toFixed(2)}ms</span>
-            (max: <span>${this.tickExecutionMax}ms</span>)
+            (${this.uiText.maxLabel} <span>${this.tickExecutionMax}ms</span>)
           </div>
           <div class="performance-line">
             ${this.uiText.tickDelay}
             <span>${this.tickDelayAvg.toFixed(2)}ms</span>
-            (max: <span>${this.tickDelayMax}ms</span>)
+            (${this.uiText.maxLabel} <span>${this.tickDelayMax}ms</span>)
           </div>
           ${this.layerStats.size
             ? html`<div class="layers-section">


### PR DESCRIPTION



## Description:

Cache translated UI labels per language/translation load
Avoid per-frame layer breakdown sorting unless expanded
Use rolling sums instead of array reduce
Drop redundant requestUpdate() calls and object clones

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
