### PR TITLE
Add Traefik integration to deployment script

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -33,11 +33,11 @@ fi
 echo "Tunnel created with ID: ${TUNNEL_ID}"
 
 # Configure the tunnel with hostname
-echo "Configuring tunnel to point to ${SUBDOMAIN}.${DOMAIN}..."
+echo "Configuring tunnel to point to tunnel-${SUBDOMAIN}.${DOMAIN}..."
 curl -s -X PUT "https://api.cloudflare.com/client/v4/accounts/${CF_ACCOUNT_ID}/cfd_tunnel/${TUNNEL_ID}/configurations" \
     -H "Authorization: Bearer ${CF_API_TOKEN}" \
     -H "Content-Type: application/json" \
-    --data "{\"config\":{\"ingress\":[{\"hostname\":\"${SUBDOMAIN}.${DOMAIN}\",\"service\":\"http://localhost:80\"},{\"service\":\"http_status:404\"}]}}"
+    --data "{\"config\":{\"ingress\":[{\"hostname\":\"tunnel-${SUBDOMAIN}.${DOMAIN}\",\"service\":\"http://localhost:80\"},{\"service\":\"http_status:404\"}]}}"
 
 # Update DNS record to point to the new tunnel
 echo "Updating DNS record to point to the new tunnel..."
@@ -55,7 +55,7 @@ if [ -z "$ZONE_ID" ] || [ "$ZONE_ID" == "null" ]; then
 fi
 
 # Check for existing record
-EXISTING_RECORDS=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=${SUBDOMAIN}.${DOMAIN}" \
+EXISTING_RECORDS=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records?name=tunnel-${SUBDOMAIN}.${DOMAIN}" \
     -H "Authorization: Bearer ${CF_API_TOKEN}" \
     -H "Content-Type: application/json")
 
@@ -68,18 +68,18 @@ if [ -z "$RECORD_ID" ] || [ "$RECORD_ID" == "null" ]; then
     DNS_RESPONSE=$(curl -s -X POST "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records" \
         -H "Authorization: Bearer ${CF_API_TOKEN}" \
         -H "Content-Type: application/json" \
-        --data "{\"type\":\"CNAME\",\"name\":\"${SUBDOMAIN}\",\"content\":\"${TUNNEL_ID}.cfargotunnel.com\",\"ttl\":1,\"proxied\":true}")
+        --data "{\"type\":\"CNAME\",\"name\":\"tunnel-${SUBDOMAIN}.${DOMAIN}\",\"content\":\"${TUNNEL_ID}.cfargotunnel.com\",\"ttl\":1,\"proxied\":true}")
 else
     # Update existing record
     echo "Updating existing DNS record..."
     DNS_RESPONSE=$(curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/${ZONE_ID}/dns_records/${RECORD_ID}" \
         -H "Authorization: Bearer ${CF_API_TOKEN}" \
         -H "Content-Type: application/json" \
-        --data "{\"type\":\"CNAME\",\"name\":\"${SUBDOMAIN}\",\"content\":\"${TUNNEL_ID}.cfargotunnel.com\",\"ttl\":1,\"proxied\":true}")
+        --data "{\"type\":\"CNAME\",\"name\":\"tunnel-${SUBDOMAIN}.${DOMAIN}\",\"content\":\"${TUNNEL_ID}.cfargotunnel.com\",\"ttl\":1,\"proxied\":true}")
 fi
 
 # Log the tunnel information
-echo "Tunnel configuration is set up! Site will be available at: https://${SUBDOMAIN}.${DOMAIN}"
+echo "Tunnel configuration is set up! Site will be available at: https://tunnel-${SUBDOMAIN}.${DOMAIN}"
 
 # Export the tunnel token for supervisord
 export CLOUDFLARE_TUNNEL_TOKEN=${TUNNEL_TOKEN}


### PR DESCRIPTION
## Description:

Connects deployed containers to Traefik for automatic reverse proxy routing, replacing the previous Cloudflare Tunnel approach.

```
 docker inspect openfront-staging-traefik --format '{{json .Config.Labels}}' | jq
{
  "traefik.enable": "true",
  "traefik.http.routers.openfront-staging-traefik.entrypoints": "web",
  "traefik.http.routers.openfront-staging-traefik.rule": "Host(`traefik.openfront.dev`)",
  "traefik.http.services.openfront-staging-traefik.loadbalancer.server.port": "80"
}
```

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
