### PR TITLE
Track lobby join rate (joins/time) per map

### DIFF
--- a/src/server/JoinRateTracker.ts
+++ b/src/server/JoinRateTracker.ts
@@ -1,0 +1,116 @@
+import { GameMapType } from "../core/game/Game";
+import { PublicGameType } from "../core/Schemas";
+
+interface JoinRateSample {
+  joinRate: number; // clients per second
+  timestamp: number;
+}
+
+/**
+ * Tracks how quickly players join lobbies for each map, per game type.
+ * Maintains a rolling window of recent samples and exposes a multiplier
+ * that MapPlaylist can use to boost popular maps.
+ */
+export class JoinRateTracker {
+  // gameType -> map -> recent samples
+  private samples = new Map<
+    PublicGameType,
+    Map<GameMapType, JoinRateSample[]>
+  >();
+
+  constructor(
+    private readonly maxSamplesPerMap: number = 30,
+    private readonly sampleMaxAgeMs: number = 2 * 60 * 60 * 1000, // 2 hours
+    private readonly alpha: number = 0.5, // max boost/reduction factor
+  ) {}
+
+  /**
+   * Record a completed lobby's join rate.
+   * Call this when a lobby transitions from Lobby → Active.
+   */
+  recordLobby(
+    gameType: PublicGameType,
+    map: GameMapType,
+    numClients: number,
+    lobbyDurationMs: number,
+  ): void {
+    if (lobbyDurationMs <= 0 || numClients <= 0) return;
+
+    const joinRate = numClients / (lobbyDurationMs / 1000);
+
+    if (!this.samples.has(gameType)) {
+      this.samples.set(gameType, new Map());
+    }
+    const byMap = this.samples.get(gameType)!;
+    if (!byMap.has(map)) {
+      byMap.set(map, []);
+    }
+
+    const mapSamples = byMap.get(map)!;
+    mapSamples.push({ joinRate, timestamp: Date.now() });
+
+    // Evict old samples
+    this.evict(mapSamples);
+  }
+
+  /**
+   * Returns a frequency multiplier for each map that has data.
+   * Maps with above-average join rates get a multiplier > 1,
+   * maps with below-average get < 1. The range is [1 - alpha, 1 + alpha].
+   * Maps with no data return no entry (caller uses base frequency as-is).
+   */
+  getFrequencyMultipliers(gameType: PublicGameType): Map<GameMapType, number> {
+    const result = new Map<GameMapType, number>();
+    const byMap = this.samples.get(gameType);
+    if (!byMap) return result;
+
+    // Compute average join rate per map
+    const avgRates = new Map<GameMapType, number>();
+    for (const [map, samples] of byMap) {
+      this.evict(samples);
+      if (samples.length === 0) continue;
+      const avg =
+        samples.reduce((sum, s) => sum + s.joinRate, 0) / samples.length;
+      avgRates.set(map, avg);
+    }
+
+    if (avgRates.size === 0) return result;
+
+    // Global average across all maps
+    let globalSum = 0;
+    for (const rate of avgRates.values()) {
+      globalSum += rate;
+    }
+    const globalAvg = globalSum / avgRates.size;
+
+    if (globalAvg <= 0) return result;
+
+    // Compute multiplier: 1 + alpha * (mapAvg - globalAvg) / globalAvg
+    // Clamped to [1 - alpha, 1 + alpha]
+    for (const [map, avg] of avgRates) {
+      const normalized = (avg - globalAvg) / globalAvg;
+      const multiplier = Math.max(
+        1 - this.alpha,
+        Math.min(1 + this.alpha, 1 + this.alpha * normalized),
+      );
+      result.set(map, multiplier);
+    }
+
+    return result;
+  }
+
+  private evict(samples: JoinRateSample[]): void {
+    const now = Date.now();
+    // Remove expired samples from the front
+    while (
+      samples.length > 0 &&
+      now - samples[0].timestamp > this.sampleMaxAgeMs
+    ) {
+      samples.shift();
+    }
+    // Cap at max samples (keep most recent)
+    while (samples.length > this.maxSamplesPerMap) {
+      samples.shift();
+    }
+  }
+}

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -1,7 +1,8 @@
 import { Worker } from "cluster";
 import winston from "winston";
 import { ServerConfig } from "../core/configuration/Config";
