### PR TITLE
Hide clan tag to prevent tag sniping

### DIFF
--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -399,9 +399,11 @@ export class LobbyTeamView extends LitElement {
   }
 
   private getClientDisplayName(client: ClientInfo): string {
-    // Only show a clan tag if the current player shares the same tag.
+    // In public games, only show a clan tag if the current player shares the same tag.
     const visibleClanTag =
-      this.currentClientClanTag && this.currentClientClanTag === client.clanTag
+      !this.isPublicGame ||
+      (this.currentClientClanTag &&
+        this.currentClientClanTag === client.clanTag)
         ? client.clanTag
         : null;
     const full = formatPlayerDisplayName(client.username, visibleClanTag);


### PR DESCRIPTION
## Description:

Resolves #3496

Hides clan tags unless it matches the current player's clan to discourage tag sniping.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

andystrangelove (aka [UN]inhibited)
