### PR TITLE
Remove random modifiers from normal games 🧹

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -162,7 +162,6 @@ export class MapPlaylist {
         isRandomSpawn: false,
         isCrowded: false,
         isHardNations,
-        startingGold: undefined,
         isAlliancesDisabled: false,
       },
       difficulty: isHardNations ? Difficulty.Hard : Difficulty.Medium,


### PR DESCRIPTION
## Description:

Removes all random modifier logic (compact, random spawn, crowded, starting gold) from normal FFA and team game configs. The hard nations modifier is preserved exclusively for HumansVsNations team games (20% chance) for balancing reasons. The `getRandomPublicGameModifiers` method was also removed as it became unused. Special game configs are unaffected.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
