### PR TITLE
add new achievement type and make the parser handle such errors gracefully

### DIFF
--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -151,7 +151,12 @@ export class SinglePlayerModal extends BaseModal {
 
     const completions =
       achievements.find(
-        (achievement) => achievement?.type === "singleplayer-map",
+        (
+          achievement,
+        ): achievement is {
+          type: "singleplayer-map";
+          data: { mapName: string; difficulty: string }[];
+        } => achievement?.type === "singleplayer-map",
       )?.data ?? [];
 
     const winsMap = new Map<GameMapType, Set<Difficulty>>();

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -60,6 +60,29 @@ const SingleplayerMapAchievementSchema = z.object({
   difficulty: z.enum(Difficulty),
 });
 
+const PlayerAchievementSchema = z.object({
+  achievement: z.string(),
+  achievedAt: z.string().nullable(),
+  gameId: z.number().nullable(),
+});
+
+const AchievementGroupSchema = z.union([
+  z.object({
+    type: z.literal("singleplayer-map"),
+    data: z.array(SingleplayerMapAchievementSchema),
+  }),
+  z.object({
+    type: z.literal("player"),
+    data: z.array(PlayerAchievementSchema),
+  }),
+  // Forward-compatible catch-all for achievement types not yet
+  // recognized by the frontend.
+  z.object({
+    type: z.string(),
+    data: z.unknown(),
+  }),
+]);
+
 export const UserMeResponseSchema = z.object({
   user: z.object({
     discord: DiscordUserSchema.optional(),
@@ -69,14 +92,7 @@ export const UserMeResponseSchema = z.object({
     publicId: z.string(),
     roles: z.string().array().optional(),
     flares: z.string().array().optional(),
-    achievements: z
-      .array(
-        z.object({
-          type: z.literal("singleplayer-map"), // TODO: change the shape to be more flexible when we have more achievements
-          data: z.array(SingleplayerMapAchievementSchema),
-        }),
-      )
-      .optional(),
+    achievements: z.array(AchievementGroupSchema).optional(),
     leaderboard: z
       .object({
         oneVone: z


### PR DESCRIPTION
## Description:

- adds a new "player" achievement type schema alongside the existing "singleplayer-map" type
- Adds a forward-compatible catch-all variant to AchievementGroupSchema so the frontend gracefully handles unrecognised achievement types instead of failing Zod validation


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
