### PR TITLE
Fix duplicate game creation when opening private lobby

### DIFF
--- a/src/client/components/BaseModal.ts
+++ b/src/client/components/BaseModal.ts
@@ -115,6 +115,7 @@ export abstract class BaseModal extends LitElement {
    * Subclasses can override onOpen() for custom behavior.
    */
   public open(): void {
+    if (this.isModalOpen) return;
     this.registerEscapeHandler();
     this.onOpen();
 


### PR DESCRIPTION
## Description:

- Prevent `BaseModal.open()` from firing `onOpen()` twice when Navigation.showPage() re-calls `open()` on inline modals
- Adds an `isModalOpen` early-return guard, matching existing behavior in `OModal.open()`

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Jish
