### PR TITLE
Dependabot: monthly grouped PR if there are Github Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,7 @@ updates:
     groups:
       updates:
         applies-to: version-updates
+        patterns: ["*"] #wildcard, needs brackets as bugfix apparently
       security:
         applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## Description:

To save on manual work, have Dependabot check monthly and create a grouped PR for Github Actions updates. Hat tip @deshack for the tip and grouping suggestion.

- For example we can update `actions/checkout@v5` to `actions/checkout@v6` already and now Dependabot will propose to do that for us. The first PR for this and other updates can be expected once this PR has been merged.

- https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/keeping-your-actions-up-to-date-with-dependabot
- Added brackets round the wildcard for patterns, as a bugfix for reports such as these: https://github.com/dependabot/dependabot-core/issues/13919. Bugfix comes from: https://discord.com/channels/1359946986937258015/1483653625342464071/1489364119009366240

- (To be clear, this does NOT add creating Version updates PRs for dependencies, that is other functionality that works differently and we don't have it enabled: https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates. It also does not touch our currently enabled Security updates.)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33