### PR TITLE
Test/sam refire

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -771,6 +771,8 @@
     "received_gold_from_conquest": "Conquered {name}, received {gold} gold",
     "conquered_no_gold": "Conquered {name} (didn't play, no gold awarded)",
     "missile_intercepted": "Missile intercepted {unit}",
+    "interceptor_destroyed": "Interceptor destroyed, retargeting {unit}",
+    "interceptor_destroyed_attacker": "{unit} survived interception, new interceptor inbound",
     "mirv_warheads_intercepted": "{count, plural, one {{count} MIRV warhead intercepted} other {{count} MIRV warheads intercepted}}",
     "sent_troops_to_player": "Sent {troops} troops to {name}",
     "received_troops_from_player": "Received {troops} troops from {name}",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -772,7 +772,7 @@
     "conquered_no_gold": "Conquered {name} (didn't play, no gold awarded)",
     "missile_intercepted": "Missile intercepted {unit}",
     "interceptor_destroyed": "Interceptor destroyed, retargeting {unit}",
-    "interceptor_destroyed_attacker": "{unit} survived interception, new interceptor inbound",
+    "interceptor_destroyed_attacker": "{unit} survived interception, will re-attempt interception, if possible",
     "mirv_warheads_intercepted": "{count, plural, one {{count} MIRV warhead intercepted} other {{count} MIRV warheads intercepted}}",
     "sent_troops_to_player": "Sent {troops} troops to {name}",
     "received_troops_from_player": "Received {troops} troops from {name}",

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -139,6 +139,7 @@ export interface Config {
   safeFromPiratesCooldownMax(): number;
   defensePostRange(): number;
   SAMCooldown(): number;
+  samRefireDelayTicks(): number;
   SiloCooldown(): number;
   minDistanceBetweenPlayers(): number;
   defensePostDefenseBonus(): number;

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -203,6 +203,11 @@ export class DefaultConfig implements Config {
   SAMCooldown(): number {
     return 75;
   }
+  samRefireDelayTicks(): number {
+    // Beta testing: adjust this constant to tune the delay before a SAM can
+    // refire at a nuke whose interceptor was destroyed. 0 = instant refire.
+    return 5;
+  }
   SiloCooldown(): number {
     return 75;
   }

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -206,7 +206,7 @@ export class DefaultConfig implements Config {
   samRefireDelayTicks(): number {
     // Beta testing: adjust this constant to tune the delay before a SAM can
     // refire at a nuke whose interceptor was destroyed. 0 = instant refire.
-    return 5;
+    return 0;
   }
   SiloCooldown(): number {
     return 75;

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -322,8 +322,7 @@ export class NukeExecution implements Execution {
         type === UnitType.AtomBomb ||
         type === UnitType.HydrogenBomb ||
         type === UnitType.MIRVWarhead ||
-        type === UnitType.MIRV ||
-        type === UnitType.SAMMissile
+        type === UnitType.MIRV
       ) {
         continue;
       }

--- a/src/core/execution/SAMMissileExecution.ts
+++ b/src/core/execution/SAMMissileExecution.ts
@@ -39,6 +39,26 @@ export class SAMMissileExecution implements Execution {
       {},
     );
     if (!this.SAMMissile.isActive()) {
+      // Interceptor was destroyed (e.g. by nuke blast) — allow SAMs to re-target this nuke
+      if (this.target.isActive()) {
+        this.target.setTargetedBySAM(false);
+        // Notify defender their interceptor was destroyed
+        this.mg.displayMessage(
+          "events_display.interceptor_destroyed",
+          MessageType.SAM_MISS,
+          this._owner.id(),
+          undefined,
+          { unit: this.target.type() },
+        );
+        // Notify attacker their nuke survived interception
+        this.mg.displayMessage(
+          "events_display.interceptor_destroyed_attacker",
+          MessageType.SAM_MISS,
+          this.target.owner().id(),
+          undefined,
+          { unit: this.target.type() },
+        );
+      }
       this.active = false;
       return;
     }
@@ -50,7 +70,7 @@ export class SAMMissileExecution implements Execution {
       this.target.owner() === this.SAMMissile.owner() ||
       !nukesWhitelist.includes(this.target.type())
     ) {
-      // Clear the flag so other SAMs can re-target this nuke
+      // If the nuke is still active but we're aborting (e.g. SAM destroyed), allow re-targeting
       if (this.target.isActive()) {
         this.target.setTargetedBySAM(false);
       }

--- a/src/core/execution/SAMMissileExecution.ts
+++ b/src/core/execution/SAMMissileExecution.ts
@@ -17,6 +17,7 @@ export class SAMMissileExecution implements Execution {
   private SAMMissile: Unit | undefined;
   private mg: Game;
   private speed: number = 0;
+  private refireDelayRemaining: number | null = null;
 
   constructor(
     private spawn: TileRef,
@@ -39,8 +40,13 @@ export class SAMMissileExecution implements Execution {
       {},
     );
     if (!this.SAMMissile.isActive()) {
-      // Interceptor was destroyed (e.g. by nuke blast) — allow SAMs to re-target this nuke
+      // Interceptor was destroyed (e.g. by nuke blast) — allow SAMs to re-target this nuke after delay
       if (this.target.isActive()) {
+        this.refireDelayRemaining ??= this.mg.config().samRefireDelayTicks();
+        if (this.refireDelayRemaining > 0) {
+          this.refireDelayRemaining--;
+          return;
+        }
         this.target.setTargetedBySAM(false);
         // Notify defender their interceptor was destroyed
         this.mg.displayMessage(

--- a/src/core/execution/SAMMissileExecution.ts
+++ b/src/core/execution/SAMMissileExecution.ts
@@ -70,7 +70,7 @@ export class SAMMissileExecution implements Execution {
       this.target.owner() === this.SAMMissile.owner() ||
       !nukesWhitelist.includes(this.target.type())
     ) {
-      // If the nuke is still active but we're aborting (e.g. SAM destroyed), allow re-targeting
+      // Clear the flag so other SAMs can re-target this nuke
       if (this.target.isActive()) {
         this.target.setTargetedBySAM(false);
       }


### PR DESCRIPTION
Requested by Evan in Discord to review: [here](https://discord.com/channels/1359946986937258015/1475308817490382938/1478839114361995474)

Since this bypasses issues, I'm looking for a confirmation from a maintainer before I finish this PR. Its current state is just meant to demonstrate the MVP.

## Description:

#3167 added SAM missile immunity to counter nuke/hydro & hydro/hydro strategies. As a result, large trade-maxing games can result in lengthy stalemates as clusters of high-level SAMs can be almost impenetrable.

#3223 added SAM missile re-targeting so SAMs will re-engage atomics whose initial interceptors were destroyed. This PR did not remove the invulnerability on the SAM interceptor.

This PR removes SAM interceptor invulnerability and adds communication to the attacker and defender that SAM interceptors have been destroyed and re-attempts.

This change will make interceptor destroying a viable strategy again, but it will be significantly nerfed compared to pre #3167 since there was a refire mechanic implemented in #3223. 

Attached is a video showing the mechanic. First attack shows SAM engaging correctly on initial contact, second attack shows SAM re-engaging once the first interceptor was destroyed.

https://github.com/user-attachments/assets/1d129bb4-ab31-4b7f-9fb3-ad0e990a735c

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

calebcohen
