### PR TITLE
teamGameSpawnAreas for Baikal ⚡

### DIFF
--- a/map-generator/assets/maps/baikal/info.json
+++ b/map-generator/assets/maps/baikal/info.json
@@ -56,5 +56,21 @@
       "name": "Listvyanka",
       "flag": "ru"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1564,
+        "width": 1330,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1564,
+        "width": 1070,
+        "x": 1430,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/baikal/manifest.json
+++ b/resources/maps/baikal/manifest.json
@@ -71,5 +71,21 @@
       "flag": "ru",
       "name": "Listvyanka"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1564,
+        "width": 1330,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1564,
+        "width": 1070,
+        "x": 1430,
+        "y": 0
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Description:

"Baikal (Nuke Wars)" has teamGameSpawnAreas (for Random Spawn), but Baikal not. Because teamGameSpawnAreas was intended for a "Nuke Wars" modifier. Let's add teamGameSpawnAreas also to Baikal to improve random spawning (special rotation) a bit (until we have a better random spawn algo).

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
