### PR TITLE
Revert "fix: resolve drawImage scaling penalty on non-square sprite height"

### DIFF
--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -290,15 +290,14 @@ export class UnitLayer implements Layer {
       .filter((unitView) => isSpriteReady(unitView))
       .forEach((unitView) => {
         const sprite = getColoredSprite(unitView, this.theme);
+        const clearsize = sprite.width + 1;
         const lastX = this.game.x(unitView.lastTile());
         const lastY = this.game.y(unitView.lastTile());
-        const clearX = Math.round(lastX - sprite.width / 2);
-        const clearY = Math.round(lastY - sprite.height / 2);
         this.context.clearRect(
-          clearX - 1,
-          clearY - 1,
-          sprite.width + 2,
-          sprite.height + 2,
+          lastX - clearsize / 2,
+          lastY - clearsize / 2,
+          clearsize,
+          clearsize,
         );
       });
   }
@@ -612,7 +611,7 @@ export class UnitLayer implements Layer {
         Math.round(x - sprite.width / 2),
         Math.round(y - sprite.height / 2),
         sprite.width,
-        sprite.height,
+        sprite.width,
       );
       if (!targetable) {
         this.context.restore();


### PR DESCRIPTION
Reverts openfrontio/OpenFrontIO#3320

doesnt do what it says

The #3320 description claimed it “resolves a performance parsing penalty” and fixes “non-square sprite” scaling/ghosting issues. 
In reality, the code change was limited to:

* **clearRect**: switched from clearing a `clearsize x clearsize` square (`clearsize = sprite.width + 1`) around `lastX/lastY` to clearing a **(sprite.width+2) x (sprite.height+2)** rect around **rounded** `clearX/clearY` (with an extra 1px pad via `-1/+2`). 
* **drawImage**: changed a single call’s destination height from `sprite.width` → `sprite.height`. 

### Why revert

For unit rendering, sprites are square, so the drawImage change is a no-op in practice, and the main effect was **clearing more pixels per frame**. Any theoretical gain from rounding coordinates is speculative, and is outweighed by the increased clear area/overdraw.