-import { PublicGameInfo, PublicGameType } from "../core/Schemas";
+import { GameMapType } from "../core/game/Game";
+import { GameID, PublicGameInfo, PublicGameType } from "../core/Schemas";
 import { generateID } from "../core/Util";
 import {
   MasterCreateGame,
@@ -9,6 +10,7 @@ import {
   MasterUpdateGame,
   WorkerMessageSchema,
 } from "./IPCBridgeSchema";
+import { JoinRateTracker } from "./JoinRateTracker";
 import { logger } from "./Logger";
 import { MapPlaylist } from "./MapPlaylist";
 import { startPolling } from "./PollingLoop";
@@ -19,12 +21,31 @@ export interface MasterLobbyServiceOptions {
   log: typeof logger;
 }
 
+interface TrackedLobby {
+  gameType: PublicGameType;
+  map: GameMapType;
+  createdAt: number;
+  lastNumClients: number;
+}
+
 export class MasterLobbyService {
   private readonly workers = new Map<number, Worker>();
   // Worker id => the lobbies it owns.
   private readonly workerLobbies = new Map<number, PublicGameInfo[]>();
   private readonly readyWorkers = new Set<number>();
   private started = false;
+
+  /**
+   * Tracks lobbies we've seen so we can measure join rate on completion.
+   * recordLobby() feeds samples into joinRateTracker when lobbies complete.
+   *
+   * TODO: Wire joinRateTracker.getFrequencyMultipliers() into
+   * MapPlaylist.buildMapsList() to dynamically weight map selection based
+   * on observed join rates — popular maps would appear more often in the
+   * generated playlists.
+   */
+  private readonly trackedLobbies = new Map<GameID, TrackedLobby>();
+  private readonly joinRateTracker = new JoinRateTracker();
 
   constructor(
     private config: ServerConfig,
@@ -80,6 +101,56 @@ export class MasterLobbyService {
     }
   }
 
+  /**
+   * Detects lobbies that disappeared (transitioned to Active) and records
+   * their join rate so the playlist can boost popular maps.
+   */
+  private recordCompletedLobbies() {
+    // Collect all current lobby IDs
+    const currentLobbyIds = new Set<GameID>();
+    for (const lobbies of this.workerLobbies.values()) {
+      for (const lobby of lobbies) {
+        currentLobbyIds.add(lobby.gameID);
+      }
+    }
+
+    // Any tracked lobby not in current set has completed
+    for (const [gameID, tracked] of this.trackedLobbies) {
+      if (!currentLobbyIds.has(gameID)) {
+        const durationMs = Date.now() - tracked.createdAt;
+        // Look up final numClients from last known snapshot
+        const numClients = tracked.lastNumClients;
+        if (numClients > 0 && durationMs > 0) {
+          this.joinRateTracker.recordLobby(
+            tracked.gameType,
+            tracked.map,
+            numClients,
+            durationMs,
+          );
+        }
+        this.trackedLobbies.delete(gameID);
+      }
+    }
+
+    // Track any new lobbies we haven't seen yet
+    for (const lobbies of this.workerLobbies.values()) {
+      for (const lobby of lobbies) {
+        const existing = this.trackedLobbies.get(lobby.gameID);
+        if (existing) {
+          // Update last known client count
+          existing.lastNumClients = lobby.numClients;
+        } else if (lobby.gameConfig) {
+          this.trackedLobbies.set(lobby.gameID, {
+            gameType: lobby.publicGameType,
+            map: lobby.gameConfig.gameMap,
+            createdAt: Date.now(),
+            lastNumClients: lobby.numClients,
+          });
+        }
+      }
+    }
+  }
+
   private getAllLobbies(): Record<PublicGameType, PublicGameInfo[]> {
     const lobbies = Array.from(this.workerLobbies.values()).flat();
 
@@ -110,6 +181,7 @@ export class MasterLobbyService {
   }
 
   private broadcastLobbies() {
+    this.recordCompletedLobbies();
     const msg = {
       type: "lobbiesBroadcast",
       publicGames: {


### PR DESCRIPTION
Adds JoinRateTracker that measures how quickly players join each map's lobby, tracked per game type (ffa/team/special). MasterLobbyService records a sample when a lobby transitions to Active. Data is kept in-memory with a rolling window (30 samples, 2h expiry). The tracker exposes getFrequencyMultipliers() for future use in adjusting map playlist frequency, but is not wired into MapPlaylist yet.

## Description:

- New JoinRateTracker class that tracks joins/second per map per game type
- MasterLobbyService detects when lobbies transition to Active and records the join rate (numClients / lobbyDuration)
- Rolling window: 30 samples per map, 2h expiry, all in-memory
- Measurement only — not yet used to alter map rotation frequency

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

kabahaly2