### PR TITLE
Maybe for v30: Add leave confirmation dialog to JoinLobbyModal 🚪

### DIFF
--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -374,6 +374,11 @@ export class JoinLobbyModal extends BaseModal {
     );
   }
 
+  public confirmBeforeClose(): boolean {
+    if (!this.currentLobbyId) return true;
+    return confirm(translateText("host_modal.leave_confirmation"));
+  }
+
   protected onClose(): void {
     this.clearCountdownTimer();
     this.stopLobbyUpdates();


### PR DESCRIPTION
## Description:

Adds a `confirmBeforeClose()` override to `JoinLobbyModal`, matching the existing behavior in `HostLobbyModal`.

Because the german streamers had a lot of problems with accidentally leaving today.

When a user is in a lobby and tries to close the modal (Escape key or clicking outside), they now get a confirmation dialog asking if they really want to leave. If the user hasn't joined a lobby yet (still on the join form), the modal closes without prompting.

Reuses the existing `host_modal.leave_confirmation` translation key.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
