### PR TITLE
perf(worker): remove heartbeat; batch game updates

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -385,15 +385,6 @@ export class ClientGameRunner {
       }
     });
 
-    const worker = this.worker;
-    const keepWorkerAlive = () => {
-      if (this.isActive) {
-        worker.sendHeartbeat();
-        requestAnimationFrame(keepWorkerAlive);
-      }
-    };
-    requestAnimationFrame(keepWorkerAlive);
-
     const onconnect = () => {
       console.log("Connected to game server!");
       this.transport.rejoinGame(this.turnsSeen);

--- a/src/core/worker/WorkerClient.ts
+++ b/src/core/worker/WorkerClient.ts
@@ -45,6 +45,13 @@ export class WorkerClient {
           this.gameUpdateCallback(message.gameUpdate);
         }
         break;
+      case "game_update_batch":
+        if (this.gameUpdateCallback && message.gameUpdates) {
+          for (const gu of message.gameUpdates) {
+            this.gameUpdateCallback(gu);
+          }
+        }
+        break;
 
       case "initialized":
       default:
@@ -100,12 +107,6 @@ export class WorkerClient {
     this.worker.postMessage({
       type: "turn",
       turn,
-    });
-  }
-
-  sendHeartbeat() {
-    this.worker.postMessage({
-      type: "heartbeat",
     });
   }
 

--- a/src/core/worker/WorkerMessages.ts
+++ b/src/core/worker/WorkerMessages.ts
@@ -10,11 +10,11 @@ import { GameUpdateViewData } from "../game/GameUpdates";
 import { ClientID, GameStartInfo, Turn } from "../Schemas";
 
 export type WorkerMessageType =
-  | "heartbeat"
   | "init"
   | "initialized"
   | "turn"
   | "game_update"
+  | "game_update_batch"
   | "player_actions"
   | "player_actions_result"
   | "player_profile"
@@ -30,10 +30,6 @@ export type WorkerMessageType =
 interface BaseWorkerMessage {
   type: WorkerMessageType;
   id?: string;
-}
-
-export interface HeartbeatMessage extends BaseWorkerMessage {
-  type: "heartbeat";
 }
 
 // Messages from main thread to worker
@@ -56,6 +52,11 @@ export interface InitializedMessage extends BaseWorkerMessage {
 export interface GameUpdateMessage extends BaseWorkerMessage {
   type: "game_update";
   gameUpdate: GameUpdateViewData;
+}
+
+export interface GameUpdateBatchMessage extends BaseWorkerMessage {
+  type: "game_update_batch";
+  gameUpdates: GameUpdateViewData[];
 }
 
 export interface PlayerActionsMessage extends BaseWorkerMessage {
@@ -116,7 +117,6 @@ export interface TransportShipSpawnResultMessage extends BaseWorkerMessage {
 
 // Union types for type safety
 export type MainThreadMessage =
-  | HeartbeatMessage
   | InitMessage
   | TurnMessage
   | PlayerActionsMessage
@@ -129,6 +129,7 @@ export type MainThreadMessage =
 export type WorkerMessage =
   | InitializedMessage
   | GameUpdateMessage
+  | GameUpdateBatchMessage
   | PlayerActionsResultMessage
   | PlayerProfileResultMessage
   | PlayerBorderTilesResultMessage


### PR DESCRIPTION
## Description:
Removes the client-driven heartbeat loop and switches worker tick execution to a worker-owned drain scheduler with batched game update delivery.

## Why
The previous flow required the client to send a `heartbeat` every animation frame just to keep the worker progressing turns. That had two costs:

1. Simulation progress was coupled to browser frame cadence.
2. Catch-up periods produced many single `game_update` messages, increasing message overhead and main-thread wakeups.

## What Changed

### 1) Remove heartbeat protocol
- Deleted `heartbeat` from `WorkerMessageType`.
- Removed `HeartbeatMessage` from `MainThreadMessage`.
- Removed `sendHeartbeat()` from `WorkerClient`.
- Removed the `requestAnimationFrame` keep-alive loop in `ClientGameRunner`.

Files:
- `src/client/ClientGameRunner.ts`
- `src/core/worker/WorkerClient.ts`
- `src/core/worker/WorkerMessages.ts`
- `src/core/worker/Worker.worker.ts`

### 2) Add batched worker-to-client updates
- Added `game_update_batch` message type and `GameUpdateBatchMessage`.
- Worker now emits one batch message containing multiple tick updates.
- `WorkerClient` handles `game_update_batch` by replaying updates to the existing callback in order.

Files:
- `src/core/worker/WorkerMessages.ts`
- `src/core/worker/WorkerClient.ts`

### 3) Move tick draining into worker
- Added a scheduler (`scheduleDrain`) and drain loop (`drain`) in `Worker.worker.ts`.
- On each `turn` message, worker enqueues turn and schedules drain.
- Drain executes up to `MAX_TICKS_BEFORE_YIELD = 4` ticks per cycle, then yields with `setTimeout(..., 0)`.
- Tick updates are collected into a batch and sent once with transferables:
  - `packedTileUpdates.buffer`
  - `packedMotionPlans.buffer` (when present)
- If backlog remains, drain reschedules itself.

File:
- `src/core/worker/Worker.worker.ts`

## Behavioral Notes
- No server protocol changes.
- Ggame update callback contract remains the same (still receives one `GameUpdateViewData` at a time in order).
- Ordering is preserved: `WorkerClient` iterates batch entries in sequence.
- Error updates are still filtered from update delivery in the worker batch path (same effective behavior as before for normal update flow).

## Expected Impact
- Fewer `postMessage` calls during backlog and burst turn delivery.
- Lower message overhead and fewer main-thread interrupts.
- Less dependence on UI frame timing for worker progress.
- Better catch-up stability due to explicit periodic yielding.

## Risk Areas
- Drain scheduling edge cases (re-entrancy / lost wake-ups).
  - Mitigated with `drainScheduled`, `draining`, and `drainRequested` flags.
- Larger per-message payloads due to batching.
  - Bounded by `MAX_TICKS_BEFORE_YIELD`.
- Any assumptions in downstream code about receiving only `game_update`.
  - Handled by adding `game_update_batch` support in `WorkerClient`.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
