### PR TITLE
Update lobby API to hide other player's clan tags in public games

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -630,17 +630,31 @@ export class GameServer {
   }
 
   private broadcastLobbyInfo() {
-    const lobbyInfo = this.gameInfo();
     this.activeClients.forEach((c) => {
       if (c.ws.readyState === WebSocket.OPEN) {
         const msg = JSON.stringify({
           type: "lobby_info",
-          lobby: lobbyInfo,
+          lobby: this.gameInfoForClient(c.clanTag ?? null),
           myClientID: c.clientID,
         } satisfies ServerLobbyInfoMessage);
         c.ws.send(msg);
       }
     });
+  }
+
+  private gameInfoForClient(recipientClanTag: string | null): GameInfo {
+    const isPublic = this.gameConfig.gameType === GameType.Public;
+    return {
+      ...this.gameInfo(),
+      clients: this.activeClients.map((c) => ({
+        username: c.username,
+        clanTag:
+          !isPublic || (recipientClanTag && c.clanTag === recipientClanTag)
+            ? (c.clanTag ?? null)
+            : null,
+        clientID: c.clientID,
+      })),
+    };
   }
 
   public start() {


### PR DESCRIPTION
Resolves #3496

## Description:

Hides the clan tag from the broadcastLobbyInfo() API unless the tag matches your own.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

andystrangelove
