### PR TITLE
For v30: Fix base language preferred over regional variant in auto-detection 🌐

### DIFF
--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -72,6 +72,7 @@ export class LangSelector extends LitElement {
     if (supported.has(lang)) return lang;
 
     const base = lang.slice(0, 2);
+    if (supported.has(base)) return base;
     const candidates = Array.from(supported).filter((key) =>
       key.startsWith(base),
     );


### PR DESCRIPTION
## Description:

When the browser reports a locale like `de-DE`, the language selector didn't find an exact match and fell through to candidate matching, where it picked `de-CH` (Swiss German) over `de` (German) because longer codes were sorted first.

This adds an early check: if the base language code (e.g. `de`) is directly supported, return it immediately before scanning regional candidates.

FYI @Aotumuri 

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
