### PR TITLE
Fix: Register Strait of Hormuz in map generator

### DIFF
--- a/map-generator/main.go
+++ b/map-generator/main.go
@@ -62,6 +62,7 @@ var maps = []struct {
 	{Name: "sierpinski"},
 	{Name: "southamerica"},
 	{Name: "straitofgibraltar"},
+	{Name: "straitofhormuz"},
 	{Name: "surrounded"},
 	{Name: "svalmel"},
 	{Name: "world"},


### PR DESCRIPTION

## Description:

This PR registers the straitofhormuz map in main.go. This ensures that the map is processed and included when running the map generator, as it was previously present in the resources but missing from the generation pipeline.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

TSProphet
