### PR TITLE
More 2 team games on Baikal, more 4 team games on Four Islands 🎉

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -133,7 +133,7 @@ export class MapPlaylist {
     const map = this.getNextMap(type);
 
     const playerTeams =
-      mode === GameMode.Team ? this.getTeamCount() : undefined;
+      mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
     const modifiers = this.getRandomPublicGameModifiers(playerTeams);
     const { startingGold } = modifiers;
@@ -214,7 +214,7 @@ export class MapPlaylist {
     const mode = Math.random() < 0.5 ? GameMode.FFA : GameMode.Team;
     const map = this.getNextMap("special");
     const playerTeams =
-      mode === GameMode.Team ? this.getTeamCount() : undefined;
+      mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
     const excludedModifiers: ModifierKey[] = [];
 
@@ -424,14 +424,27 @@ export class MapPlaylist {
       if (type !== "special" && ARCADE_MAPS.has(map)) {
         return;
       }
-      for (let i = 0; i < (frequency[key] ?? 0); i++) {
+      let freq = frequency[key] ?? 0;
+      // Double frequency for Baikal and FourIslands in team games
+      if (type === "team" && (key === "Baikal" || key === "FourIslands")) {
+        freq *= 2;
+      }
+      for (let i = 0; i < freq; i++) {
         maps.push(map);
       }
     });
     return maps;
   }
 
-  private getTeamCount(): TeamCountConfig {
+  private getTeamCount(map: GameMapType): TeamCountConfig {
+    // Override team count for specific maps (75% chance)
+    if (map === GameMapType.Baikal && Math.random() < 0.75) {
+      return 2;
+    }
+    if (map === GameMapType.FourIslands && Math.random() < 0.75) {
+      return 4;
+    }
+
     const totalWeight = TEAM_WEIGHTS.reduce((sum, w) => sum + w.weight, 0);
     const roll = Math.random() * totalWeight;
 


### PR DESCRIPTION
## Description:

I promised something to a redditor:

<img width="640" height="304" alt="image" src="https://github.com/user-attachments/assets/fa319f15-f67f-486f-a5ad-598aeef7779a" />

### Changes

- **Map-specific team count overrides** with 75% probability:
  - **Baikal**: 2 teams (plays into the natural two-sided geography)
  - **Four Islands**: 4 teams (one team per island)
  - Remaining 25% falls through to the normal weighted random team selection
- **Doubled playlist frequency** for Baikal (5→10) and Four Islands (4→8) in the team game playlist, making them appear twice as often

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
