### PR TITLE
Hide lobby card time badge when undefined and use lowercase s ✨

### DIFF
--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -193,7 +193,7 @@ export class GameModeSelector extends LitElement {
 
     let timeDisplay: string = "";
     if (timeRemaining === undefined) {
-      timeDisplay = "-s";
+      timeDisplay = "";
     } else if (timeRemaining > 0) {
       timeDisplay = renderDuration(timeRemaining);
     } else {
@@ -238,12 +238,14 @@ export class GameModeSelector extends LitElement {
                   )}
                 </div>`
               : html`<div></div>`}
-            <div class="shrink-0">
-              <span
-                class="text-[10px] font-bold uppercase tracking-widest bg-blue-600 px-2 py-0.5 rounded"
-                >${timeDisplay}</span
-              >
-            </div>
+            ${timeDisplay
+              ? html`<div class="shrink-0">
+                  <span
+                    class="text-[10px] font-bold normal-case tracking-widest bg-blue-600 px-2 py-0.5 rounded"
+                    >${timeDisplay}</span
+                  >
+                </div>`
+              : null}
           </div>
         </div>
         <div class="flex items-center justify-between px-3 py-2">


### PR DESCRIPTION
## Description:

**Fix lobby card time badge display**

- Hide the time badge entirely when no start time is available, instead of showing "-s" (looks weird)
- Use `normal-case` on the badge so the "s" unit in durations (e.g. "45s") stays lowercase

**Previous**

<img width="368" height="237" alt="image" src="https://github.com/user-attachments/assets/fcdcdd74-f9d9-47ea-a1dc-32b5f29c94bf" />

**Now**

<img width="729" height="473" alt="image" src="https://github.com/user-attachments/assets/b346180a-46a3-4aaf-96c2-203d404b8fbb" />


## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
