### PR TITLE
Fix WorldRotated enum value to match lang key 🌐

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -356,7 +356,7 @@
     "amazonriverwide": "Amazon River Wide",
     "reglaciatedantarctica": "Reglaciated Antarctica",
     "theboxplus": "The Box PLUS",
-    "worldrotated": "World for Mobile",
+    "worldrotated": "World Rotated",
     "mediterranean": "Mediterranean"
   },
   "map_categories": {

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -147,7 +147,7 @@ export enum GameMapType {
   AmazonRiverWide = "Amazon River Wide",
   ReglaciatedAntarctica = "Reglaciated Antarctica",
   TheBoxPlus = "The Box Plus",
-  WorldRotated = "World for Mobile",
+  WorldRotated = "World Rotated",
   Mediterranean = "Mediterranean",
 }
 


### PR DESCRIPTION
## Description:

Fixes this display bug, says "WORLD ROTATED" now

<img width="235" height="140" alt="image" src="https://github.com/user-attachments/assets/dc8bb97d-350a-4ced-a63d-f3564479ba41" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin