### PR TITLE
Map-Generator README: Add needed steps

### DIFF
--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -34,7 +34,8 @@ the [Official Openfront Wiki](https://openfront.wiki/Map_Making)
    `go run . --maps=northamerica,world`
 
 6. Find the output folder at `../resources/maps/<map_name>`
-7. Run Prettier: `npm run format`
+7. Go back to the root directory: `cd ..`
+8. Run Prettier: `npm run format`
    This rewrites ALL files in place. Git figures out which files are actually changed, don't worry.
    Alternatively, you can either run Prettier per file: `npx prettier --write resources/maps/<map_name>/<file_name>` or in VSCode install the Prettier extension and per file do Show and run Commands > Format Document.
 


### PR DESCRIPTION
## Description:

Map-Generator README:

- Add needed step to open map-generator folder before installing depenencies and running the generator. Otherwise errors will arise.

- And add last step to run Prettier with some information on other options, as map makers aren't generally developers per se.

- Reword/reorder a bit for easier understanding.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33