### PR TITLE
Exclude extreme modifiers on Four Islands 🏝️

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -225,6 +225,12 @@ export class MapPlaylist {
       excludedModifiers.push("isRandomSpawn");
     }
 
+    // No extreme modifiers on FourIslands - Causes 3h long stalemates
+    if (map === GameMapType.FourIslands) {
+      excludedModifiers.push("goldMultiplier");
+      excludedModifiers.push("startingGold25M");
+    }
+
     // Hard nations modifier only applies when nations are present (not HvN, which is always hard)
     if (mode === GameMode.Team) {
       excludedModifiers.push("isHardNations");
@@ -324,7 +330,6 @@ export class MapPlaylist {
       disabledUnits.push(UnitType.SAMLauncher);
     }
 
-    // 3min peace = 180s = 1800 ticks
     // 4min peace = 240s = 2400 ticks
     const peaceTimeDuration = isPeaceTime ? 240 * 10 : undefined;
 


### PR DESCRIPTION
## Description:

I saw multiple occasions of 3h long four islands team games because of the 2x gold multiplier. For example [here](https://www.reddit.com/r/Openfront/comments/1sca6g4/endless_game/).
People just get too many SAMs.
Without the extreme gold amount, team games on four islands are actually fun.

This PR excludes `goldMultiplier` and `startingGold25M` from special game modifiers when the map is FourIslands.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin