### PR TITLE
Faster action runs (still free)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ permissions: {}
 jobs:
   build:
     name: 🏗️ Build
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -32,7 +32,7 @@ jobs:
           retention-days: 1
   test:
     name: 🔬 Test
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - name: Checkout repository
@@ -48,7 +48,7 @@ jobs:
 
   eslint:
     name: 🔍 ESLint
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -61,7 +61,7 @@ jobs:
 
   prettier:
     name: 🎨 Prettier
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
     if: ${{ github.event_name == 'workflow_dispatch' || github.repository == 'openfrontio/OpenFrontIO' }}
     # Use different logic based on event type
     name: Deploy to ${{ inputs.target_domain || 'openfront.dev' }}
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     environment: ${{ inputs.target_domain == 'openfront.io' && 'prod' || '' }}
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions: {}
 jobs:
   build:
     name: 🏗️ Build
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@v5
@@ -47,7 +47,7 @@ jobs:
 
   deploy-alpha:
     name: 🧪 Deploy to alpha
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     timeout-minutes: 30
     needs: [build]
     steps:
@@ -97,7 +97,7 @@ jobs:
 
   deploy-beta:
     name: 🐞 Deploy to beta
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [build, deploy-alpha]
     timeout-minutes: 30
     environment: prod-beta
@@ -148,7 +148,7 @@ jobs:
 
   deploy-blue:
     name: 🔵 Deploy to blue
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [build, deploy-alpha]
     timeout-minutes: 30
     environment: prod-blue
@@ -199,7 +199,7 @@ jobs:
 
   deploy-green:
     name: 🟢 Deploy to green
-    runs-on: blacksmith-8vcpu-ubuntu-2404
+    runs-on: blacksmith-2vcpu-ubuntu-2404
     needs: [build, deploy-alpha]
     timeout-minutes: 30
     environment: prod-green


### PR DESCRIPTION
## Description:

Use Blacksmith for faster and free action runs. 

Chose their 2vCPU runners to fit our usage best, and the workflows/steps it would fit us best within their free plan.

Now we can choose between a combination of CI/Test and Release, or Deploy and Release to migrate within the free plan. Release profits from more than 1 minute faster deploy to the production instance alone.

**2vCPU (see full performance comparisons below):**
CI/Test: ~26% faster (1m 21s > 52s = 29s)
Deploy: ~19.5% faster (2m 39s > 2m 8s = 31s)
Release: cannot measure without real release, but its Deploy steps could be somewhat comparable to deploy in % faster. Which could mean that its Deploy to Green step for v0.30.12 would have taken 4m 44s instead of 5m 53s.


**INFORMATION AND CHOICES**

- See https://docs.blacksmith.sh/introduction/quickstart

- 3000 free free per month for public repositories with 2 vCPU runners, 1500 minutes free for 4 vCPU,  750 minutes for 8 vCPU. See https://www.blacksmith.sh/pricing or https://docs.blacksmith.sh/blacksmith-runners/overview#is-there-a-free-tier

- GitHub's plans to ask 0.002 USD per minute GitHub Actions for self-hosted runners would have applied to Blacksmith too. Were it not those plans were postponed and more importantly, runners will remain free for public repositories (see https://github.blog/changelog/2025-12-16-coming-soon-simpler-pricing-and-a-better-experience-for-github-actions/).

