### PR TITLE
switch live gameplay websocket traffic to binary

### DIFF
--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -1,4 +1,10 @@
 import { z } from "zod";
+import {
+  binaryContextFromGameStartInfo,
+  decodeBinaryServerGameplayMessage,
+  encodeBinaryClientGameplayMessage,
+  isBinaryGameplayClientMessage,
+} from "../core/BinaryCodec";
 import { EventBus, GameEvent } from "../core/EventBus";
 import {
   AllPlayers,
@@ -20,6 +26,7 @@ import {
   ClientRejoinMessage,
   ClientSendWinnerMessage,
   GameConfig,
+  GameStartInfo,
   Intent,
   ServerMessage,
   ServerMessageSchema,
@@ -178,13 +185,15 @@ export class Transport {
 
   private localServer: LocalServer;
 
-  private buffer: string[] = [];
+  private buffer: Array<string | Uint8Array> = [];
 
   private onconnect: () => void;
   private onmessage: (msg: ServerMessage) => void;
 
   private pingInterval: number | null = null;
   public readonly isLocal: boolean;
+  private binaryGameplayActive = false;
+  private binaryContext?: ReturnType<typeof binaryContextFromGameStartInfo>;
 
   constructor(
     private lobbyConfig: LobbyConfig,
@@ -324,12 +333,14 @@ export class Transport {
   ) {
     this.startPing();
     this.killExistingSocket();
+    this.binaryGameplayActive = false;
     const wsHost = window.location.host;
     const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const workerPath = this.lobbyConfig.serverConfig.workerPath(
       this.lobbyConfig.gameID,
     );
     this.socket = new WebSocket(`${wsProtocol}//${wsHost}/${workerPath}`);
+    this.socket.binaryType = "arraybuffer";
     this.onconnect = onconnect;
     this.onmessage = onmessage;
     this.socket.onopen = () => {
@@ -351,14 +362,31 @@ export class Transport {
     };
     this.socket.onmessage = (event: MessageEvent) => {
       try {
-        const parsed = JSON.parse(event.data);
-        const result = ServerMessageSchema.safeParse(parsed);
-        if (!result.success) {
-          const error = z.prettifyError(result.error);
-          console.error("Error parsing server message", error);
+        if (typeof event.data === "string") {
+          const parsed = JSON.parse(event.data);
+          const result = ServerMessageSchema.safeParse(parsed);
+          if (!result.success) {
+            const error = z.prettifyError(result.error);
+            console.error("Error parsing server message", error);
+            return;
+          }
+          if (result.data.type === "start") {
+            this.activateBinaryGameplay(result.data.gameStartInfo);
+          }
+          this.onmessage(result.data);
           return;
         }
-        this.onmessage(result.data);
+
+        if (!this.binaryContext) {
+          console.error("Received binary gameplay message before start");
+          return;
+        }
+
+        const message = decodeBinaryServerGameplayMessage(
+          event.data as ArrayBuffer,
+          this.binaryContext,
+        );
+        this.onmessage(message);
       } catch (e) {
         console.error("Error in onmessage handler:", e, event.data);
         return;
@@ -669,18 +697,35 @@ export class Transport {
       // Socket missing, do nothing
       return;
     }
-    const str = JSON.stringify(msg, replacer);
+    const payload = this.serializeMessage(msg);
     if (this.socket.readyState === WebSocket.CLOSED) {
       // Buffer message
       console.warn("socket not ready, closing and trying later");
       this.socket.close();
       this.socket = null;
       this.connectRemote(this.onconnect, this.onmessage);
-      this.buffer.push(str);
+      this.buffer.push(payload);
     } else {
       // Send the message directly
-      this.socket.send(str);
+      this.socket.send(payload);
     }
+  }
+
+  private serializeMessage(msg: ClientMessage): string | Uint8Array {
+    if (this.binaryGameplayActive && isBinaryGameplayClientMessage(msg)) {
+      if (!this.binaryContext) {
+        throw new Error("Binary gameplay active without context");
+      }
+      return encodeBinaryClientGameplayMessage(msg, this.binaryContext);
+    }
+    return JSON.stringify(msg, replacer);
+  }
+
+  private activateBinaryGameplay(
+    gameStartInfo: Pick<GameStartInfo, "players">,
+  ) {
+    this.binaryContext = binaryContextFromGameStartInfo(gameStartInfo);
+    this.binaryGameplayActive = true;
   }
 
   private killExistingSocket(): void {

--- a/src/core/BinaryCodec.ts
+++ b/src/core/BinaryCodec.ts
@@ -5,6 +5,7 @@ import {
   BinaryMessageType,
   BinaryProtocolContext,
   BinaryServerGameplayMessage,
+  INLINE_PLAYER_ID_INDEX,
   INTENT_FLAG_OPTION_A,
   INTENT_FLAG_OPTION_B,
   createBinaryProtocolContext,
@@ -29,7 +30,7 @@ import {
   ServerTurnMessage,
   StampedIntent,
 } from "./Schemas";
-import { UnitType } from "./game/Game";
+import { AllPlayers, UnitType } from "./game/Game";
 
 const textEncoder = new TextEncoder();
 const textDecoder = new TextDecoder();
@@ -460,7 +461,7 @@ function encodeIntent(
   switch (intent.type) {
     case "attack":
       if (intent.targetID !== null) {
-        writer.writeUint16(playerIdToIndex(intent.targetID, context));
+        writePlayerRef(writer, intent.targetID, context);
       }
       if (intent.troops !== null) {
         writer.writeFloat64(intent.troops);
@@ -473,7 +474,7 @@ function encodeIntent(
       writer.writeUint32(intent.tile);
       return;
     case "mark_disconnected":
-      writer.writeUint16(playerIdToIndex(intent.clientID, context));
+      writeRequiredPlayerRef(writer, intent.clientID, context);
       writer.writeBoolean(intent.isDisconnected);
       return;
     case "boat":
@@ -484,23 +485,23 @@ function encodeIntent(
       writer.writeUint32(intent.unitID);
       return;
     case "allianceRequest":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writeRequiredPlayerRef(writer, intent.recipient, context);
       return;
     case "allianceReject":
-      writer.writeUint16(playerIdToIndex(intent.requestor, context));
+      writeRequiredPlayerRef(writer, intent.requestor, context);
       return;
     case "breakAlliance":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writeRequiredPlayerRef(writer, intent.recipient, context);
       return;
     case "targetPlayer":
-      writer.writeUint16(playerIdToIndex(intent.target, context));
+      writeRequiredPlayerRef(writer, intent.target, context);
       return;
     case "emoji":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writePlayerRef(writer, intent.recipient, context);
       writer.writeUint16(intent.emoji);
       return;
     case "donate_gold":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writeRequiredPlayerRef(writer, intent.recipient, context);
       if (intent.gold === null) {
         writer.writeBoolean(false);
       } else {
@@ -509,7 +510,7 @@ function encodeIntent(
       }
       return;
     case "donate_troops":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writeRequiredPlayerRef(writer, intent.recipient, context);
       if (intent.troops === null) {
         writer.writeBoolean(false);
       } else {
@@ -526,7 +527,7 @@ function encodeIntent(
       writer.writeUint32(intent.unitId);
       return;
     case "embargo":
-      writer.writeUint16(playerIdToIndex(intent.targetID, context));
+      writeRequiredPlayerRef(writer, intent.targetID, context);
       writer.writeBoolean(intent.action === "start");
       return;
     case "embargo_all":
@@ -537,14 +538,14 @@ function encodeIntent(
       writer.writeUint32(intent.tile);
       return;
     case "quick_chat":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writeRequiredPlayerRef(writer, intent.recipient, context);
       writer.writeString(intent.quickChatKey);
       if (intent.target !== undefined) {
-        writer.writeUint16(playerIdToIndex(intent.target, context));
+        writeRequiredPlayerRef(writer, intent.target, context);
       }
       return;
     case "allianceExtension":
-      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writeRequiredPlayerRef(writer, intent.recipient, context);
       return;
     case "delete_unit":
       writer.writeUint32(intent.unitId);
@@ -576,9 +577,7 @@ function decodeIntent(
       const hasTroops = (flags & INTENT_FLAG_OPTION_B) !== 0;
       return {
         type: "attack",
-        targetID: hasTarget
-          ? requireClientId(reader.readUint16(), context)
-          : null,
+        targetID: hasTarget ? readRequiredPlayerRef(reader, context) : null,
         troops: hasTroops ? reader.readFloat64() : null,
       };
     }
@@ -598,7 +597,7 @@ function decodeIntent(
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "mark_disconnected",
-        clientID: requireClientId(reader.readUint16(), context),
+        clientID: readRequiredPlayerRef(reader, context),
         isDisconnected: reader.readBoolean(),
       };
     case "boat":
@@ -618,29 +617,29 @@ function decodeIntent(
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "allianceRequest",
-        recipient: requireClientId(reader.readUint16(), context),
+        recipient: readRequiredPlayerRef(reader, context),
       };
     case "allianceReject":
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "allianceReject",
-        requestor: requireClientId(reader.readUint16(), context),
+        requestor: readRequiredPlayerRef(reader, context),
       };
     case "breakAlliance":
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "breakAlliance",
-        recipient: requireClientId(reader.readUint16(), context),
+        recipient: readRequiredPlayerRef(reader, context),
       };
     case "targetPlayer":
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "targetPlayer",
-        target: requireClientId(reader.readUint16(), context),
+        target: readRequiredPlayerRef(reader, context),
       };
     case "emoji": {
       assertIntentFlags(intentType, flags, 0);
-      const recipient = playerIndexToId(reader.readUint16(), context);
+      const recipient = readPlayerRef(reader, context);
       if (recipient === null) {
         throw new Error("Emoji recipient cannot be null");
       }
@@ -652,7 +651,7 @@ function decodeIntent(
     }
     case "donate_gold": {
       assertIntentFlags(intentType, flags, 0);
-      const recipient = requireClientId(reader.readUint16(), context);
+      const recipient = readRequiredPlayerRef(reader, context);
       const hasGold = reader.readBoolean();
       return {
         type: "donate_gold",
@@ -662,7 +661,7 @@ function decodeIntent(
     }
     case "donate_troops": {
       assertIntentFlags(intentType, flags, 0);
-      const recipient = requireClientId(reader.readUint16(), context);
+      const recipient = readRequiredPlayerRef(reader, context);
       const hasTroops = reader.readBoolean();
       return {
         type: "donate_troops",
@@ -699,7 +698,7 @@ function decodeIntent(
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "embargo",
-        targetID: requireClientId(reader.readUint16(), context),
+        targetID: readRequiredPlayerRef(reader, context),
         action: reader.readBoolean() ? "start" : "stop",
       };
     case "embargo_all":
@@ -717,11 +716,11 @@ function decodeIntent(
       };
     case "quick_chat": {
       assertIntentFlags(intentType, flags, INTENT_FLAG_OPTION_A);
-      const recipient = requireClientId(reader.readUint16(), context);
+      const recipient = readRequiredPlayerRef(reader, context);
       const quickChatKey = reader.readString();
       const target =
         (flags & INTENT_FLAG_OPTION_A) !== 0
-          ? requireClientId(reader.readUint16(), context)
+          ? readRequiredPlayerRef(reader, context)
           : undefined;
       if (!QuickChatKeySchema.safeParse(quickChatKey).success) {
         throw new Error(`Invalid quick chat key: ${quickChatKey}`);
@@ -737,7 +736,7 @@ function decodeIntent(
       assertIntentFlags(intentType, flags, 0);
       return {
         type: "allianceExtension",
-        recipient: requireClientId(reader.readUint16(), context),
+        recipient: readRequiredPlayerRef(reader, context),
       };
     case "delete_unit":
       assertIntentFlags(intentType, flags, 0);
@@ -771,6 +770,54 @@ function assertIntentFlags(
       `Unsupported flags ${invalidFlags} for binary intent type ${intentType}`,
     );
   }
+}
+
+function writePlayerRef(
+  writer: BinaryWriter,
+  playerId: string | null | typeof AllPlayers,
+  context: BinaryProtocolContext,
+) {
+  if (playerId === null || playerId === AllPlayers) {
+    writer.writeUint16(playerIdToIndex(playerId, context));
+    return;
+  }
+  const mappedIndex = context.playerIdToIndex.get(playerId);
+  if (mappedIndex !== undefined) {
+    writer.writeUint16(mappedIndex);
+    return;
+  }
+  writer.writeUint16(INLINE_PLAYER_ID_INDEX);
+  writer.writeString(playerId);
+}
+
+function writeRequiredPlayerRef(
+  writer: BinaryWriter,
+  playerId: string,
+  context: BinaryProtocolContext,
+) {
+  writePlayerRef(writer, playerId, context);
+}
+
+function readPlayerRef(
+  reader: BinaryReader,
+  context: BinaryProtocolContext,
+): string | null | typeof AllPlayers {
+  const playerIndex = reader.readUint16();
+  if (playerIndex === INLINE_PLAYER_ID_INDEX) {
+    return reader.readString();
+  }
+  return playerIndexToId(playerIndex, context);
+}
+
+function readRequiredPlayerRef(
+  reader: BinaryReader,
+  context: BinaryProtocolContext,
+): string {
+  const playerId = readPlayerRef(reader, context);
+  if (playerId === null || playerId === AllPlayers) {
+    throw new Error(`Expected player ID, received ${String(playerId)}`);
+  }
+  return playerId;
 }
 
 export function isBinaryGameplayClientMessage(

--- a/src/core/BinaryCodec.ts
+++ b/src/core/BinaryCodec.ts
@@ -1,0 +1,784 @@
+import {
+  BINARY_HEADER_SIZE,
+  BINARY_PROTOCOL_VERSION,
+  BinaryClientGameplayMessage,
+  BinaryMessageType,
+  BinaryProtocolContext,
+  BinaryServerGameplayMessage,
+  INTENT_FLAG_OPTION_A,
+  INTENT_FLAG_OPTION_B,
+  createBinaryProtocolContext,
+  intentTypeToOpcode,
+  opcodeToIntentType,
+  opcodeToUnitType,
+  playerIdToIndex,
+  playerIndexToId,
+  requireClientId,
+  stampedIntentClientIndex,
+  unitTypeToOpcode,
+} from "./BinaryProtocol";
+import {
+  ClientHashMessage,
+  ClientIntentMessage,
+  ClientMessage,
+  ClientPingMessage,
+  GameStartInfo,
+  Intent,
+  QuickChatKeySchema,
+  ServerDesyncMessage,
+  ServerTurnMessage,
+  StampedIntent,
+} from "./Schemas";
+import { UnitType } from "./game/Game";
+
+const textEncoder = new TextEncoder();
+const textDecoder = new TextDecoder();
+
+class BinaryWriter {
+  private readonly chunks: Uint8Array[] = [];
+  private totalLength = 0;
+
+  writeUint8(value: number) {
+    const chunk = new Uint8Array(1);
+    chunk[0] = value;
+    this.push(chunk);
+  }
+
+  writeUint16(value: number) {
+    const chunk = new Uint8Array(2);
+    new DataView(chunk.buffer).setUint16(0, value, true);
+    this.push(chunk);
+  }
+
+  writeUint32(value: number) {
+    const chunk = new Uint8Array(4);
+    new DataView(chunk.buffer).setUint32(0, value, true);
+    this.push(chunk);
+  }
+
+  writeInt32(value: number) {
+    const chunk = new Uint8Array(4);
+    new DataView(chunk.buffer).setInt32(0, value, true);
+    this.push(chunk);
+  }
+
+  writeFloat64(value: number) {
+    const chunk = new Uint8Array(8);
+    new DataView(chunk.buffer).setFloat64(0, value, true);
+    this.push(chunk);
+  }
+
+  writeBoolean(value: boolean) {
+    this.writeUint8(value ? 1 : 0);
+  }
+
+  writeString(value: string) {
+    const encoded = textEncoder.encode(value);
+    this.writeUint16(encoded.length);
+    this.push(encoded);
+  }
+
+  writeFrame(
+    messageType: BinaryMessageType,
+    writePayload: () => void,
+  ): Uint8Array {
+    this.writeUint8(BINARY_PROTOCOL_VERSION);
+    this.writeUint8(messageType);
+    this.writeUint16(0);
+    writePayload();
+    return this.finish();
+  }
+
+  finish(): Uint8Array {
+    const output = new Uint8Array(this.totalLength);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      output.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return output;
+  }
+
+  private push(chunk: Uint8Array) {
+    this.chunks.push(chunk);
+    this.totalLength += chunk.length;
+  }
+}
+
+class BinaryReader {
+  private readonly view: DataView;
+  private offset = 0;
+
+  constructor(private readonly bytes: Uint8Array) {
+    this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+
+  readHeader(expectedType: BinaryMessageType) {
+    if (this.bytes.byteLength < BINARY_HEADER_SIZE) {
+      throw new Error("Binary frame too short");
+    }
+    const version = this.readUint8();
+    if (version !== BINARY_PROTOCOL_VERSION) {
+      throw new Error(`Unsupported binary protocol version: ${version}`);
+    }
+    const messageType = this.readUint8();
+    if (messageType !== expectedType) {
+      throw new Error(
+        `Unexpected binary message type: expected ${expectedType}, received ${messageType}`,
+      );
+    }
+    const flags = this.readUint16();
+    if (flags !== 0) {
+      throw new Error(`Unsupported binary header flags: ${flags}`);
+    }
+  }
+
+  readUint8(): number {
+    this.ensureAvailable(1);
+    const value = this.view.getUint8(this.offset);
+    this.offset += 1;
+    return value;
+  }
+
+  readUint16(): number {
+    this.ensureAvailable(2);
+    const value = this.view.getUint16(this.offset, true);
+    this.offset += 2;
+    return value;
+  }
+
+  readUint32(): number {
+    this.ensureAvailable(4);
+    const value = this.view.getUint32(this.offset, true);
+    this.offset += 4;
+    return value;
+  }
+
+  readInt32(): number {
+    this.ensureAvailable(4);
+    const value = this.view.getInt32(this.offset, true);
+    this.offset += 4;
+    return value;
+  }
+
+  readFloat64(): number {
+    this.ensureAvailable(8);
+    const value = this.view.getFloat64(this.offset, true);
+    this.offset += 8;
+    return value;
+  }
+
+  readBoolean(): boolean {
+    const value = this.readUint8();
+    if (value !== 0 && value !== 1) {
+      throw new Error(`Invalid boolean value: ${value}`);
+    }
+    return value === 1;
+  }
+
+  readString(): string {
+    const length = this.readUint16();
+    this.ensureAvailable(length);
+    const value = textDecoder.decode(
+      this.bytes.subarray(this.offset, this.offset + length),
+    );
+    this.offset += length;
+    return value;
+  }
+
+  ensureFinished() {
+    if (this.offset !== this.bytes.byteLength) {
+      throw new Error(
+        `Unexpected trailing bytes: ${this.bytes.byteLength - this.offset}`,
+      );
+    }
+  }
+
+  private ensureAvailable(length: number) {
+    if (this.offset + length > this.bytes.byteLength) {
+      throw new Error("Unexpected end of binary frame");
+    }
+  }
+}
+
+export function binaryContextFromGameStartInfo(
+  gameStartInfo: Pick<GameStartInfo, "players">,
+): BinaryProtocolContext {
+  return createBinaryProtocolContext(gameStartInfo);
+}
+
+export function toUint8Array(data: ArrayBuffer | Uint8Array): Uint8Array {
+  if (data instanceof Uint8Array) {
+    return data;
+  }
+  return new Uint8Array(data);
+}
+
+export function encodeBinaryClientGameplayMessage(
+  message: BinaryClientGameplayMessage,
+  context: BinaryProtocolContext,
+): Uint8Array {
+  switch (message.type) {
+    case "intent":
+      return encodeClientIntentMessage(message, context);
+    case "hash":
+      return encodeClientHashMessage(message);
+    case "ping":
+      return encodeClientPingMessage(message);
+  }
+}
+
+export function decodeBinaryClientGameplayMessage(
+  data: ArrayBuffer | Uint8Array,
+  context: BinaryProtocolContext,
+): ClientIntentMessage | ClientHashMessage | ClientPingMessage {
+  const bytes = toUint8Array(data);
+  if (bytes.byteLength < BINARY_HEADER_SIZE) {
+    throw new Error("Binary frame too short");
+  }
+
+  switch (bytes[1]) {
+    case BinaryMessageType.Intent:
+      return decodeClientIntentMessage(bytes, context);
+    case BinaryMessageType.Hash:
+      return decodeClientHashMessage(bytes);
+    case BinaryMessageType.Ping:
+      return decodeClientPingMessage(bytes);
+    default:
+      throw new Error(`Unknown client binary message type: ${bytes[1]}`);
+  }
+}
+
+export function encodeBinaryServerGameplayMessage(
+  message: BinaryServerGameplayMessage,
+  context: BinaryProtocolContext,
+): Uint8Array {
+  switch (message.type) {
+    case "turn":
+      return encodeServerTurnMessage(message, context);
+    case "desync":
+      return encodeServerDesyncMessage(message);
+  }
+}
+
+export function decodeBinaryServerGameplayMessage(
+  data: ArrayBuffer | Uint8Array,
+  context: BinaryProtocolContext,
+): ServerTurnMessage | ServerDesyncMessage {
+  const bytes = toUint8Array(data);
+  if (bytes.byteLength < BINARY_HEADER_SIZE) {
+    throw new Error("Binary frame too short");
+  }
+
+  switch (bytes[1]) {
+    case BinaryMessageType.Turn:
+      return decodeServerTurnMessage(bytes, context);
+    case BinaryMessageType.Desync:
+      return decodeServerDesyncMessage(bytes);
+    default:
+      throw new Error(`Unknown server binary message type: ${bytes[1]}`);
+  }
+}
+
+export function encodeClientIntentMessage(
+  message: ClientIntentMessage,
+  context: BinaryProtocolContext,
+): Uint8Array {
+  const writer = new BinaryWriter();
+  return writer.writeFrame(BinaryMessageType.Intent, () => {
+    encodeIntent(writer, message.intent, context);
+  });
+}
+
+export function decodeClientIntentMessage(
+  data: ArrayBuffer | Uint8Array,
+  context: BinaryProtocolContext,
+): ClientIntentMessage {
+  const reader = new BinaryReader(toUint8Array(data));
+  reader.readHeader(BinaryMessageType.Intent);
+  const intent = decodeIntent(reader, context);
+  reader.ensureFinished();
+  return {
+    type: "intent",
+    intent,
+  };
+}
+
+export function encodeClientHashMessage(
+  message: ClientHashMessage,
+): Uint8Array {
+  const writer = new BinaryWriter();
+  return writer.writeFrame(BinaryMessageType.Hash, () => {
+    writer.writeUint32(message.turnNumber);
+    writer.writeInt32(message.hash);
+  });
+}
+
+export function decodeClientHashMessage(
+  data: ArrayBuffer | Uint8Array,
+): ClientHashMessage {
+  const reader = new BinaryReader(toUint8Array(data));
+  reader.readHeader(BinaryMessageType.Hash);
+  const turnNumber = reader.readUint32();
+  const hash = reader.readInt32();
+  reader.ensureFinished();
+  return {
+    type: "hash",
+    turnNumber,
+    hash,
+  };
+}
+
+export function encodeClientPingMessage(
+  _message: ClientPingMessage,
+): Uint8Array {
+  const writer = new BinaryWriter();
+  return writer.writeFrame(BinaryMessageType.Ping, () => {});
+}
+
+export function decodeClientPingMessage(
+  data: ArrayBuffer | Uint8Array,
+): ClientPingMessage {
+  const reader = new BinaryReader(toUint8Array(data));
+  reader.readHeader(BinaryMessageType.Ping);
+  reader.ensureFinished();
+  return { type: "ping" };
+}
+
+export function encodeServerTurnMessage(
+  message: ServerTurnMessage,
+  context: BinaryProtocolContext,
+): Uint8Array {
+  const writer = new BinaryWriter();
+  return writer.writeFrame(BinaryMessageType.Turn, () => {
+    writer.writeUint32(message.turn.turnNumber);
+    writer.writeUint16(message.turn.intents.length);
+    for (const intent of message.turn.intents) {
+      writer.writeUint16(stampedIntentClientIndex(intent, context));
+      encodeIntent(writer, intent, context);
+    }
+  });
+}
+
+export function decodeServerTurnMessage(
+  data: ArrayBuffer | Uint8Array,
+  context: BinaryProtocolContext,
+): ServerTurnMessage {
+  const reader = new BinaryReader(toUint8Array(data));
+  reader.readHeader(BinaryMessageType.Turn);
+  const turnNumber = reader.readUint32();
+  const intentCount = reader.readUint16();
+  const intents: StampedIntent[] = [];
+  for (let i = 0; i < intentCount; i++) {
+    const clientIndex = reader.readUint16();
+    const clientID = requireClientId(clientIndex, context);
+    const intent = decodeIntent(reader, context);
+    intents.push({
+      ...intent,
+      clientID,
+    } as StampedIntent);
+  }
+  reader.ensureFinished();
+  return {
+    type: "turn",
+    turn: {
+      turnNumber,
+      intents,
+    },
+  };
+}
+
+export function encodeServerDesyncMessage(
+  message: ServerDesyncMessage,
+): Uint8Array {
+  const writer = new BinaryWriter();
+  return writer.writeFrame(BinaryMessageType.Desync, () => {
+    writer.writeUint32(message.turn);
+    writer.writeBoolean(message.correctHash !== null);
+    if (message.correctHash !== null) {
+      writer.writeInt32(message.correctHash);
+    }
+    writer.writeUint16(message.clientsWithCorrectHash);
+    writer.writeUint16(message.totalActiveClients);
+  });
+}
+
+export function decodeServerDesyncMessage(
+  data: ArrayBuffer | Uint8Array,
+): ServerDesyncMessage {
+  const reader = new BinaryReader(toUint8Array(data));
+  reader.readHeader(BinaryMessageType.Desync);
+  const turn = reader.readUint32();
+  const hasCorrectHash = reader.readBoolean();
+  const correctHash = hasCorrectHash ? reader.readInt32() : null;
+  const clientsWithCorrectHash = reader.readUint16();
+  const totalActiveClients = reader.readUint16();
+  reader.ensureFinished();
+  return {
+    type: "desync",
+    turn,
+    correctHash,
+    clientsWithCorrectHash,
+    totalActiveClients,
+  };
+}
+
+function encodeIntent(
+  writer: BinaryWriter,
+  intent: Intent,
+  context: BinaryProtocolContext,
+) {
+  const intentOpcode = intentTypeToOpcode(intent.type);
+  writer.writeUint8(intentOpcode);
+
+  let flags = 0;
+  switch (intent.type) {
+    case "attack":
+      if (intent.targetID !== null) {
+        flags |= INTENT_FLAG_OPTION_A;
+      }
+      if (intent.troops !== null) {
+        flags |= INTENT_FLAG_OPTION_B;
+      }
+      break;
+    case "build_unit":
+      if (intent.rocketDirectionUp !== undefined) {
+        flags |= INTENT_FLAG_OPTION_A;
+      }
+      if (intent.rocketDirectionUp) {
+        flags |= INTENT_FLAG_OPTION_B;
+      }
+      break;
+    case "quick_chat":
+      if (intent.target !== undefined) {
+        flags |= INTENT_FLAG_OPTION_A;
+      }
+      break;
+  }
+  writer.writeUint16(flags);
+
+  switch (intent.type) {
+    case "attack":
+      if (intent.targetID !== null) {
+        writer.writeUint16(playerIdToIndex(intent.targetID, context));
+      }
+      if (intent.troops !== null) {
+        writer.writeFloat64(intent.troops);
+      }
+      return;
+    case "cancel_attack":
+      writer.writeString(intent.attackID);
+      return;
+    case "spawn":
+      writer.writeUint32(intent.tile);
+      return;
+    case "mark_disconnected":
+      writer.writeUint16(playerIdToIndex(intent.clientID, context));
+      writer.writeBoolean(intent.isDisconnected);
+      return;
+    case "boat":
+      writer.writeFloat64(intent.troops);
+      writer.writeUint32(intent.dst);
+      return;
+    case "cancel_boat":
+      writer.writeUint32(intent.unitID);
+      return;
+    case "allianceRequest":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      return;
+    case "allianceReject":
+      writer.writeUint16(playerIdToIndex(intent.requestor, context));
+      return;
+    case "breakAlliance":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      return;
+    case "targetPlayer":
+      writer.writeUint16(playerIdToIndex(intent.target, context));
+      return;
+    case "emoji":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writer.writeUint16(intent.emoji);
+      return;
+    case "donate_gold":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      if (intent.gold === null) {
+        writer.writeBoolean(false);
+      } else {
+        writer.writeBoolean(true);
+        writer.writeFloat64(intent.gold);
+      }
+      return;
+    case "donate_troops":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      if (intent.troops === null) {
+        writer.writeBoolean(false);
+      } else {
+        writer.writeBoolean(true);
+        writer.writeFloat64(intent.troops);
+      }
+      return;
+    case "build_unit":
+      writer.writeUint8(unitTypeToOpcode(intent.unit));
+      writer.writeUint32(intent.tile);
+      return;
+    case "upgrade_structure":
+      writer.writeUint8(unitTypeToOpcode(intent.unit));
+      writer.writeUint32(intent.unitId);
+      return;
+    case "embargo":
+      writer.writeUint16(playerIdToIndex(intent.targetID, context));
+      writer.writeBoolean(intent.action === "start");
+      return;
+    case "embargo_all":
+      writer.writeBoolean(intent.action === "start");
+      return;
+    case "move_warship":
+      writer.writeUint32(intent.unitId);
+      writer.writeUint32(intent.tile);
+      return;
+    case "quick_chat":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      writer.writeString(intent.quickChatKey);
+      if (intent.target !== undefined) {
+        writer.writeUint16(playerIdToIndex(intent.target, context));
+      }
+      return;
+    case "allianceExtension":
+      writer.writeUint16(playerIdToIndex(intent.recipient, context));
+      return;
+    case "delete_unit":
+      writer.writeUint32(intent.unitId);
+      return;
+    case "toggle_pause":
+      writer.writeBoolean(intent.paused);
+      return;
+    case "kick_player":
+    case "update_game_config":
+      throw new Error(`Unsupported binary intent type: ${intent.type}`);
+  }
+}
+
+function decodeIntent(
+  reader: BinaryReader,
+  context: BinaryProtocolContext,
+): Intent {
+  const intentType = opcodeToIntentType(reader.readUint8());
+  const flags = reader.readUint16();
+
+  switch (intentType) {
+    case "attack": {
+      assertIntentFlags(
+        intentType,
+        flags,
+        INTENT_FLAG_OPTION_A | INTENT_FLAG_OPTION_B,
+      );
+      const hasTarget = (flags & INTENT_FLAG_OPTION_A) !== 0;
+      const hasTroops = (flags & INTENT_FLAG_OPTION_B) !== 0;
+      return {
+        type: "attack",
+        targetID: hasTarget
+          ? requireClientId(reader.readUint16(), context)
+          : null,
+        troops: hasTroops ? reader.readFloat64() : null,
+      };
+    }
+    case "cancel_attack":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "cancel_attack",
+        attackID: reader.readString(),
+      };
+    case "spawn":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "spawn",
+        tile: reader.readUint32(),
+      };
+    case "mark_disconnected":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "mark_disconnected",
+        clientID: requireClientId(reader.readUint16(), context),
+        isDisconnected: reader.readBoolean(),
+      };
+    case "boat":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "boat",
+        troops: reader.readFloat64(),
+        dst: reader.readUint32(),
+      };
+    case "cancel_boat":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "cancel_boat",
+        unitID: reader.readUint32(),
+      };
+    case "allianceRequest":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "allianceRequest",
+        recipient: requireClientId(reader.readUint16(), context),
+      };
+    case "allianceReject":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "allianceReject",
+        requestor: requireClientId(reader.readUint16(), context),
+      };
+    case "breakAlliance":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "breakAlliance",
+        recipient: requireClientId(reader.readUint16(), context),
+      };
+    case "targetPlayer":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "targetPlayer",
+        target: requireClientId(reader.readUint16(), context),
+      };
+    case "emoji": {
+      assertIntentFlags(intentType, flags, 0);
+      const recipient = playerIndexToId(reader.readUint16(), context);
+      if (recipient === null) {
+        throw new Error("Emoji recipient cannot be null");
+      }
+      return {
+        type: "emoji",
+        recipient,
+        emoji: reader.readUint16(),
+      };
+    }
+    case "donate_gold": {
+      assertIntentFlags(intentType, flags, 0);
+      const recipient = requireClientId(reader.readUint16(), context);
+      const hasGold = reader.readBoolean();
+      return {
+        type: "donate_gold",
+        recipient,
+        gold: hasGold ? reader.readFloat64() : null,
+      };
+    }
+    case "donate_troops": {
+      assertIntentFlags(intentType, flags, 0);
+      const recipient = requireClientId(reader.readUint16(), context);
+      const hasTroops = reader.readBoolean();
+      return {
+        type: "donate_troops",
+        recipient,
+        troops: hasTroops ? reader.readFloat64() : null,
+      };
+    }
+    case "build_unit": {
+      assertIntentFlags(
+        intentType,
+        flags,
+        INTENT_FLAG_OPTION_A | INTENT_FLAG_OPTION_B,
+      );
+      const unit = decodeUnit(reader.readUint8());
+      const tile = reader.readUint32();
+      const hasRocketDirection = (flags & INTENT_FLAG_OPTION_A) !== 0;
+      const rocketDirectionUp =
+        hasRocketDirection && (flags & INTENT_FLAG_OPTION_B) !== 0;
+      return {
+        type: "build_unit",
+        unit,
+        tile,
+        rocketDirectionUp: hasRocketDirection ? rocketDirectionUp : undefined,
+      };
+    }
+    case "upgrade_structure":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "upgrade_structure",
+        unit: decodeUnit(reader.readUint8()),
+        unitId: reader.readUint32(),
+      };
+    case "embargo":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "embargo",
+        targetID: requireClientId(reader.readUint16(), context),
+        action: reader.readBoolean() ? "start" : "stop",
+      };
+    case "embargo_all":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "embargo_all",
+        action: reader.readBoolean() ? "start" : "stop",
+      };
+    case "move_warship":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "move_warship",
+        unitId: reader.readUint32(),
+        tile: reader.readUint32(),
+      };
+    case "quick_chat": {
+      assertIntentFlags(intentType, flags, INTENT_FLAG_OPTION_A);
+      const recipient = requireClientId(reader.readUint16(), context);
+      const quickChatKey = reader.readString();
+      const target =
+        (flags & INTENT_FLAG_OPTION_A) !== 0
+          ? requireClientId(reader.readUint16(), context)
+          : undefined;
+      if (!QuickChatKeySchema.safeParse(quickChatKey).success) {
+        throw new Error(`Invalid quick chat key: ${quickChatKey}`);
+      }
+      return {
+        type: "quick_chat",
+        recipient,
+        quickChatKey,
+        target,
+      };
+    }
+    case "allianceExtension":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "allianceExtension",
+        recipient: requireClientId(reader.readUint16(), context),
+      };
+    case "delete_unit":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "delete_unit",
+        unitId: reader.readUint32(),
+      };
+    case "toggle_pause":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "toggle_pause",
+        paused: reader.readBoolean(),
+      };
+  }
+
+  throw new Error(`Unhandled binary intent type: ${intentType}`);
+}
+
+function decodeUnit(opcode: number): UnitType {
+  return opcodeToUnitType(opcode);
+}
+
+function assertIntentFlags(
+  intentType: Intent["type"],
+  flags: number,
+  allowedFlags: number,
+) {
+  const invalidFlags = flags & ~allowedFlags;
+  if (invalidFlags !== 0) {
+    throw new Error(
+      `Unsupported flags ${invalidFlags} for binary intent type ${intentType}`,
+    );
+  }
+}
+
+export function isBinaryGameplayClientMessage(
+  message: ClientMessage,
+): message is BinaryClientGameplayMessage {
+  return (
+    message.type === "intent" ||
+    message.type === "hash" ||
+    message.type === "ping"
+  );
+}

--- a/src/core/BinaryCodec.ts
+++ b/src/core/BinaryCodec.ts
@@ -9,6 +9,7 @@ import {
   INTENT_FLAG_OPTION_A,
   INTENT_FLAG_OPTION_B,
   createBinaryProtocolContext,
+  hasBinaryIntentOpcode,
   intentTypeToOpcode,
   opcodeToIntentType,
   opcodeToUnitType,
@@ -554,6 +555,8 @@ function encodeIntent(
       writer.writeBoolean(intent.paused);
       return;
     case "kick_player":
+      writeRequiredPlayerRef(writer, intent.target, context);
+      return;
     case "update_game_config":
       throw new Error(`Unsupported binary intent type: ${intent.type}`);
   }
@@ -750,6 +753,12 @@ function decodeIntent(
         type: "toggle_pause",
         paused: reader.readBoolean(),
       };
+    case "kick_player":
+      assertIntentFlags(intentType, flags, 0);
+      return {
+        type: "kick_player",
+        target: readRequiredPlayerRef(reader, context),
+      };
   }
 
   throw new Error(`Unhandled binary intent type: ${intentType}`);
@@ -824,7 +833,7 @@ export function isBinaryGameplayClientMessage(
   message: ClientMessage,
 ): message is BinaryClientGameplayMessage {
   return (
-    message.type === "intent" ||
+    (message.type === "intent" && hasBinaryIntentOpcode(message.intent.type)) ||
     message.type === "hash" ||
     message.type === "ping"
   );

--- a/src/core/BinaryProtocol.ts
+++ b/src/core/BinaryProtocol.ts
@@ -1,0 +1,235 @@
+import {
+  ClientHashMessage,
+  ClientID,
+  ClientIntentMessage,
+  ClientPingMessage,
+  GameStartInfo,
+  Intent,
+  ServerDesyncMessage,
+  ServerTurnMessage,
+  StampedIntent,
+} from "./Schemas";
+import { AllPlayers, UnitType } from "./game/Game";
+
+export const BINARY_PROTOCOL_VERSION = 1;
+
+export const BINARY_HEADER_SIZE = 4;
+export const NO_PLAYER_INDEX = 0xffff;
+export const ALL_PLAYERS_INDEX = 0xfffe;
+
+export enum BinaryMessageType {
+  Intent = 1,
+  Turn = 2,
+  Hash = 3,
+  Ping = 4,
+  Desync = 5,
+}
+
+export enum BinaryIntentType {
+  Attack = 1,
+  CancelAttack = 2,
+  Spawn = 3,
+  MarkDisconnected = 4,
+  BoatAttack = 5,
+  CancelBoat = 6,
+  AllianceRequest = 7,
+  AllianceReject = 8,
+  BreakAlliance = 9,
+  TargetPlayer = 10,
+  Emoji = 11,
+  DonateGold = 12,
+  DonateTroops = 13,
+  BuildUnit = 14,
+  UpgradeStructure = 15,
+  Embargo = 16,
+  EmbargoAll = 17,
+  MoveWarship = 18,
+  QuickChat = 19,
+  AllianceExtension = 20,
+  DeleteUnit = 21,
+  TogglePause = 22,
+}
+
+export const INTENT_FLAG_OPTION_A = 1 << 0;
+export const INTENT_FLAG_OPTION_B = 1 << 1;
+
+export type BinaryClientGameplayMessage =
+  | ClientIntentMessage
+  | ClientHashMessage
+  | ClientPingMessage;
+
+export type BinaryServerGameplayMessage =
+  | ServerTurnMessage
+  | ServerDesyncMessage;
+
+const INTENT_TYPE_TO_OPCODE: Record<
+  Intent["type"],
+  BinaryIntentType | undefined
+> = {
+  attack: BinaryIntentType.Attack,
+  cancel_attack: BinaryIntentType.CancelAttack,
+  spawn: BinaryIntentType.Spawn,
+  mark_disconnected: BinaryIntentType.MarkDisconnected,
+  boat: BinaryIntentType.BoatAttack,
+  cancel_boat: BinaryIntentType.CancelBoat,
+  allianceRequest: BinaryIntentType.AllianceRequest,
+  allianceReject: BinaryIntentType.AllianceReject,
+  breakAlliance: BinaryIntentType.BreakAlliance,
+  targetPlayer: BinaryIntentType.TargetPlayer,
+  emoji: BinaryIntentType.Emoji,
+  donate_gold: BinaryIntentType.DonateGold,
+  donate_troops: BinaryIntentType.DonateTroops,
+  build_unit: BinaryIntentType.BuildUnit,
+  upgrade_structure: BinaryIntentType.UpgradeStructure,
+  embargo: BinaryIntentType.Embargo,
+  embargo_all: BinaryIntentType.EmbargoAll,
+  move_warship: BinaryIntentType.MoveWarship,
+  quick_chat: BinaryIntentType.QuickChat,
+  allianceExtension: BinaryIntentType.AllianceExtension,
+  delete_unit: BinaryIntentType.DeleteUnit,
+  kick_player: undefined,
+  toggle_pause: BinaryIntentType.TogglePause,
+  update_game_config: undefined,
+};
+
+const OPCODE_TO_INTENT_TYPE: Record<BinaryIntentType, Intent["type"]> = {
+  [BinaryIntentType.Attack]: "attack",
+  [BinaryIntentType.CancelAttack]: "cancel_attack",
+  [BinaryIntentType.Spawn]: "spawn",
+  [BinaryIntentType.MarkDisconnected]: "mark_disconnected",
+  [BinaryIntentType.BoatAttack]: "boat",
+  [BinaryIntentType.CancelBoat]: "cancel_boat",
+  [BinaryIntentType.AllianceRequest]: "allianceRequest",
+  [BinaryIntentType.AllianceReject]: "allianceReject",
+  [BinaryIntentType.BreakAlliance]: "breakAlliance",
+  [BinaryIntentType.TargetPlayer]: "targetPlayer",
+  [BinaryIntentType.Emoji]: "emoji",
+  [BinaryIntentType.DonateGold]: "donate_gold",
+  [BinaryIntentType.DonateTroops]: "donate_troops",
+  [BinaryIntentType.BuildUnit]: "build_unit",
+  [BinaryIntentType.UpgradeStructure]: "upgrade_structure",
+  [BinaryIntentType.Embargo]: "embargo",
+  [BinaryIntentType.EmbargoAll]: "embargo_all",
+  [BinaryIntentType.MoveWarship]: "move_warship",
+  [BinaryIntentType.QuickChat]: "quick_chat",
+  [BinaryIntentType.AllianceExtension]: "allianceExtension",
+  [BinaryIntentType.DeleteUnit]: "delete_unit",
+  [BinaryIntentType.TogglePause]: "toggle_pause",
+};
+
+const UNIT_TYPE_TO_OPCODE = new Map<UnitType, number>(
+  Object.values(UnitType).map((type, index) => [type, index + 1]),
+);
+
+const OPCODE_TO_UNIT_TYPE = new Map<number, UnitType>(
+  Object.values(UnitType).map((type, index) => [index + 1, type]),
+);
+
+export interface BinaryProtocolContext {
+  readonly playerIds: readonly ClientID[];
+  readonly playerIdToIndex: ReadonlyMap<ClientID, number>;
+}
+
+export function createBinaryProtocolContext(
+  gameStartInfo: Pick<GameStartInfo, "players">,
+): BinaryProtocolContext {
+  const playerIds = gameStartInfo.players.map((player) => player.clientID);
+  const playerIdToIndex = new Map<ClientID, number>();
+  playerIds.forEach((clientID, index) => {
+    playerIdToIndex.set(clientID, index);
+  });
+  return {
+    playerIds,
+    playerIdToIndex,
+  };
+}
+
+export function intentTypeToOpcode(
+  intentType: Intent["type"],
+): BinaryIntentType {
+  const opcode = INTENT_TYPE_TO_OPCODE[intentType];
+  if (opcode === undefined) {
+    throw new Error(`Unsupported binary intent type: ${intentType}`);
+  }
+  return opcode;
+}
+
+export function opcodeToIntentType(opcode: number): Intent["type"] {
+  const intentType = OPCODE_TO_INTENT_TYPE[opcode as BinaryIntentType];
+  if (intentType === undefined) {
+    throw new Error(`Unknown binary intent opcode: ${opcode}`);
+  }
+  return intentType;
+}
+
+export function unitTypeToOpcode(unitType: UnitType): number {
+  const opcode = UNIT_TYPE_TO_OPCODE.get(unitType);
+  if (opcode === undefined) {
+    throw new Error(`Unknown unit type: ${unitType}`);
+  }
+  return opcode;
+}
+
+export function opcodeToUnitType(opcode: number): UnitType {
+  const unitType = OPCODE_TO_UNIT_TYPE.get(opcode);
+  if (unitType === undefined) {
+    throw new Error(`Unknown unit opcode: ${opcode}`);
+  }
+  return unitType;
+}
+
+export function playerIdToIndex(
+  playerId: ClientID | null | typeof AllPlayers,
+  context: BinaryProtocolContext,
+): number {
+  if (playerId === null) {
+    return NO_PLAYER_INDEX;
+  }
+  if (playerId === AllPlayers) {
+    return ALL_PLAYERS_INDEX;
+  }
+  const index = context.playerIdToIndex.get(playerId);
+  if (index === undefined) {
+    throw new Error(`Unknown player ID: ${playerId}`);
+  }
+  return index;
+}
+
+export function playerIndexToId(
+  playerIndex: number,
+  context: BinaryProtocolContext,
+): ClientID | null | typeof AllPlayers {
+  if (playerIndex === NO_PLAYER_INDEX) {
+    return null;
+  }
+  if (playerIndex === ALL_PLAYERS_INDEX) {
+    return AllPlayers;
+  }
+  const playerId = context.playerIds[playerIndex];
+  if (playerId === undefined) {
+    throw new Error(`Invalid player index: ${playerIndex}`);
+  }
+  return playerId;
+}
+
+export function requireClientId(
+  playerIndex: number,
+  context: BinaryProtocolContext,
+): ClientID {
+  const playerId = playerIndexToId(playerIndex, context);
+  if (playerId === null || playerId === AllPlayers) {
+    throw new Error(`Expected client player index, received ${playerIndex}`);
+  }
+  return playerId;
+}
+
+export function stampedIntentClientIndex(
+  intent: Pick<StampedIntent, "clientID">,
+  context: BinaryProtocolContext,
+): number {
+  const index = context.playerIdToIndex.get(intent.clientID);
+  if (index === undefined) {
+    throw new Error(`Unknown stamped client ID: ${intent.clientID}`);
+  }
+  return index;
+}

--- a/src/core/BinaryProtocol.ts
+++ b/src/core/BinaryProtocol.ts
@@ -49,6 +49,7 @@ export enum BinaryIntentType {
   AllianceExtension = 20,
   DeleteUnit = 21,
   TogglePause = 22,
+  KickPlayer = 23,
 }
 
 export const INTENT_FLAG_OPTION_A = 1 << 0;
@@ -88,7 +89,7 @@ const INTENT_TYPE_TO_OPCODE: Record<
   quick_chat: BinaryIntentType.QuickChat,
   allianceExtension: BinaryIntentType.AllianceExtension,
   delete_unit: BinaryIntentType.DeleteUnit,
-  kick_player: undefined,
+  kick_player: BinaryIntentType.KickPlayer,
   toggle_pause: BinaryIntentType.TogglePause,
   update_game_config: undefined,
 };
@@ -116,6 +117,7 @@ const OPCODE_TO_INTENT_TYPE: Record<BinaryIntentType, Intent["type"]> = {
   [BinaryIntentType.AllianceExtension]: "allianceExtension",
   [BinaryIntentType.DeleteUnit]: "delete_unit",
   [BinaryIntentType.TogglePause]: "toggle_pause",
+  [BinaryIntentType.KickPlayer]: "kick_player",
 };
 
 const UNIT_TYPE_TO_OPCODE = new Map<UnitType, number>(
@@ -153,6 +155,10 @@ export function intentTypeToOpcode(
     throw new Error(`Unsupported binary intent type: ${intentType}`);
   }
   return opcode;
+}
+
+export function hasBinaryIntentOpcode(intentType: Intent["type"]): boolean {
+  return INTENT_TYPE_TO_OPCODE[intentType] !== undefined;
 }
 
 export function opcodeToIntentType(opcode: number): Intent["type"] {

--- a/src/core/BinaryProtocol.ts
+++ b/src/core/BinaryProtocol.ts
@@ -16,6 +16,7 @@ export const BINARY_PROTOCOL_VERSION = 1;
 export const BINARY_HEADER_SIZE = 4;
 export const NO_PLAYER_INDEX = 0xffff;
 export const ALL_PLAYERS_INDEX = 0xfffe;
+export const INLINE_PLAYER_ID_INDEX = 0xfffd;
 
 export enum BinaryMessageType {
   Intent = 1,

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -336,10 +336,20 @@ export class GameServer {
             return;
           }
 
-          const clientMsg = decodeBinaryClientGameplayMessage(
-            rawDataToUint8Array(message),
-            this.binaryContext,
-          );
+          let clientMsg;
+          try {
+            clientMsg = decodeBinaryClientGameplayMessage(
+              rawDataToUint8Array(message),
+              this.binaryContext,
+            );
+          } catch (e) {
+            this.log.warn(`Failed to parse client binary message, kicking`, {
+              clientID: client.clientID,
+              error: String(e),
+            });
+            this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
+            return;
+          }
           if (!this.checkRateLimit(client, clientMsg.type, bytes)) {
             return;
           }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1,11 +1,17 @@
 import ipAnonymize from "ip-anonymize";
 import { Logger } from "winston";
-import WebSocket from "ws";
+import WebSocket, { RawData } from "ws";
 import { z } from "zod";
+import {
+  binaryContextFromGameStartInfo,
+  decodeBinaryClientGameplayMessage,
+  encodeBinaryServerGameplayMessage,
+} from "../core/BinaryCodec";
 import { GameEnv, ServerConfig } from "../core/configuration/Config";
 import { GameType } from "../core/game/Game";
 import {
   ClientID,
+  ClientMessage,
   ClientMessageSchema,
   ClientSendWinnerMessage,
   GameConfig,
@@ -19,7 +25,6 @@ import {
   ServerLobbyInfoMessage,
   ServerPrestartMessageSchema,
   ServerStartGameMessage,
-  ServerTurnMessage,
   StampedIntent,
   Turn,
 } from "../core/Schemas";
@@ -87,6 +92,7 @@ export class GameServer {
   private _hasEnded = false;
 
   private lobbyInfoIntervalId: ReturnType<typeof setInterval> | null = null;
+  private binaryContext?: ReturnType<typeof binaryContextFromGameStartInfo>;
 
   private visibleAt?: number;
 
@@ -317,11 +323,33 @@ export class GameServer {
 
   private addListeners(client: Client) {
     client.ws.removeAllListeners("message");
-    client.ws.on("message", async (message: string) => {
+    client.ws.on("message", async (message: RawData, isBinary: boolean) => {
       try {
+        const bytes = rawDataByteLength(message);
+
+        if (isBinary) {
+          if (!this._hasStarted || !this.binaryContext) {
+            this.log.warn(`Received binary gameplay message before start`, {
+              clientID: client.clientID,
+            });
+            this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
+            return;
+          }
+
+          const clientMsg = decodeBinaryClientGameplayMessage(
+            rawDataToUint8Array(message),
+            this.binaryContext,
+          );
+          if (!this.checkRateLimit(client, clientMsg.type, bytes)) {
+            return;
+          }
+          this.processClientMessage(client, clientMsg);
+          return;
+        }
+
         let json: unknown;
         try {
-          json = JSON.parse(message);
+          json = JSON.parse(rawDataToString(message));
         } catch (e) {
           this.log.warn(`Failed to parse client message JSON, kicking`, {
             clientID: client.clientID,
@@ -330,6 +358,7 @@ export class GameServer {
           this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
           return;
         }
+
         const parsed = ClientMessageSchema.safeParse(json);
         if (!parsed.success) {
           this.log.warn(`Failed to parse client message, kicking`, {
@@ -340,192 +369,25 @@ export class GameServer {
           return;
         }
         const clientMsg = parsed.data;
-        const bytes = Buffer.byteLength(message, "utf8");
-        const rateResult = this.intentRateLimiter.check(
-          client.clientID,
-          clientMsg.type,
-          bytes,
-        );
-        if (rateResult === "kick") {
-          this.log.warn(`Client rate limit exceeded, kicking`, {
+
+        if (
+          this._hasStarted &&
+          (clientMsg.type === "intent" ||
+            clientMsg.type === "ping" ||
+            clientMsg.type === "hash")
+        ) {
+          this.log.warn(`Received JSON gameplay message after start`, {
             clientID: client.clientID,
             type: clientMsg.type,
           });
-          this.kickClient(client.clientID, KICK_REASON_TOO_MUCH_DATA);
+          this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
           return;
         }
-        if (rateResult === "limit") {
-          this.log.warn(`Client message rate limit exceeded, dropping`, {
-            clientID: client.clientID,
-            type: clientMsg.type,
-          });
+
+        if (!this.checkRateLimit(client, clientMsg.type, bytes)) {
           return;
         }
-        switch (clientMsg.type) {
-          case "rejoin": {
-            // Client is already connected, no auth required, send start game message if game has started
-            if (this._hasStarted) {
-              this.sendStartGameMsg(client.ws, clientMsg.lastTurn);
-            }
-            break;
-          }
-          case "intent": {
-            // Server stamps clientID from the authenticated connection
-            const stampedIntent = {
-              ...clientMsg.intent,
-              clientID: client.clientID,
-            };
-            switch (stampedIntent.type) {
-              case "mark_disconnected": {
-                this.log.warn(
-                  `Should not receive mark_disconnected intent from client`,
-                );
-                return;
-              }
-
-              // Handle kick_player intent via WebSocket
-              case "kick_player": {
-                // Check if the authenticated client is the lobby creator
-                if (client.clientID !== this.lobbyCreatorID) {
-                  this.log.warn(`Only lobby creator can kick players`, {
-                    clientID: client.clientID,
-                    creatorID: this.lobbyCreatorID,
-                    target: stampedIntent.target,
-                    gameID: this.id,
-                  });
-                  return;
-                }
-
-                // Don't allow lobby creator to kick themselves
-                if (client.clientID === stampedIntent.target) {
-                  this.log.warn(`Cannot kick yourself`, {
-                    clientID: client.clientID,
-                  });
-                  return;
-                }
-
-                // Log and execute the kick
-                this.log.info(`Lobby creator initiated kick of player`, {
-                  creatorID: client.clientID,
-                  target: stampedIntent.target,
-                  gameID: this.id,
-                  kickMethod: "websocket",
-                });
-
-                this.kickClient(
-                  stampedIntent.target,
-                  KICK_REASON_LOBBY_CREATOR,
-                );
-                return;
-              }
-              case "update_game_config": {
-                // Only lobby creator can update config
-                if (client.clientID !== this.lobbyCreatorID) {
-                  this.log.warn(`Only lobby creator can update game config`, {
-                    clientID: client.clientID,
-                    creatorID: this.lobbyCreatorID,
-                    gameID: this.id,
-                  });
-                  return;
-                }
-
-                if (this.isPublic()) {
-                  this.log.warn(`Cannot update public game via WebSocket`, {
-                    gameID: this.id,
-                    clientID: client.clientID,
-                  });
-                  return;
-                }
-
-                if (this.hasStarted()) {
-                  this.log.warn(
-                    `Cannot update game config after it has started`,
-                    {
-                      gameID: this.id,
-                      clientID: client.clientID,
-                    },
-                  );
-                  return;
-                }
-
-                if (stampedIntent.config.gameType === GameType.Public) {
-                  this.log.warn(`Cannot update game to public via WebSocket`, {
-                    gameID: this.id,
-                    clientID: client.clientID,
-                  });
-                  return;
-                }
-
-                this.log.info(
-                  `Lobby creator updated game config via WebSocket`,
-                  {
-                    creatorID: client.clientID,
-                    gameID: this.id,
-                  },
-                );
-
-                this.updateGameConfig(stampedIntent.config);
-                return;
-              }
-              case "toggle_pause": {
-                // Only lobby creator can pause/resume
-                if (client.clientID !== this.lobbyCreatorID) {
-                  this.log.warn(`Only lobby creator can toggle pause`, {
-                    clientID: client.clientID,
-                    creatorID: this.lobbyCreatorID,
-                    gameID: this.id,
-                  });
-                  return;
-                }
-
-                if (stampedIntent.paused) {
-                  // Pausing: send intent and complete current turn before pause takes effect
-                  this.addIntent(stampedIntent);
-                  this.endTurn();
-                  this.isPaused = true;
-                } else {
-                  // Unpausing: clear pause flag before sending intent so next turn can execute
-                  this.isPaused = false;
-                  this.addIntent(stampedIntent);
-                  this.endTurn();
-                }
-
-                this.log.info(`Game ${this.isPaused ? "paused" : "resumed"}`, {
-                  clientID: client.clientID,
-                  gameID: this.id,
-                });
-                break;
-              }
-              default: {
-                // Don't process intents while game is paused
-                if (!this.isPaused) {
-                  this.addIntent(stampedIntent);
-                }
-                break;
-              }
-            }
-            break;
-          }
-          case "ping": {
-            this.lastPingUpdate = Date.now();
-            client.lastPing = Date.now();
-            break;
-          }
-          case "hash": {
-            client.hashes.set(clientMsg.turnNumber, clientMsg.hash);
-            break;
-          }
-          case "winner": {
-            this.handleWinner(client, clientMsg);
-            break;
-          }
-          default: {
-            this.log.warn(`Unknown message type: ${(clientMsg as any).type}`, {
-              clientID: client.clientID,
-            });
-            break;
-          }
-        }
+        this.processClientMessage(client, clientMsg);
       } catch (error) {
         this.log.info(
           `error handline websocket request in game server: ${error}`,
@@ -573,6 +435,177 @@ export class GameServer {
       this.activeClients = this.activeClients.filter(
         (c) => c.clientID !== client.clientID,
       );
+    }
+  }
+
+  private checkRateLimit(client: Client, type: string, bytes: number): boolean {
+    const rateResult = this.intentRateLimiter.check(
+      client.clientID,
+      type,
+      bytes,
+    );
+    if (rateResult === "kick") {
+      this.log.warn(`Client rate limit exceeded, kicking`, {
+        clientID: client.clientID,
+        type,
+      });
+      this.kickClient(client.clientID, KICK_REASON_TOO_MUCH_DATA);
+      return false;
+    }
+    if (rateResult === "limit") {
+      this.log.warn(`Client message rate limit exceeded, dropping`, {
+        clientID: client.clientID,
+        type,
+      });
+      return false;
+    }
+    return true;
+  }
+
+  private processClientMessage(client: Client, clientMsg: ClientMessage) {
+    switch (clientMsg.type) {
+      case "rejoin": {
+        if (this._hasStarted) {
+          this.sendStartGameMsg(client.ws, clientMsg.lastTurn);
+        }
+        break;
+      }
+      case "intent": {
+        const stampedIntent = {
+          ...clientMsg.intent,
+          clientID: client.clientID,
+        };
+        switch (stampedIntent.type) {
+          case "mark_disconnected": {
+            this.log.warn(
+              `Should not receive mark_disconnected intent from client`,
+            );
+            return;
+          }
+          case "kick_player": {
+            if (client.clientID !== this.lobbyCreatorID) {
+              this.log.warn(`Only lobby creator can kick players`, {
+                clientID: client.clientID,
+                creatorID: this.lobbyCreatorID,
+                target: stampedIntent.target,
+                gameID: this.id,
+              });
+              return;
+            }
+
+            if (client.clientID === stampedIntent.target) {
+              this.log.warn(`Cannot kick yourself`, {
+                clientID: client.clientID,
+              });
+              return;
+            }
+
+            this.log.info(`Lobby creator initiated kick of player`, {
+              creatorID: client.clientID,
+              target: stampedIntent.target,
+              gameID: this.id,
+              kickMethod: "websocket",
+            });
+
+            this.kickClient(stampedIntent.target, KICK_REASON_LOBBY_CREATOR);
+            return;
+          }
+          case "update_game_config": {
+            if (client.clientID !== this.lobbyCreatorID) {
+              this.log.warn(`Only lobby creator can update game config`, {
+                clientID: client.clientID,
+                creatorID: this.lobbyCreatorID,
+                gameID: this.id,
+              });
+              return;
+            }
+
+            if (this.isPublic()) {
+              this.log.warn(`Cannot update public game via WebSocket`, {
+                gameID: this.id,
+                clientID: client.clientID,
+              });
+              return;
+            }
+
+            if (this.hasStarted()) {
+              this.log.warn(`Cannot update game config after it has started`, {
+                gameID: this.id,
+                clientID: client.clientID,
+              });
+              return;
+            }
+
+            if (stampedIntent.config.gameType === GameType.Public) {
+              this.log.warn(`Cannot update game to public via WebSocket`, {
+                gameID: this.id,
+                clientID: client.clientID,
+              });
+              return;
+            }
+
+            this.log.info(`Lobby creator updated game config via WebSocket`, {
+              creatorID: client.clientID,
+              gameID: this.id,
+            });
+
+            this.updateGameConfig(stampedIntent.config);
+            return;
+          }
+          case "toggle_pause": {
+            if (client.clientID !== this.lobbyCreatorID) {
+              this.log.warn(`Only lobby creator can toggle pause`, {
+                clientID: client.clientID,
+                creatorID: this.lobbyCreatorID,
+                gameID: this.id,
+              });
+              return;
+            }
+
+            if (stampedIntent.paused) {
+              this.addIntent(stampedIntent);
+              this.endTurn();
+              this.isPaused = true;
+            } else {
+              this.isPaused = false;
+              this.addIntent(stampedIntent);
+              this.endTurn();
+            }
+
+            this.log.info(`Game ${this.isPaused ? "paused" : "resumed"}`, {
+              clientID: client.clientID,
+              gameID: this.id,
+            });
+            break;
+          }
+          default: {
+            if (!this.isPaused) {
+              this.addIntent(stampedIntent);
+            }
+            break;
+          }
+        }
+        break;
+      }
+      case "ping": {
+        this.lastPingUpdate = Date.now();
+        client.lastPing = Date.now();
+        break;
+      }
+      case "hash": {
+        client.hashes.set(clientMsg.turnNumber, clientMsg.hash);
+        break;
+      }
+      case "winner": {
+        this.handleWinner(client, clientMsg);
+        break;
+      }
+      default: {
+        this.log.warn(`Unknown message type: ${(clientMsg as any).type}`, {
+          clientID: client.clientID,
+        });
+        break;
+      }
     }
   }
 
@@ -694,6 +727,7 @@ export class GameServer {
       return;
     }
     this.gameStartInfo = result.data satisfies GameStartInfo;
+    this.binaryContext = binaryContextFromGameStartInfo(this.gameStartInfo);
 
     this.endTurnIntervalID = setInterval(
       () => this.endTurn(),
@@ -762,10 +796,16 @@ export class GameServer {
     this.handleSynchronization();
     this.checkDisconnectedStatus();
 
-    const msg = JSON.stringify({
-      type: "turn",
-      turn: pastTurn,
-    } satisfies ServerTurnMessage);
+    if (!this.binaryContext) {
+      throw new Error("Binary gameplay context missing after start");
+    }
+    const msg = encodeBinaryServerGameplayMessage(
+      {
+        type: "turn",
+        turn: pastTurn,
+      },
+      this.binaryContext,
+    );
     this.activeClients.forEach((c) => {
       c.ws.send(msg);
     });
@@ -956,6 +996,7 @@ export class GameServer {
         clientID,
         reasonKey,
       });
+      return;
     }
   }
 
@@ -1067,7 +1108,13 @@ export class GameServer {
       return;
     }
 
-    const desyncMsg = JSON.stringify(serverDesync.data);
+    if (!this.binaryContext) {
+      throw new Error("Binary gameplay context missing for desync");
+    }
+    const desyncMsg = encodeBinaryServerGameplayMessage(
+      serverDesync.data,
+      this.binaryContext,
+    );
     for (const c of outOfSyncClients) {
       this.outOfSyncClients.add(c.clientID);
       if (this.sentDesyncMessageClients.has(c.clientID)) {
@@ -1174,4 +1221,40 @@ export class GameServer {
     );
     this.archiveGame();
   }
+}
+
+function rawDataToString(message: RawData): string {
+  if (typeof message === "string") {
+    return message;
+  }
+  if (Array.isArray(message)) {
+    return Buffer.concat(message).toString("utf8");
+  }
+  if (message instanceof ArrayBuffer) {
+    return Buffer.from(message).toString("utf8");
+  }
+  return message.toString("utf8");
+}
+
+function rawDataToUint8Array(message: RawData): Uint8Array {
+  if (typeof message === "string") {
+    return new Uint8Array(Buffer.from(message, "utf8"));
+  }
+  if (Array.isArray(message)) {
+    return Buffer.concat(message);
+  }
+  if (message instanceof ArrayBuffer) {
+    return new Uint8Array(message);
+  }
+  return message;
+}
+
+function rawDataByteLength(message: RawData): number {
+  if (typeof message === "string") {
+    return Buffer.byteLength(message, "utf8");
+  }
+  if (Array.isArray(message)) {
+    return message.reduce((total, chunk) => total + chunk.byteLength, 0);
+  }
+  return message.byteLength;
 }

--- a/tests/core/BinaryCodec.test.ts
+++ b/tests/core/BinaryCodec.test.ts
@@ -40,6 +40,14 @@ const clientIntentMessages: ClientIntentMessage[] = [
     type: "intent",
     intent: {
       type: "attack",
+      targetID: "kli0dx59",
+      troops: 18,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "attack",
       targetID: null,
       troops: null,
     },
@@ -291,6 +299,26 @@ describe("BinaryCodec", () => {
             recipient: AllPlayers,
             emoji: 2,
             clientID: "P0000002",
+          },
+        ],
+      },
+    };
+    const encoded = encodeBinaryServerGameplayMessage(message, context);
+    const decoded = decodeBinaryServerGameplayMessage(encoded, context);
+    expect(decoded).toEqual(message);
+  });
+
+  it("round-trips server turn messages with non-lobby target ids", () => {
+    const message: ServerTurnMessage = {
+      type: "turn",
+      turn: {
+        turnNumber: 6,
+        intents: [
+          {
+            type: "attack",
+            targetID: "kli0dx59",
+            troops: 9,
+            clientID: "P0000001",
           },
         ],
       },

--- a/tests/core/BinaryCodec.test.ts
+++ b/tests/core/BinaryCodec.test.ts
@@ -5,6 +5,7 @@ import {
   decodeBinaryServerGameplayMessage,
   encodeBinaryClientGameplayMessage,
   encodeBinaryServerGameplayMessage,
+  isBinaryGameplayClientMessage,
 } from "../../src/core/BinaryCodec";
 import { BINARY_PROTOCOL_VERSION } from "../../src/core/BinaryProtocol";
 import {
@@ -251,6 +252,13 @@ const clientIntentMessages: ClientIntentMessage[] = [
       paused: true,
     },
   },
+  {
+    type: "intent",
+    intent: {
+      type: "kick_player",
+      target: "P0000002",
+    },
+  },
 ];
 
 describe("BinaryCodec", () => {
@@ -281,6 +289,28 @@ describe("BinaryCodec", () => {
     const encoded = encodeBinaryClientGameplayMessage(message, context);
     const decoded = decodeBinaryClientGameplayMessage(encoded, context);
     expect(decoded).toEqual(message);
+  });
+
+  it("only classifies supported intents as binary gameplay messages", () => {
+    expect(
+      isBinaryGameplayClientMessage({
+        type: "intent",
+        intent: {
+          type: "kick_player",
+          target: "P0000002",
+        },
+      } as ClientIntentMessage),
+    ).toBe(true);
+
+    expect(
+      isBinaryGameplayClientMessage({
+        type: "intent",
+        intent: {
+          type: "update_game_config",
+          config: {},
+        },
+      } as ClientIntentMessage),
+    ).toBe(false);
   });
 
   it("round-trips server turn messages", () => {

--- a/tests/core/BinaryCodec.test.ts
+++ b/tests/core/BinaryCodec.test.ts
@@ -1,0 +1,385 @@
+import { describe, expect, it } from "vitest";
+import {
+  binaryContextFromGameStartInfo,
+  decodeBinaryClientGameplayMessage,
+  decodeBinaryServerGameplayMessage,
+  encodeBinaryClientGameplayMessage,
+  encodeBinaryServerGameplayMessage,
+} from "../../src/core/BinaryCodec";
+import { BINARY_PROTOCOL_VERSION } from "../../src/core/BinaryProtocol";
+import {
+  ClientHashMessage,
+  ClientIntentMessage,
+  ClientPingMessage,
+  QuickChatKeySchema,
+  ServerDesyncMessage,
+  ServerTurnMessage,
+} from "../../src/core/Schemas";
+import { AllPlayers, UnitType } from "../../src/core/game/Game";
+
+const quickChatKey = QuickChatKeySchema.options[0];
+
+const context = binaryContextFromGameStartInfo({
+  players: [
+    { clientID: "P0000001" },
+    { clientID: "P0000002" },
+    { clientID: "P0000003" },
+  ],
+} as any);
+
+const clientIntentMessages: ClientIntentMessage[] = [
+  {
+    type: "intent",
+    intent: {
+      type: "attack",
+      targetID: "P0000002",
+      troops: 12.5,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "attack",
+      targetID: null,
+      troops: null,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "cancel_attack",
+      attackID: "attack-123",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "spawn",
+      tile: 42,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "mark_disconnected",
+      clientID: "P0000002",
+      isDisconnected: true,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "boat",
+      troops: 99,
+      dst: 123,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "cancel_boat",
+      unitID: 77,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "allianceRequest",
+      recipient: "P0000002",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "allianceReject",
+      requestor: "P0000002",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "breakAlliance",
+      recipient: "P0000002",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "targetPlayer",
+      target: "P0000002",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "emoji",
+      recipient: "P0000002",
+      emoji: 3,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "emoji",
+      recipient: AllPlayers,
+      emoji: 4,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "donate_gold",
+      recipient: "P0000002",
+      gold: 250,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "donate_gold",
+      recipient: "P0000002",
+      gold: null,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "donate_troops",
+      recipient: "P0000002",
+      troops: 25,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "donate_troops",
+      recipient: "P0000002",
+      troops: null,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "build_unit",
+      unit: UnitType.Warship,
+      tile: 7,
+      rocketDirectionUp: true,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "build_unit",
+      unit: UnitType.Port,
+      tile: 8,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "upgrade_structure",
+      unit: UnitType.City,
+      unitId: 9,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "embargo",
+      targetID: "P0000002",
+      action: "start",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "embargo_all",
+      action: "stop",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "move_warship",
+      unitId: 55,
+      tile: 88,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "quick_chat",
+      recipient: "P0000002",
+      quickChatKey,
+      target: "P0000003",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "quick_chat",
+      recipient: "P0000002",
+      quickChatKey,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "allianceExtension",
+      recipient: "P0000002",
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "delete_unit",
+      unitId: 101,
+    },
+  },
+  {
+    type: "intent",
+    intent: {
+      type: "toggle_pause",
+      paused: true,
+    },
+  },
+];
+
+describe("BinaryCodec", () => {
+  it.each(clientIntentMessages)(
+    "round-trips client gameplay intent %#",
+    (message) => {
+      const encoded = encodeBinaryClientGameplayMessage(message, context);
+      const decoded = decodeBinaryClientGameplayMessage(encoded, context);
+      expect(decoded).toEqual(message);
+    },
+  );
+
+  it("round-trips hash messages", () => {
+    const message: ClientHashMessage = {
+      type: "hash",
+      turnNumber: 12,
+      hash: 34567,
+    };
+    const encoded = encodeBinaryClientGameplayMessage(message, context);
+    const decoded = decodeBinaryClientGameplayMessage(encoded, context);
+    expect(decoded).toEqual(message);
+  });
+
+  it("round-trips ping messages", () => {
+    const message: ClientPingMessage = {
+      type: "ping",
+    };
+    const encoded = encodeBinaryClientGameplayMessage(message, context);
+    const decoded = decodeBinaryClientGameplayMessage(encoded, context);
+    expect(decoded).toEqual(message);
+  });
+
+  it("round-trips server turn messages", () => {
+    const message: ServerTurnMessage = {
+      type: "turn",
+      turn: {
+        turnNumber: 5,
+        intents: [
+          {
+            type: "spawn",
+            tile: 10,
+            clientID: "P0000001",
+          },
+          {
+            type: "emoji",
+            recipient: AllPlayers,
+            emoji: 2,
+            clientID: "P0000002",
+          },
+        ],
+      },
+    };
+    const encoded = encodeBinaryServerGameplayMessage(message, context);
+    const decoded = decodeBinaryServerGameplayMessage(encoded, context);
+    expect(decoded).toEqual(message);
+  });
+
+  it("round-trips server desync messages", () => {
+    const message: ServerDesyncMessage = {
+      type: "desync",
+      turn: 9,
+      correctHash: 777,
+      clientsWithCorrectHash: 3,
+      totalActiveClients: 4,
+    };
+    const encoded = encodeBinaryServerGameplayMessage(message, context);
+    const decoded = decodeBinaryServerGameplayMessage(encoded, context);
+    expect(decoded).toEqual(message);
+  });
+
+  it("rejects unknown protocol versions", () => {
+    const encoded = encodeBinaryClientGameplayMessage(
+      {
+        type: "ping",
+      },
+      context,
+    );
+    encoded[0] = BINARY_PROTOCOL_VERSION + 1;
+    expect(() => decodeBinaryClientGameplayMessage(encoded, context)).toThrow(
+      /Unsupported binary protocol version/,
+    );
+  });
+
+  it("rejects invalid player indexes", () => {
+    const encoded = encodeBinaryServerGameplayMessage(
+      {
+        type: "turn",
+        turn: {
+          turnNumber: 1,
+          intents: [
+            {
+              type: "spawn",
+              tile: 3,
+              clientID: "P0000001",
+            },
+          ],
+        },
+      },
+      context,
+    );
+    encoded[10] = 99;
+    expect(() => decodeBinaryServerGameplayMessage(encoded, context)).toThrow(
+      /Invalid player index/,
+    );
+  });
+
+  it("rejects invalid intent flags", () => {
+    const encoded = encodeBinaryClientGameplayMessage(
+      {
+        type: "intent",
+        intent: {
+          type: "spawn",
+          tile: 1,
+        },
+      },
+      context,
+    );
+    encoded[5] = 0x04;
+    expect(() => decodeBinaryClientGameplayMessage(encoded, context)).toThrow(
+      /Unsupported flags/,
+    );
+  });
+
+  it("rejects truncated frames", () => {
+    const encoded = encodeBinaryServerGameplayMessage(
+      {
+        type: "desync",
+        turn: 4,
+        correctHash: null,
+        clientsWithCorrectHash: 1,
+        totalActiveClients: 2,
+      },
+      context,
+    );
+    const truncated = encoded.subarray(0, encoded.length - 1);
+    expect(() => decodeBinaryServerGameplayMessage(truncated, context)).toThrow(
+      /Unexpected end of binary frame/,
+    );
+  });
+});

--- a/tests/server/GameServerBinaryProtocol.test.ts
+++ b/tests/server/GameServerBinaryProtocol.test.ts
@@ -163,6 +163,80 @@ describe("GameServer binary gameplay protocol", () => {
     );
   });
 
+  it("round-trips binary attacks that target bot-style ids", () => {
+    const logger = createMockLogger();
+    const game = new GameServer(
+      "TEST0003",
+      logger as any,
+      Date.now(),
+      {
+        turnIntervalMs: () => 100,
+        env: () => 0,
+      } as any,
+      createGameConfig(),
+    );
+
+    const clientA = createClient(
+      "P0000001",
+      "44444444-4444-4444-8444-444444444444",
+      "Alice",
+    );
+
+    expect(game.joinClient(clientA.client)).toBe("joined");
+    game.start();
+
+    const startPayload = clientA.ws.sent.find(
+      (message): message is string =>
+        typeof message === "string" && message.includes('"type":"start"'),
+    );
+    expect(startPayload).toBeDefined();
+
+    const binaryContext = binaryContextFromGameStartInfo(
+      JSON.parse(startPayload!).gameStartInfo,
+    );
+    const attackMessage = encodeBinaryClientGameplayMessage(
+      {
+        type: "intent",
+        intent: {
+          type: "attack",
+          targetID: "kli0dx59",
+          troops: 25,
+        },
+      },
+      binaryContext,
+    );
+
+    clientA.ws.emit("message", attackMessage, true);
+    (game as any).endTurn();
+
+    const binaryTurn = [...clientA.ws.sent]
+      .reverse()
+      .find(
+        (message): message is Uint8Array =>
+          message instanceof Uint8Array && message[1] === 2,
+      );
+    expect(binaryTurn).toBeDefined();
+
+    const decodedTurn = decodeBinaryServerGameplayMessage(
+      binaryTurn!,
+      binaryContext,
+    );
+    expect(decodedTurn.type).toBe("turn");
+    if (decodedTurn.type !== "turn") {
+      throw new Error("Expected binary turn message");
+    }
+    expect(decodedTurn.turn.intents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "attack",
+          targetID: "kli0dx59",
+          troops: 25,
+          clientID: "P0000001",
+        }),
+      ]),
+    );
+  });
+
   it("accepts JSON rejoin after start and responds with JSON start", () => {
     const logger = createMockLogger();
     const game = new GameServer(

--- a/tests/server/GameServerBinaryProtocol.test.ts
+++ b/tests/server/GameServerBinaryProtocol.test.ts
@@ -237,6 +237,65 @@ describe("GameServer binary gameplay protocol", () => {
     );
   });
 
+  it("supports host kicks via binary gameplay intents after start", () => {
+    const logger = createMockLogger();
+    const hostPersistentId = "66666666-6666-4666-8666-666666666666";
+    const game = new GameServer(
+      "TEST0005",
+      logger as any,
+      Date.now(),
+      {
+        turnIntervalMs: () => 100,
+        env: () => 0,
+      } as any,
+      createGameConfig(),
+      hostPersistentId,
+    );
+
+    const host = createClient("P0000001", hostPersistentId, "Host");
+    const target = createClient(
+      "P0000002",
+      "77777777-7777-4777-8777-777777777777",
+      "Target",
+    );
+
+    expect(game.joinClient(host.client)).toBe("joined");
+    expect(game.joinClient(target.client)).toBe("joined");
+    game.start();
+
+    const startPayload = host.ws.sent.find(
+      (message): message is string =>
+        typeof message === "string" && message.includes('"type":"start"'),
+    );
+    expect(startPayload).toBeDefined();
+
+    const binaryContext = binaryContextFromGameStartInfo(
+      JSON.parse(startPayload!).gameStartInfo,
+    );
+    const kickMessage = encodeBinaryClientGameplayMessage(
+      {
+        type: "intent",
+        intent: {
+          type: "kick_player",
+          target: "P0000002",
+        },
+      },
+      binaryContext,
+    );
+
+    host.ws.emit("message", kickMessage, true);
+
+    expect(target.ws.sent).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('"error":"kick_reason.lobby_creator"'),
+      ]),
+    );
+    expect(target.ws.readyState).toBe(3);
+    expect(game.activeClients.map((client) => client.clientID)).toEqual([
+      "P0000001",
+    ]);
+  });
+
   it("kicks malformed binary gameplay messages after start", () => {
     const logger = createMockLogger();
     const game = new GameServer(

--- a/tests/server/GameServerBinaryProtocol.test.ts
+++ b/tests/server/GameServerBinaryProtocol.test.ts
@@ -237,6 +237,38 @@ describe("GameServer binary gameplay protocol", () => {
     );
   });
 
+  it("kicks malformed binary gameplay messages after start", () => {
+    const logger = createMockLogger();
+    const game = new GameServer(
+      "TEST0004",
+      logger as any,
+      Date.now(),
+      {
+        turnIntervalMs: () => 100,
+        env: () => 0,
+      } as any,
+      createGameConfig(),
+    );
+
+    const clientA = createClient(
+      "P0000001",
+      "55555555-5555-4555-8555-555555555555",
+      "Alice",
+    );
+
+    expect(game.joinClient(clientA.client)).toBe("joined");
+    game.start();
+
+    clientA.ws.sent.length = 0;
+    clientA.ws.emit("message", new Uint8Array([99, 1, 0, 0]), true);
+
+    expect(clientA.ws.sent).toEqual([
+      expect.stringContaining('"error":"kick_reason.invalid_message"'),
+    ]);
+    expect(clientA.ws.readyState).toBe(3);
+    expect(game.activeClients).toHaveLength(0);
+  });
+
   it("accepts JSON rejoin after start and responds with JSON start", () => {
     const logger = createMockLogger();
     const game = new GameServer(

--- a/tests/server/GameServerBinaryProtocol.test.ts
+++ b/tests/server/GameServerBinaryProtocol.test.ts
@@ -1,0 +1,203 @@
+import { EventEmitter } from "events";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/server/Archive", () => ({
+  archive: vi.fn(),
+  finalizeGameRecord: vi.fn((record) => record),
+}));
+
+import {
+  binaryContextFromGameStartInfo,
+  decodeBinaryServerGameplayMessage,
+  encodeBinaryClientGameplayMessage,
+} from "../../src/core/BinaryCodec";
+import {
+  Difficulty,
+  GameMapSize,
+  GameMapType,
+  GameMode,
+  GameType,
+} from "../../src/core/game/Game";
+import type { GameConfig } from "../../src/core/Schemas";
+import { Client } from "../../src/server/Client";
+import { GameServer } from "../../src/server/GameServer";
+
+class MockWebSocket extends EventEmitter {
+  public readonly sent: Array<string | Uint8Array> = [];
+  public readyState = 1;
+
+  send(message: string | Uint8Array) {
+    this.sent.push(message);
+  }
+
+  close(_code?: number, _reason?: string) {
+    this.readyState = 3;
+    this.emit("close");
+  }
+}
+
+function createMockLogger() {
+  return {
+    child: vi.fn().mockReturnThis(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+function createGameConfig(): GameConfig {
+  return {
+    donateGold: false,
+    donateTroops: false,
+    gameMap: GameMapType.World,
+    gameType: GameType.Private,
+    gameMapSize: GameMapSize.Normal,
+    difficulty: Difficulty.Easy,
+    nations: "default",
+    infiniteGold: false,
+    infiniteTroops: false,
+    instantBuild: false,
+    randomSpawn: false,
+    gameMode: GameMode.FFA,
+    bots: 0,
+    disabledUnits: [],
+  };
+}
+
+function createClient(
+  clientID: string,
+  persistentID: string,
+  username: string,
+) {
+  const ws = new MockWebSocket();
+  const client = new Client(
+    clientID as any,
+    persistentID,
+    null,
+    undefined,
+    undefined,
+    "127.0.0.1",
+    username,
+    null,
+    ws as any,
+    undefined,
+  );
+  return { client, ws };
+}
+
+describe("GameServer binary gameplay protocol", () => {
+  it("keeps start JSON and emits live turns as binary", async () => {
+    const logger = createMockLogger();
+    const game = new GameServer(
+      "TEST0001",
+      logger as any,
+      Date.now(),
+      {
+        turnIntervalMs: () => 100,
+        env: () => 0,
+      } as any,
+      createGameConfig(),
+    );
+
+    const clientA = createClient(
+      "P0000001",
+      "11111111-1111-4111-8111-111111111111",
+      "Alice",
+    );
+    const clientB = createClient(
+      "P0000002",
+      "22222222-2222-4222-8222-222222222222",
+      "Bob",
+    );
+
+    expect(game.joinClient(clientA.client)).toBe("joined");
+    expect(game.joinClient(clientB.client)).toBe("joined");
+
+    game.start();
+
+    const startPayload = clientA.ws.sent.find(
+      (message): message is string =>
+        typeof message === "string" && message.includes('"type":"start"'),
+    );
+    expect(startPayload).toBeDefined();
+
+    const binaryContext = binaryContextFromGameStartInfo(
+      JSON.parse(startPayload!).gameStartInfo,
+    );
+    const spawnMessage = encodeBinaryClientGameplayMessage(
+      {
+        type: "intent",
+        intent: {
+          type: "spawn",
+          tile: 123,
+        },
+      },
+      binaryContext,
+    );
+
+    clientA.ws.emit("message", spawnMessage, true);
+    (game as any).endTurn();
+
+    const binaryTurn = clientA.ws.sent.find(
+      (message): message is Uint8Array =>
+        message instanceof Uint8Array && message[1] === 2,
+    );
+    expect(binaryTurn).toBeDefined();
+
+    const decodedTurn = decodeBinaryServerGameplayMessage(
+      binaryTurn!,
+      binaryContext,
+    );
+    expect(decodedTurn.type).toBe("turn");
+    if (decodedTurn.type !== "turn") {
+      throw new Error("Expected binary turn message");
+    }
+    expect(decodedTurn.turn.intents).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: "spawn",
+          tile: 123,
+          clientID: "P0000001",
+        }),
+      ]),
+    );
+  });
+
+  it("accepts JSON rejoin after start and responds with JSON start", () => {
+    const logger = createMockLogger();
+    const game = new GameServer(
+      "TEST0002",
+      logger as any,
+      Date.now(),
+      {
+        turnIntervalMs: () => 100,
+        env: () => 0,
+      } as any,
+      createGameConfig(),
+    );
+
+    const clientA = createClient(
+      "P0000001",
+      "33333333-3333-4333-8333-333333333333",
+      "Alice",
+    );
+    expect(game.joinClient(clientA.client)).toBe("joined");
+    game.start();
+
+    clientA.ws.sent.length = 0;
+    clientA.ws.emit(
+      "message",
+      JSON.stringify({
+        type: "rejoin",
+        gameID: "TEST0002",
+        lastTurn: 0,
+        token: "33333333-3333-4333-8333-333333333333",
+      }),
+      false,
+    );
+
+    expect(clientA.ws.sent).toHaveLength(1);
+    expect(typeof clientA.ws.sent[0]).toBe("string");
+    expect(clientA.ws.sent[0]).toContain('"type":"start"');
+  });
+});


### PR DESCRIPTION
## Description:
Switch live gameplay WebSocket traffic from JSON to binary while keeping setup and reconnect messages as JSON.

JSON remains for:
- `join`, `rejoin`
- `lobby_info`, `prestart`, `start`
- `error`, `winner`

Binary is now used for:
- client -> server: `intent`, `hash`, `ping`
- server -> client: `turn`, `desync`

## Changes

- Added a shared binary codec in `src/core/BinaryProtocol.ts` and `src/core/BinaryCodec.ts`
- Updated client transport to send/receive binary gameplay frames after `start`
- Updated server gameplay handling to decode binary client frames and emit binary turns/desyncs
- Preserved existing lockstep behavior, auth stamping, reconnect flow, rate limiting, and turn cadence
- Fixed binary player refs to support bot/nation runtime IDs, matching the old JSON behavior

## Testing

- `npx tsc --noEmit`
- `npx vitest run tests/core/BinaryCodec.test.ts tests/server/GameServerBinaryProtocol.test.ts`


Out of scope/todo:
- binary `start`
- reconnect "catch-up" payloads
- WebTransport / WebRTC migration

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [ ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
