### PR TITLE
[Bugfix] Force end 170mins

### DIFF
--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -20,8 +20,8 @@ export class WinCheckExecution implements Execution {
   private mg: Game | null = null;
 
   // Hard time limit (in seconds) to force a winner before the server's
-  // maxGameDuration hard kill.
-  private static readonly HARD_TIME_LIMIT_SECONDS = 1 * 60;
+  // maxGameDuration hard kill. 170mins (10 mins before 3hrs)
+  private static readonly HARD_TIME_LIMIT_SECONDS = 170 * 60;
 
   constructor() {}
 


### PR DESCRIPTION
## Description:

instead of just killing the server, lets save 10m before, then kill the server at 3hr mark, so at least we have a proper savegame.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
