### PR TITLE
Fix: prevent 2-3 public lobbies showing the same map/max players/number of teams

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -167,7 +167,7 @@ export class MapPlaylist {
       }
 
       this.firstMapToLast(type);
-    } while (true);
+    } while (true); // eslint-disable-line no-constant-condition
   }
 
   private async buildConfig(

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -156,9 +156,14 @@ export class MapPlaylist {
     const maxAttempts = 6;
     let attempts = 0;
 
+    // Capture playlist length because isCompact decision depends on it in buildConfig, and
+    // cycleNextMap could modify playlist length via generateNewPlaylist
+    this.ensurePlaylistPopulated(type);
+    const playlistLength = this.playlists[type].length;
+
     while (true) {
       const map = this.peekNextMap(type);
-      const config = await this.buildConfig(type, map);
+      const config = await this.buildConfig(type, map, playlistLength);
       attempts++;
 
       if (notInUse(config) || attempts >= maxAttempts) {
@@ -173,6 +178,7 @@ export class MapPlaylist {
   private async buildConfig(
     type: PublicGameType,
     map: GameMapType,
+    playlistLength: number = this.playlists[type].length,
   ): Promise<GameConfig> {
     if (type === "special") {
       return this.buildSpecialConfig(map);
@@ -182,8 +188,7 @@ export class MapPlaylist {
     const playerTeams =
       mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
-    let isCompact: boolean | undefined =
-      this.playlists[type].length % 3 === 0 || undefined;
+    let isCompact: boolean | undefined = playlistLength % 3 === 0 || undefined;
     if (
       isCompact &&
       mode === GameMode.Team &&

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -156,7 +156,7 @@ export class MapPlaylist {
     const maxAttempts = 6;
     let attempts = 0;
 
-    do {
+    while (true) {
       const map = this.tryFirstMap(type);
       const config = await this.buildConfig(type, map);
       attempts++;
@@ -167,7 +167,7 @@ export class MapPlaylist {
       }
 
       this.firstMapToLast(type);
-    } while (true); // eslint-disable-line no-constant-condition
+    }
   }
 
   private async buildConfig(

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -149,14 +149,36 @@ export class MapPlaylist {
     team: [],
   };
 
-  public async gameConfig(type: PublicGameType): Promise<GameConfig> {
+  public async gameConfigNotInUse(
+    type: PublicGameType,
+    isInUse: (config: GameConfig) => boolean,
+  ): Promise<GameConfig> {
+    const maxAttempts = 6;
+    let attempts = 0;
+
+    do {
+      const map = this.tryFirstMap(type);
+      const config = await this.buildConfig(type, map);
+      attempts++;
+
+      if (!isInUse(config) || attempts >= maxAttempts) {
+        this.useFirstMap(type);
+        return config;
+      }
+
+      this.firstMapToLast(type);
+    } while (true);
+  }
+
+  private async buildConfig(
+    type: PublicGameType,
+    map: GameMapType,
+  ): Promise<GameConfig> {
     if (type === "special") {
-      return this.getSpecialConfig();
+      return this.buildSpecialConfig(map);
     }
 
     const mode = type === "ffa" ? GameMode.FFA : GameMode.Team;
-    const map = this.getNextMap(type);
-
     const playerTeams =
       mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
@@ -199,9 +221,8 @@ export class MapPlaylist {
     } satisfies GameConfig;
   }
 
-  private async getSpecialConfig(): Promise<GameConfig> {
+  private async buildSpecialConfig(map: GameMapType): Promise<GameConfig> {
     const mode = Math.random() < 0.5 ? GameMode.FFA : GameMode.Team;
-    const map = this.getNextMap("special");
     const playerTeams =
       mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
@@ -401,12 +422,22 @@ export class MapPlaylist {
     } satisfies GameConfig;
   }
 
-  private getNextMap(type: PublicGameType): GameMapType {
+  private tryFirstMap(type: PublicGameType): GameMapType {
     const playlist = this.playlists[type];
     if (playlist.length === 0) {
       playlist.push(...this.generateNewPlaylist(type));
     }
-    return playlist.shift()!;
+    return playlist[0];
+  }
+
+  private useFirstMap(type: PublicGameType): GameMapType {
+    this.tryFirstMap(type); // Ensure this.playlists[type] is populated
+    return this.playlists[type].shift()!;
+  }
+
+  private firstMapToLast(type: PublicGameType): void {
+    this.tryFirstMap(type);
+    this.playlists[type].push(this.playlists[type].shift()!);
   }
 
   private generateNewPlaylist(type: PublicGameType): GameMapType[] {

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -151,7 +151,7 @@ export class MapPlaylist {
 
   public async gameConfigNotInUse(
     type: PublicGameType,
-    isInUse: (config: GameConfig) => boolean,
+    notInUse: (config: GameConfig) => boolean,
   ): Promise<GameConfig> {
     const maxAttempts = 6;
     let attempts = 0;
@@ -161,7 +161,7 @@ export class MapPlaylist {
       const config = await this.buildConfig(type, map);
       attempts++;
 
-      if (!isInUse(config) || attempts >= maxAttempts) {
+      if (notInUse(config) || attempts >= maxAttempts) {
         this.consumeNextMap(type);
         return config;
       }

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -157,16 +157,16 @@ export class MapPlaylist {
     let attempts = 0;
 
     while (true) {
-      const map = this.tryFirstMap(type);
+      const map = this.peekNextMap(type);
       const config = await this.buildConfig(type, map);
       attempts++;
 
       if (!isInUse(config) || attempts >= maxAttempts) {
-        this.useFirstMap(type);
+        this.consumeNextMap(type);
         return config;
       }
 
-      this.firstMapToLast(type);
+      this.cycleNextMap(type);
     }
   }
 
@@ -422,22 +422,29 @@ export class MapPlaylist {
     } satisfies GameConfig;
   }
 
-  private tryFirstMap(type: PublicGameType): GameMapType {
-    const playlist = this.playlists[type];
-    if (playlist.length === 0) {
-      playlist.push(...this.generateNewPlaylist(type));
+  private ensurePlaylistPopulated(type: PublicGameType): void {
+    if (this.playlists[type].length === 0) {
+      this.playlists[type].push(...this.generateNewPlaylist(type));
     }
-    return playlist[0];
   }
 
-  private useFirstMap(type: PublicGameType): GameMapType {
-    this.tryFirstMap(type); // Ensure this.playlists[type] is populated
+  private peekNextMap(type: PublicGameType): GameMapType {
+    this.ensurePlaylistPopulated(type);
+    return this.playlists[type][0];
+  }
+
+  private consumeNextMap(type: PublicGameType): GameMapType {
+    this.ensurePlaylistPopulated(type);
     return this.playlists[type].shift()!;
   }
 
-  private firstMapToLast(type: PublicGameType): void {
-    this.tryFirstMap(type);
-    this.playlists[type].push(this.playlists[type].shift()!);
+  private cycleNextMap(type: PublicGameType): void {
+    this.ensurePlaylistPopulated(type);
+    const map = this.playlists[type].shift()!;
+
+    if (!this.addNextMapNonConsecutive(this.playlists[type], [map])) {
+      this.playlists[type].push(...this.generateNewPlaylist(type));
+    }
   }
 
   private generateNewPlaylist(type: PublicGameType): GameMapType[] {

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -439,8 +439,7 @@ export class MapPlaylist {
   }
 
   private cycleNextMap(type: PublicGameType): void {
-    this.ensurePlaylistPopulated(type);
-    const map = this.playlists[type].shift()!;
+    const map = this.consumeNextMap(type);
 
     if (!this.addNextMapNonConsecutive(this.playlists[type], [map])) {
       this.playlists[type].push(...this.generateNewPlaylist(type));

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -134,17 +134,17 @@ export class MasterLobbyService {
     const lobbiesByType = this.getAllLobbies();
     const lobbyTypes = Object.keys(lobbiesByType) as PublicGameType[];
 
-    const usedMaps = new Set<string>();
-    const usedTeamTypes = new Set<string>();
-    const usedMaxPlayers = new Set<number>();
+    const inUseMaps = new Set<string>();
+    const inUseNumTeams = new Set<string>();
+    const inUseMaxPlayers = new Set<number>();
 
     const recordInUse = (config: GameConfig) => {
-      usedMaps.add(config.gameMap);
+      inUseMaps.add(config.gameMap);
       if (config.playerTeams !== undefined) {
-        usedTeamTypes.add(String(config.playerTeams));
+        inUseNumTeams.add(String(config.playerTeams));
       }
       if (config.maxPlayers !== undefined) {
-        usedMaxPlayers.add(config.maxPlayers);
+        inUseMaxPlayers.add(config.maxPlayers);
       }
     };
 
@@ -177,16 +177,16 @@ export class MasterLobbyService {
       }
 
       const gameConfig = await this.playlist.gameConfigNotInUse(type, (c) => {
-        if (usedMaps.has(c.gameMap)) return false;
+        if (inUseMaps.has(c.gameMap)) return false;
 
         if (
           c.playerTeams !== undefined &&
-          usedTeamTypes.has(String(c.playerTeams))
+          inUseNumTeams.has(String(c.playerTeams))
         ) {
           return false;
         }
 
-        if (c.maxPlayers !== undefined && usedMaxPlayers.has(c.maxPlayers)) {
+        if (c.maxPlayers !== undefined && inUseMaxPlayers.has(c.maxPlayers)) {
           return false;
         }
 

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -177,20 +177,20 @@ export class MasterLobbyService {
       }
 
       const gameConfig = await this.playlist.gameConfigNotInUse(type, (c) => {
-        if (usedMaps.has(c.gameMap)) return true;
+        if (usedMaps.has(c.gameMap)) return false;
 
         if (
           c.playerTeams !== undefined &&
           usedTeamTypes.has(String(c.playerTeams))
         ) {
-          return true;
+          return false;
         }
 
         if (c.maxPlayers !== undefined && usedMaxPlayers.has(c.maxPlayers)) {
-          return true;
+          return false;
         }
 
-        return false;
+        return true;
       });
 
       recordInUse(gameConfig);

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -1,7 +1,7 @@
 import { Worker } from "cluster";
 import winston from "winston";
 import { ServerConfig } from "../core/configuration/Config";
-import { GameConfig, PublicGameInfo, PublicGameType } from "../core/Schemas";
+import { PublicGameInfo, PublicGameType } from "../core/Schemas";
 import { generateID } from "../core/Util";
 import {
   MasterCreateGame,
@@ -132,31 +132,24 @@ export class MasterLobbyService {
 
   private async maybeScheduleLobby() {
     const lobbiesByType = this.getAllLobbies();
-    const lobbyTypes = Object.keys(lobbiesByType) as PublicGameType[];
 
-    const inUseMaps = new Set<string>();
-    const inUseNumTeams = new Set<string>();
-    const inUseMaxPlayers = new Set<number>();
+    const activeConfigs = Object.values(lobbiesByType)
+      .map((lobbies) => lobbies[0]?.gameConfig)
+      .filter((c) => c !== undefined);
 
-    const recordInUse = (config: GameConfig) => {
-      inUseMaps.add(config.gameMap);
-      if (config.playerTeams !== undefined) {
-        inUseNumTeams.add(String(config.playerTeams));
-      }
-      if (config.maxPlayers !== undefined) {
-        inUseMaxPlayers.add(config.maxPlayers);
-      }
-    };
+    const activeMaps = new Set(activeConfigs.map((c) => c.gameMap));
+    const activeNumTeams = new Set(
+      activeConfigs
+        .filter((c) => c.playerTeams !== undefined)
+        .map((c) => String(c.playerTeams)),
+    );
+    const activeMaxPlayers = new Set(
+      activeConfigs
+        .filter((c) => c.maxPlayers !== undefined)
+        .map((c) => c.maxPlayers),
+    );
 
-    for (const type of lobbyTypes) {
-      const lobbies = lobbiesByType[type];
-      const nextLobby = lobbies[0];
-      if (nextLobby && nextLobby.gameConfig) {
-        recordInUse(nextLobby.gameConfig);
-      }
-    }
-
-    for (const type of lobbyTypes) {
+    for (const type of Object.keys(lobbiesByType) as PublicGameType[]) {
       const lobbies = lobbiesByType[type];
 
       // Always ensure the next lobby has a timer, even if we already have 2+
@@ -177,23 +170,29 @@ export class MasterLobbyService {
       }
 
       const gameConfig = await this.playlist.gameConfigNotInUse(type, (c) => {
-        if (inUseMaps.has(c.gameMap)) return false;
+        if (activeMaps.has(c.gameMap)) return false;
 
         if (
           c.playerTeams !== undefined &&
-          inUseNumTeams.has(String(c.playerTeams))
+          activeNumTeams.has(String(c.playerTeams))
         ) {
           return false;
         }
 
-        if (c.maxPlayers !== undefined && inUseMaxPlayers.has(c.maxPlayers)) {
+        if (c.maxPlayers !== undefined && activeMaxPlayers.has(c.maxPlayers)) {
           return false;
         }
 
         return true;
       });
 
-      recordInUse(gameConfig);
+      activeMaps.add(gameConfig.gameMap);
+      if (gameConfig.playerTeams !== undefined) {
+        activeNumTeams.add(String(gameConfig.playerTeams));
+      }
+      if (gameConfig.maxPlayers !== undefined) {
+        activeMaxPlayers.add(gameConfig.maxPlayers);
+      }
 
       this.sendMessageToWorker({
         type: "createGame",

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -1,7 +1,7 @@
 import { Worker } from "cluster";
 import winston from "winston";
 import { ServerConfig } from "../core/configuration/Config";
-import { PublicGameInfo, PublicGameType } from "../core/Schemas";
+import { GameConfig, PublicGameInfo, PublicGameType } from "../core/Schemas";
 import { generateID } from "../core/Util";
 import {
   MasterCreateGame,
@@ -132,14 +132,33 @@ export class MasterLobbyService {
 
   private async maybeScheduleLobby() {
     const lobbiesByType = this.getAllLobbies();
+    const lobbyTypes = Object.keys(lobbiesByType) as PublicGameType[];
 
-    for (const type of Object.keys(lobbiesByType) as PublicGameType[]) {
+    const usedMaps = new Set<string>();
+    const usedTeamTypes = new Set<string>();
+    const usedMaxPlayers = new Set<number>();
+
+    const recordInUse = (config: GameConfig) => {
+      usedMaps.add(config.gameMap);
+      if (config.playerTeams !== undefined) {
+        usedTeamTypes.add(String(config.playerTeams));
+      }
+      if (config.maxPlayers !== undefined) {
+        usedMaxPlayers.add(config.maxPlayers);
+      }
+    };
+
+    for (const type of lobbyTypes) {
+      const lobbies = lobbiesByType[type];
+      const nextLobby = lobbies[0];
+      if (nextLobby && nextLobby.gameConfig) {
+        recordInUse(nextLobby.gameConfig);
+      }
+    }
+
+    for (const type of lobbyTypes) {
       const lobbies = lobbiesByType[type];
 
-      // Always ensure the next lobby has a timer, even if we already have 2+
-      // lobbies. This prevents a race where two lobbies are created before
-      // either receives a startsAt (IPC round-trip delay), leaving both stuck
-      // without a countdown.
       const nextLobby = lobbies[0];
       if (nextLobby && nextLobby.startsAt === undefined) {
         this.sendMessageToWorker({
@@ -153,10 +172,29 @@ export class MasterLobbyService {
         continue;
       }
 
+      const gameConfig = await this.playlist.gameConfigNotInUse(type, (c) => {
+        if (usedMaps.has(c.gameMap)) return true;
+
+        if (
+          c.playerTeams !== undefined &&
+          usedTeamTypes.has(String(c.playerTeams))
+        ) {
+          return true;
+        }
+
+        if (c.maxPlayers !== undefined && usedMaxPlayers.has(c.maxPlayers)) {
+          return true;
+        }
+
+        return false;
+      });
+
+      recordInUse(gameConfig);
+
       this.sendMessageToWorker({
         type: "createGame",
         gameID: generateID(),
-        gameConfig: await this.playlist.gameConfig(type),
+        gameConfig,
         publicGameType: type,
       } satisfies MasterCreateGame);
     }

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -159,6 +159,10 @@ export class MasterLobbyService {
     for (const type of lobbyTypes) {
       const lobbies = lobbiesByType[type];
 
+      // Always ensure the next lobby has a timer, even if we already have 2+
+      // lobbies. This prevents a race where two lobbies are created before
+      // either receives a startsAt (IPC round-trip delay), leaving both stuck
+      // without a countdown.
       const nextLobby = lobbies[0];
       if (nextLobby && nextLobby.startsAt === undefined) {
         this.sendMessageToWorker({


### PR DESCRIPTION
## Description:

Try to prevent two or three of the public lobbies having the same map/number of players/number of teams. Six tries max before it just goes with what is has. We could make it e.g. three tries if six is two much. 

Because it is (relatively) quite frequently happening that public lobbies have:

- one map showing up in two or even three lobbies at the same time. For example all 3 having the Montreal map. If players have a dislike of that map, it may be hard to fill up 2-3 lobbies with the map. Also it simply gives less choice.
- for teams games, the Special Mix lobby has 42 Humans vs 42 Nations and the Teams lobby also has 42 Humans vs 42 Nations. Harder to fill up if both are the same while there's a group waiting for a non-Nations team game or disliking Humans vs Nations.
- two or three lobbies with the same number of players. For example two 125 players. Making it harder to fill up because of their sheer size, but again also giving less choice especially if players don't like big lobbies. Same goes for medium or small lobbies. Also, same maxPlayers leads to same team sizes if the number of teams is the same.

Example of what this PR fixes https://discord.com/channels/1359946986937258015/1381347989464809664/1491449032206323917:
![image (1)](https://github.com/user-attachments/assets/a6274d75-074d-469e-8149-26fee4202597)

Other reports: https://discord.com/channels/1284581928254701718/1284581928833388619/1495082648798892063, https://discord.com/channels/1359946986937258015/1360078040222142564/1492656932723622109, https://discord.com/channels/1359946986937258015/1450487807242932336/1505139133964877845

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33