- Our Action runs are currently also free for the public repo with the [standard GitHub-hosted runners](https://docs.github.com/en/billing/concepts/product-billing/github-actions), but those are slower.

- Blacksmith caches dependencies and build outputs by default when running jobs with them.

- Blacksmith's docker build layer caching isn't free ([0.50 USD/GB/month](https://docs.blacksmith.sh/blacksmith-caching/docker-builds#pricing)). While GHCR [currently is free](https://docs.github.com/en/billing/concepts/product-billing/github-packages#free-use-of-github-packages), so it's better to stick with GHCR for now for that.

**PERFORMANCE MEASUREMENTS**

**With 4vCPU Blacksmith against the default GitHub runners:**

Gave the Deploy job 3 runs, to let Blacksmith be able to build up and use cache.

Compared this PR (with the Blacksmith runners, and the Node 24 commits with new Action versions merged from main. Includes Deploy action.). CI/Prettier: 42s, CI/Build: 44s, CI/ESLint: 37s, CI/Test: 40s, PR/Has Milestone: 4s, PR/Validate Description: 5s, Deploy: 2m10s

with: 
- PR 3475 (1 file, Github runners, also has the Node 24 commits with new Action versions merged from main. Includes Deploy action.). CI/Prettier: 1m2s, CI/Build: 59s, CI/ESLint: 55s, CI/Test: 1m22s, PR/Has Milestone: 5s, PR/Validate Description: 2s, Deploy: 2m42s

- PR 3450 (6 files, Github runners, also has the Node 24 commits with new Action versions merged from main. Includes Deploy action.)
CI/Prettier: 1m2s, CI/Build: 57s, CI/ESLint: 54s, CI/Test: 1m18s, PR/Has Milestone: 5s, PR/Validate Description: 5s, Deploy: 2m36s

- PR 3439 (10 files, Github runners, Node 20 workflows. No Deploy action.)
CI/Prettier: 1m6s, CI/Build: 58s, CI/ESLint: 56s, CI/Test: 1m23s, PR/Has Milestone: 3s, PR/Validate Description: 4s

- PR 3438 (1 file, Github runners, Node 20 workflows. No Deploy action.)
CI/Prettier: 1m3s, CI/Build: 58s, CI/ESLint: 52s, CI/Test: 1m21s, PR/Has Milestone: 3s, PR/Validate Description: 5s

**4vCPU:**
CI/Prettier: ~34% faster on average (1m 3.25s > 42s = 21.25s)
CI/Build: ~24% faster on average (58s > 44s = 14s)
CI/ESLint: ~32% faster (54.25s > 37s = 17.25s)
CI/Test: ~51% faster (1m 21s > 40s = 41s)
Deploy: ~18% faster (2m 39s > 2m10s = 29s)
PR/Has Milestone AND PR/Validate Description: 1s slower on all Blacksmith machines so better left on Github runners (maybe slightly longer startup time for Blacksmith which negates faster script run, or less fast access to the PR).
PR/Stale AND PR/author: not measured. The first is a cron job so not measured and has write access, second has  write access too (CodeRabbit advises to use GitHub runners for PR/Has Milestone and PR/Stale since they have write rights on the PR anyway, so better keep the PR ones on ubuntu-latest)
Release: cannot measure without real release, but its Deploy steps could be somewhat comparable to deploy in % faster. Which could mean that its Deploy to Green step for v0.30.12 would have taken 4m 49s instead of 5m 53s.

Overall: 31.8% (18-51%) or 24s (14-41s) faster per workflow, on average. For Release action step Deploy to Green/Blue, an estimated 1m 4s faster release to Prod based on the performance gains for the Deploy action.

**With 8vCPU Blacksmith against the default GitHub runners:**

Gave the Deploy job 3 runs, to let Blacksmith be able to build up and use cache.

Compared this PR with the same PRs as for the 4vCPU comparison above. 
This PR: CI/Prettier: 39s, CI/Build: 37s, CI/ESLint: 36s, CI/Test: 37s, PR/Has Milestone: 5s, PR/Validate Description: 5s, Deploy: 2m7s (fastest was 1m 28s with the 3rd deploy of the same commit, after Blacksmith had probably been able to cache things)

**8vCPU:**
CI/Prettier: ~38.5% faster on average (1m 3.25s > 39s = 24.25s)
CI/Build: ~36.5% faster on average (58s > 37s = 21s)
CI/ESLint: ~33.5% faster (54.25s > 36s = 18.25s)
CI/Test: ~54.5% faster (1m 21s > 37s = 44s)
Deploy: ~20% faster (2m 39s > 2m 7s = 32s)
Release: cannot measure without real release, but its Deploy steps could be somewhat comparable to deploy in % faster. Which could mean that its Deploy to Green step for v0.30.12 would have taken 4m 42s instead of 5m 53s.

Overall: 36.6% (20-54.5%) or 34.9s (18.25-44s) faster per workflow, on average. For Release action step Deploy to Green/Blue, an estimated 1m 11s faster release to Prod based on the performance gains for the Deploy action.

With 2vCPU Blacksmith against the default GitHub runners:

Compared PR 3474 (with the Blacksmith runners, and the Node 24 commits with new Action versions merged from main. Includes Deploy action.). CI/Prettier: 58s, CI/Build: 37s, CI/ESLint: 36s, CI/Test: 37s, PR/Has Milestone: 5s, PR/Validate Description: 5s, Deploy: 2m7s (fastest was 1m 28s with the 3rd deploy of the same commit, after Blacksmith had probably been able to cache things)

Only ran on 3 Steps/Workflows:

CI/Test: ~26% faster (1m 21s > 52s = 29s)
Deploy: ~19.5% faster (2m 39s > 2m 8s = 31s)
Release: cannot measure without real release, but its Deploy steps could be somewhat comparable to deploy in % faster. Which could mean that its Deploy to Green step for v0.30.12 would have taken 4m 44s instead of 5m 53s.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33