### PR TITLE
Perf/fix(NukeExecution/NukeTrajectoryPreviewLayer): unnecessary fetch and pass to listNukeBreakAlliance

### DIFF
--- a/src/client/graphics/layers/NukeTrajectoryPreviewLayer.ts
+++ b/src/client/graphics/layers/NukeTrajectoryPreviewLayer.ts
@@ -246,12 +246,6 @@ export class NukeTrajectoryPreviewLayer implements Layer {
       game: this.game,
       targetTile,
       magnitude: this.game.config().nukeMagnitudes(ghostStructure),
-      allySmallIds: new Set(
-        this.game
-          .myPlayer()
-          ?.allies()
-          .map((a) => a.smallID()),
-      ),
       threshold: this.game.config().nukeAllianceBreakThreshold(),
     });
     // Find the point where SAM can intercept

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -89,7 +89,6 @@ export class NukeExecution implements Execution {
       game: this.mg,
       targetTile: this.dst,
       magnitude,
-      allySmallIds: new Set(this.player.allies().map((a) => a.smallID())),
       threshold: this.mg.config().nukeAllianceBreakThreshold(),
     });
 

--- a/src/core/execution/Util.ts
+++ b/src/core/execution/Util.ts
@@ -39,7 +39,7 @@ export interface NukeAllianceCheckParams {
   game: Game | GameView;
   targetTile: TileRef;
   magnitude: NukeMagnitude;
-  allySmallIds: Set<number>;
+  allySmallIds?: Set<number>;
   threshold: number;
 }
 
@@ -52,7 +52,7 @@ export function wouldNukeBreakAlliance(
 ): boolean {
   const { game, targetTile, magnitude, allySmallIds, threshold } = params;
 
-  if (allySmallIds.size === 0) {
+  if (!allySmallIds || allySmallIds.size === 0) {
     return false;
   }
 


### PR DESCRIPTION
## Description:

Perf/fix: listNukeBreakAlliance doesn't ask for allySmallIds and doesn't do anything with it. But both NukeExecution and NukeTrajectoryPreviewLayer do fetch and pass allySmallIds to it.

Make allySmallIds optional, have wouldNukeBreakAlliance (which does use allySmallIds) handle it potentially being undefined, and remove fetch and pass of allySmallIds to listNukeBreakAlliance.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33