### PR TITLE
Add random skin tile for owned skins

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -892,6 +892,7 @@
     "pattern": {
       "default": "Default"
     },
+    "random_skin": "Random",
     "select_skin": "Select Skin",
     "selected": "selected"
   },

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -130,9 +130,54 @@ export function patternRelationship(
   return "purchasable";
 }
 
+export function isRandomSkinSelected(): boolean {
+  return localStorage.getItem("territoryPattern") === "random";
+}
+
+async function resolveRandomPattern(): Promise<PlayerPattern | null> {
+  const cosmetics = await fetchCosmetics();
+  if (!cosmetics) return null;
+
+  const userMe = await getUserMe();
+
+  const ownedPatterns: PlayerPattern[] = [];
+  for (const [name, pattern] of Object.entries(cosmetics.patterns)) {
+    const colorPalettes = pattern.colorPalettes
+      ? [...pattern.colorPalettes, null]
+      : [null];
+    for (const cp of colorPalettes) {
+      const rel = patternRelationship(pattern, cp, userMe || false, null);
+      if (rel === "owned") {
+        ownedPatterns.push({
+          name,
+          patternData: pattern.pattern,
+          colorPalette: cp
+            ? (cosmetics.colorPalettes?.[cp.name] ?? undefined)
+            : undefined,
+        });
+      }
+    }
+  }
+
+  if (ownedPatterns.length === 0) return null;
+  return ownedPatterns[Math.floor(Math.random() * ownedPatterns.length)];
+}
+
 export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
   const userSettings = new UserSettings();
   const cosmetics = await fetchCosmetics();
+
+  // Handle random skin selection
+  if (isRandomSkinSelected()) {
+    const randomPattern = await resolveRandomPattern();
+    return {
+      flag: userSettings.getFlag(),
+      color: userSettings.getSelectedColor() ?? undefined,
+      patternName: randomPattern?.name ?? undefined,
+      patternColorPaletteName: randomPattern?.colorPalette?.name ?? undefined,
+    };
+  }
+
   let pattern: PlayerPattern | null =
     userSettings.getSelectedPatternName(cosmetics);
 

