### PR TITLE
Reduce spawn phase duration when random spawn is enabled ⏱️

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -545,10 +545,13 @@ export class DefaultConfig implements Config {
     return 3;
   }
   numSpawnPhaseTurns(): number {
-    return this._gameConfig.gameType === GameType.Singleplayer ||
-      this.isRandomSpawn()
-      ? 100
-      : 300;
+    if (this._gameConfig.gameType === GameType.Singleplayer) {
+      return 100;
+    }
+    if (this.isRandomSpawn()) {
+      return 150;
+    }
+    return 300;
   }
   numBots(): number {
     return this.bots();


### PR DESCRIPTION
## Description:

Reduces `numSpawnPhaseTurns` from 300 to 100 (matching singleplayer duration) when random spawn is active. Since players can't choose their spawn location in random spawn mode, there's no need for the full 300-tick spawn phase.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin