### PR TITLE
Fix labels in public lobby modifier display 🏷️

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -24,6 +24,7 @@
     "copied": "Copied!",
     "click_to_copy": "Click to copy",
     "enabled": "Enabled",
+    "disabled": "Disabled",
     "map_default": "Map default"
   },
   "main": {
@@ -488,8 +489,10 @@
     "crowded": "Crowded",
     "hard_nations": "Hard Nations",
     "starting_gold": "{amount}M Starting Gold",
+    "starting_gold_label": "Starting Gold",
     "gold_multiplier": "x{amount} Gold Multiplier",
-    "disable_alliances": "Alliances Disabled"
+    "disable_alliances": "Alliances Disabled",
+    "disable_alliances_label": "Alliances"
   },
   "select_lang": {
     "title": "Select Language"

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -159,7 +159,7 @@ export function getActiveModifiers(
       (modifiers.startingGold / 1_000_000).toPrecision(12),
     );
     result.push({
-      labelKey: "host_modal.starting_gold",
+      labelKey: "public_game_modifier.starting_gold_label",
       badgeKey: "public_game_modifier.starting_gold",
       badgeParams: {
         amount: millions,
@@ -181,8 +181,9 @@ export function getActiveModifiers(
   }
   if (modifiers.isAlliancesDisabled) {
     result.push({
-      labelKey: "host_modal.disable_alliances",
+      labelKey: "public_game_modifier.disable_alliances_label",
       badgeKey: "public_game_modifier.disable_alliances",
+      formattedValue: translateText("common.disabled"),
     });
   }
   return result;


### PR DESCRIPTION
## Description:

Fixes two issues in the join lobby modal's modifier display:

1. **Starting Gold**: Label showed "Starting Gold (Millions)" with value "5M", duplicating "millions". Now shows "Starting Gold" as the label, keeping "5M" as the value.
2. **Disable Alliances**: Label showed "Disable Alliances" with value "Enabled", which is confusing. Now shows "Alliances" as the label with "Disabled" as the value.

Join Lobby Modal needs a general rework, I will probably make an PR

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
