### PR TITLE
Add missing Massachusetts country code

### DIFF
--- a/resources/countries.json
+++ b/resources/countries.json
@@ -1232,6 +1232,11 @@
     "name": "Maine"
   },
   {
+    "code": "Massachusetts",
+    "continent": "North America",
+    "name": "Massachusetts"
+  },
+  {
     "code": "mw",
     "continent": "Africa",
     "name": "Malawi"


### PR DESCRIPTION
Massachusetts has a flag SVG, but does not appear in the selection because it's missing from the countries.json.

## Description:

Add Massachusetts to countries.json

