### PR TITLE
Update name censor to check for certain substrings

### DIFF
--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -84,7 +84,9 @@ export function createMatcher(bannedWords: string[]): RegExpMatcher {
   });
   return {
     hasMatch: (input: string) =>
-      substringMatcher.hasMatch(input) || collapseMatcher.hasMatch(input),
+      input.toLowerCase().includes("kkk") ||
+      substringMatcher.hasMatch(input) ||
+      collapseMatcher.hasMatch(input),
     getAllMatches: (input: string, sorted?: boolean) => [
       ...substringMatcher.getAllMatches(input, sorted),
       ...collapseMatcher.getAllMatches(input, sorted),
@@ -118,7 +120,9 @@ function censorUsernameWithMatcher(
     ? username.replace(`[${clanTag}]`, "").trim()
     : username;
 
-  const clanTagIsProfane = clanTag ? matcher.hasMatch(clanTag) : false;
+  const clanTagIsProfane = clanTag
+    ? matcher.hasMatch(clanTag) || clanTag.toLowerCase() === "ss"
+    : false;
   const usernameIsProfane = matcher.hasMatch(nameWithoutClan);
 
   const censoredName = usernameIsProfane

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -131,6 +131,13 @@ describe("UsernameCensor", () => {
       // "snigger" is whitelisted in englishDataset
       expect(matcher.hasMatch("snigger")).toBe(false);
     });
+
+    test("catches kkk as substring", () => {
+      expect(matcher.hasMatch("kkk")).toBe(true);
+      expect(matcher.hasMatch("KKK")).toBe(true);
+      expect(matcher.hasMatch("kkklover")).toBe(true);
+      expect(matcher.hasMatch("ilovekkkboys")).toBe(true);
+    });
   });
 
   describe("censorUsername", () => {
@@ -184,6 +191,15 @@ describe("UsernameCensor", () => {
       test("removes clan tag containing banned word as substring (≤5 chars)", () => {
         expect(checker.censorUsername("[JEWS]CoolPlayer")).toBe("CoolPlayer");
         expect(checker.censorUsername("[NAZI]CoolPlayer")).toBe("CoolPlayer");
+      });
+
+      test("removes [SS] clan tag", () => {
+        expect(checker.censorUsername("[SS]Player")).toBe("Player");
+        expect(checker.censorUsername("[ss]Player")).toBe("Player");
+      });
+
+      test("removes [KKK] clan tag", () => {
+        expect(checker.censorUsername("[KKK]Player")).toBe("Player");
       });
 
       test("keeps clean clan tag when username is clean", () => {


### PR DESCRIPTION
## Description:

The deduper was converting profane words like "kkk" => "k" and then censoring all usernames with the letter "k", so instead we just hardcode and check for substrings for profane phrases like that.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
