### PR TITLE
Add naval AA upgrades to warships

### DIFF
--- a/src/client/graphics/layers/NukeTrajectoryPreviewLayer.ts
+++ b/src/client/graphics/layers/NukeTrajectoryPreviewLayer.ts
@@ -74,6 +74,38 @@ export class NukeTrajectoryPreviewLayer implements Layer {
     this.drawTrajectoryPreview(context);
   }
 
+  private canBeInterceptedByAirDefense(
+    unit: ReturnType<GameView["nearbyUnits"]>[number]["unit"],
+    distSquared: number,
+    targetTile: TileRef,
+    playersToBreakAllianceWith: Set<number>,
+  ): boolean {
+    if (
+      unit.owner().isMe() ||
+      (this.game.myPlayer()?.isFriendly(unit.owner()) &&
+        !playersToBreakAllianceWith.has(unit.owner().smallID()))
+    ) {
+      return false;
+    }
+
+    const range = this.game.config().samRange(unit.level());
+    if (distSquared > range * range) {
+      return false;
+    }
+
+    if (unit.type() !== UnitType.Warship) {
+      return true;
+    }
+
+    if (unit.level() <= 1 || !this.game.isOcean(targetTile)) {
+      return false;
+    }
+
+    return (
+      this.game.euclideanDistSquared(unit.tile(), targetTile) <= range * range
+    );
+  }
+
   /**
    * Update trajectory preview - called from tick() to cache spawn tile via expensive player.buildables() call
    * This only runs when target tile changes, minimizing worker thread communication
@@ -276,21 +308,18 @@ export class NukeTrajectoryPreviewLayer implements Layer {
     // Check trajectory
     for (let i = 0; i < this.trajectoryPoints.length; i++) {
       const tile = this.trajectoryPoints[i];
-      for (const sam of this.game.nearbyUnits(
+      for (const airDefense of this.game.nearbyUnits(
         tile,
         this.game.config().maxSamRange(),
-        UnitType.SAMLauncher,
+        [UnitType.SAMLauncher, UnitType.Warship],
       )) {
         if (
-          sam.unit.owner().isMe() ||
-          (this.game.myPlayer()?.isFriendly(sam.unit.owner()) &&
-            !playersToBreakAllianceWith.has(sam.unit.owner().smallID()))
-        ) {
-          continue;
-        }
-        if (
-          sam.distSquared <=
-          this.game.config().samRange(sam.unit.level()) ** 2
+          this.canBeInterceptedByAirDefense(
+            airDefense.unit,
+            airDefense.distSquared,
+            targetTile,
+            playersToBreakAllianceWith,
+          )
         ) {
           this.targetedIndex = i;
           break;

--- a/src/client/graphics/layers/SAMRadiusLayer.ts
+++ b/src/client/graphics/layers/SAMRadiusLayer.ts
@@ -19,15 +19,17 @@ interface SAMRadius {
   arcs: Interval[];
 }
 
-interface SamInfo {
+interface AirDefenseInfo {
   ownerId: number;
   level: number;
+  tile: number;
+  type: UnitType;
 }
 /**
- * Layer responsible for rendering SAM launcher defense radii
+ * Layer responsible for rendering air-defense radii.
  */
 export class SAMRadiusLayer implements Layer {
-  private readonly samLaunchers: Map<number, SamInfo> = new Map(); // Track SAM launcher IDs -> SAM info
+  private readonly airDefenseUnits: Map<number, AirDefenseInfo> = new Map();
   // track whether the stroke should be shown due to hover or due to an active build ghost
   private hoveredShow: boolean = false;
   private ghostShow: boolean = false;
@@ -43,7 +45,8 @@ export class SAMRadiusLayer implements Layer {
     this.hoveredShow =
       !!types &&
       (types.indexOf(UnitType.SAMLauncher) !== -1 ||
-        types.indexOf(UnitType.City) !== -1);
+        types.indexOf(UnitType.City) !== -1 ||
+        types.indexOf(UnitType.Warship) !== -1);
     this.updateVisibility();
   }
 
@@ -54,7 +57,7 @@ export class SAMRadiusLayer implements Layer {
   ) {}
 
   init() {
-    // Listen for game updates to detect SAM launcher changes
+    // Listen for game updates to detect air-defense changes.
     // Also listen for UI toggle structure events so we can show borders when
     // the user is hovering the Atom/Hydrogen option (UnitDisplay emits
     // ToggleStructureEvent with SAMLauncher included in the list).
@@ -68,14 +71,18 @@ export class SAMRadiusLayer implements Layer {
   }
 
   tick() {
-    // Check for updates to SAM launchers
+    // Check for updates to air-defense units
     const unitUpdates = this.game.updatesSinceLastTick()?.[GameUpdateType.Unit];
     if (unitUpdates) {
       for (const update of unitUpdates) {
         const unit = this.game.unit(update.id);
-        if (unit && unit.type() === UnitType.SAMLauncher) {
+        if (
+          unit &&
+          (unit.type() === UnitType.SAMLauncher ||
+            unit.type() === UnitType.Warship)
+        ) {
           if (this.hasChanged(unit)) {
-            this.needsRedraw = true; // A SAM changed: radiuses shall be recomputed when necessary
+            this.needsRedraw = true;
             break;
           }
         }
@@ -86,6 +93,7 @@ export class SAMRadiusLayer implements Layer {
     this.ghostShow =
       this.uiState.ghostStructure === UnitType.MissileSilo ||
       this.uiState.ghostStructure === UnitType.SAMLauncher ||
+      this.uiState.ghostStructure === UnitType.Warship ||
       this.uiState.ghostStructure === UnitType.City ||
       this.uiState.ghostStructure === UnitType.AtomBomb ||
       this.uiState.ghostStructure === UnitType.HydrogenBomb;
@@ -95,7 +103,7 @@ export class SAMRadiusLayer implements Layer {
   renderLayer(context: CanvasRenderingContext2D) {
     if (this.visible) {
       if (this.needsRedraw) {
-        // SAM changed: the radiuses needs to be updated
+        // Air-defense coverage changed, so the radii need to be recomputed.
         this.computeCircleUnions();
         this.needsRedraw = false;
       }
@@ -120,39 +128,46 @@ export class SAMRadiusLayer implements Layer {
   }
 
   private hasChanged(unit: UnitView): boolean {
-    const samInfos = this.samLaunchers.get(unit.id());
-    const isNew = samInfos === undefined;
-    const active = unit.isActive();
+    const info = this.airDefenseUnits.get(unit.id());
+    const isTracked = info !== undefined;
+    const isRelevant =
+      unit.isActive() &&
+      (unit.type() === UnitType.SAMLauncher || unit.level() > 1);
     const ownerId = unit.owner().smallID();
-    let hasChanges = isNew || !active; // was built or destroyed
-    hasChanges ||= !isNew && samInfos.ownerId !== ownerId; // Sam owner changed
-    hasChanges ||= !isNew && samInfos.level !== unit.level(); // Sam leveled up
+    let hasChanges = (!isTracked && isRelevant) || (isTracked && !isRelevant);
+    hasChanges ||= isTracked && info.ownerId !== ownerId;
+    hasChanges ||= isTracked && info.level !== unit.level();
+    hasChanges ||= isTracked && info.tile !== unit.tile();
+    hasChanges ||= isTracked && info.type !== unit.type();
     return hasChanges;
   }
 
-  private getAllSamRanges(): SAMRadius[] {
-    // Get all active SAM launchers
-    const samLaunchers = this.game
-      .units(UnitType.SAMLauncher)
-      .filter((unit) => unit.isActive());
+  private getAllAirDefenseRanges(): SAMRadius[] {
+    const airDefenseUnits = this.game
+      .units(UnitType.SAMLauncher, UnitType.Warship)
+      .filter(
+        (unit) =>
+          unit.isActive() &&
+          (unit.type() === UnitType.SAMLauncher || unit.level() > 1),
+      );
 
-    // Update our tracking set
-    this.samLaunchers.clear();
-    samLaunchers.forEach((sam) =>
-      this.samLaunchers.set(sam.id(), {
-        ownerId: sam.owner().smallID(),
-        level: sam.level(),
+    this.airDefenseUnits.clear();
+    airDefenseUnits.forEach((unit) =>
+      this.airDefenseUnits.set(unit.id(), {
+        ownerId: unit.owner().smallID(),
+        level: unit.level(),
+        tile: unit.tile(),
+        type: unit.type(),
       }),
     );
 
-    // Collect radius data
-    const radiuses = samLaunchers.map((sam) => {
-      const tile = sam.tile();
+    const radiuses = airDefenseUnits.map((unit) => {
+      const tile = unit.tile();
       return {
         x: this.game.x(tile),
         y: this.game.y(tile),
-        r: this.game.config().samRange(sam.level()),
-        owner: sam.owner(),
+        r: this.game.config().samRange(unit.level()),
+        owner: unit.owner(),
         arcs: [],
       };
     });
@@ -311,7 +326,7 @@ export class SAMRadiusLayer implements Layer {
    * Compute for each circle which angular segments are NOT covered by any other circle
    */
   private computeCircleUnions() {
-    this.samRanges = this.getAllSamRanges();
+    this.samRanges = this.getAllAirDefenseRanges();
     for (let i = 0; i < this.samRanges.length; i++) {
       const a = this.samRanges[i];
       this.computeUncoveredArcIntervals(a, this.samRanges);

--- a/src/client/graphics/layers/StructureDrawingUtils.ts
+++ b/src/client/graphics/layers/StructureDrawingUtils.ts
@@ -468,6 +468,12 @@ export class SpriteFactory {
       case UnitType.SAMLauncher:
         radius = this.game.config().samRange(level ?? 1);
         break;
+      case UnitType.Warship:
+        if ((level ?? 1) <= 1) {
+          return null;
+        }
+        radius = this.game.config().samRange(level ?? 1);
+        break;
       case UnitType.Factory:
         radius = this.game.config().trainStationMaxRange();
         break;

--- a/src/client/graphics/layers/StructureIconsLayer.ts
+++ b/src/client/graphics/layers/StructureIconsLayer.ts
@@ -565,7 +565,10 @@ export class StructureIconsLayer implements Layer {
   private resolveGhostRangeLevel(
     buildableUnit: BuildableUnit,
   ): number | undefined {
-    if (buildableUnit.type !== UnitType.SAMLauncher) {
+    if (
+      buildableUnit.type !== UnitType.SAMLauncher &&
+      buildableUnit.type !== UnitType.Warship
+    ) {
       return undefined;
     }
     if (buildableUnit.canUpgrade !== false) {
@@ -573,11 +576,11 @@ export class StructureIconsLayer implements Layer {
       if (existing) {
         return existing.level() + 1;
       } else {
-        console.error("Failed to find existing SAMLauncher for upgrade");
+        console.error("Failed to find existing air-defense unit for upgrade");
       }
     }
 
-    return 1;
+    return buildableUnit.type === UnitType.Warship ? undefined : 1;
   }
 
   private updateGhostRange(level?: number, targetingAlly: boolean = false) {

--- a/src/client/graphics/layers/UILayer.ts
+++ b/src/client/graphics/layers/UILayer.ts
@@ -111,6 +111,9 @@ export class UILayer implements Layer {
     switch (unit.type()) {
       case UnitType.Warship: {
         this.drawHealthBar(unit);
+        if (unit.level() > 1 && unit.missileReadinesss() < 1) {
+          this.createLoadingBar(unit);
+        }
         break;
       }
       case UnitType.City:
@@ -330,6 +333,7 @@ export class UILayer implements Layer {
     switch (unit.type()) {
       case UnitType.MissileSilo:
       case UnitType.SAMLauncher:
+      case UnitType.Warship:
         return !unit.markedForDeletion()
           ? unit.missileReadinesss()
           : this.deletionProgress(this.game, unit);

--- a/src/client/graphics/layers/UnitDisplay.ts
+++ b/src/client/graphics/layers/UnitDisplay.ts
@@ -45,6 +45,20 @@ export class UnitDisplay extends LitElement implements Layer {
   private allDisabled = false;
   private _hoveredUnit: PlayerBuildableUnitType | null = null;
 
+  private hoverStructureTypes(
+    unitType: PlayerBuildableUnitType,
+  ): PlayerBuildableUnitType[] {
+    switch (unitType) {
+      case UnitType.AtomBomb:
+      case UnitType.HydrogenBomb:
+        return [UnitType.MissileSilo, UnitType.SAMLauncher];
+      case UnitType.Warship:
+        return [UnitType.Port, UnitType.Warship];
+      default:
+        return [unitType];
+    }
+  }
+
   createRenderRoot() {
     return this;
   }
@@ -273,22 +287,9 @@ export class UnitDisplay extends LitElement implements Layer {
             this.requestUpdate();
           }}
           @mouseenter=${() => {
-            switch (unitType) {
-              case UnitType.AtomBomb:
-              case UnitType.HydrogenBomb:
-                this.eventBus?.emit(
-                  new ToggleStructureEvent([
-                    UnitType.MissileSilo,
-                    UnitType.SAMLauncher,
-                  ]),
-                );
-                break;
-              case UnitType.Warship:
-                this.eventBus?.emit(new ToggleStructureEvent([UnitType.Port]));
-                break;
-              default:
-                this.eventBus?.emit(new ToggleStructureEvent([unitType]));
-            }
+            this.eventBus?.emit(
+              new ToggleStructureEvent(this.hoverStructureTypes(unitType)),
+            );
           }}
           @mouseleave=${() =>
             this.eventBus?.emit(new ToggleStructureEvent(null))}

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -352,6 +352,7 @@ export class DefaultConfig implements Config {
             UnitType.Warship,
           ),
           maxHealth: 1000,
+          upgradable: true,
         };
         break;
       case UnitType.Shell:

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -1,7 +1,6 @@
 import {
   Execution,
   Game,
-  isUnit,
   MessageType,
   Player,
   Unit,
@@ -10,194 +9,11 @@ import {
 import { TileRef } from "../game/GameMap";
 import { PseudoRandom } from "../PseudoRandom";
 import { SAMMissileExecution } from "./SAMMissileExecution";
-
-type Target = {
-  unit: Unit;
-  tile: TileRef;
-};
-
-type InterceptionTile = {
-  tile: TileRef;
-  tick: number;
-};
-
-/**
- * Smart SAM targeting system preshoting nukes so its range is strictly enforced
- */
-class SAMTargetingSystem {
-  // Interception tiles are computed a single time, but it may not be reachable yet.
-  // Store the result so it can be intercepted at the proper time, rather than recomputing each tick.
-  // Null interception tile means there are no interception tiles in range. Store it to avoid recomputing.
-  private readonly precomputedNukes: Map<number, InterceptionTile | null> =
-    new Map();
-  private readonly missileSpeed: number;
-
-  constructor(
-    private readonly mg: Game,
-    private readonly sam: Unit,
-  ) {
-    this.missileSpeed = this.mg.config().defaultSamMissileSpeed();
-  }
-
-  updateUnreachableNukes(nearbyUnits: { unit: Unit; distSquared: number }[]) {
-    if (this.precomputedNukes.size === 0) {
-      return;
-    }
-
-    // Avoid per-tick allocations for the common case where only a few nukes are tracked.
-    if (this.precomputedNukes.size <= 16) {
-      for (const nukeId of this.precomputedNukes.keys()) {
-        let found = false;
-        for (const u of nearbyUnits) {
-          if (u.unit.id() === nukeId) {
-            found = true;
-            break;
-          }
-        }
-        if (!found) {
-          this.precomputedNukes.delete(nukeId);
-        }
-      }
-      return;
-    }
-
-    const nearbyUnitSet = new Set<number>();
-    for (const u of nearbyUnits) {
-      nearbyUnitSet.add(u.unit.id());
-    }
-    for (const nukeId of this.precomputedNukes.keys()) {
-      if (!nearbyUnitSet.has(nukeId)) {
-        this.precomputedNukes.delete(nukeId);
-      }
-    }
-  }
-
-  private tickToReach(currentTile: TileRef, tile: TileRef): number {
-    return Math.ceil(
-      this.mg.manhattanDist(currentTile, tile) / this.missileSpeed,
-    );
-  }
-
-  private computeInterceptionTile(
-    unit: Unit,
-    samTile: TileRef,
-    rangeSquared: number,
-  ): InterceptionTile | undefined {
-    const trajectory = unit.trajectory();
-    const currentIndex = unit.trajectoryIndex();
-    const explosionTick: number = trajectory.length - currentIndex;
-    for (let i = currentIndex; i < trajectory.length; i++) {
-      const trajectoryTile = trajectory[i];
-      if (
-        trajectoryTile.targetable &&
-        this.mg.euclideanDistSquared(samTile, trajectoryTile.tile) <=
-          rangeSquared
-      ) {
-        const nukeTickToReach = i - currentIndex;
-        const samTickToReach = this.tickToReach(samTile, trajectoryTile.tile);
-        const tickBeforeShooting = nukeTickToReach - samTickToReach;
-        if (samTickToReach < explosionTick && tickBeforeShooting >= 0) {
-          return { tick: tickBeforeShooting, tile: trajectoryTile.tile };
-        }
-      }
-    }
-    return undefined;
-  }
-
-  public getSingleTarget(ticks: number): Target | null {
-    const samTile = this.sam.tile();
-    const range = this.mg.config().samRange(this.sam.level());
-    const rangeSquared = range * range;
-
-    // Look beyond the SAM range so it can preshot nukes
-    const detectionRange = this.mg.config().maxSamRange() * 2;
-    const nukes = this.mg.nearbyUnits(
-      samTile,
-      detectionRange,
-      [UnitType.AtomBomb, UnitType.HydrogenBomb],
-      ({ unit }) => {
-        if (!isUnit(unit) || unit.targetedBySAM()) return false;
-        if (unit.owner() === this.sam.owner()) return false;
-
-        const samOwner = this.sam.owner();
-        const nukeOwner = unit.owner();
-
-        // After game-over in team games, SAMs also target teammate nukes (aftergame fun)
-        if (samOwner.isFriendly(nukeOwner)) {
-          return (
-            this.mg.getWinner() !== null && samOwner.isOnSameTeam(nukeOwner)
-          );
-        }
-
-        return true;
-      },
-    );
-
-    // Clear unreachable nukes that went out of range
-    this.updateUnreachableNukes(nukes);
-
-    let best: Target | null = null;
-    for (const nuke of nukes) {
-      const nukeId = nuke.unit.id();
-      const cached = this.precomputedNukes.get(nukeId);
-      if (cached !== undefined) {
-        if (cached === null) {
-          // Already computed as unreachable, skip
-          continue;
-        }
-        if (cached.tick === ticks) {
-          // Time to shoot!
-          const target = { tile: cached.tile, unit: nuke.unit };
-          if (
-            best === null ||
-            (target.unit.type() === UnitType.HydrogenBomb &&
-              best.unit.type() !== UnitType.HydrogenBomb)
-          ) {
-            best = target;
-          }
-          this.precomputedNukes.delete(nukeId);
-          continue;
-        }
-        if (cached.tick > ticks) {
-          // Not due yet, skip for now.
-          continue;
-        }
-        // Missed the planned tick (e.g was on cooldown), recompute a new interception tile if possible
-        this.precomputedNukes.delete(nukeId);
-      }
-      const interceptionTile = this.computeInterceptionTile(
-        nuke.unit,
-        samTile,
-        rangeSquared,
-      );
-      if (interceptionTile !== undefined) {
-        if (interceptionTile.tick <= 1) {
-          // Shoot instantly
-
-          const target = { unit: nuke.unit, tile: interceptionTile.tile };
-          if (
-            best === null ||
-            (target.unit.type() === UnitType.HydrogenBomb &&
-              best.unit.type() !== UnitType.HydrogenBomb)
-          ) {
-            best = target;
-          }
-        } else {
-          // Nuke will be reachable but not yet. Store the result.
-          this.precomputedNukes.set(nukeId, {
-            tick: interceptionTile.tick + ticks,
-            tile: interceptionTile.tile,
-          });
-        }
-      } else {
-        // Store unreachable nukes in order to prevent useless interception computation
-        this.precomputedNukes.set(nukeId, null);
-      }
-    }
-
-    return best;
-  }
-}
+import {
+  AirDefenseTarget,
+  AirDefenseTargetingSystem,
+  findMirvWarheadTargets,
+} from "./utils/AirDefenseUtils";
 
 export class SAMLauncherExecution implements Execution {
   private mg: Game;
@@ -207,7 +23,7 @@ export class SAMLauncherExecution implements Execution {
   // shoot the one targeting very close (MIRVWarheadProtectionRadius)
   private MIRVWarheadSearchRadius = 400;
   private MIRVWarheadProtectionRadius = 50;
-  private targetingSystem: SAMTargetingSystem;
+  private targetingSystem: AirDefenseTargetingSystem;
 
   private pseudoRandom: PseudoRandom | undefined;
 
@@ -241,7 +57,7 @@ export class SAMLauncherExecution implements Execution {
       }
       this.sam = this.player.buildUnit(UnitType.SAMLauncher, spawnTile, {});
     }
-    this.targetingSystem ??= new SAMTargetingSystem(this.mg, this.sam);
+    this.targetingSystem ??= new AirDefenseTargetingSystem(this.mg, this.sam);
 
     if (this.sam.isUnderConstruction()) {
       return;
@@ -272,41 +88,23 @@ export class SAMLauncherExecution implements Execution {
 
     this.pseudoRandom ??= new PseudoRandom(this.sam.id());
 
-    const mirvWarheadTargets = this.mg.nearbyUnits(
-      this.sam.tile(),
-      this.MIRVWarheadSearchRadius,
-      UnitType.MIRVWarhead,
-      ({ unit }) => {
-        if (!isUnit(unit)) return false;
-        if (unit.owner() === this.player) return false;
-
-        // After game-over in team games, SAMs also target teammate MIRVs (aftergame fun)
-        const nukeOwner = unit.owner();
-        if (this.player.isFriendly(nukeOwner)) {
-          if (
-            this.mg.getWinner() === null ||
-            !this.player.isOnSameTeam(nukeOwner)
-          ) {
-            return false;
-          }
-        }
-
+    const mirvWarheadTargets = findMirvWarheadTargets(
+      this.mg,
+      this.sam,
+      (unit, interceptor, game) => {
         const dst = unit.targetTile();
         return (
-          this.sam !== null &&
           dst !== undefined &&
-          this.mg.manhattanDist(dst, this.sam.tile()) <
+          game.manhattanDist(dst, interceptor.tile()) <
             this.MIRVWarheadProtectionRadius
         );
       },
+      this.MIRVWarheadSearchRadius,
     );
 
-    let target: Target | null = null;
+    let target: AirDefenseTarget | null = null;
     if (mirvWarheadTargets.length === 0) {
       target = this.targetingSystem.getSingleTarget(ticks);
-      if (target !== null) {
-        console.log("Target acquired");
-      }
     }
 
     // target is already filtered to exclude nukes targeted by other SAMs

--- a/src/core/execution/WarshipExecution.ts
+++ b/src/core/execution/WarshipExecution.ts
@@ -2,6 +2,7 @@ import {
   Execution,
   Game,
   isUnit,
+  MessageType,
   OwnerComp,
   Unit,
   UnitParams,
@@ -11,15 +12,24 @@ import { TileRef } from "../game/GameMap";
 import { PathFinding } from "../pathfinding/PathFinder";
 import { PathStatus, SteppingPathFinder } from "../pathfinding/types";
 import { PseudoRandom } from "../PseudoRandom";
+import { SAMMissileExecution } from "./SAMMissileExecution";
 import { ShellExecution } from "./ShellExecution";
+import {
+  AirDefenseTarget,
+  AirDefenseTargetingSystem,
+  findMirvWarheadTargets,
+} from "./utils/AirDefenseUtils";
 
 export class WarshipExecution implements Execution {
+  private readonly MIRVWarheadSearchRadius = 400;
+  private readonly MIRVWarheadProtectionRadius = 50;
   private random: PseudoRandom;
   private warship: Unit;
   private mg: Game;
   private pathfinder: SteppingPathFinder<TileRef>;
   private lastShellAttack = 0;
   private alreadySentShell = new Set<Unit>();
+  private airDefenseTargetingSystem: AirDefenseTargetingSystem | undefined;
 
   constructor(
     private input: (UnitParams<UnitType.Warship> & OwnerComp) | Unit,
@@ -64,15 +74,15 @@ export class WarshipExecution implements Execution {
     this.warship.setTargetUnit(this.findTargetUnit());
     if (this.warship.targetUnit()?.type() === UnitType.TradeShip) {
       this.huntDownTradeShip();
-      return;
+    } else {
+      this.patrol();
+
+      if (this.warship.targetUnit() !== undefined) {
+        this.shootTarget();
+      }
     }
 
-    this.patrol();
-
-    if (this.warship.targetUnit() !== undefined) {
-      this.shootTarget();
-      return;
-    }
+    this.handleAirDefense(ticks);
   }
 
   private findTargetUnit(): Unit | undefined {
@@ -231,6 +241,98 @@ export class WarshipExecution implements Execution {
 
   activeDuringSpawnPhase(): boolean {
     return false;
+  }
+
+  private handleAirDefense(ticks: number) {
+    if (this.warship.level() <= 1) {
+      return;
+    }
+
+    if (this.warship.isInCooldown()) {
+      const frontTime = this.warship.missileTimerQueue()[0];
+      if (frontTime === undefined) {
+        return;
+      }
+      const cooldown =
+        this.mg.config().SAMCooldown() - (this.mg.ticks() - frontTime);
+      if (cooldown <= 0) {
+        this.warship.reloadMissile();
+      }
+      return;
+    }
+
+    this.airDefenseTargetingSystem ??= new AirDefenseTargetingSystem(
+      this.mg,
+      this.warship,
+      (unit, interceptor, game) => {
+        const dst = unit.targetTile();
+        if (dst === undefined || !game.isOcean(dst)) {
+          return false;
+        }
+        const range = game.config().samRange(interceptor.level());
+        return (
+          game.euclideanDistSquared(interceptor.tile(), dst) <= range * range
+        );
+      },
+    );
+
+    const mirvWarheadTargets = findMirvWarheadTargets(
+      this.mg,
+      this.warship,
+      (unit, interceptor, game) => {
+        const dst = unit.targetTile();
+        return (
+          dst !== undefined &&
+          game.isOcean(dst) &&
+          game.manhattanDist(dst, interceptor.tile()) <
+            this.MIRVWarheadProtectionRadius
+        );
+      },
+      this.MIRVWarheadSearchRadius,
+    );
+
+    let target: AirDefenseTarget | null = null;
+    if (mirvWarheadTargets.length === 0) {
+      target = this.airDefenseTargetingSystem.getSingleTarget(ticks);
+    }
+
+    if (target === null && mirvWarheadTargets.length === 0) {
+      return;
+    }
+
+    this.warship.launch();
+
+    if (mirvWarheadTargets.length > 0) {
+      const owner = this.warship.owner();
+      this.mg.displayMessage(
+        "events_display.mirv_warheads_intercepted",
+        MessageType.SAM_HIT,
+        owner.id(),
+        undefined,
+        { count: mirvWarheadTargets.length },
+      );
+
+      mirvWarheadTargets.forEach(({ unit }) => unit.delete());
+      this.mg
+        .stats()
+        .bombIntercept(owner, UnitType.MIRVWarhead, mirvWarheadTargets.length);
+      return;
+    }
+
+    if (target === null) {
+      return;
+    }
+
+    target.unit.setTargetedBySAM(true);
+    this.mg.addExecution(
+      new SAMMissileExecution(
+        this.warship.tile(),
+        this.warship.owner(),
+        this.warship,
+        target.unit,
+        target.tile,
+      ),
+    );
   }
 
   randomTile(allowShoreline: boolean = false): TileRef | undefined {

--- a/src/core/execution/utils/AirDefenseUtils.ts
+++ b/src/core/execution/utils/AirDefenseUtils.ts
@@ -1,0 +1,239 @@
+import { Game, isUnit, Player, Unit, UnitType } from "../../game/Game";
+import { TileRef } from "../../game/GameMap";
+
+export type AirDefenseTarget = {
+  unit: Unit;
+  tile: TileRef;
+};
+
+type InterceptionTile = {
+  tile: TileRef;
+  tick: number;
+};
+
+export type AirDefenseUnitFilter = (
+  unit: Unit,
+  interceptor: Unit,
+  game: Game,
+) => boolean;
+
+function canTargetEnemyAirUnit(
+  owner: Player,
+  threat: Unit,
+  game: Game,
+): boolean {
+  if (threat.owner() === owner) {
+    return false;
+  }
+
+  const threatOwner = threat.owner();
+
+  // After game-over in team games, air defense also targets teammate threats.
+  if (owner.isFriendly(threatOwner)) {
+    return game.getWinner() !== null && owner.isOnSameTeam(threatOwner);
+  }
+
+  return true;
+}
+
+export class AirDefenseTargetingSystem {
+  // Interception tiles are computed once and reused until either the threat leaves
+  // the search area or the interceptor changes tile/level.
+  private readonly precomputedNukes: Map<number, InterceptionTile | null> =
+    new Map();
+  private readonly missileSpeed: number;
+  private lastInterceptorOwnerId: string | null = null;
+  private lastInterceptorTile: TileRef | null = null;
+  private lastInterceptorLevel: number | null = null;
+
+  constructor(
+    private readonly mg: Game,
+    private readonly interceptor: Unit,
+    private readonly unitFilter?: AirDefenseUnitFilter,
+  ) {
+    this.missileSpeed = this.mg.config().defaultSamMissileSpeed();
+  }
+
+  private resetIfInterceptorChanged() {
+    const ownerId = this.interceptor.owner().id();
+    const tile = this.interceptor.tile();
+    const level = this.interceptor.level();
+    if (
+      this.lastInterceptorOwnerId === ownerId &&
+      this.lastInterceptorTile === tile &&
+      this.lastInterceptorLevel === level
+    ) {
+      return;
+    }
+
+    this.lastInterceptorOwnerId = ownerId;
+    this.lastInterceptorTile = tile;
+    this.lastInterceptorLevel = level;
+    this.precomputedNukes.clear();
+  }
+
+  private updateUnreachableNukes(
+    nearbyUnits: { unit: Unit; distSquared: number }[],
+  ) {
+    if (this.precomputedNukes.size === 0) {
+      return;
+    }
+
+    if (this.precomputedNukes.size <= 16) {
+      for (const nukeId of this.precomputedNukes.keys()) {
+        let found = false;
+        for (const u of nearbyUnits) {
+          if (u.unit.id() === nukeId) {
+            found = true;
+            break;
+          }
+        }
+        if (!found) {
+          this.precomputedNukes.delete(nukeId);
+        }
+      }
+      return;
+    }
+
+    const nearbyUnitSet = new Set<number>();
+    for (const u of nearbyUnits) {
+      nearbyUnitSet.add(u.unit.id());
+    }
+    for (const nukeId of this.precomputedNukes.keys()) {
+      if (!nearbyUnitSet.has(nukeId)) {
+        this.precomputedNukes.delete(nukeId);
+      }
+    }
+  }
+
+  private tickToReach(currentTile: TileRef, tile: TileRef): number {
+    return Math.ceil(
+      this.mg.manhattanDist(currentTile, tile) / this.missileSpeed,
+    );
+  }
+
+  private computeInterceptionTile(
+    unit: Unit,
+    interceptorTile: TileRef,
+    rangeSquared: number,
+  ): InterceptionTile | undefined {
+    const trajectory = unit.trajectory();
+    const currentIndex = unit.trajectoryIndex();
+    const explosionTick = trajectory.length - currentIndex;
+    for (let i = currentIndex; i < trajectory.length; i++) {
+      const trajectoryTile = trajectory[i];
+      if (
+        trajectoryTile.targetable &&
+        this.mg.euclideanDistSquared(interceptorTile, trajectoryTile.tile) <=
+          rangeSquared
+      ) {
+        const nukeTickToReach = i - currentIndex;
+        const samTickToReach = this.tickToReach(
+          interceptorTile,
+          trajectoryTile.tile,
+        );
+        const tickBeforeShooting = nukeTickToReach - samTickToReach;
+        if (samTickToReach < explosionTick && tickBeforeShooting >= 0) {
+          return { tick: tickBeforeShooting, tile: trajectoryTile.tile };
+        }
+      }
+    }
+    return undefined;
+  }
+
+  public getSingleTarget(ticks: number): AirDefenseTarget | null {
+    this.resetIfInterceptorChanged();
+
+    const interceptorTile = this.interceptor.tile();
+    const range = this.mg.config().samRange(this.interceptor.level());
+    const rangeSquared = range * range;
+
+    const detectionRange = this.mg.config().maxSamRange() * 2;
+    const nukes = this.mg.nearbyUnits(
+      interceptorTile,
+      detectionRange,
+      [UnitType.AtomBomb, UnitType.HydrogenBomb],
+      ({ unit }) => {
+        if (!isUnit(unit) || unit.targetedBySAM()) return false;
+        if (!canTargetEnemyAirUnit(this.interceptor.owner(), unit, this.mg)) {
+          return false;
+        }
+        return this.unitFilter?.(unit, this.interceptor, this.mg) ?? true;
+      },
+    );
+
+    this.updateUnreachableNukes(nukes);
+
+    let best: AirDefenseTarget | null = null;
+    for (const nuke of nukes) {
+      const nukeId = nuke.unit.id();
+      const cached = this.precomputedNukes.get(nukeId);
+      if (cached !== undefined) {
+        if (cached === null) {
+          continue;
+        }
+        if (cached.tick === ticks) {
+          const target = { tile: cached.tile, unit: nuke.unit };
+          if (
+            best === null ||
+            (target.unit.type() === UnitType.HydrogenBomb &&
+              best.unit.type() !== UnitType.HydrogenBomb)
+          ) {
+            best = target;
+          }
+          this.precomputedNukes.delete(nukeId);
+          continue;
+        }
+        if (cached.tick > ticks) {
+          continue;
+        }
+        this.precomputedNukes.delete(nukeId);
+      }
+
+      const interceptionTile = this.computeInterceptionTile(
+        nuke.unit,
+        interceptorTile,
+        rangeSquared,
+      );
+      if (interceptionTile !== undefined) {
+        if (interceptionTile.tick <= 1) {
+          const target = { unit: nuke.unit, tile: interceptionTile.tile };
+          if (
+            best === null ||
+            (target.unit.type() === UnitType.HydrogenBomb &&
+              best.unit.type() !== UnitType.HydrogenBomb)
+          ) {
+            best = target;
+          }
+        } else {
+          this.precomputedNukes.set(nukeId, {
+            tick: interceptionTile.tick + ticks,
+            tile: interceptionTile.tile,
+          });
+        }
+      } else {
+        this.precomputedNukes.set(nukeId, null);
+      }
+    }
+
+    return best;
+  }
+}
+
+export function findMirvWarheadTargets(
+  mg: Game,
+  interceptor: Unit,
+  unitFilter?: AirDefenseUnitFilter,
+  searchRadius: number = 400,
+): Array<{ unit: Unit; distSquared: number }> {
+  return mg.nearbyUnits(
+    interceptor.tile(),
+    searchRadius,
+    UnitType.MIRVWarhead,
+    ({ unit }) => {
+      if (!isUnit(unit)) return false;
+      if (!canTargetEnemyAirUnit(interceptor.owner(), unit, mg)) return false;
+      return unitFilter?.(unit, interceptor, mg) ?? true;
+    },
+  );
+}

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -169,7 +169,8 @@ export class UnitView {
     let readiness = missilesReady / maxMissiles;
 
     const cooldownDuration =
-      this.data.unitType === UnitType.SAMLauncher
+      this.data.unitType === UnitType.SAMLauncher ||
+      this.data.unitType === UnitType.Warship
         ? this.gameView.config().SAMCooldown()
         : this.gameView.config().SiloCooldown();
 

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -453,7 +453,11 @@ export class UnitImpl implements Unit {
 
   increaseLevel(): void {
     this._level++;
-    if ([UnitType.MissileSilo, UnitType.SAMLauncher].includes(this.type())) {
+    if (
+      [UnitType.MissileSilo, UnitType.SAMLauncher, UnitType.Warship].includes(
+        this.type(),
+      )
+    ) {
       this._missileTimerQueue.push(this.mg.ticks());
     }
     this.mg.addUpdate(this.toUpdate());
@@ -461,7 +465,11 @@ export class UnitImpl implements Unit {
 
   decreaseLevel(destroyer?: Player): void {
     this._level--;
-    if ([UnitType.MissileSilo, UnitType.SAMLauncher].includes(this.type())) {
+    if (
+      [UnitType.MissileSilo, UnitType.SAMLauncher, UnitType.Warship].includes(
+        this.type(),
+      )
+    ) {
       this._missileTimerQueue.pop();
     }
     if (this._level <= 0) {

--- a/tests/Warship.test.ts
+++ b/tests/Warship.test.ts
@@ -1,4 +1,5 @@
 import { MoveWarshipExecution } from "../src/core/execution/MoveWarshipExecution";
+import { UpgradeStructureExecution } from "../src/core/execution/UpgradeStructureExecution";
 import { WarshipExecution } from "../src/core/execution/WarshipExecution";
 import {
   Game,
@@ -15,26 +16,132 @@ let game: Game;
 let player1: Player;
 let player2: Player;
 
+function buildWarship(
+  owner: Player,
+  tile = game.ref(coastX + 3, 10),
+  level = 1,
+) {
+  const warship = owner.buildUnit(UnitType.Warship, tile, {
+    patrolTile: tile,
+  });
+  for (let i = 1; i < level; i++) {
+    warship.increaseLevel();
+  }
+  game.addExecution(new WarshipExecution(warship));
+  return warship;
+}
+
+function buildShortNuke(
+  owner: Player,
+  type: UnitType.AtomBomb | UnitType.HydrogenBomb,
+  targetTile: number,
+) {
+  return owner.buildUnit(type, game.ref(coastX + 3, 8), {
+    targetTile,
+    trajectory: [
+      { tile: game.ref(coastX + 3, 8), targetable: true },
+      { tile: game.ref(coastX + 4, 9), targetable: true },
+      { tile: targetTile, targetable: true },
+    ],
+  });
+}
+
+async function setupGame(gameConfig: Parameters<typeof setup>[1] = {}) {
+  game = await setup(
+    "half_land_half_ocean",
+    {
+      infiniteGold: true,
+      instantBuild: true,
+      ...gameConfig,
+    },
+    [
+      new PlayerInfo("boat dude", PlayerType.Human, null, "player_1_id"),
+      new PlayerInfo("boat dude", PlayerType.Human, null, "player_2_id"),
+    ],
+  );
+
+  while (game.inSpawnPhase()) {
+    game.executeNextTick();
+  }
+
+  player1 = game.player("player_1_id");
+  player2 = game.player("player_2_id");
+}
+
 describe("Warship", () => {
   beforeEach(async () => {
-    game = await setup(
-      "half_land_half_ocean",
+    await setupGame();
+  });
+
+  test("Warship can be upgraded through buildables and upgrade execution", async () => {
+    await setupGame({ infiniteGold: false });
+    player1.addGold(1_000_000n);
+    player1.conquer(game.ref(coastX, 10));
+    player1.buildUnit(UnitType.Port, game.ref(coastX, 10), {});
+    const warship = player1.buildUnit(
+      UnitType.Warship,
+      game.ref(coastX + 3, 10),
       {
-        infiniteGold: true,
-        instantBuild: true,
+        patrolTile: game.ref(coastX + 3, 10),
       },
-      [
-        new PlayerInfo("boat dude", PlayerType.Human, null, "player_1_id"),
-        new PlayerInfo("boat dude", PlayerType.Human, null, "player_2_id"),
-      ],
     );
 
-    while (game.inSpawnPhase()) {
-      game.executeNextTick();
-    }
+    const buildable = player1
+      .buildableUnits(game.ref(coastX + 3, 10))
+      .find((bu) => bu.type === UnitType.Warship);
 
-    player1 = game.player("player_1_id");
-    player2 = game.player("player_2_id");
+    expect(buildable).toBeDefined();
+    expect(buildable!.canUpgrade).toBe(warship.id());
+
+    game.addExecution(new UpgradeStructureExecution(player1, warship.id()));
+    executeTicks(game, 2);
+
+    expect(warship.level()).toBe(2);
+  });
+
+  test("Warship upgrade is blocked when too far, under construction, marked for deletion, or unaffordable", async () => {
+    await setupGame({ infiniteGold: false });
+    player1.addGold(1_000_000n);
+    player1.conquer(game.ref(coastX, 10));
+    player1.buildUnit(UnitType.Port, game.ref(coastX, 10), {});
+    const nearbyWarship = player1.buildUnit(
+      UnitType.Warship,
+      game.ref(coastX + 3, 10),
+      {
+        patrolTile: game.ref(coastX + 3, 10),
+      },
+    );
+    expect(
+      player1.findUnitToUpgrade(UnitType.Warship, game.ref(coastX + 3, 10)),
+    ).toBe(nearbyWarship);
+    game.config().structureMinDist = () => 1;
+    expect(
+      player1.findUnitToUpgrade(UnitType.Warship, game.ref(coastX + 3, 12)),
+    ).toBe(false);
+
+    nearbyWarship.setUnderConstruction(true);
+    expect(
+      player1.findUnitToUpgrade(UnitType.Warship, game.ref(coastX + 3, 10)),
+    ).toBe(false);
+    nearbyWarship.setUnderConstruction(false);
+
+    nearbyWarship.markForDeletion();
+    expect(
+      player1.findUnitToUpgrade(UnitType.Warship, game.ref(coastX + 3, 10)),
+    ).toBe(false);
+
+    const unaffordableWarship = player1.buildUnit(
+      UnitType.Warship,
+      game.ref(coastX + 6, 10),
+      {
+        patrolTile: game.ref(coastX + 6, 10),
+      },
+    );
+
+    player1.removeGold(player1.gold());
+    expect(
+      player1.findUnitToUpgrade(UnitType.Warship, unaffordableWarship.tile()),
+    ).toBe(false);
   });
 
   test("Warship heals only if player has port", async () => {
@@ -198,6 +305,121 @@ describe("Warship", () => {
 
     // Trade ship should not be captured
     expect(tradeShip.owner().id()).toBe(player2.id());
+  });
+
+  test("Level 1 warship does not intercept sea-targeted nukes", async () => {
+    game.config().warshipPatrolRange = () => 0;
+    buildWarship(player1);
+
+    const nuke = buildShortNuke(
+      player2,
+      UnitType.AtomBomb,
+      game.ref(coastX + 5, 10),
+    );
+
+    executeTicks(game, 3);
+
+    expect(nuke.isActive()).toBe(true);
+  });
+
+  test.each([UnitType.AtomBomb, UnitType.HydrogenBomb] as const)(
+    "Level 2 warship intercepts %s aimed at sea",
+    async (nukeType) => {
+      game.config().warshipPatrolRange = () => 0;
+      buildWarship(player1, game.ref(coastX + 3, 10), 2);
+
+      const nuke = buildShortNuke(player2, nukeType, game.ref(coastX + 5, 10));
+
+      executeTicks(game, 3);
+
+      expect(nuke.isActive()).toBe(false);
+    },
+  );
+
+  test("Level 2 warship ignores land-targeted nukes", async () => {
+    game.config().warshipPatrolRange = () => 0;
+    buildWarship(player1, game.ref(coastX + 3, 10), 2);
+
+    const nuke = buildShortNuke(
+      player2,
+      UnitType.AtomBomb,
+      game.ref(coastX, 10),
+    );
+
+    executeTicks(game, 3);
+
+    expect(nuke.isActive()).toBe(true);
+  });
+
+  test("Two upgraded warships do not target the same nuke twice", async () => {
+    game.config().warshipPatrolRange = () => 0;
+    const warship1 = buildWarship(player1, game.ref(coastX + 3, 10), 2);
+    const warship2 = buildWarship(player1, game.ref(coastX + 3, 11), 2);
+
+    const nuke = buildShortNuke(
+      player2,
+      UnitType.AtomBomb,
+      game.ref(coastX + 5, 10),
+    );
+
+    executeTicks(game, 3);
+
+    expect(nuke.isActive()).toBe(false);
+    expect([warship1, warship2].filter((w) => w.isInCooldown())).toHaveLength(
+      1,
+    );
+  });
+
+  test("Upgraded warship uses SAM cooldown timing after intercepting", async () => {
+    game.config().warshipPatrolRange = () => 0;
+    const warship = buildWarship(player1, game.ref(coastX + 3, 10), 2);
+
+    const nuke = buildShortNuke(
+      player2,
+      UnitType.AtomBomb,
+      game.ref(coastX + 5, 10),
+    );
+
+    executeTicks(game, 3);
+
+    expect(nuke.isActive()).toBe(false);
+    expect(warship.isInCooldown()).toBe(true);
+
+    for (let i = 0; i < game.config().SAMCooldown() - 3; i++) {
+      game.executeNextTick();
+      expect(warship.isInCooldown()).toBe(true);
+    }
+
+    executeTicks(game, 2);
+
+    expect(warship.isInCooldown()).toBe(false);
+  });
+
+  test("Level 2 warship intercepts sea-targeted MIRV warheads", async () => {
+    game.config().warshipPatrolRange = () => 0;
+    const warship = buildWarship(player1, game.ref(coastX + 3, 10), 2);
+    const seaTarget = game.ref(coastX + 4, 10);
+
+    const warhead1 = player2.buildUnit(
+      UnitType.MIRVWarhead,
+      game.ref(coastX + 6, 10),
+      {
+        targetTile: seaTarget,
+      },
+    );
+    const warhead2 = player2.buildUnit(
+      UnitType.MIRVWarhead,
+      game.ref(coastX + 6, 11),
+      {
+        targetTile: seaTarget,
+      },
+    );
+
+    executeTicks(game, 2);
+
+    expect(warhead1.isActive()).toBe(false);
+    expect(warhead2.isActive()).toBe(false);
+    expect(warship.isInCooldown()).toBe(true);
   });
 
   test("MoveWarshipExecution fails if player is not the owner", async () => {

--- a/tests/client/graphics/layers/NukeTrajectoryPreviewLayer.test.ts
+++ b/tests/client/graphics/layers/NukeTrajectoryPreviewLayer.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "vitest";
+import { NukeTrajectoryPreviewLayer } from "../../../../src/client/graphics/layers/NukeTrajectoryPreviewLayer";
+import { UnitType } from "../../../../src/core/game/Game";
+
+function createLayer(isOcean: boolean) {
+  return new NukeTrajectoryPreviewLayer(
+    {
+      config: () => ({
+        samRange: () => 10,
+      }),
+      euclideanDistSquared: () => 25,
+      isOcean: () => isOcean,
+      myPlayer: () => ({
+        isFriendly: () => false,
+      }),
+    } as any,
+    {} as any,
+    {} as any,
+    {} as any,
+  );
+}
+
+function mockWarship(level: number) {
+  return {
+    level: () => level,
+    owner: () => ({
+      isMe: () => false,
+      smallID: () => 2,
+    }),
+    tile: () => 42,
+    type: () => UnitType.Warship,
+  };
+}
+
+describe("NukeTrajectoryPreviewLayer", () => {
+  test("predicts interception by upgraded warships for sea targets", () => {
+    const layer = createLayer(true) as any;
+
+    expect(
+      layer.canBeInterceptedByAirDefense(
+        mockWarship(2),
+        25,
+        84,
+        new Set<number>(),
+      ),
+    ).toBe(true);
+  });
+
+  test("ignores upgraded warships for land targets", () => {
+    const layer = createLayer(false) as any;
+
+    expect(
+      layer.canBeInterceptedByAirDefense(
+        mockWarship(2),
+        25,
+        84,
+        new Set<number>(),
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/client/graphics/layers/SAMRadiusLayer.test.ts
+++ b/tests/client/graphics/layers/SAMRadiusLayer.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test, vi } from "vitest";
+import { SAMRadiusLayer } from "../../../../src/client/graphics/layers/SAMRadiusLayer";
+import { UnitType } from "../../../../src/core/game/Game";
+
+function mockAirDefenseUnit(type: UnitType, level: number, tile = 42) {
+  return {
+    id: () => 100 + level,
+    isActive: () => true,
+    level: () => level,
+    owner: () => ({ smallID: () => 1 }),
+    tile: () => tile,
+    type: () => type,
+  };
+}
+
+describe("SAMRadiusLayer", () => {
+  test("includes upgraded warships in air-defense ranges", () => {
+    const layer = new SAMRadiusLayer(
+      {
+        config: () => ({
+          samRange: vi.fn((level: number) => level * 10),
+        }),
+        units: vi.fn(() => [mockAirDefenseUnit(UnitType.Warship, 2)]),
+        x: vi.fn(() => 12),
+        y: vi.fn(() => 24),
+      } as any,
+      { on: vi.fn() } as any,
+      {} as any,
+    );
+
+    const ranges = (layer as any).getAllAirDefenseRanges();
+
+    expect(ranges).toHaveLength(1);
+    expect(ranges[0]).toMatchObject({ x: 12, y: 24, r: 20 });
+  });
+
+  test("excludes level 1 warships from air-defense ranges", () => {
+    const layer = new SAMRadiusLayer(
+      {
+        config: () => ({
+          samRange: vi.fn((level: number) => level * 10),
+        }),
+        units: vi.fn(() => [mockAirDefenseUnit(UnitType.Warship, 1)]),
+        x: vi.fn(() => 12),
+        y: vi.fn(() => 24),
+      } as any,
+      { on: vi.fn() } as any,
+      {} as any,
+    );
+
+    const ranges = (layer as any).getAllAirDefenseRanges();
+
+    expect(ranges).toHaveLength(0);
+  });
+
+  test("redraws when an upgraded warship moves", () => {
+    const layer = new SAMRadiusLayer(
+      {
+        config: () => ({
+          samRange: vi.fn((level: number) => level * 10),
+        }),
+        units: vi.fn(() => [mockAirDefenseUnit(UnitType.Warship, 2, 42)]),
+        x: vi.fn(() => 12),
+        y: vi.fn(() => 24),
+      } as any,
+      { on: vi.fn() } as any,
+      {} as any,
+    );
+
+    (layer as any).getAllAirDefenseRanges();
+
+    expect(
+      (layer as any).hasChanged(mockAirDefenseUnit(UnitType.Warship, 2, 84)),
+    ).toBe(true);
+  });
+});

--- a/tests/client/graphics/layers/UnitDisplay.test.ts
+++ b/tests/client/graphics/layers/UnitDisplay.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { UnitDisplay } from "../../../../src/client/graphics/layers/UnitDisplay";
+import { UnitType } from "../../../../src/core/game/Game";
+
+describe("UnitDisplay hoverStructureTypes", () => {
+  const unitDisplay = new UnitDisplay() as any;
+
+  test("shows port and naval AA context when hovering warships", () => {
+    expect(unitDisplay.hoverStructureTypes(UnitType.Warship)).toEqual([
+      UnitType.Port,
+      UnitType.Warship,
+    ]);
+  });
+
+  test("shows silo and SAM context when hovering standard nukes", () => {
+    expect(unitDisplay.hoverStructureTypes(UnitType.AtomBomb)).toEqual([
+      UnitType.MissileSilo,
+      UnitType.SAMLauncher,
+    ]);
+    expect(unitDisplay.hoverStructureTypes(UnitType.HydrogenBomb)).toEqual([
+      UnitType.MissileSilo,
+      UnitType.SAMLauncher,
+    ]);
+  });
+});


### PR DESCRIPTION
## Description:

- Make warships upgradable and give level 2+ warships SAM-style interception against sea-targeted nukes.
- Share air-defense targeting logic between SAM launchers and upgraded warships, including MIRV warhead handling.
- Update client air-defense visuals and nuke trajectory preview to include upgraded warships.
- No new user-facing strings were added.
- Verified locally with `npm test` and `npm run build-prod`.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Just reply here