### PR TITLE
Increase spawn immunity from 30s to 45s for 5M starting gold maps 🛡️

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -136,6 +136,9 @@ export abstract class DefaultServerConfig implements ServerConfig {
   }
 }
 
+/** SAM launcher construction duration in ticks (non-instant-build). */
+export const SAM_CONSTRUCTION_TICKS = 30 * 10;
+
 export class DefaultConfig implements Config {
   private pastelTheme: PastelTheme = new PastelTheme();
   private pastelThemeDark: PastelThemeDark = new PastelThemeDark();
@@ -430,7 +433,9 @@ export class DefaultConfig implements Config {
               Math.min(3_000_000, (numUnits + 1) * 1_500_000),
             UnitType.SAMLauncher,
           ),
-          constructionDuration: this.instantBuild() ? 0 : 30 * 10,
+          constructionDuration: this.instantBuild()
+            ? 0
+            : SAM_CONSTRUCTION_TICKS,
           upgradable: true,
         };
         break;

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -1,3 +1,4 @@
+import { SAM_CONSTRUCTION_TICKS } from "../core/configuration/DefaultConfig";
 import {
   Difficulty,
   Duos,
@@ -607,7 +608,7 @@ export class MapPlaylist {
    * Centralised spawn-immunity duration logic.
    * - HumansVsNations: always 5s (nations can't benefit from longer PVP immunity)
    * - 25M starting gold: 2:30min (extra time to compensate for high gold)
-   * - 5M starting gold: 45s (15s longer than it takes to build a SAM)
+   * - 5M starting gold: SAM build time + 15s (enough to build a SAM)
    * - Default: 5s
    */
   private getSpawnImmunityDuration(
@@ -617,7 +618,7 @@ export class MapPlaylist {
     if (playerTeams === HumansVsNations) return 5 * 10;
     if (startingGold !== undefined && startingGold >= 25_000_000)
       return 150 * 10;
-    if (startingGold) return 45 * 10;
+    if (startingGold) return SAM_CONSTRUCTION_TICKS + 15 * 10;
     return 5 * 10;
   }
 


### PR DESCRIPTION
## Description:

Increases the spawn immunity duration from 30s to 45s for maps with 5M starting gold. 

The previous 30s was too short - 45s gives players 15s longer than it takes to build a SAM, allowing them to establish basic defenses before becoming vulnerable.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
