### PR TITLE
Skip multi-tab detection during replays 🛠️

### DIFF
--- a/src/client/graphics/layers/MultiTabModal.ts
+++ b/src/client/graphics/layers/MultiTabModal.ts
@@ -31,7 +31,8 @@ export class MultiTabModal extends LitElement implements Layer {
     if (
       this.game.inSpawnPhase() ||
       this.game.config().gameConfig().gameType === GameType.Singleplayer ||
-      this.game.config().serverConfig().env() === GameEnv.Dev
+      this.game.config().serverConfig().env() === GameEnv.Dev ||
+      this.game.config().isReplay()
     ) {
       return;
     }


### PR DESCRIPTION
## Description:

Multi-tab detection was incorrectly penalizing users watching replays. Added `isReplay()` check to `MultiTabModal.tick()` so the detector is never initialized when viewing a replay.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
