### PR TITLE
Revert "Rearrange homepage game boxes & tune special modifier probabilities 🎲"

### DIFF
--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -150,30 +150,35 @@ export class GameModeSelector extends LitElement {
         <div
           class="grid grid-cols-1 sm:grid-cols-[2fr_1fr] gap-4 sm:h-[min(24rem,40vh)]"
         >
-          <!-- Left col: FFA (desktop only) -->
-          ${ffa
+          <!-- Left col: main card (desktop only) -->
+          ${special
             ? html`<div class="hidden sm:block">
-                ${this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))}
+                ${this.renderSpecialLobbyCard(special)}
               </div>`
-            : nothing}
+            : ffa
+              ? html`<div class="hidden sm:block">
+                  ${this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))}
+                </div>`
+              : nothing}
 
-          <!-- Right col: Teams + Special (desktop only) -->
-          ${teams || special
-            ? html`<div class="hidden sm:flex sm:flex-col sm:gap-4">
-                ${teams
-                  ? html`<div class="flex-1 min-h-0">
-                      ${this.renderLobbyCard(teams, this.getLobbyTitle(teams))}
-                    </div>`
-                  : nothing}
-                ${special
-                  ? html`<div class="flex-1 min-h-0">
-                      ${this.renderSpecialLobbyCard(special)}
-                    </div>`
-                  : nothing}
-              </div>`
-            : nothing}
+          <!-- Right col: FFA + teams (desktop only) -->
+          <div class="hidden sm:flex sm:flex-col sm:gap-4">
+            ${special && ffa
+              ? html`<div class="flex-1 min-h-0">
+                  ${this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))}
+                </div>`
+              : nothing}
+            ${teams
+              ? html`<div class="flex-1 min-h-0">
+                  ${this.renderLobbyCard(teams, this.getLobbyTitle(teams))}
+                </div>`
+              : nothing}
+          </div>
 
-          <!-- Mobile: ffa, teams, special inline -->
+          <!-- Mobile: special, ffa, teams inline -->
+          <div class="sm:hidden">
+            ${special ? this.renderSpecialLobbyCard(special) : nothing}
+          </div>
           <div class="sm:hidden">
             ${ffa
               ? this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))
@@ -183,9 +188,6 @@ export class GameModeSelector extends LitElement {
             ${teams
               ? this.renderLobbyCard(teams, this.getLobbyTitle(teams))
               : nothing}
-          </div>
-          <div class="sm:hidden">
-            ${special ? this.renderSpecialLobbyCard(special) : nothing}
           </div>
         </div>
 

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -109,14 +109,14 @@ type ModifierKey =
 
 // Each entry represents one "ticket" in the pool. More tickets = higher chance of selection.
 const SPECIAL_MODIFIER_POOL: ModifierKey[] = [
-  ...Array<ModifierKey>(8).fill("isRandomSpawn"),
-  ...Array<ModifierKey>(16).fill("isCompact"),
-  ...Array<ModifierKey>(3).fill("isCrowded"), // should be quite rare as it causes max-size lobbies
-  ...Array<ModifierKey>(1).fill("isHardNations"), // should be quite rare because it's just for the PvPvE enjoyers
-  ...Array<ModifierKey>(16).fill("startingGold"),
-  ...Array<ModifierKey>(4).fill("startingGoldHigh"), // should be quite rare because it's very crazy
-  ...Array<ModifierKey>(6).fill("goldMultiplier"),
-  ...Array<ModifierKey>(1).fill("isAlliancesDisabled"), // should be quite rare because it removes a key element of OpenFront
+  ...Array<ModifierKey>(4).fill("isRandomSpawn"),
+  ...Array<ModifierKey>(8).fill("isCompact"),
+  ...Array<ModifierKey>(1).fill("isCrowded"),
+  ...Array<ModifierKey>(1).fill("isHardNations"),
+  ...Array<ModifierKey>(8).fill("startingGold"),
+  ...Array<ModifierKey>(1).fill("startingGoldHigh"),
+  ...Array<ModifierKey>(1).fill("goldMultiplier"),
+  ...Array<ModifierKey>(1).fill("isAlliancesDisabled"),
 ];
 
 // Modifiers that cannot be active at the same time.
@@ -515,16 +515,16 @@ export class MapPlaylist {
     count?: number,
     countReduction: number = 0,
   ): PublicGameModifiers {
-    // Roll how many modifiers to pick: 40% → 1, 40% → 2, 15% → 3, 5% → 4
-    const modifierCountRoll = Math.floor(Math.random() * 100) + 1;
+    // Roll how many modifiers to pick: 30% → 1, 40% → 2, 20% → 3, 10% → 4
+    const modifierCountRoll = Math.floor(Math.random() * 10) + 1;
     const k = Math.max(
       0,
       (count ??
-        (modifierCountRoll <= 40
+        (modifierCountRoll <= 3
           ? 1
-          : modifierCountRoll <= 80
+          : modifierCountRoll <= 7
             ? 2
-            : modifierCountRoll <= 95
+            : modifierCountRoll <= 9
               ? 3
               : 4)) - countReduction,
     );


### PR DESCRIPTION
## Description:

Reverts openfrontio/OpenFrontIO#3420

Evan only reverted on v30 branch but not on main, that was probably not intended?
Apparently special should stay where it is right now

## Checklist

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Discord

FloPinguin