### PR TITLE
Fix public lobby timer stuck due to IPC race condition

### DIFF
--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -135,17 +135,22 @@ export class MasterLobbyService {
 
     for (const type of Object.keys(lobbiesByType) as PublicGameType[]) {
       const lobbies = lobbiesByType[type];
-      if (lobbies.length >= 2) {
-        continue;
-      }
+
+      // Always ensure the next lobby has a timer, even if we already have 2+
+      // lobbies. This prevents a race where two lobbies are created before
+      // either receives a startsAt (IPC round-trip delay), leaving both stuck
+      // without a countdown.
       const nextLobby = lobbies[0];
       if (nextLobby && nextLobby.startsAt === undefined) {
-        // The previous game has started, so we need to set the timer on the next game.
         this.sendMessageToWorker({
           type: "updateLobby",
           gameID: nextLobby.gameID,
           startsAt: Date.now() + this.config.gameCreationRate(),
         });
+      }
+
+      if (lobbies.length >= 2) {
+        continue;
       }
 
       this.sendMessageToWorker({


### PR DESCRIPTION
## Description:

Fixes a race condition where two public lobbies could be created for the same game type before either receives a startsAt timestamp (due to IPC round-trip delay between master and worker). Once both exist without timers, the lobbies.length >= 2 guard prevented either from ever getting one — leaving the lobby permanently stuck unless it filled to max capacity.

Moves the timer-setting logic before the lobby count guard so it always runs.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Jish
