### PR TITLE
Pr naval balance

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -334,6 +334,7 @@ export class DefaultConfig implements Config {
       case UnitType.TransportShip:
         info = {
           cost: () => 0n,
+          maxHealth: 500,
         };
         break;
       case UnitType.Warship:
@@ -348,7 +349,7 @@ export class DefaultConfig implements Config {
       case UnitType.Shell:
         info = {
           cost: () => 0n,
-          damage: 250,
+          damage: 30,
         };
         break;
       case UnitType.SAMMissile:
@@ -896,7 +897,7 @@ export class DefaultConfig implements Config {
   }
 
   warshipShellAttackRate(): number {
-    return 20;
+    return 40;
   }
 
   defensePostShellAttackRate(): number {

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -349,7 +349,7 @@ export class DefaultConfig implements Config {
       case UnitType.Shell:
         info = {
           cost: () => 0n,
-          damage: 30,
+          damage: 250,
         };
         break;
       case UnitType.SAMMissile:

--- a/src/core/execution/ShellExecution.ts
+++ b/src/core/execution/ShellExecution.ts
@@ -74,18 +74,7 @@ export class ShellExecution implements Execution {
 
     const roll = this.random.nextInt(1, 6);
     const damageMultiplier = (roll - 1) * 25 + 200;
-    const rawDamage = Math.round((baseDamage / 250) * damageMultiplier);
-
-    if (this.target.type() !== UnitType.TransportShip) {
-      return rawDamage;
-    }
-
-    // Heavier troop transports are harder to sink, with diminishing returns.
-    // ~1 troop => x1.27 resistance, ~1k => x3.7, ~100k => x5.5.
-    const troops = Math.max(1, this.target.troops());
-    const resistanceMultiplier = 1 + Math.log10(troops + 1) * 0.9;
-
-    return Math.max(1, Math.round(rawDamage / resistanceMultiplier));
+    return Math.round((baseDamage / 250) * damageMultiplier);
   }
 
   private applyFixedTroopLossOnTransport(): boolean {
@@ -99,7 +88,7 @@ export class ShellExecution implements Execution {
     }
 
     // Fixed troop loss per shell hit (not percentage based).
-    const fixedLossPerHit = 70000;
+    const fixedLossPerHit = 80000;
     const nextTroops = Math.max(0, currentTroops - fixedLossPerHit);
     this.target.setTroops(nextTroops);
     this.target.touch();

--- a/src/core/execution/ShellExecution.ts
+++ b/src/core/execution/ShellExecution.ts
@@ -52,6 +52,12 @@ export class ShellExecution implements Execution {
       );
       if (result.status === PathStatus.COMPLETE) {
         this.active = false;
+        const handledTransportHit = this.applyFixedTroopLossOnTransport();
+        if (handledTransportHit) {
+          this.shell.setReachedTarget();
+          this.shell.delete(false);
+          return;
+        }
         this.target.modifyHealth(-this.effectOnTarget(), this._owner);
         this.shell.setReachedTarget();
         this.shell.delete(false);
@@ -68,8 +74,42 @@ export class ShellExecution implements Execution {
 
     const roll = this.random.nextInt(1, 6);
     const damageMultiplier = (roll - 1) * 25 + 200;
+    const rawDamage = Math.round((baseDamage / 250) * damageMultiplier);
 
-    return Math.round((baseDamage / 250) * damageMultiplier);
+    if (this.target.type() !== UnitType.TransportShip) {
+      return rawDamage;
+    }
+
+    // Heavier troop transports are harder to sink, with diminishing returns.
+    // ~1 troop => x1.27 resistance, ~1k => x3.7, ~100k => x5.5.
+    const troops = Math.max(1, this.target.troops());
+    const resistanceMultiplier = 1 + Math.log10(troops + 1) * 0.9;
+
+    return Math.max(1, Math.round(rawDamage / resistanceMultiplier));
+  }
+
+  private applyFixedTroopLossOnTransport(): boolean {
+    if (this.target.type() !== UnitType.TransportShip) {
+      return false;
+    }
+
+    const currentTroops = this.target.troops();
+    if (currentTroops <= 0) {
+      return true;
+    }
+
+    // Fixed troop loss per shell hit (not percentage based).
+    const fixedLossPerHit = 70000;
+    const nextTroops = Math.max(0, currentTroops - fixedLossPerHit);
+    this.target.setTroops(nextTroops);
+    this.target.touch();
+
+    if (nextTroops === 0) {
+      this.target.delete(true, this._owner);
+    }
+
+    // Transport hits are fully resolved by troop loss; skip HP damage.
+    return true;
   }
 
   public getEffectOnTargetForTesting(): number {

--- a/src/core/execution/WarshipExecution.ts
+++ b/src/core/execution/WarshipExecution.ts
@@ -150,23 +150,32 @@ export class WarshipExecution implements Execution {
   }
 
   private shootTarget() {
+    const target = this.warship.targetUnit();
+    if (target === undefined) {
+      return;
+    }
+
     const shellAttackRate = this.mg.config().warshipShellAttackRate();
-    if (this.mg.ticks() - this.lastShellAttack > shellAttackRate) {
-      if (this.warship.targetUnit()?.type() !== UnitType.TransportShip) {
-        // Warships don't need to reload when attacking transport ships.
-        this.lastShellAttack = this.mg.ticks();
-      }
+    // Keep transport shelling much faster than warship-vs-warship, but 2x slower than old "every tick" behavior.
+    const transportAttackRate = Math.max(1, Math.floor(shellAttackRate / 20));
+    const effectiveAttackRate =
+      target.type() === UnitType.TransportShip
+        ? transportAttackRate
+        : shellAttackRate;
+
+    if (this.mg.ticks() - this.lastShellAttack >= effectiveAttackRate) {
+      this.lastShellAttack = this.mg.ticks();
       this.mg.addExecution(
         new ShellExecution(
           this.warship.tile(),
           this.warship.owner(),
           this.warship,
-          this.warship.targetUnit()!,
+          target,
         ),
       );
-      if (!this.warship.targetUnit()!.hasHealth()) {
+      if (!target.hasHealth()) {
         // Don't send multiple shells to target that can be oneshotted
-        this.alreadySentShell.add(this.warship.targetUnit()!);
+        this.alreadySentShell.add(target);
         this.warship.setTargetUnit(undefined);
         return;
       }


### PR DESCRIPTION
## Description:

This PR rebalances naval interactions to make transport-vs-warship engagements less binary and more readable during fights, while keeping the existing combat system intact.
What changed
    1. Warship firing cadence adjusted by target type
        ◦ Warship shell cadence is now context-aware:
            ▪ Faster cadence against transport ships.
    2. Transport hits now apply fixed troop loss
        ◦ When a shell reaches a transport, damage is resolved primarily through troop loss, using a -8000 troops fixed per-hit amount.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

HulKiora
