### PR TITLE
Keep build mode active when player can afford another build

### DIFF
--- a/src/client/graphics/layers/StructureIconsLayer.ts
+++ b/src/client/graphics/layers/StructureIconsLayer.ts
@@ -471,6 +471,7 @@ export class StructureIconsLayer implements Layer {
       this.removeGhostStructure();
     } else if (this.ghostUnit.buildableUnit.canBuild) {
       const unitType = this.ghostUnit.buildableUnit.type;
+      const cost = this.ghostUnit.buildableUnit.cost;
       const rocketDirectionUp =
         unitType === UnitType.AtomBomb || unitType === UnitType.HydrogenBomb
           ? this.uiState.rocketDirectionUp
@@ -483,7 +484,16 @@ export class StructureIconsLayer implements Layer {
         ),
       );
       if (!shouldPreserveGhostAfterBuild(unitType)) {
-        this.removeGhostStructure();
+        const myPlayer = this.game.myPlayer();
+        const remainingGold = myPlayer ? myPlayer.gold() - cost : 0n;
+        if (remainingGold >= cost) {
+          // Stay in build mode - player can afford another one.
+          // Reset buildable state so renderGhost re-evaluates on next frame.
+          this.ghostUnit.buildableUnit.canBuild = false;
+          this.ghostUnit.buildableUnit.canUpgrade = false;
+        } else {
+          this.removeGhostStructure();
+        }
       }
     } else {
       this.removeGhostStructure();


### PR DESCRIPTION
## Summary
- After placing a structure, the game now checks if the player has enough remaining gold to build the same structure again
- If affordable, build mode stays active so the player can place another without re-entering build mode
- If not affordable, build mode exits as before

Fixes #3399

## Test plan
- [ ] Build a city when you have enough gold for 2+ cities — build mode should remain active after placing the first
- [ ] Build a city when you can only afford one — build mode should exit after placing it
- [ ] Nukes (AtomBomb/HydrogenBomb) should continue to always preserve build mode regardless of gold
- [ ] Upgrades should continue to exit build mode after upgrading