### PR TITLE
fix: prevent zoom keys getting stuck when browser zoom shortcut is used

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -266,6 +266,9 @@ export class InputHandler {
         this.eventBus.emit(new MouseMoveEvent(e.clientX, e.clientY));
       }
     });
+    // Clear all tracked keys when the window loses focus so keys that had
+    // their keyup swallowed by the browser (e.g. cmd+zoom) don't stay stuck.
+    window.addEventListener("blur", () => this.activeKeys.clear());
     this.pointers.clear();
 
     this.moveInterval = setInterval(() => {
@@ -358,7 +361,14 @@ export class InputHandler {
         this.eventBus.emit(new ConfirmGhostStructureEvent());
       }
 
+      // Don't track zoom keys when a meta/ctrl modifier is held — that means
+      // the browser is handling its own zoom (cmd+/cmd-) and the keyup will
+      // never fire, which would leave the key stuck in activeKeys forever.
+      const isBrowserZoomCombo =
+        (e.metaKey || e.ctrlKey) && (e.code === "Minus" || e.code === "Equal");
+
       if (
+        !isBrowserZoomCombo &&
         [
           this.keybinds.moveUp,
           this.keybinds.moveDown,


### PR DESCRIPTION
## Bug

When the user changes browser zoom with cmd+Plus or cmd+Minus and then returns to 100%, the game starts zooming in uncontrollably and cannot be stopped.

## Root Cause

The browser intercepts cmd+Plus/Minus for its own zoom handling, so the `keyup` event never fires. This left `Equal` or `Minus` stuck in `activeKeys` forever. The 1ms interval in `moveInterval` kept seeing those keys as held and continuously emitted `ZoomEvent`.

## Fix

- Skip adding `Minus`/`Equal` to `activeKeys` when a meta/ctrl modifier is held (i.e. it's a browser zoom combo, not a game zoom)
- Add a `window.blur` listener to clear all `activeKeys` as a general safety net for any future stuck-key scenarios