### PR TITLE
perf(translateText): speed up translateText

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -351,24 +351,26 @@ export const translateText = (
   }
 
   const translations = langSelector.translations;
-  if (!translations) return key;
+  const defaultTranslations = langSelector.defaultTranslations;
+  if (!translations && !defaultTranslations) return key;
 
   if (self.lastLang !== langSelector.currentLang) {
     self.formatterCache.clear();
     self.lastLang = langSelector.currentLang;
   }
 
-  const hasPrimaryTranslation = translations[key] !== undefined;
-  let message = translations[key];
+  let message = translations?.[key];
+  const hasPrimaryTranslation = message !== undefined;
 
-  if (!message && langSelector.defaultTranslations) {
-    message = langSelector.defaultTranslations[key];
-  }
+  message ??= defaultTranslations?.[key];
 
-  if (!message) return key;
+  if (message === undefined) return key;
 
   // Fast path: no params and no ICU placeholders.
-  if (resolvedParams === EMPTY_TRANSLATION_PARAMS && !message.includes("{")) {
+  if (
+    resolvedParams === EMPTY_TRANSLATION_PARAMS &&
+    message.indexOf("{") === -1
+  ) {
     return message;
   }
 


### PR DESCRIPTION
## Description:

Cache lang-selector lookup
Avoid per-call empty params allocation
Add fast-path for non-ICU strings

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