--- a/src/client/TerritoryPatternsModal.ts
+++ b/src/client/TerritoryPatternsModal.ts
@@ -114,6 +114,7 @@ export class TerritoryPatternsModal extends BaseModal {
 
   private renderPatternGrid(): TemplateResult {
     const buttons: TemplateResult[] = [];
+    const ownedPatterns: PlayerPattern[] = [];
     const patterns: (Pattern | null)[] = [
       null,
       ...Object.values(this.cosmetics?.patterns ?? {}),
@@ -131,6 +132,15 @@ export class TerritoryPatternsModal extends BaseModal {
             this.userMeResponse,
             this.affiliateCode,
           );
+        }
+        if (rel === "owned" && pattern !== null) {
+          ownedPatterns.push({
+            name: pattern.name,
+            patternData: pattern.pattern,
+            colorPalette:
+              this.cosmetics?.colorPalettes?.[colorPalette?.name ?? ""] ??
+              undefined,
+          });
         }
         if (rel === "blocked") {
           continue;
@@ -164,6 +174,35 @@ export class TerritoryPatternsModal extends BaseModal {
           ></pattern-button>
         `);
       }
+    }
+
+    // Insert random skin tile after "Default" when viewing owned skins
+    if (this.showOnlyOwned && ownedPatterns.length >= 1) {
+      const randomTile = html`
+        <div
+          class="flex flex-col items-center justify-between gap-2 p-3 bg-white/5 backdrop-blur-sm border border-white/10 rounded-xl w-48 h-full transition-all duration-200 hover:bg-white/10 hover:border-white/20 hover:shadow-xl"
+        >
+          <button
+            class="group relative flex flex-col items-center w-full gap-2 rounded-lg cursor-pointer transition-all duration-200 flex-1"
+            @click=${() => this.selectRandomPattern()}
+          >
+            <div class="flex flex-col items-center w-full">
+              <div
+                class="text-xs font-bold text-white uppercase tracking-wider mb-1 text-center truncate w-full"
+              >
+                ${translateText("territory_patterns.random_skin")}
+              </div>
+              <div class="h-[22px] mb-2 w-full"></div>
+            </div>
+            <div
+              class="w-full aspect-square flex items-center justify-center bg-white/5 rounded-lg p-2 border border-white/10 group-hover:border-white/20 transition-colors duration-200 overflow-hidden"
+            >
+              <span class="text-5xl">🎲</span>
+            </div>
+          </button>
+        </div>
+      `;
+      buttons.splice(1, 0, randomTile);
     }
 
     return html`
@@ -304,6 +343,24 @@ export class TerritoryPatternsModal extends BaseModal {
     this.isActive = false;
     this.affiliateCode = null;
     super.close();
+  }
+
+  private selectRandomPattern() {
+    this.selectedColor = null;
+    this.userSettings.setSelectedColor(undefined);
+    this.userSettings.setSelectedPatternName("random");
+    this.selectedPattern = null;
+    this.refresh();
+    this.dispatchEvent(new CustomEvent("pattern-selected", { bubbles: true }));
+    window.dispatchEvent(
+      new CustomEvent("show-message", {
+        detail: {
+          message: `${translateText("territory_patterns.random_skin")} ${translateText("territory_patterns.selected")}`,
+          duration: 2000,
+        },
+      }),
+    );
+    this.close();
   }
 
   private selectPattern(pattern: PlayerPattern | null) {

--- a/tests/client/RandomSkin.test.ts
+++ b/tests/client/RandomSkin.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getPlayerCosmeticsRefs,
+  isRandomSkinSelected,
+  patternRelationship,
+} from "../../src/client/Cosmetics";
+import type { UserMeResponse } from "../../src/core/ApiSchemas";
+import type { Pattern } from "../../src/core/CosmeticSchemas";
+
+// Mock the Api module
+vi.mock("../../src/client/Api", () => ({
+  getApiBase: vi.fn(() => "http://localhost"),
+  getUserMe: vi.fn(() => Promise.resolve(false)),
+  createCheckoutSession: vi.fn(),
+  hasLinkedAccount: vi.fn(() => false),
+}));
+
+const mockPatterns = {
+  pattern_a: {
+    name: "pattern_a",
+    pattern: "base64data_a",
+    colorPalettes: [{ name: "red", isArchived: false }],
+    product: null,
+    affiliateCode: null,
+  } as unknown as Pattern,
+  pattern_b: {
+    name: "pattern_b",
+    pattern: "base64data_b",
+    colorPalettes: null,
+    product: null,
+    affiliateCode: null,
+  } as unknown as Pattern,
+};
+
+const mockCosmetics = {
+  patterns: mockPatterns,
+  colorPalettes: {
+    red: {
+      name: "red",
+      primaryColor: "#ff0000",
+      secondaryColor: "#000000",
+    },
+  },
+};
+
+// Mock fetchCosmetics by mocking the fetch call
+vi.stubGlobal(
+  "fetch",
+  vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve(mockCosmetics),
+    }),
+  ),
+);
+
+describe("Random Skin Selection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  describe("isRandomSkinSelected", () => {
+    it("returns false when no pattern is selected", () => {
+      expect(isRandomSkinSelected()).toBe(false);
+    });
+
+    it("returns false when a specific pattern is selected", () => {
+      localStorage.setItem("territoryPattern", "pattern:pattern_a:red");
+      expect(isRandomSkinSelected()).toBe(false);
+    });
+
+    it("returns true when random is selected", () => {
+      localStorage.setItem("territoryPattern", "random");
+      expect(isRandomSkinSelected()).toBe(true);
+    });
+  });
+
+  describe("patternRelationship", () => {
+    const pattern = mockPatterns.pattern_a;
+
+    it("returns owned when user has pattern:* flare", () => {
+      const userMe = {
+        player: { flares: ["pattern:*"] },
+      } as unknown as UserMeResponse;
+      expect(patternRelationship(pattern, { name: "red" }, userMe, null)).toBe(
+        "owned",
+      );
+    });
+
+    it("returns owned when user has specific flare", () => {
+      const userMe = {
+        player: { flares: ["pattern:pattern_a:red"] },
+      } as unknown as UserMeResponse;
+      expect(patternRelationship(pattern, { name: "red" }, userMe, null)).toBe(
+        "owned",
+      );
+    });
+
+    it("returns blocked when user has no flares and pattern not for sale", () => {
+      const userMe = {
+        player: { flares: [] },
+      } as unknown as UserMeResponse;
+      expect(patternRelationship(pattern, { name: "red" }, userMe, null)).toBe(
+        "blocked",
+      );
+    });
+  });
+
+  describe("getPlayerCosmeticsRefs with random", () => {
+    it("returns no pattern when random is set but user owns no skins", async () => {
+      localStorage.setItem("territoryPattern", "random");
+      const refs = await getPlayerCosmeticsRefs();
+      // With no owned patterns (getUserMe returns false, no flares),
+      // resolveRandomPattern returns null
+      expect(refs.patternName).toBeUndefined();
+    });
+
+    it("returns no pattern when cosmetics schema validation fails", async () => {
+      localStorage.setItem("territoryPattern", "pattern:pattern_a:red");
+      const refs = await getPlayerCosmeticsRefs();
+      // fetchCosmetics returns null because mock data doesn't pass
+      // CosmeticsSchema validation, so getSelectedPatternName(null)
+      // returns null and patternName is undefined
+      expect(refs.patternName).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Description:

Adds a "Random" tile (🎲) to the skin selector grid. When a player owns 1 or more skins and views "My Skins", the Random tile appears as the first tile in the grid. Selecting it stores a `"random"` marker in localStorage. Each time the player joins a game, a random owned skin is picked from their collection — so the skin changes every game automatically.
<img width="787" height="629" alt="Capture d’écran 2026-03-02 à 16 26 38" src="https://github.com/user-attachments/assets/b3d0e3c6-e4a3-481e-8199-5b6c3d39add4" />


### Changes:
- **TerritoryPatternsModal.ts**: Added random tile to the "My Skins" grid + `selectRandomPattern()` method that stores the `"random"` marker
- **Cosmetics.ts**: Added `isRandomSkinSelected()` and `resolveRandomPattern()` — resolves a random owned skin at game join time in `getPlayerCosmeticsRefs()`
- tests for theses features

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

gazeux33