### PR TITLE
Feat: add sortability and click to focus to team leadboard

### DIFF
--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -3,7 +3,6 @@ import { customElement, property, state } from "lit/decorators.js";
 import { EventBus } from "../../../core/EventBus";
 import { GameMode, Team, UnitType } from "../../../core/game/Game";
 import { GameView, PlayerView } from "../../../core/game/GameView";
-import { GoToPlayerEvent } from "./Leaderboard";
 import {
   formatPercentage,
   renderNumber,
@@ -11,17 +10,24 @@ import {
   translateText,
 } from "../../Utils";
 import { Layer } from "./Layer";
+import { GoToPlayerEvent } from "./Leaderboard";
 
 interface TeamEntry {
   teamName: string;
   isMyTeam: boolean;
   totalScoreStr: string;
   totalGold: string;
+  totalGoldRaw: bigint;
   totalMaxTroops: string;
+  totalMaxTroopsRaw: number;
   totalSAMs: string;
+  totalSAMsRaw: number;
   totalLaunchers: string;
+  totalLaunchersRaw: number;
   totalWarShips: string;
+  totalWarShipsRaw: number;
   totalCities: string;
+  totalCitiesRaw: number;
   totalScoreSort: number;
   players: PlayerView[];
 }
@@ -39,7 +45,14 @@ export class TeamStats extends LitElement implements Layer {
 
   @state()
   @state()
-  private _sortKey: "tiles" | "gold" | "maxtroops" | "launchers" | "sams" | "warships" | "cities" = "tiles";
+  private _sortKey:
+    | "tiles"
+    | "gold"
+    | "maxtroops"
+    | "launchers"
+    | "sams"
+    | "warships"
+    | "cities" = "tiles";
 
   @state()
   private _sortOrder: "asc" | "desc" = "desc";
@@ -67,7 +80,16 @@ export class TeamStats extends LitElement implements Layer {
     this.updateTeamStats();
   }
 
-  private setSort(key: "tiles" | "gold" | "maxtroops" | "launchers" | "sams" | "warships" | "cities") {
+  private setSort(
+    key:
+      | "tiles"
+      | "gold"
+      | "maxtroops"
+      | "launchers"
+      | "sams"
+      | "warships"
+      | "cities",
+  ) {
     if (this._sortKey === key) {
       this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
     } else {
@@ -129,13 +151,19 @@ export class TeamStats extends LitElement implements Layer {
           totalScoreStr: formatPercentage(totalScorePercent),
           totalScoreSort,
           totalGold: renderNumber(totalGold),
+          totalGoldRaw: totalGold,
           totalMaxTroops: renderTroops(totalMaxTroops),
+          totalMaxTroopsRaw: totalMaxTroops,
           players: teamPlayers,
 
           totalLaunchers: renderNumber(totalLaunchers),
+          totalLaunchersRaw: totalLaunchers,
           totalSAMs: renderNumber(totalSAMs),
+          totalSAMsRaw: totalSAMs,
           totalWarShips: renderNumber(totalWarShips),
+          totalWarShipsRaw: totalWarShips,
           totalCities: renderNumber(totalCities),
+          totalCitiesRaw: totalCities,
         };
       })
       .sort((a, b) => {
@@ -144,17 +172,26 @@ export class TeamStats extends LitElement implements Layer {
 
         switch (this._sortKey) {
           case "gold":
-            return compare(parseFloat(a.totalGold.replace(/,/g, "")), parseFloat(b.totalGold.replace(/,/g, "")));
+            return compare(Number(a.totalGoldRaw), Number(b.totalGoldRaw));
           case "maxtroops":
-            return compare(parseFloat(a.totalMaxTroops.replace(/,/g, "")), parseFloat(b.totalMaxTroops.replace(/,/g, "")));
+            return compare(
+              Number(a.totalMaxTroopsRaw),
+              Number(b.totalMaxTroopsRaw),
+            );
           case "launchers":
-            return compare(parseFloat(a.totalLaunchers.replace(/,/g, "")), parseFloat(b.totalLaunchers.replace(/,/g, "")));
+            return compare(
+              Number(a.totalLaunchersRaw),
+              Number(b.totalLaunchersRaw),
+            );
           case "sams":
-            return compare(parseFloat(a.totalSAMs.replace(/,/g, "")), parseFloat(b.totalSAMs.replace(/,/g, "")));
+            return compare(Number(a.totalSAMsRaw), Number(b.totalSAMsRaw));
           case "warships":
-            return compare(parseFloat(a.totalWarShips.replace(/,/g, "")), parseFloat(b.totalWarShips.replace(/,/g, "")));
+            return compare(
+              Number(a.totalWarShipsRaw),
+              Number(b.totalWarShipsRaw),
+            );
           case "cities":
-            return compare(parseFloat(a.totalCities.replace(/,/g, "")), parseFloat(b.totalCities.replace(/,/g, "")));
+            return compare(Number(a.totalCitiesRaw), Number(b.totalCitiesRaw));
           default:
             return compare(a.totalScoreSort, b.totalScoreSort);
         }
@@ -191,8 +228,8 @@ export class TeamStats extends LitElement implements Layer {
       >
         <div
           class="grid w-full"
-          style="grid-template-columns: ${this.showUnits 
-            ? "minmax(50px, 70px) minmax(60px, 120px) minmax(60px, 80px) minmax(60px, 110px) minmax(60px, 90px)" 
+          style="grid-template-columns: ${this.showUnits
+            ? "minmax(50px, 70px) minmax(60px, 120px) minmax(60px, 80px) minmax(60px, 110px) minmax(60px, 90px)"
             : "minmax(50px, 70px) minmax(60px, 100px) minmax(60px, 100px) minmax(60px, 120px)"};"
         >
           <!-- Header -->
@@ -237,7 +274,7 @@ export class TeamStats extends LitElement implements Layer {
                   </div>
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
-                  @click=${() => this.setSort("cities")}
+                    @click=${() => this.setSort("cities")}
                   >
                     ${translateText("leaderboard.cities")}
                     ${this._sortKey === "cities"

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -363,7 +363,7 @@ export class TeamStats extends LitElement implements Layer {
             this.showUnits
               ? html`
                   <div
-                    class="contents"
+                    class="contents group"
                     role="link"
                     tabindex="0"
                     @click=${() => this.handleTeamClick(team)}
@@ -371,29 +371,29 @@ export class TeamStats extends LitElement implements Layer {
                       this._handleKeyDown(e, () => this.handleTeamClick(team))}
                   >
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer ${team.isMyTeam
                         ? "font-bold"
                         : ""}"
                     >
                       ${team.teamName}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalLaunchers}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalSAMs}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalWarShips}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalCities}
                     </div>
@@ -401,7 +401,7 @@ export class TeamStats extends LitElement implements Layer {
                 `
               : html`
                   <div
-                    class="contents"
+                    class="contents group"
                     role="link"
                     tabindex="0"
                     @click=${() => this.handleTeamClick(team)}
@@ -409,24 +409,24 @@ export class TeamStats extends LitElement implements Layer {
                       this._handleKeyDown(e, () => this.handleTeamClick(team))}
                   >
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer ${team.isMyTeam
                         ? "font-bold"
                         : ""}"
                     >
                       ${team.teamName}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalScoreStr}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalGold}
                     </div>
                     <div
-                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                      class="py-1.5 border-b border-slate-500 text-center cursor-pointer"
                     >
                       ${team.totalMaxTroops}
                     </div>

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -1,5 +1,5 @@
 import { LitElement, html } from "lit";
-import { customElement, property } from "lit/decorators.js";
+import { customElement, property, state } from "lit/decorators.js";
 import { EventBus } from "../../../core/EventBus";
 import { GameMode, Team, UnitType } from "../../../core/game/Game";
 import { GameView, PlayerView } from "../../../core/game/GameView";
@@ -36,6 +36,12 @@ export class TeamStats extends LitElement implements Layer {
   private showUnits = false;
   private _myTeam: Team | null = null;
 
+  @state()
+  private _sortKey: "tiles" | "gold" | "maxtroops" = "tiles";
+
+  @state()
+  private _sortOrder: "asc" | "desc" = "desc";
+
   createRenderRoot() {
     return this; // use light DOM for Tailwind
   }
@@ -56,6 +62,16 @@ export class TeamStats extends LitElement implements Layer {
 
     if (!this.visible) return;
 
+    this.updateTeamStats();
+  }
+
+  private setSort(key: "tiles" | "gold" | "maxtroops") {
+    if (this._sortKey === key) {
+      this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
+    } else {
+      this._sortKey = key;
+      this._sortOrder = "desc";
+    }
     this.updateTeamStats();
   }
 
@@ -120,7 +136,26 @@ export class TeamStats extends LitElement implements Layer {
           totalCities: renderNumber(totalCities),
         };
       })
-      .sort((a, b) => b.totalScoreSort - a.totalScoreSort);
+      .sort((a, b) => {
+        const compare = (v1: number, v2: number) =>
+          this._sortOrder === "asc" ? v1 - v2 : v2 - v1;
+
+        switch (this._sortKey) {
+          case "gold":
+            // Converting back to numbers for comparison like Leaderboard.ts
+            return compare(
+              parseFloat(a.totalGold.replace(/,/g, "")),
+              parseFloat(b.totalGold.replace(/,/g, "")),
+            );
+          case "maxtroops":
+            return compare(
+              parseFloat(a.totalMaxTroops.replace(/,/g, "")),
+              parseFloat(b.totalMaxTroops.replace(/,/g, "")),
+            );
+          default:
+            return compare(a.totalScoreSort, b.totalScoreSort);
+        }
+      });
 
     this.requestUpdate();
   }
@@ -140,8 +175,10 @@ export class TeamStats extends LitElement implements Layer {
         @contextmenu=${(e: MouseEvent) => e.preventDefault()}
       >
         <div
-          class="grid w-full grid-cols-[repeat(var(--cols),1fr)]"
-          style="--cols:${this.showUnits ? 5 : 4};"
+          class="grid w-full"
+          style="grid-template-columns: ${this.showUnits 
+            ? "minmax(50px, 70px) repeat(4, minmax(50px, 90px))" 
+            : "minmax(50px, 70px) minmax(60px, 100px) minmax(60px, 100px) minmax(60px, 120px)"};"
         >
           <!-- Header -->
           <div class="contents font-bold bg-slate-700/60">
@@ -174,18 +211,36 @@ export class TeamStats extends LitElement implements Layer {
               : html`
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    @click=${() => this.setSort("tiles")}
                   >
                     ${translateText("leaderboard.owned")}
+                    ${this._sortKey === "tiles"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    @click=${() => this.setSort("gold")}
                   >
                     ${translateText("leaderboard.gold")}
+                    ${this._sortKey === "gold"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    @click=${() => this.setSort("maxtroops")}
                   >
                     ${translateText("leaderboard.maxtroops")}
+                    ${this._sortKey === "maxtroops"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                 `}
           </div>

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -44,7 +44,6 @@ export class TeamStats extends LitElement implements Layer {
   private _myTeam: Team | null = null;
 
   @state()
-  @state()
   private _sortKey:
     | "tiles"
     | "gold"
@@ -78,6 +77,13 @@ export class TeamStats extends LitElement implements Layer {
     if (!this.visible) return;
 
     this.updateTeamStats();
+  }
+
+  private _handleKeyDown(e: KeyboardEvent, callback: () => void) {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      callback();
+    }
   }
 
   private setSort(
@@ -169,10 +175,15 @@ export class TeamStats extends LitElement implements Layer {
       .sort((a, b) => {
         const compare = (v1: number, v2: number) =>
           this._sortOrder === "asc" ? v1 - v2 : v2 - v1;
+        const compareBigInt = (v1: bigint, v2: bigint) => {
+          if (v1 === v2) return 0;
+          const less = v1 < v2;
+          return this._sortOrder === "asc" ? (less ? -1 : 1) : less ? 1 : -1;
+        };
 
         switch (this._sortKey) {
           case "gold":
-            return compare(Number(a.totalGoldRaw), Number(b.totalGoldRaw));
+            return compareBigInt(a.totalGoldRaw, b.totalGoldRaw);
           case "maxtroops":
             return compare(
               Number(a.totalMaxTroopsRaw),
@@ -232,7 +243,6 @@ export class TeamStats extends LitElement implements Layer {
             ? "minmax(50px, 70px) minmax(60px, 120px) minmax(60px, 80px) minmax(60px, 110px) minmax(60px, 90px)"
             : "minmax(50px, 70px) minmax(60px, 100px) minmax(60px, 100px) minmax(60px, 120px)"};"
         >
-          <!-- Header -->
           <div class="contents font-bold bg-slate-700/60">
             <div class="p-1.5 md:p-2.5 text-center border-b border-slate-500">
               ${translateText("leaderboard.team")}
@@ -240,8 +250,11 @@ export class TeamStats extends LitElement implements Layer {
             ${this.showUnits
               ? html`
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("launchers")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("launchers"))}
                   >
                     ${translateText("leaderboard.launchers")}
                     ${this._sortKey === "launchers"
@@ -251,8 +264,11 @@ export class TeamStats extends LitElement implements Layer {
                       : ""}
                   </div>
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("sams")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("sams"))}
                   >
                     ${translateText("leaderboard.sams")}
                     ${this._sortKey === "sams"
@@ -262,8 +278,11 @@ export class TeamStats extends LitElement implements Layer {
                       : ""}
                   </div>
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("warships")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("warships"))}
                   >
                     ${translateText("leaderboard.warships")}
                     ${this._sortKey === "warships"
@@ -273,8 +292,11 @@ export class TeamStats extends LitElement implements Layer {
                       : ""}
                   </div>
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("cities")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("cities"))}
                   >
                     ${translateText("leaderboard.cities")}
                     ${this._sortKey === "cities"
@@ -286,8 +308,11 @@ export class TeamStats extends LitElement implements Layer {
                 `
               : html`
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("tiles")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("tiles"))}
                   >
                     ${translateText("leaderboard.owned")}
                     ${this._sortKey === "tiles"
@@ -297,8 +322,11 @@ export class TeamStats extends LitElement implements Layer {
                       : ""}
                   </div>
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("gold")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("gold"))}
                   >
                     ${translateText("leaderboard.gold")}
                     ${this._sortKey === "gold"
@@ -308,8 +336,11 @@ export class TeamStats extends LitElement implements Layer {
                       : ""}
                   </div>
                   <div
-                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    class="p-1.5 md:p-2.5 text-center border-b border-slate-500 cursor-pointer focus:bg-slate-600 outline-none"
+                    role="button"
+                    tabindex="0"
                     @click=${() => this.setSort("maxtroops")}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("maxtroops"))}
                   >
                     ${translateText("leaderboard.maxtroops")}
                     ${this._sortKey === "maxtroops"
@@ -321,50 +352,51 @@ export class TeamStats extends LitElement implements Layer {
                 `}
           </div>
 
-          <!-- Data rows -->
           ${this.teams.map((team) =>
             this.showUnits
               ? html`
-                  <div
-                    class="contents hover:bg-slate-600/60 text-center cursor-pointer ${team.isMyTeam
-                      ? "font-bold"
-                      : ""}"
+                  <div 
+                    class="contents" 
+                    role="link" 
+                    tabindex="0"
                     @click=${() => this.handleTeamClick(team)}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.handleTeamClick(team))}
                   >
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam ? "font-bold" : ""}">
                       ${team.teamName}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalLaunchers}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalSAMs}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalWarShips}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalCities}
                     </div>
                   </div>
                 `
               : html`
