### PR TITLE
Remove modifiers from normal FFA/Team games (And increase chance of gold multiplier for special games, decrease random spawn) 🎲

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -110,7 +110,7 @@ type ModifierKey =
 
 // Each entry represents one "ticket" in the pool. More tickets = higher chance of selection.
 const SPECIAL_MODIFIER_POOL: ModifierKey[] = [
-  ...Array<ModifierKey>(4).fill("isRandomSpawn"),
+  ...Array<ModifierKey>(2).fill("isRandomSpawn"),
   ...Array<ModifierKey>(8).fill("isCompact"),
   ...Array<ModifierKey>(1).fill("isCrowded"),
   ...Array<ModifierKey>(1).fill("isHardNations"),


### PR DESCRIPTION
## Description:

Normal (FFA and Team) public games no longer roll random modifiers.
Special games remain fully unaffected and continue to use random modifiers as before.

I also increased the gold multiplier ticket count in the special modifier pool from 1 to 4 because of player feedback.

Edit: And because I saw complaints of too much random spawn I decreased the chance of it.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
