### PR TITLE
Fix: player name and location on wrong spot on the map

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -97,8 +97,11 @@ export class PlayerExecution implements Execution {
       }
     }
 
-    if (ticks - this.lastCalc > this.ticksPerClusterCalc) {
-      if (this.player.lastTileChange() > this.lastCalc) {
+    if (
+      ticks - this.lastCalc > this.ticksPerClusterCalc ||
+      this.player.numTilesOwned() < 100
+    ) {
+      if (this.player.lastTileChange() >= this.lastCalc) {
         this.lastCalc = ticks;
         const start = performance.now();
         this.removeClusters();


### PR DESCRIPTION
## Description:

Fixes https://github.com/openfrontio/OpenFrontIO/issues/1021

Fixes issue that has been there since the beginning. Player name and location and conquest FX (swords) not being in the right place. It can happen at any time during a game and can be game-breaking in that regard. 

This makes it hard to find players, especially when trying to eliminate their last few tiles on some island. So when clicking name in leaderboard > wrong tiles. And when seeing name > above wrong tiles. Bug report: https://discord.com/channels/1284581928254701718/1444669324571967680

Also, when removing those last tiles, the wait time between updates of player location can make it frustrating to find and eliminate them fast. You need 2-3 clicks on their name in leaderboard, before finally being moved to their current location.


**Cause:**
largestClusterBoundingBox not being changed when last attack happened in same tick removeClusters last ran. 

**Fix:** 
Also call removeClusters, and therefore update largestClusterBoundingBox , when LastTileChange was AT lastCalc tick.

**Also:** 
Run removeClusters if player owns less than 100 tiles, don't wait for ticksPerClusterCalc in that case. This way, sniping off the last couple of island tiles of the player is easier. So it doesn't take 2-3 clicks bbut just 1 click on the player name in the Leaderboard before the camera moves to the next little island they are on. Also their last clusters are annexed faster, only helping with the faster cleanup.
I think this is an optional to the fix in this PR, but still an important QoL fix for sniping those last tiles quickly.

**BEFORE:**
https://github.com/user-attachments/assets/0960a4d3-7f8b-4368-9531-8244356bff17

**AFTER:** (also notice how it now just takes 1 click in the leaderboard to immediately go to their next location, not 2-3 clicks)
https://youtu.be/qXJPekjsrP4

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33