### PR TITLE
Refactor/Fix(UserSettings): last localstorage calls now use UserSettings, and Keybinds fixes

### DIFF
--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -26,20 +26,17 @@ export class HelpModal extends BaseModal {
   private getKeybinds(): Record<string, string> {
     let saved: Record<string, string> = {};
     const userSettings = new UserSettings();
-    try {
-      const parsed = JSON.parse(userSettings.keybinds());
-      saved = Object.fromEntries(
-        Object.entries(parsed)
-          .map(([k, v]) => {
-            if (this.isKeybindObject(v)) return [k, v.value];
-            if (typeof v === "string") return [k, v];
-            return [k, undefined];
-          })
-          .filter(([, v]) => typeof v === "string" && v !== "Null"),
-      ) as Record<string, string>;
-    } catch (e) {
-      console.warn("Invalid keybinds JSON:", e);
-    }
+    const parsed = userSettings.parsedKeybinds();
+
+    saved = Object.fromEntries(
+      Object.entries(parsed)
+        .map(([k, v]) => {
+          if (this.isKeybindObject(v)) return [k, v.value];
+          if (typeof v === "string") return [k, v];
+          return [k, undefined];
+        })
+        .filter(([, v]) => typeof v === "string" && v !== "Null"),
+    ) as Record<string, string>;
 
     const isMac = Platform.isMac;
     return {

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -2,6 +2,7 @@ import { html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
 import { translateText, TUTORIAL_VIDEO_URL } from "../client/Utils";
 import { assetUrl } from "../core/AssetUrls";
+import { UserSettings } from "../core/game/UserSettings";
 import { BaseModal } from "./components/BaseModal";
 import "./components/Difficulties";
 import { modalHeader } from "./components/ui/ModalHeader";
@@ -24,10 +25,9 @@ export class HelpModal extends BaseModal {
 
   private getKeybinds(): Record<string, string> {
     let saved: Record<string, string> = {};
+    const userSettings = new UserSettings();
     try {
-      const parsed = JSON.parse(
-        localStorage.getItem("settings.keybinds") ?? "{}",
-      );
+      const parsed = JSON.parse(userSettings.keybinds() || "{}");
       saved = Object.fromEntries(
         Object.entries(parsed)
           .map(([k, v]) => {

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -14,29 +14,15 @@ export class HelpModal extends BaseModal {
   @state() private keybinds: Record<string, string> = this.getKeybinds();
   @query("#tutorial-video-iframe") private videoIframe?: HTMLIFrameElement;
 
-  private isKeybindObject(v: unknown): v is { value: string } {
-    return (
-      typeof v === "object" &&
-      v !== null &&
-      "value" in v &&
-      typeof (v as any).value === "string"
-    );
-  }
-
   private getKeybinds(): Record<string, string> {
-    let saved: Record<string, string> = {};
     const userSettings = new UserSettings();
-    const parsed = userSettings.parsedKeybinds();
+    const saved = userSettings.normalizedKeybinds();
 
-    saved = Object.fromEntries(
-      Object.entries(parsed)
-        .map(([k, v]) => {
-          if (this.isKeybindObject(v)) return [k, v.value];
-          if (typeof v === "string") return [k, v];
-          return [k, undefined];
-        })
-        .filter(([, v]) => typeof v === "string" && v !== "Null"),
-    ) as Record<string, string>;
+    for (const k in saved) {
+      if (saved[k] === "Null") {
+        delete saved[k];
+      }
+    }
 
     const isMac = Platform.isMac;
     return {

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -27,7 +27,7 @@ export class HelpModal extends BaseModal {
     let saved: Record<string, string> = {};
     const userSettings = new UserSettings();
     try {
-      const parsed = JSON.parse(userSettings.keybinds() || "{}");
+      const parsed = JSON.parse(userSettings.keybinds());
       saved = Object.fromEntries(
         Object.entries(parsed)
           .map(([k, v]) => {

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -15,38 +15,7 @@ export class HelpModal extends BaseModal {
   @query("#tutorial-video-iframe") private videoIframe?: HTMLIFrameElement;
 
   private getKeybinds(): Record<string, string> {
-    const userSettings = new UserSettings();
-    const saved = userSettings.normalizedKeybinds();
-
-    for (const k in saved) {
-      if (saved[k] === "Null") {
-        delete saved[k];
-      }
-    }
-
-    const isMac = Platform.isMac;
-    return {
-      toggleView: "Space",
-      coordinateGrid: "KeyM",
-      centerCamera: "KeyC",
-      moveUp: "KeyW",
-      moveDown: "KeyS",
-      moveLeft: "KeyA",
-      moveRight: "KeyD",
-      zoomOut: "KeyQ",
-      zoomIn: "KeyE",
-      attackRatioDown: "KeyT",
-      attackRatioUp: "KeyY",
-      swapDirection: "KeyU",
-      shiftKey: "ShiftLeft",
-      modifierKey: isMac ? "MetaLeft" : "ControlLeft",
-      altKey: "AltLeft",
-      resetGfx: "KeyR",
-      pauseGame: "KeyP",
-      gameSpeedUp: "Period",
-      gameSpeedDown: "Comma",
-      ...saved,
-    };
+    return new UserSettings().keybinds(Platform.isMac);
   }
 
   private getKeyLabel(code: string): string {

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -185,31 +185,27 @@ export class InputHandler {
 
   initialize() {
     let saved: Record<string, string> = {};
-    try {
-      const parsed = JSON.parse(this.userSettings.keybinds());
-      // flatten { key: {key, value} } → { key: value } and accept legacy string values
-      saved = Object.fromEntries(
-        Object.entries(parsed)
-          .map(([k, v]) => {
-            // Extract value from nested object or plain string
-            let val: unknown;
-            if (v && typeof v === "object" && "value" in v) {
-              val = (v as { value: unknown }).value;
-            } else {
-              val = v;
-            }
+    const parsed = this.userSettings.parsedKeybinds();
 
-            // Map invalid values to undefined (filtered later)
-            if (typeof val !== "string") {
-              return [k, undefined];
-            }
-            return [k, val];
-          })
-          .filter(([, v]) => typeof v === "string"),
-      ) as Record<string, string>;
-    } catch (e) {
-      console.warn("Invalid keybinds JSON:", e);
-    }
+    // flatten { key: {key, value} } → { key: value } and accept legacy string values
+    saved = Object.fromEntries(
+      Object.entries(parsed)
+        .map(([k, v]) => {
+          // Extract value from nested object or plain string
+          let val: unknown;
+          if (v && typeof v === "object" && "value" in v) {
+            val = (v as { value: unknown }).value;
+          } else {
+            val = v;
+          }
+          // Map invalid values to undefined (filtered later)
+          if (typeof val !== "string") {
+            return [k, undefined];
+          }
+          return [k, val];
+        })
+        .filter(([, v]) => typeof v === "string"),
+    ) as Record<string, string>;
 
     // Mac users might have different keybinds
     const isMac = Platform.isMac;

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -185,7 +185,7 @@ export class InputHandler {
   initialize() {
     let saved: Record<string, string> = {};
     try {
-      const parsed = JSON.parse(this.userSettings.keybinds() || "{}");
+      const parsed = JSON.parse(this.userSettings.keybinds());
       // flatten { key: {key, value} } → { key: value } and accept legacy string values
       saved = Object.fromEntries(
         Object.entries(parsed)

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -184,29 +184,7 @@ export class InputHandler {
   ) {}
 
   initialize() {
-    let saved: Record<string, string> = {};
-    const parsed = this.userSettings.parsedKeybinds();
-
-    // flatten { key: {key, value} } → { key: value } and accept legacy string values
-    saved = Object.fromEntries(
-      Object.entries(parsed)
-        .map(([k, v]) => {
-          // Extract value from nested object or plain string
-          let val: unknown;
-          if (v && typeof v === "object" && "value" in v) {
-            val = (v as { value: unknown }).value;
-          } else {
-            val = v;
-          }
-          // Map invalid values to undefined (filtered later)
-          if (typeof val !== "string") {
-            return [k, undefined];
-          }
-          return [k, val];
-        })
-        .filter(([, v]) => typeof v === "string"),
-    ) as Record<string, string>;
-
+    const saved = this.userSettings.normalizedKeybinds();
     // Mac users might have different keybinds
     const isMac = Platform.isMac;
 

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -184,42 +184,7 @@ export class InputHandler {
   ) {}
 
   initialize() {
-    const saved = this.userSettings.normalizedKeybinds();
-    // Mac users might have different keybinds
-    const isMac = Platform.isMac;
-
-    this.keybinds = {
-      toggleView: "Space",
-      coordinateGrid: "KeyM",
-      centerCamera: "KeyC",
-      moveUp: "KeyW",
-      moveDown: "KeyS",
-      moveLeft: "KeyA",
-      moveRight: "KeyD",
-      zoomOut: "KeyQ",
-      zoomIn: "KeyE",
-      attackRatioDown: "KeyT",
-      attackRatioUp: "KeyY",
-      boatAttack: "KeyB",
-      groundAttack: "KeyG",
-      swapDirection: "KeyU",
-      modifierKey: isMac ? "MetaLeft" : "ControlLeft",
-      altKey: "AltLeft",
-      buildCity: "Digit1",
-      buildFactory: "Digit2",
-      buildPort: "Digit3",
-      buildDefensePost: "Digit4",
-      buildMissileSilo: "Digit5",
-      buildSamLauncher: "Digit6",
-      buildWarship: "Digit7",
-      buildAtomBomb: "Digit8",
-      buildHydrogenBomb: "Digit9",
-      buildMIRV: "Digit0",
-      pauseGame: "KeyP",
-      gameSpeedUp: "Period",
-      gameSpeedDown: "Comma",
-      ...saved,
-    };
+    this.keybinds = this.userSettings.keybinds(Platform.isMac);
 
     this.canvas.addEventListener("pointerdown", (e) => this.onPointerDown(e));
     window.addEventListener("pointerup", (e) => this.onPointerUp(e));

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -185,9 +185,7 @@ export class InputHandler {
   initialize() {
     let saved: Record<string, string> = {};
     try {
-      const parsed = JSON.parse(
-        localStorage.getItem("settings.keybinds") ?? "{}",
-      );
+      const parsed = JSON.parse(this.userSettings.keybinds() || "{}");
       // flatten { key: {key, value} } → { key: value } and accept legacy string values
       saved = Object.fromEntries(
         Object.entries(parsed)

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -44,8 +44,7 @@ export class UserSettingModal extends BaseModal {
       return;
     }
 
-    const validated: Record<string, { value: string; key: string }> =
-      {};
+    const validated: Record<string, { value: string; key: string }> = {};
 
     for (const [action, entry] of Object.entries(parsed)) {
       if (typeof entry === "string") {

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -74,32 +74,33 @@ export class UserSettingModal extends BaseModal {
     const parsed = this.userSettings.parsedKeybinds();
     if (Object.keys(parsed).length === 0) return;
 
-    const isValid = Object.values(parsed).every((entry) => {
-      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
-        return false;
-      }
-      if (!("key" in entry) || typeof (entry as any).key !== "string") {
-        return false;
-      }
-      if (!("value" in entry)) {
-        return false;
-      }
-      const value = (entry as any).value;
-      if (typeof value === "string") {
-        return true;
-      }
-      if (Array.isArray(value)) {
-        return value.every((v) => typeof v === "string");
-      }
-      return false;
-    });
+    const validated: Record<string, { value: string | string[]; key: string }> =
+      {};
 
-    if (isValid) {
-      this.keybinds = parsed;
-    } else {
-      console.warn(
-        "Invalid keybinds structure: entries must be objects with 'key' (string) and 'value' (string or string[]) properties. Ignoring saved data.",
-      );
+    for (const [action, entry] of Object.entries(parsed)) {
+      if (typeof entry === "string") {
+        validated[action] = { value: entry, key: entry };
+      } else if (
+        typeof entry === "object" &&
+        entry !== null &&
+        !Array.isArray(entry)
+      ) {
+        let value = (entry as any).value ?? "Null";
+        let key = (entry as any).key ?? value;
+
+        if (
+          (typeof value === "string" ||
+            (Array.isArray(value) &&
+              value.every((v) => typeof v === "string"))) &&
+          typeof key === "string"
+        ) {
+          validated[action] = { value, key };
+        }
+      }
+    }
+
+    if (Object.keys(validated).length > 0) {
+      this.keybinds = validated;
     }
   }
 

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -53,7 +53,9 @@ export class UserSettingModal extends BaseModal {
         !Array.isArray(entry)
       ) {
         const value = (entry as any).value ?? "Null";
-        const key = (entry as any).key ?? value;
+        const key =
+          (entry as any).key ??
+          (Array.isArray(value) ? (value[0] ?? "") : value);
 
         if (
           (typeof value === "string" ||
@@ -137,9 +139,9 @@ export class UserSettingModal extends BaseModal {
         }),
       );
 
-      const element = this.renderRoot.querySelector(
+      const element = this.renderRoot.querySelector<SettingKeybind>(
         `setting-keybind[action="${action}"]`,
-      ) satisfies SettingKeybind | null;
+      );
       if (element) {
         element.value = prevValue ?? this.defaultKeybinds[action] ?? "";
         element.requestUpdate();

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -81,7 +81,7 @@ export class UserSettingModal extends BaseModal {
   ) {
     const { action, value, key, prevValue } = e.detail;
 
-    const activeKeybinds = this.defaultKeybinds;
+    const activeKeybinds = { ...this.defaultKeybinds };
     for (const [k, v] of Object.entries(this.userKeybinds)) {
       const normalizedValue = Array.isArray(v.value)
         ? v.value[0] || ""

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -71,52 +71,35 @@ export class UserSettingModal extends BaseModal {
   }
 
   private loadKeybindsFromStorage() {
-    const savedKeybinds = this.userSettings.keybinds();
-    try {
-      const parsed = JSON.parse(savedKeybinds);
-      if (
-        typeof parsed === "object" &&
-        parsed !== null &&
-        !Array.isArray(parsed)
-      ) {
-        const isValid = Object.values(parsed).every((entry) => {
-          if (
-            typeof entry !== "object" ||
-            entry === null ||
-            Array.isArray(entry)
-          ) {
-            return false;
-          }
-          if (!("key" in entry) || typeof (entry as any).key !== "string") {
-            return false;
-          }
-          if (!("value" in entry)) {
-            return false;
-          }
-          const value = (entry as any).value;
-          if (typeof value === "string") {
-            return true;
-          }
-          if (Array.isArray(value)) {
-            return value.every((v) => typeof v === "string");
-          }
-          return false;
-        });
+    const parsed = this.userSettings.parsedKeybinds();
+    if (Object.keys(parsed).length === 0) return;
 
-        if (isValid) {
-          this.keybinds = parsed;
-        } else {
-          console.warn(
-            "Invalid keybinds structure: entries must be objects with 'key' (string) and 'value' (string or string[]) properties. Ignoring saved data.",
-          );
-        }
-      } else {
-        console.warn(
-          "Invalid keybinds data: expected non-array object. Ignoring saved data.",
-        );
+    const isValid = Object.values(parsed).every((entry) => {
+      if (typeof entry !== "object" || entry === null || Array.isArray(entry)) {
+        return false;
       }
-    } catch (e) {
-      console.warn("Invalid keybinds JSON:", e);
+      if (!("key" in entry) || typeof (entry as any).key !== "string") {
+        return false;
+      }
+      if (!("value" in entry)) {
+        return false;
+      }
+      const value = (entry as any).value;
+      if (typeof value === "string") {
+        return true;
+      }
+      if (Array.isArray(value)) {
+        return value.every((v) => typeof v === "string");
+      }
+      return false;
+    });
+
+    if (isValid) {
+      this.keybinds = parsed;
+    } else {
+      console.warn(
+        "Invalid keybinds structure: entries must be objects with 'key' (string) and 'value' (string or string[]) properties. Ignoring saved data.",
+      );
     }
   }
 

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -24,7 +24,7 @@ export class UserSettingModal extends BaseModal {
 
   @state() private userKeybinds: Record<
     string,
-    { value: string | string[]; key: string }
+    { value: string; key: string }
   > = {};
 
   connectedCallback() {
@@ -44,7 +44,7 @@ export class UserSettingModal extends BaseModal {
       return;
     }
 
-    const validated: Record<string, { value: string | string[]; key: string }> =
+    const validated: Record<string, { value: string; key: string }> =
       {};
 
     for (const [action, entry] of Object.entries(parsed)) {
@@ -86,9 +86,7 @@ export class UserSettingModal extends BaseModal {
 
     const activeKeybinds = { ...this.defaultKeybinds };
     for (const [k, v] of Object.entries(this.userKeybinds)) {
-      const normalizedValue = Array.isArray(v.value)
-        ? v.value[0] || ""
-        : v.value;
+      const normalizedValue = v.value;
       if (normalizedValue === "Null") {
         delete activeKeybinds[k];
       } else {
@@ -160,9 +158,7 @@ export class UserSettingModal extends BaseModal {
   private getKeyValue(action: string): string | undefined {
     const entry = this.userKeybinds[action];
     if (!entry) return undefined;
-    const normalizedValue = Array.isArray(entry.value)
-      ? entry.value[0] || ""
-      : entry.value;
+    const normalizedValue = entry.value;
     if (normalizedValue === "Null") return "";
     return normalizedValue || undefined;
   }

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -72,8 +72,6 @@ export class UserSettingModal extends BaseModal {
 
   private loadKeybindsFromStorage() {
     const savedKeybinds = this.userSettings.keybinds();
-    if (!savedKeybinds) return;
-
     try {
       const parsed = JSON.parse(savedKeybinds);
       if (

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -85,8 +85,8 @@ export class UserSettingModal extends BaseModal {
         entry !== null &&
         !Array.isArray(entry)
       ) {
-        let value = (entry as any).value ?? "Null";
-        let key = (entry as any).key ?? value;
+        const value = (entry as any).value ?? "Null";
+        const key = (entry as any).key ?? value;
 
         if (
           (typeof value === "string" ||

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -1,7 +1,7 @@
 import { html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { formatKeyForDisplay, translateText } from "../client/Utils";
-import { UserSettings } from "../core/game/UserSettings";
+import { getDefaultKeybinds, UserSettings } from "../core/game/UserSettings";
 import "./components/baseComponents/setting/SettingKeybind";
 import { SettingKeybind } from "./components/baseComponents/setting/SettingKeybind";
 import "./components/baseComponents/setting/SettingNumber";
@@ -12,50 +12,17 @@ import { BaseModal } from "./components/BaseModal";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { Platform } from "./Platform";
 
-const isMac = Platform.isMac;
-
-const DefaultKeybinds: Record<string, string> = {
-  toggleView: "Space",
-  coordinateGrid: "KeyM",
-  buildCity: "Digit1",
-  buildFactory: "Digit2",
-  buildPort: "Digit3",
-  buildDefensePost: "Digit4",
-  buildMissileSilo: "Digit5",
-  buildSamLauncher: "Digit6",
-  buildWarship: "Digit7",
-  buildAtomBomb: "Digit8",
-  buildHydrogenBomb: "Digit9",
-  buildMIRV: "Digit0",
-  attackRatioDown: "KeyT",
-  attackRatioUp: "KeyY",
-  boatAttack: "KeyB",
-  groundAttack: "KeyG",
-  swapDirection: "KeyU",
-  zoomOut: "KeyQ",
-  zoomIn: "KeyE",
-  centerCamera: "KeyC",
-  moveUp: "KeyW",
-  moveLeft: "KeyA",
-  moveDown: "KeyS",
-  moveRight: "KeyD",
-  modifierKey: isMac ? "MetaLeft" : "ControlLeft",
-  altKey: "AltLeft",
-  pauseGame: "KeyP",
-  gameSpeedUp: "Period",
-  gameSpeedDown: "Comma",
-};
-
 @customElement("user-setting")
 export class UserSettingModal extends BaseModal {
   private userSettings: UserSettings = new UserSettings();
+  private readonly defaultKeybinds = getDefaultKeybinds(Platform.isMac);
 
   @state() private activeTab: "basic" | "keybinds" = "basic";
 
   @state() private keySequence: string[] = [];
   @state() private showEasterEggSettings = false;
 
-  @state() private keybinds: Record<
+  @state() private userKeybinds: Record<
     string,
     { value: string | string[]; key: string }
   > = {};
@@ -71,7 +38,7 @@ export class UserSettingModal extends BaseModal {
   }
 
   private loadKeybindsFromStorage() {
-    const parsed = this.userSettings.parsedKeybinds();
+    const parsed = this.userSettings.parsedUserKeybinds();
     if (Object.keys(parsed).length === 0) return;
 
     const validated: Record<string, { value: string | string[]; key: string }> =
@@ -100,7 +67,7 @@ export class UserSettingModal extends BaseModal {
     }
 
     if (Object.keys(validated).length > 0) {
-      this.keybinds = validated;
+      this.userKeybinds = validated;
     }
   }
 
@@ -114,8 +81,8 @@ export class UserSettingModal extends BaseModal {
   ) {
     const { action, value, key, prevValue } = e.detail;
 
-    const activeKeybinds: Record<string, string> = { ...DefaultKeybinds };
-    for (const [k, v] of Object.entries(this.keybinds)) {
+    const activeKeybinds = this.defaultKeybinds;
+    for (const [k, v] of Object.entries(this.userKeybinds)) {
       const normalizedValue = Array.isArray(v.value)
         ? v.value[0] || ""
         : v.value;
@@ -172,20 +139,23 @@ export class UserSettingModal extends BaseModal {
 
       const element = this.renderRoot.querySelector(
         `setting-keybind[action="${action}"]`,
-      ) as SettingKeybind;
+      ) satisfies SettingKeybind | null;
       if (element) {
-        element.value = prevValue ?? DefaultKeybinds[action] ?? "";
+        element.value = prevValue ?? this.defaultKeybinds[action] ?? "";
         element.requestUpdate();
       }
       return;
     }
 
-    this.keybinds = { ...this.keybinds, [action]: { value: value, key: key } };
-    this.userSettings.setKeybinds(JSON.stringify(this.keybinds));
+    this.userKeybinds = {
+      ...this.userKeybinds,
+      [action]: { value: value, key: key },
+    };
+    this.userSettings.setKeybinds(this.userKeybinds);
   }
 
   private getKeyValue(action: string): string | undefined {
-    const entry = this.keybinds[action];
+    const entry = this.userKeybinds[action];
     if (!entry) return undefined;
     const normalizedValue = Array.isArray(entry.value)
       ? entry.value[0] || ""
@@ -195,7 +165,7 @@ export class UserSettingModal extends BaseModal {
   }
 
   private getKeyChar(action: string): string {
-    const entry = this.keybinds[action];
+    const entry = this.userKeybinds[action];
     if (!entry) return "";
     return entry.key || "";
   }
@@ -435,7 +405,7 @@ export class UserSettingModal extends BaseModal {
         action="coordinateGrid"
         label=${translateText("user_setting.coordinate_grid_label")}
         description=${translateText("user_setting.coordinate_grid_desc")}
-        defaultKey=${DefaultKeybinds.coordinateGrid}
+        defaultKey=${this.defaultKeybinds.coordinateGrid}
         .value=${this.getKeyValue("coordinateGrid")}
         .display=${this.getKeyChar("coordinateGrid")}
         @change=${this.handleKeybindChange}
@@ -557,7 +527,7 @@ export class UserSettingModal extends BaseModal {
         action="modifierKey"
         label=${translateText("user_setting.build_menu_modifier")}
         description=${translateText("user_setting.build_menu_modifier_desc")}
-        .defaultKey=${DefaultKeybinds.modifierKey}
+        .defaultKey=${this.defaultKeybinds.modifierKey}
         .value=${this.getKeyValue("modifierKey")}
         .display=${this.getKeyChar("modifierKey")}
         @change=${this.handleKeybindChange}
@@ -567,7 +537,7 @@ export class UserSettingModal extends BaseModal {
         action="altKey"
         label=${translateText("user_setting.emoji_menu_modifier")}
         description=${translateText("user_setting.emoji_menu_modifier_desc")}
-        .defaultKey=${DefaultKeybinds.altKey}
+        .defaultKey=${this.defaultKeybinds.altKey}
         .value=${this.getKeyValue("altKey")}
         .display=${this.getKeyChar("altKey")}
         @change=${this.handleKeybindChange}
@@ -577,7 +547,7 @@ export class UserSettingModal extends BaseModal {
         action="pauseGame"
         label=${translateText("user_setting.pause_game")}
         description=${translateText("user_setting.pause_game_desc")}
-        .defaultKey=${DefaultKeybinds.pauseGame}
+        .defaultKey=${this.defaultKeybinds.pauseGame}
         .value=${this.getKeyValue("pauseGame")}
         .display=${this.getKeyChar("pauseGame")}
         @change=${this.handleKeybindChange}
@@ -587,7 +557,7 @@ export class UserSettingModal extends BaseModal {
         action="gameSpeedUp"
         label=${translateText("user_setting.game_speed_up")}
         description=${translateText("user_setting.game_speed_up_desc")}
-        .defaultKey=${DefaultKeybinds.gameSpeedUp}
+        .defaultKey=${this.defaultKeybinds.gameSpeedUp}
         .value=${this.getKeyValue("gameSpeedUp")}
         .display=${this.getKeyChar("gameSpeedUp")}
         @change=${this.handleKeybindChange}
@@ -597,7 +567,7 @@ export class UserSettingModal extends BaseModal {
         action="gameSpeedDown"
         label=${translateText("user_setting.game_speed_down")}
         description=${translateText("user_setting.game_speed_down_desc")}
-        .defaultKey=${DefaultKeybinds.gameSpeedDown}
+        .defaultKey=${this.defaultKeybinds.gameSpeedDown}
         .value=${this.getKeyValue("gameSpeedDown")}
         .display=${this.getKeyChar("gameSpeedDown")}
         @change=${this.handleKeybindChange}
@@ -663,7 +633,7 @@ export class UserSettingModal extends BaseModal {
         action="swapDirection"
         label=${translateText("user_setting.swap_direction")}
         description=${translateText("user_setting.swap_direction_desc")}
-        .defaultKey=${DefaultKeybinds.swapDirection}
+        .defaultKey=${this.defaultKeybinds.swapDirection}
         .value=${this.getKeyValue("swapDirection")}
         .display=${this.getKeyChar("swapDirection")}
         @change=${this.handleKeybindChange}

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -39,7 +39,10 @@ export class UserSettingModal extends BaseModal {
 
   private loadKeybindsFromStorage() {
     const parsed = this.userSettings.parsedUserKeybinds();
-    if (Object.keys(parsed).length === 0) return;
+    if (Object.keys(parsed).length === 0) {
+      this.userKeybinds = {};
+      return;
+    }
 
     const validated: Record<string, { value: string | string[]; key: string }> =
       {};
@@ -52,25 +55,23 @@ export class UserSettingModal extends BaseModal {
         entry !== null &&
         !Array.isArray(entry)
       ) {
-        const value = (entry as any).value ?? "Null";
-        const key =
-          (entry as any).key ??
-          (Array.isArray(value) ? (value[0] ?? "") : value);
+        const rawValue = (entry as any).value ?? "Null";
+        const value = Array.isArray(rawValue)
+          ? rawValue.find((v) => typeof v === "string")
+          : rawValue;
 
-        if (
-          (typeof value === "string" ||
-            (Array.isArray(value) &&
-              value.every((v) => typeof v === "string"))) &&
-          typeof key === "string"
-        ) {
+        const rawKey = (entry as any).key ?? value;
+        const key = Array.isArray(rawKey)
+          ? rawKey.find((v) => typeof v === "string")
+          : rawKey;
+
+        if (typeof value === "string" && typeof key === "string") {
           validated[action] = { value, key };
         }
       }
     }
 
-    if (Object.keys(validated).length > 0) {
-      this.userKeybinds = validated;
-    }
+    this.userKeybinds = validated;
   }
 
   private handleKeybindChange(

--- a/src/client/graphics/layers/ControlPanel.ts
+++ b/src/client/graphics/layers/ControlPanel.ts
@@ -4,6 +4,7 @@ import { assetUrl } from "../../../core/AssetUrls";
 import { EventBus } from "../../../core/EventBus";
 import { Gold } from "../../../core/game/Game";
 import { GameView } from "../../../core/game/GameView";
+import { UserSettings } from "../../../core/game/UserSettings";
 import { ClientID } from "../../../core/Schemas";
 import { AttackRatioEvent } from "../../InputHandler";
 import { renderNumber, renderTroops } from "../../Utils";
@@ -50,9 +51,7 @@ export class ControlPanel extends LitElement implements Layer {
   }
 
   init() {
-    this.attackRatio = Number(
-      localStorage.getItem("settings.attackRatio") ?? "0.2",
-    );
+    this.attackRatio = new UserSettings().attackRatio();
     this.uiState.attackRatio = this.attackRatio;
     this.eventBus.on(AttackRatioEvent, (event) => {
       let newAttackRatio = this.attackRatio + event.attackRatio / 100;

--- a/src/client/graphics/layers/UnitDisplay.ts
+++ b/src/client/graphics/layers/UnitDisplay.ts
@@ -55,13 +55,10 @@ export class UnitDisplay extends LitElement implements Layer {
     const config = this.game.config();
     const userSettings = new UserSettings();
 
-    const savedKeybinds = userSettings.keybinds();
-    if (savedKeybinds) {
-      try {
-        this.keybinds = JSON.parse(savedKeybinds);
-      } catch (e) {
-        console.warn("Invalid keybinds JSON:", e);
-      }
+    try {
+      this.keybinds = JSON.parse(userSettings.keybinds());
+    } catch (e) {
+      console.warn("Invalid keybinds JSON:", e);
     }
 
     this.allDisabled = BuildMenus.types.every((u) => config.isUnitDisabled(u));

--- a/src/client/graphics/layers/UnitDisplay.ts
+++ b/src/client/graphics/layers/UnitDisplay.ts
@@ -55,11 +55,7 @@ export class UnitDisplay extends LitElement implements Layer {
     const config = this.game.config();
     const userSettings = new UserSettings();
 
-    try {
-      this.keybinds = JSON.parse(userSettings.keybinds());
-    } catch (e) {
-      console.warn("Invalid keybinds JSON:", e);
-    }
+    this.keybinds = userSettings.parsedKeybinds();
 
     this.allDisabled = BuildMenus.types.every((u) => config.isUnitDisabled(u));
     this.requestUpdate();

--- a/src/client/graphics/layers/UnitDisplay.ts
+++ b/src/client/graphics/layers/UnitDisplay.ts
@@ -10,6 +10,7 @@ import {
   UnitType,
 } from "../../../core/game/Game";
 import { GameView } from "../../../core/game/GameView";
+import { UserSettings } from "../../../core/game/UserSettings";
 import {
   GhostStructureChangedEvent,
   ToggleStructureEvent,
@@ -52,8 +53,9 @@ export class UnitDisplay extends LitElement implements Layer {
 
   init() {
     const config = this.game.config();
+    const userSettings = new UserSettings();
 
-    const savedKeybinds = localStorage.getItem("settings.keybinds");
+    const savedKeybinds = userSettings.keybinds();
     if (savedKeybinds) {
       try {
         this.keybinds = JSON.parse(savedKeybinds);

--- a/src/client/graphics/layers/UnitDisplay.ts
+++ b/src/client/graphics/layers/UnitDisplay.ts
@@ -55,7 +55,7 @@ export class UnitDisplay extends LitElement implements Layer {
     const config = this.game.config();
     const userSettings = new UserSettings();
 
-    this.keybinds = userSettings.parsedKeybinds();
+    this.keybinds = userSettings.parsedUserKeybinds();
 
     this.allDisabled = BuildMenus.types.every((u) => config.isUnitDisabled(u));
     this.requestUpdate();

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -284,12 +284,26 @@ export class UserSettings {
     this.setFloat("settings.attackRatio", value);
   }
 
-  keybinds(): string {
-    return this.getString(KEYBINDS_KEY, "{}");
+  // In case localStorage was manually edited to be invalid, return an empty object
+  parsedKeybinds(): Record<string, any> {
+    const raw = this.getString(KEYBINDS_KEY, "{}");
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch (e) {
+      console.warn("Invalid keybinds JSON:", e);
+    }
+    return {};
   }
 
-  setKeybinds(value: string): void {
-    this.setString(KEYBINDS_KEY, value);
+  setKeybinds(value: string | Record<string, any>): void {
+    if (typeof value === "string") {
+      this.setString(KEYBINDS_KEY, value);
+    } else {
+      this.setString(KEYBINDS_KEY, JSON.stringify(value));
+    }
   }
 
   soundEffectsVolume(): number {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -7,6 +7,7 @@ export const FLAG_KEY = "flag";
 export const COLOR_KEY = "settings.territoryColor";
 export const DARK_MODE_KEY = "settings.darkMode";
 export const PERFORMANCE_OVERLAY_KEY = "settings.performanceOverlay";
+export const KEYBINDS_KEY = "settings.keybinds";
 
 export class UserSettings {
   private static cache = new Map<string, string | null>();
@@ -40,7 +41,7 @@ export class UserSettings {
     }
   }
 
-  private removeCached(key: string, emitChange: boolean = true) {
+  public removeCached(key: string, emitChange: boolean = true) {
     localStorage.removeItem(key);
     UserSettings.cache.set(key, null);
     if (emitChange) {
@@ -296,11 +297,11 @@ export class UserSettings {
   }
 
   keybinds(): string {
-    return this.getString("settings.keybinds", "");
+    return this.getString(KEYBINDS_KEY, "");
   }
 
   setKeybinds(value: string): void {
-    this.setString("settings.keybinds", value);
+    this.setString(KEYBINDS_KEY, value);
   }
 
   soundEffectsVolume(): number {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -298,6 +298,22 @@ export class UserSettings {
     return {};
   }
 
+  // Returns a flat keybind map { action: "keyCode" }, handling nested objects and legacy strings
+  normalizedKeybinds(): Record<string, string> {
+    const parsed = this.parsedKeybinds();
+    return Object.fromEntries(
+      Object.entries(parsed)
+        .map(([k, v]) => {
+          let val = v;
+          if (v && typeof v === "object" && "value" in v) {
+            val = v.value;
+          }
+          return [k, val];
+        })
+        .filter(([, v]) => typeof v === "string")
+    ) as Record<string, string>;
+  }
+
   setKeybinds(value: string | Record<string, any>): void {
     if (typeof value === "string") {
       this.setString(KEYBINDS_KEY, value);

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -1,6 +1,42 @@
 import { Cosmetics } from "../CosmeticSchemas";
 import { PlayerPattern } from "../Schemas";
 
+export function getDefaultKeybinds(isMac: boolean): Record<string, string> {
+  return {
+    toggleView: "Space",
+    coordinateGrid: "KeyM",
+    buildCity: "Digit1",
+    buildFactory: "Digit2",
+    buildPort: "Digit3",
+    buildDefensePost: "Digit4",
+    buildMissileSilo: "Digit5",
+    buildSamLauncher: "Digit6",
+    buildWarship: "Digit7",
+    buildAtomBomb: "Digit8",
+    buildHydrogenBomb: "Digit9",
+    buildMIRV: "Digit0",
+    attackRatioDown: "KeyT",
+    attackRatioUp: "KeyY",
+    boatAttack: "KeyB",
+    groundAttack: "KeyG",
+    swapDirection: "KeyU",
+    zoomOut: "KeyQ",
+    zoomIn: "KeyE",
+    centerCamera: "KeyC",
+    moveUp: "KeyW",
+    moveLeft: "KeyA",
+    moveDown: "KeyS",
+    moveRight: "KeyD",
+    modifierKey: isMac ? "MetaLeft" : "ControlLeft",
+    altKey: "AltLeft",
+    shiftKey: "ShiftLeft",
+    resetGfx: "KeyR",
+    pauseGame: "KeyP",
+    gameSpeedUp: "Period",
+    gameSpeedDown: "Comma",
+  };
+}
+
 export const USER_SETTINGS_CHANGED_EVENT = "event:user-settings-changed";
 export const PATTERN_KEY = "territoryPattern";
 export const FLAG_KEY = "flag";
@@ -285,7 +321,7 @@ export class UserSettings {
   }
 
   // In case localStorage was manually edited to be invalid, return an empty object
-  parsedKeybinds(): Record<string, any> {
+  parsedUserKeybinds(): Record<string, any> {
     const raw = this.getString(KEYBINDS_KEY, "{}");
     try {
       const parsed = JSON.parse(raw);
@@ -299,8 +335,8 @@ export class UserSettings {
   }
 
   // Returns a flat keybind map { action: "keyCode" }, handling nested objects and legacy strings
-  normalizedKeybinds(): Record<string, string> {
-    const parsed = this.parsedKeybinds();
+  private normalizedUserKeybinds(): Record<string, string> {
+    const parsed = this.parsedUserKeybinds();
     return Object.fromEntries(
       Object.entries(parsed)
         // Extract value from nested object or plain string, filter out non-string values
@@ -316,6 +352,23 @@ export class UserSettings {
         })
         .filter(([, v]) => typeof v === "string"),
     ) as Record<string, string>;
+  }
+
+  keybinds(isMac: boolean): Record<string, string> {
+    const merged = {
+      ...getDefaultKeybinds(isMac),
+      ...this.normalizedUserKeybinds(),
+    };
+    // Actually unbind key: if Unbind is clicked in UserSettingsModal, eg. for Attack Ratio Up,
+    // keybind is "Null". Even if it is in default kindbinds (Y), it should not work anymore.
+    // The key (Y) can now be bound to another action like Boat Attack, and no two actions listen to the same key.
+    for (const k in merged) {
+      if (merged[k] === "Null") {
+        delete merged[k];
+      }
+    }
+
+    return merged;
   }
 
   setKeybinds(value: string | Record<string, any>): void {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -297,7 +297,7 @@ export class UserSettings {
   }
 
   keybinds(): string {
-    return this.getString(KEYBINDS_KEY, "");
+    return this.getString(KEYBINDS_KEY, "{}");
   }
 
   setKeybinds(value: string): void {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -303,6 +303,7 @@ export class UserSettings {
     const parsed = this.parsedKeybinds();
     return Object.fromEntries(
       Object.entries(parsed)
+        // Extract value from nested object or plain string, filter out non-string values
         .map(([k, v]) => {
           let val = v;
           if (v && typeof v === "object" && "value" in v) {
@@ -310,7 +311,7 @@ export class UserSettings {
           }
           return [k, val];
         })
-        .filter(([, v]) => typeof v === "string")
+        .filter(([, v]) => typeof v === "string"),
     ) as Record<string, string>;
   }
 

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -306,8 +306,11 @@ export class UserSettings {
         // Extract value from nested object or plain string, filter out non-string values
         .map(([k, v]) => {
           let val = v;
-          if (v && typeof v === "object" && "value" in v) {
+          if (v && typeof v === "object" && !Array.isArray(v) && "value" in v) {
             val = v.value;
+          }
+          if (Array.isArray(val) && typeof val[0] === "string") {
+            val = val[0];
           }
           return [k, val];
         })

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -44,7 +44,7 @@ describe("InputHandler AutoUpgrade", () => {
 
   beforeEach(() => {
     testSettings = new UserSettings();
-    testSettings.removeCached(KEYBINDS_KEY);
+    testSettings.removeCached(KEYBINDS_KEY, false);
 
     mockGameView = { inSpawnPhase: () => false } as GameView;
     mockCanvas = document.createElement("canvas");

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -6,6 +6,7 @@ import {
 import { UIState } from "../src/client/graphics/UIState";
 import { EventBus } from "../src/core/EventBus";
 import { UnitType } from "../src/core/game/Game";
+import { KEYBINDS_KEY, UserSettings } from "../src/core/game/UserSettings";
 
 class MockPointerEvent {
   button: number;
@@ -31,8 +32,12 @@ describe("InputHandler AutoUpgrade", () => {
   let inputHandler: InputHandler;
   let eventBus: EventBus;
   let mockCanvas: HTMLCanvasElement;
+  let testSettings: UserSettings;
 
   beforeEach(() => {
+    testSettings = new UserSettings();
+    testSettings.removeCached(KEYBINDS_KEY);
+
     mockCanvas = document.createElement("canvas");
     mockCanvas.width = 800;
     mockCanvas.height = 600;
@@ -416,15 +421,11 @@ describe("InputHandler AutoUpgrade", () => {
   });
 
   describe("Keybinds JSON parsing", () => {
-    beforeEach(() => {
-      localStorage.removeItem("settings.keybinds");
-    });
-
     test("parses nested object values and flattens them to strings", () => {
       const nested = {
         moveUp: { key: "moveUp", value: "KeyZ" },
       };
-      localStorage.setItem("settings.keybinds", JSON.stringify(nested));
+      testSettings.setKeybinds(JSON.stringify(nested));
 
       inputHandler.initialize();
 
@@ -432,10 +433,7 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("accepts legacy string values", () => {
-      localStorage.setItem(
-        "settings.keybinds",
-        JSON.stringify({ moveUp: "KeyX" }),
-      );
+      testSettings.setKeybinds(JSON.stringify({ moveUp: "KeyX" }));
 
       inputHandler.initialize();
 
@@ -447,7 +445,7 @@ describe("InputHandler AutoUpgrade", () => {
         moveUp: { key: "moveUp", value: null },
         moveLeft: "Null",
       };
-      localStorage.setItem("settings.keybinds", JSON.stringify(mixed));
+      testSettings.setKeybinds(JSON.stringify(mixed));
 
       inputHandler.initialize();
 
@@ -458,7 +456,7 @@ describe("InputHandler AutoUpgrade", () => {
 
     test("handles invalid JSON gracefully and warns", () => {
       const spy = vi.spyOn(console, "warn").mockImplementation(() => {});
-      localStorage.setItem("settings.keybinds", "not a json");
+      testSettings.setKeybinds("not a json");
 
       inputHandler.initialize();
 
@@ -473,7 +471,6 @@ describe("InputHandler AutoUpgrade", () => {
     let uiState: UIState;
 
     beforeEach(() => {
-      localStorage.removeItem("settings.keybinds");
       uiState = {
         attackRatio: 20,
         ghostStructure: null,
@@ -524,7 +521,6 @@ describe("InputHandler AutoUpgrade", () => {
 
   describe("Numpad number keys for build keybinds", () => {
     beforeEach(() => {
-      localStorage.removeItem("settings.keybinds");
       inputHandler.destroy();
       const uiState: UIState = {
         attackRatio: 20,
@@ -561,7 +557,6 @@ describe("InputHandler AutoUpgrade", () => {
 
   describe("Build keybind two-phase matching (exact code first, then digit/Numpad alias)", () => {
     beforeEach(() => {
-      localStorage.removeItem("settings.keybinds");
       inputHandler.destroy();
       const uiState: UIState = {
         attackRatio: 20,
@@ -575,8 +570,7 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("exact code match wins: Digit1 sets City when buildCity=Digit1 and buildFactory=Numpad1", () => {
-      localStorage.setItem(
-        "settings.keybinds",
+      testSettings.setKeybinds(
         JSON.stringify({
           buildCity: "Digit1",
           buildFactory: "Numpad1",
@@ -601,8 +595,7 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("exact code match wins: Numpad1 sets Factory when buildCity=Digit1 and buildFactory=Numpad1", () => {
-      localStorage.setItem(
-        "settings.keybinds",
+      testSettings.setKeybinds(
         JSON.stringify({
           buildCity: "Digit1",
           buildFactory: "Numpad1",
@@ -627,10 +620,7 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("digit alias used when no exact match: Numpad1 sets City when only buildCity=Digit1", () => {
-      localStorage.setItem(
-        "settings.keybinds",
-        JSON.stringify({ buildCity: "Digit1" }),
-      );
+      testSettings.setKeybinds(JSON.stringify({ buildCity: "Digit1" }));
       inputHandler.destroy();
       const uiState: UIState = {
         attackRatio: 20,

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -37,9 +37,9 @@ global.PointerEvent = MockPointerEvent as any;
 
 describe("InputHandler AutoUpgrade", () => {
   let inputHandler: InputHandler;
+  let mockGameView: GameView;
   let eventBus: EventBus;
   let mockCanvas: HTMLCanvasElement;
-  let mockGameView: GameView;
   let testSettings: UserSettings;
 
   beforeEach(() => {

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -37,7 +37,6 @@ global.PointerEvent = MockPointerEvent as any;
 
 describe("InputHandler AutoUpgrade", () => {
   let inputHandler: InputHandler;
-  let mockGameView: GameView;
   let eventBus: EventBus;
   let mockCanvas: HTMLCanvasElement;
   let mockGameView: GameView;

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -500,7 +500,7 @@ describe("InputHandler AutoUpgrade", () => {
       expect((inputHandler as any).keybinds.moveUp).toBe("KeyX");
     });
 
-    test("ignores non-string values and preserves defaults, but keeps 'Null' for unbound keys", () => {
+    test("ignores non-string values and preserves defaults, removes 'Null' for unbound keys", () => {
       const mixed = {
         moveUp: { key: "moveUp", value: null },
         moveLeft: "Null",

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -485,7 +485,7 @@ describe("InputHandler AutoUpgrade", () => {
       const nested = {
         moveUp: { key: "moveUp", value: "KeyZ" },
       };
-      testSettings.setKeybinds(JSON.stringify(nested));
+      testSettings.setKeybinds(nested);
 
       inputHandler.initialize();
 
@@ -493,7 +493,7 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("accepts legacy string values", () => {
-      testSettings.setKeybinds(JSON.stringify({ moveUp: "KeyX" }));
+      testSettings.setKeybinds({ moveUp: "KeyX" });
 
       inputHandler.initialize();
 
@@ -505,13 +505,13 @@ describe("InputHandler AutoUpgrade", () => {
         moveUp: { key: "moveUp", value: null },
         moveLeft: "Null",
       };
-      testSettings.setKeybinds(JSON.stringify(mixed));
+      testSettings.setKeybinds(mixed);
 
       inputHandler.initialize();
 
       expect((inputHandler as any).keybinds.moveUp).toBe("KeyW");
-      // "Null" is preserved to indicate unbound keybind
-      expect((inputHandler as any).keybinds.moveLeft).toBe("Null");
+      // "Null" entries are removed entirely to indicate unbound keybind
+      expect((inputHandler as any).keybinds.moveLeft).toBeUndefined();
     });
 
     test("handles invalid JSON gracefully and warns", () => {
@@ -645,12 +645,10 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("exact code match wins: Digit1 sets City when buildCity=Digit1 and buildFactory=Numpad1", () => {
-      testSettings.setKeybinds(
-        JSON.stringify({
-          buildCity: "Digit1",
-          buildFactory: "Numpad1",
-        }),
-      );
+      testSettings.setKeybinds({
+        buildCity: "Digit1",
+        buildFactory: "Numpad1",
+      });
       inputHandler.destroy();
       const uiState: UIState = {
         attackRatio: 20,
@@ -675,12 +673,10 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("exact code match wins: Numpad1 sets Factory when buildCity=Digit1 and buildFactory=Numpad1", () => {
-      testSettings.setKeybinds(
-        JSON.stringify({
-          buildCity: "Digit1",
-          buildFactory: "Numpad1",
-        }),
-      );
+      testSettings.setKeybinds({
+        buildCity: "Digit1",
+        buildFactory: "Numpad1",
+      });
       inputHandler.destroy();
       const uiState: UIState = {
         attackRatio: 20,
@@ -705,7 +701,7 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("digit alias used when no exact match: Numpad1 sets City when only buildCity=Digit1", () => {
-      testSettings.setKeybinds(JSON.stringify({ buildCity: "Digit1" }));
+      testSettings.setKeybinds({ buildCity: "Digit1" });
       inputHandler.destroy();
       const uiState: UIState = {
         attackRatio: 20,


### PR DESCRIPTION
## Description:

1) Have last localstorage calls for keybinds and attack ratio also use UserSettings cache instead, after #3481. Remaining calls to localstorage are for different things than user settings, so they are left as is.

2) Consolidate and centralize keybinds logic. And three fixes for it.

- **UnitDisplay** and **UserSettingsModal**: _parsedUserKeybinds_ is introduced in **UserSettings** to centralize their logic. It is also used by _normalizedUserKeybinds_, see point below.

- **UserSettingsModal**
-- replaced unwanted cast `as SettingKeybind` by a typed QuerySelector.
-- renamed this.keybinds to this.userKeybinds for more clarity, and distinction from defaultKeybinds.
-- state private _userKeybinds_: remove type string[] since loadKeybindsFromStorage replaces a value array by its first string element, so it can not contain string[] anymore.
-- _handleKeybindChange_ and _getKeyValue_: no need to check for Array.isArray anymore, see above reason.
-- **Fix**: checks after calling _parsedUserKeybinds_ are improved a bit: don't delete all keybinds and print a console warning when finding just one invalid keybind and (i think i have seen people complaining about things being removed). Instead it now migrates or throws out the invalid ones but keeps the valid ones. Also works with the "Null" value expected and removed within **UserSettingsModal**._handleyKeybindChange_() and in **HelpModal**. When legacy value is an array and key is empty, don't put value as key but get first array element or empty string as key name. So that check on line 68 is true.

- **HelpModal** and **InputHandler**: Also centralize/consolidate their logic more, by having __keybinds()_ from **UserSettings** perform fetching _getDefaultKeybinds_ and _normalizedUserKeybinds_. 
-- Functionality in _normalizedUserKeybinds_ is the same: Where HelpModal did return [k, v.value] if typeof (v as any).value === "string", this is now handled by lines 309-310 of normalizedKeybinds still the same but with less lines. Same for old HelplModal if (typeof v === "string") return [k, v], this is stil returned by line 112 of normalizedKeybinds. And return [k, undefined] when (typeof val !== "string") as was done in InputHandler, isn't needed as values that weren't strings were already filtered out right after which we still do on line 314 of normalizedKeybinds. 
-- **Fix** in _normalizedUserKeybinds_: added one extra thing that was a discrepancy between **HelpModal**/**InputHandler** and **UserSettingsModal** before: **UserSettingsModal** would handle array values, and normalize them by picking only the first value if it is a string. Now have _normalizedKeybinds_ do the same. Otherwise it would have thrown those values out while **UserSettingsModal** would have kept the first value. This may still help a returning player who hasn't played in the last version (i think i have seen people complaining about things being removed, but that may not have been about this). And makes the logic more consistent between **UserSettingsModal** and **HelpModal**/**InputHandler**.

- **UserSettings**: 
-- _getDefaultKeybinds_: centralized/consolidated logic, accepts Platform.isMac parameter. In **HelpModal**, **InputHandler** and **UserSettingsModal** the same list with default keybinds was hardcoded. Now they all read from _getDefaultKeybinds_. The list of default keybinds in **HelpModal** was a little shorter, but that doesn't matter since its _render_() function has hardcoded which of the hotkeys **HelpModal** shows. Have thought about putting default keybinds in **DefaultConfig** but with all the logic handled through **UserSettings**, this seemed the better place in the current refactor.
-- _removeCached_: make public, now that **InputHandler.test.ts** needs to be able to call it. We could instead make a public function like removeKeybinds() and keep removeCached() private, but went with this for now.
-- _parsedUserKeybinds_: centralized/consolidated logic for **UserSettingsModal**/**UserDisplay**. Always returns an object, even an empty one if the JSON wasn't parsable.
-- _normalizedKeybinds_: centralized/consolidated logic. Used by _keybinds_() which is now called by **HelpModal**/**InputHandler**.
-- _keybinds_: now uses getDefaultKeybinds() and normalizedKeybinds() to get the default and user changed keybinds.
-- **Fix** in _keybinds_: it now removes a key if it is Unbound by the user in **UserSettingsModal**. Instead of first loading the parsedUserKeybinds, removing "Null" keys from it, and then merging that with defaultKeybinds (so default key would overwrite an unbound key), we now merge parsedUserKeybinds with defaultKeybinds and after that remove "Null" keys from it (so that unbound key stays removed).
For example if Boat Attack Up is set to "None" ("Null") by clicking Unbind, there is now no hotkey working for it anymore. Even when the default is "B". 
Why? This prevents the user from being confused, they have deliberately Unbound it, they don't understand why it still works (have seen bug reports and game feedback about this)? Also more importantly: they used to now be able to bind "B" to another action. Effectively making key "B" bound to two actions: the user choosen one and Boat Attack. This also makes the logic more consistent. Because building hotkeys in **UnitDisplay** already didn't work when unbound, eg. when Build Missile Silo was Unbound, the "5" key did not do anything anymore (there is a fallback in **UnitDisplay** in case the key is actually null, but it does respect "Null" as it should).
-- _setKeybinds_: have it accept an object, it stringifies it itself. Callers UserSettingsModal and InputHandler.test.ts now just send either a string or an object.

- **InputHandler.test.ts**: 
-- use **UserSettings** functions instead of localStorage for more real-world testing.
-- change test "ignores non-string values and preserves defaults, removes 'Null' for unbound keys". As explained above, as a fix we no longer preserve unbound ("Null") keys within InputHandler. UserSettings.keybinds() now removes "Null" keys as explained above.

- ControlPanel: use UserSettings to fetch initial attack ratio.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33