-                  <div
-                    class="contents hover:bg-slate-600/60 text-center cursor-pointer ${team.isMyTeam
-                      ? "font-bold"
-                      : ""}"
+                  <div 
+                    class="contents"
+                    role="link" 
+                    tabindex="0"
                     @click=${() => this.handleTeamClick(team)}
+                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.handleTeamClick(team))}
                   >
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam ? "font-bold" : ""}">
                       ${team.teamName}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalScoreStr}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalGold}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500">
+                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
                       ${team.totalMaxTroops}
                     </div>
                   </div>

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -3,6 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { EventBus } from "../../../core/EventBus";
 import { GameMode, Team, UnitType } from "../../../core/game/Game";
 import { GameView, PlayerView } from "../../../core/game/GameView";
+import { GoToPlayerEvent } from "./Leaderboard";
 import {
   formatPercentage,
   renderNumber,
@@ -162,6 +163,18 @@ export class TeamStats extends LitElement implements Layer {
     this.requestUpdate();
   }
 
+  private handleTeamClick(team: TeamEntry) {
+    if (this.eventBus === null || team.players.length === 0) return;
+
+    // Identify the player with the most tiles
+    const strongestPlayer = [...team.players]
+      .filter((p) => p.isAlive())
+      .sort((a, b) => b.numTilesOwned() - a.numTilesOwned())[0];
+
+    if (strongestPlayer) {
+      this.eventBus.emit(new GoToPlayerEvent(strongestPlayer));
+    }
+  }
   renderLayer(context: CanvasRenderingContext2D) {}
 
   shouldTransform(): boolean {
@@ -279,6 +292,7 @@ export class TeamStats extends LitElement implements Layer {
                     class="contents hover:bg-slate-600/60 text-center cursor-pointer ${team.isMyTeam
                       ? "font-bold"
                       : ""}"
+                    @click=${() => this.handleTeamClick(team)}
                   >
                     <div class="py-1.5 border-b border-slate-500">
                       ${team.teamName}
@@ -302,6 +316,7 @@ export class TeamStats extends LitElement implements Layer {
                     class="contents hover:bg-slate-600/60 text-center cursor-pointer ${team.isMyTeam
                       ? "font-bold"
                       : ""}"
+                    @click=${() => this.handleTeamClick(team)}
                   >
                     <div class="py-1.5 border-b border-slate-500">
                       ${team.teamName}

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -254,7 +254,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("launchers")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("launchers"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("launchers"))}
                   >
                     ${translateText("leaderboard.launchers")}
                     ${this._sortKey === "launchers"
@@ -268,7 +269,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("sams")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("sams"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("sams"))}
                   >
                     ${translateText("leaderboard.sams")}
                     ${this._sortKey === "sams"
@@ -282,7 +284,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("warships")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("warships"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("warships"))}
                   >
                     ${translateText("leaderboard.warships")}
                     ${this._sortKey === "warships"
@@ -296,7 +299,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("cities")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("cities"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("cities"))}
                   >
                     ${translateText("leaderboard.cities")}
                     ${this._sortKey === "cities"
@@ -312,7 +316,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("tiles")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("tiles"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("tiles"))}
                   >
                     ${translateText("leaderboard.owned")}
                     ${this._sortKey === "tiles"
@@ -326,7 +331,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("gold")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("gold"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("gold"))}
                   >
                     ${translateText("leaderboard.gold")}
                     ${this._sortKey === "gold"
@@ -340,7 +346,8 @@ export class TeamStats extends LitElement implements Layer {
                     role="button"
                     tabindex="0"
                     @click=${() => this.setSort("maxtroops")}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.setSort("maxtroops"))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.setSort("maxtroops"))}
                   >
                     ${translateText("leaderboard.maxtroops")}
                     ${this._sortKey === "maxtroops"
@@ -355,48 +362,72 @@ export class TeamStats extends LitElement implements Layer {
           ${this.teams.map((team) =>
             this.showUnits
               ? html`
-                  <div 
-                    class="contents" 
-                    role="link" 
+                  <div
+                    class="contents"
+                    role="link"
                     tabindex="0"
                     @click=${() => this.handleTeamClick(team)}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.handleTeamClick(team))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.handleTeamClick(team))}
                   >
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam ? "font-bold" : ""}">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam
+                        ? "font-bold"
+                        : ""}"
+                    >
                       ${team.teamName}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalLaunchers}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalSAMs}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalWarShips}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalCities}
                     </div>
                   </div>
                 `
               : html`
-                  <div 
+                  <div
                     class="contents"
-                    role="link" 
+                    role="link"
                     tabindex="0"
                     @click=${() => this.handleTeamClick(team)}
-                    @keydown=${(e: KeyboardEvent) => this._handleKeyDown(e, () => this.handleTeamClick(team))}
+                    @keydown=${(e: KeyboardEvent) =>
+                      this._handleKeyDown(e, () => this.handleTeamClick(team))}
                   >
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam ? "font-bold" : ""}">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer ${team.isMyTeam
+                        ? "font-bold"
+                        : ""}"
+                    >
                       ${team.teamName}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalScoreStr}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalGold}
                     </div>
-                    <div class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer">
+                    <div
+                      class="py-1.5 border-b border-slate-500 text-center hover:bg-slate-600/60 cursor-pointer"
+                    >
                       ${team.totalMaxTroops}
                     </div>
                   </div>

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -37,7 +37,8 @@ export class TeamStats extends LitElement implements Layer {
   private _myTeam: Team | null = null;
 
   @state()
-  private _sortKey: "tiles" | "gold" | "maxtroops" = "tiles";
+  @state()
+  private _sortKey: "tiles" | "gold" | "maxtroops" | "launchers" | "sams" | "warships" | "cities" = "tiles";
 
   @state()
   private _sortOrder: "asc" | "desc" = "desc";
@@ -65,7 +66,7 @@ export class TeamStats extends LitElement implements Layer {
     this.updateTeamStats();
   }
 
-  private setSort(key: "tiles" | "gold" | "maxtroops") {
+  private setSort(key: "tiles" | "gold" | "maxtroops" | "launchers" | "sams" | "warships" | "cities") {
     if (this._sortKey === key) {
       this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
     } else {
@@ -142,16 +143,17 @@ export class TeamStats extends LitElement implements Layer {
 
         switch (this._sortKey) {
           case "gold":
-            // Converting back to numbers for comparison like Leaderboard.ts
-            return compare(
-              parseFloat(a.totalGold.replace(/,/g, "")),
-              parseFloat(b.totalGold.replace(/,/g, "")),
-            );
+            return compare(parseFloat(a.totalGold.replace(/,/g, "")), parseFloat(b.totalGold.replace(/,/g, "")));
           case "maxtroops":
-            return compare(
-              parseFloat(a.totalMaxTroops.replace(/,/g, "")),
-              parseFloat(b.totalMaxTroops.replace(/,/g, "")),
-            );
+            return compare(parseFloat(a.totalMaxTroops.replace(/,/g, "")), parseFloat(b.totalMaxTroops.replace(/,/g, "")));
+          case "launchers":
+            return compare(parseFloat(a.totalLaunchers.replace(/,/g, "")), parseFloat(b.totalLaunchers.replace(/,/g, "")));
+          case "sams":
+            return compare(parseFloat(a.totalSAMs.replace(/,/g, "")), parseFloat(b.totalSAMs.replace(/,/g, "")));
+          case "warships":
+            return compare(parseFloat(a.totalWarShips.replace(/,/g, "")), parseFloat(b.totalWarShips.replace(/,/g, "")));
+          case "cities":
+            return compare(parseFloat(a.totalCities.replace(/,/g, "")), parseFloat(b.totalCities.replace(/,/g, "")));
           default:
             return compare(a.totalScoreSort, b.totalScoreSort);
         }
@@ -177,7 +179,7 @@ export class TeamStats extends LitElement implements Layer {
         <div
           class="grid w-full"
           style="grid-template-columns: ${this.showUnits 
-            ? "minmax(50px, 70px) repeat(4, minmax(50px, 90px))" 
+            ? "minmax(50px, 70px) minmax(60px, 120px) minmax(60px, 80px) minmax(60px, 110px) minmax(60px, 90px)" 
             : "minmax(50px, 70px) minmax(60px, 100px) minmax(60px, 100px) minmax(60px, 120px)"};"
         >
           <!-- Header -->
@@ -189,23 +191,47 @@ export class TeamStats extends LitElement implements Layer {
               ? html`
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    @click=${() => this.setSort("launchers")}
                   >
                     ${translateText("leaderboard.launchers")}
+                    ${this._sortKey === "launchers"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    @click=${() => this.setSort("sams")}
                   >
                     ${translateText("leaderboard.sams")}
+                    ${this._sortKey === "sams"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                    @click=${() => this.setSort("warships")}
                   >
                     ${translateText("leaderboard.warships")}
+                    ${this._sortKey === "warships"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                   <div
                     class="p-1.5 md:p-2.5 text-center border-b border-slate-500"
+                  @click=${() => this.setSort("cities")}
                   >
                     ${translateText("leaderboard.cities")}
+                    ${this._sortKey === "cities"
+                      ? this._sortOrder === "asc"
+                        ? "⬆️"
+                        : "⬇️"
+                      : ""}
                   </div>
                 `
               : html`

--- a/src/client/graphics/layers/TeamStats.ts
+++ b/src/client/graphics/layers/TeamStats.ts
@@ -9,8 +9,8 @@ import {
   renderTroops,
   translateText,
 } from "../../Utils";
+import { GoToPlayerEvent } from "../TransformHandler";
 import { Layer } from "./Layer";
-import { GoToPlayerEvent } from "./Leaderboard";
 
 interface TeamEntry {
   teamName: string;

--- a/tests/client/graphics/layers/TeamStatsModal.test.ts
+++ b/tests/client/graphics/layers/TeamStatsModal.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GoToPlayerEvent } from "../../../../src/client/graphics/layers/Leaderboard";
+import { TeamStats } from "../../../../src/client/graphics/layers/TeamStats";
+import { GameMode } from "../../../../src/core/game/Game";
+
+// Mocks für Utilities
+vi.mock("../../src/client/Utils", () => ({
+  translateText: vi.fn((key) => key),
+  formatPercentage: vi.fn((val) => `${(val * 100).toFixed(0)}%`),
+  renderNumber: vi.fn((val) => String(val)),
+  renderTroops: vi.fn((val) => String(val)),
+}));
+
+describe("TeamStats Component", () => {
+  let element: TeamStats;
+  let mockGame: any;
+  let mockEventBus: any;
+
+  beforeEach(async () => {
+    // 1. Mock EventBus
+    mockEventBus = {
+      emit: vi.fn(),
+    };
+
+    // 2. Mock GameView & PlayerViews
+    const createPlayer = (id: string, team: string, tiles: number) => ({
+      id,
+      team: () => team,
+      isAlive: () => true,
+      gold: () => 100n,
+      numTilesOwned: () => tiles,
+      totalUnitLevels: vi.fn(() => 5),
+    });
+
+    mockGame = {
+      config: () => ({
+        gameConfig: () => ({ gameMode: GameMode.Team }),
+        maxTroops: () => 1000,
+      }),
+      playerViews: vi.fn(() => [
+        createPlayer("p1", "Red", 10), // Schwächerer Spieler
+        createPlayer("p2", "Red", 50), // Bester Spieler in Team Red
+        createPlayer("p3", "Blue", 20),
+      ]),
+      myPlayer: () => ({ team: () => "Red" }),
+      inSpawnPhase: () => false,
+      numLandTiles: () => 1000,
+      numTilesWithFallout: () => 0,
+    };
+
+    if (!customElements.get("team-stats")) {
+      customElements.define("team-stats", TeamStats);
+    }
+
+    element = document.createElement("team-stats") as TeamStats;
+    element.game = mockGame;
+    element.eventBus = mockEventBus;
+    element.visible = true;
+
+    document.body.appendChild(element);
+    await element.updateComplete;
+    // Initialer Tick um Daten zu laden
+    element.tick();
+    await element.updateComplete;
+  });
+
+  afterEach(() => {
+    document.body.removeChild(element);
+    vi.clearAllMocks();
+  });
+
+  describe("Sorting Interaction", () => {
+    it("should change sort key and order when clicking headers", async () => {
+      // Suche den Header für "Gold" (basierend auf dem translateText mock)
+      const goldHeader = Array.from(
+        element.querySelectorAll('[role="button"]'),
+      ).find((el) =>
+        el.textContent?.includes("leaderboard.gold"),
+      ) as HTMLElement;
+
+      expect(goldHeader).toBeTruthy();
+
+      // Erster Klick: Sortiere nach Gold (desc)
+      goldHeader.click();
+      await element.updateComplete;
+      expect((element as any)._sortKey).toBe("gold");
+      expect((element as any)._sortOrder).toBe("desc");
+
+      // Zweiter Klick: Wechselt zu asc
+      goldHeader.click();
+      await element.updateComplete;
+      expect((element as any)._sortOrder).toBe("asc");
+    });
+
+    it("should correctly sort teams based on tiles owned", () => {
+      // Team Red hat 60 Tiles (10+50), Team Blue hat 20.
+      // Standard-Sortierung ist Tiles desc.
+      expect(element.teams[0].teamName).toBe("Red");
+      expect(element.teams[1].teamName).toBe("Blue");
+    });
+  });
+
+  describe("Team Focus (GoToPlayerEvent)", () => {
+    it("should emit GoToPlayerEvent for the strongest player when clicking a team row", async () => {
+      // Wir suchen die Zeile für Team Red
+      const redTeamRow = Array.from(
+        element.querySelectorAll('[role="link"]'),
+      ).find((el) => el.textContent?.includes("Red")) as HTMLElement;
+
+      expect(redTeamRow).toBeTruthy();
+
+      // Klick auf die Zeile
+      redTeamRow.click();
+
+      const emittedEvent = mockEventBus.emit.mock.calls[0][0];
+      expect(emittedEvent).toBeInstanceOf(GoToPlayerEvent);
+      expect(emittedEvent.player.id).toBe("p2");
+    });
+  });
+
+  describe("UI Toggles", () => {
+    it("should toggle between simple and unit stats view", async () => {
+      const toggleButton = element.querySelector(
+        "button.team-stats-button",
+      ) as HTMLButtonElement;
+
+      expect((element as any).showUnits).toBe(false);
+
+      toggleButton.click();
+      await element.updateComplete;
+
+      expect((element as any).showUnits).toBe(true);
+      // Prüfen ob neue Spalten gerendert werden (z.B. Launchers)
+      expect(element.innerHTML).toContain("leaderboard.launchers");
+    });
+  });
+});

--- a/tests/client/graphics/layers/TeamStatsModal.test.ts
+++ b/tests/client/graphics/layers/TeamStatsModal.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GoToPlayerEvent } from "../../../../src/client/graphics/layers/Leaderboard";
+import { GoToPlayerEvent } from "../../../../src/client/graphics/TransformHandler";
 import { TeamStats } from "../../../../src/client/graphics/layers/TeamStats";
 import { GameMode } from "../../../../src/core/game/Game";
 


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #3330


## Description:

Describe the PR.
This PR adds the sortability of the player leaderboard to the team leaderboard. This allows sorting for tiles, gold, troops and the units i.e. SAMS etc. Additionally clicking on a team in the leaderboard now focuses on the largest player of that team. 
This is my first pr overall so any feedback would be appreciated (esspecially for the test).
I also thought about adding a new row that displays the amount of alive players / nations per team, what do you guys think?

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

<img width="624" height="405" alt="Screenshot from 2026-03-03 22-06-49" src="https://github.com/user-attachments/assets/01cc9104-0d9d-4a03-ad97-b4a8a2f28542" />
<img width="608" height="420" alt="Screenshot from 2026-03-03 22-07-14" src="https://github.com/user-attachments/assets/8329d77f-b3b4-4cd6-94b3-cb6ba932e8c3" />

## Please put your Discord username so you can be contacted if a bug or regression is found:

lakoeris
