### PR TITLE
Add only allow custom name if logged in

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -8,6 +8,7 @@ import {
   GameStartInfo,
   PublicGameInfo,
 } from "../core/Schemas";
+import { createAnonUsername } from "../core/Util";
 import { GameEnv } from "../core/configuration/Config";
 import { getRuntimeClientServerConfig } from "../core/configuration/ConfigLoader";
 import { GameType } from "../core/game/Game";
@@ -55,7 +56,7 @@ import {
 } from "./Transport";
 import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
-import { genAnonUsername, UsernameInput } from "./UsernameInput";
+import { UsernameInput } from "./UsernameInput";
 import {
   getDiscordAvatarUrl,
   incrementGamesPlayed,
@@ -756,7 +757,7 @@ class Client {
       serverConfig: config,
       cosmetics: await getPlayerCosmeticsRefs(),
       turnstileToken: await this.getTurnstileToken(lobby),
-      playerName: this.usernameInput?.getUsername() ?? genAnonUsername(),
+      playerName: this.usernameInput?.getUsername() ?? createAnonUsername(),
       playerClanTag: this.usernameInput?.getClanTag() ?? null,
       gameStartInfo: lobby.gameStartInfo ?? lobby.gameRecord?.info,
       gameRecord: lobby.gameRecord,

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -1,8 +1,9 @@
 import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { v4 as uuidv4 } from "uuid";
+import { hasLinkedAccount } from "../client/Api";
 import { translateText } from "../client/Utils";
-import { sanitizeClanTag } from "../core/Util";
+import { UserMeResponse } from "../core/ApiSchemas";
+import { createAnonUsername, sanitizeClanTag } from "../core/Util";
 import {
   MAX_CLAN_TAG_LENGTH,
   MAX_USERNAME_LENGTH,
@@ -26,10 +27,19 @@ const clanTagKey: string = "clanTag";
 export class UsernameInput extends LitElement {
   @state() private baseUsername: string = "";
   @state() private clanTag: string = "";
+  @state() private linked = false;
 
   @property({ type: String }) validationError: string = "";
   private _isValid: boolean = true;
   private _lastValidatedLang: string | null = null;
+
+  private _onUserMe = (event: CustomEvent<UserMeResponse | false>) => {
+    this.linked = hasLinkedAccount(event.detail);
+    if (!this.linked) {
+      this.baseUsername = createAnonUsername();
+      this.validateAndStore();
+    }
+  };
 
   // Remove static styles since we're using Tailwind
 
@@ -65,6 +75,18 @@ export class UsernameInput extends LitElement {
         this.validateAndStore();
       }
     });
+    document.addEventListener(
+      "userMeResponse",
+      this._onUserMe as EventListener,
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener(
+      "userMeResponse",
+      this._onUserMe as EventListener,
+    );
   }
 
   protected updated(): void {
@@ -91,17 +113,26 @@ export class UsernameInput extends LitElement {
       this.baseUsername = storedUsername;
       this.validateAndStore();
     } else {
-      this.baseUsername = genAnonUsername();
+      this.baseUsername = createAnonUsername();
       this.validateAndStore();
     }
   }
 
   render() {
     return html`
-      <div class="flex items-center w-full h-full gap-2">
+      <div class="relative flex items-center w-full h-full gap-2">
+        ${!this.linked
+          ? html`
+              <div
+                class="absolute inset-0 z-10 cursor-pointer"
+                @click=${() => window.showPage?.("page-account")}
+              ></div>
+            `
+          : null}
         <input
           type="text"
           .value=${this.clanTag}
+          ?disabled=${!this.linked}
           @input=${this.handleClanTagChange}
           placeholder="${translateText("username.tag")}"
           minlength="${MIN_CLAN_TAG_LENGTH}"
@@ -111,6 +142,7 @@ export class UsernameInput extends LitElement {
         <input
           type="text"
           .value=${this.baseUsername}
+          ?disabled=${!this.linked}
           @input=${this.handleUsernameChange}
           placeholder="${translateText("username.enter_username")}"
           minlength="${MIN_USERNAME_LENGTH}"
@@ -221,12 +253,4 @@ export class UsernameInput extends LitElement {
     this.showValidationFeedback();
     return false;
   }
-}
-
-export function genAnonUsername(): string {
-  const uuid = uuidv4();
-  const cleanUuid = uuid.replace(/-/g, "").toLowerCase();
-  const decimal = BigInt(`0x${cleanUuid}`);
-  const threeDigits = decimal % 1000n;
-  return "Anon" + threeDigits.toString().padStart(3, "0");
 }

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify";
 import { customAlphabet } from "nanoid";
+import { v4 as uuidv4 } from "uuid";
 import { Cell, PlayerType, Unit } from "./game/Game";
 import { GameMap, TileRef } from "./game/GameMap";
 import {
@@ -344,6 +345,14 @@ export function minInt(a: bigint, b: bigint): bigint {
 export function withinInt(num: bigint, min: bigint, max: bigint): bigint {
   const atLeastMin = maxInt(num, min);
   return minInt(atLeastMin, max);
+}
+
+export function createAnonUsername(): string {
+  const uuid = uuidv4();
+  const cleanUuid = uuid.replace(/-/g, "").toLowerCase();
+  const decimal = BigInt(`0x${cleanUuid}`);
+  const threeDigits = decimal % 1000n;
+  return "Anon" + threeDigits.toString().padStart(3, "0");
 }
 
 export function createRandomName(

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -16,7 +16,7 @@ import {
   PartialGameRecordSchema,
   ServerErrorMessage,
 } from "../core/Schemas";
-import { generateID, replacer } from "../core/Util";
+import { createAnonUsername, generateID, replacer } from "../core/Util";
 import { CreateGameInputSchema } from "../core/WorkerSchemas";
 import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
@@ -377,61 +377,59 @@ export async function startWorker() {
           return;
         }
 
-        // Normalize username and clan tag before any rejoin/join handling.
-        // If this connection maps to an existing lobby client, we still want
-        // the latest pre-join identity to be reflected.
-        const { clanTag: censoredClanTag, username: censoredUsername } =
-          privilegeRefresher
-            .get()
-            .censor(clientMsg.username, clientMsg.clanTag ?? null);
-
-        // Try to reconnect an existing client (e.g., page refresh)
-        // If successful, skip all authorization
-        if (
-          gm.rejoinClient(ws, persistentId, clientMsg.gameID, 0, {
-            username: censoredUsername,
-            clanTag: censoredClanTag,
-          })
-        ) {
-          return;
-        }
-
         let roles: string[] | undefined;
         let flares: string[] | undefined;
+        let isLoggedIn = false;
 
-        const allowedFlares = config.allowedFlares();
-        if (claims === null) {
-          if (allowedFlares !== undefined) {
-            log.warn("Unauthorized: Anonymous user attempted to join game");
-            ws.close(1002, "Unauthorized");
-            return;
-          }
-        } else {
-          // Verify token and get player permissions
-          const result = await getUserMe(clientMsg.token, config);
-          if (result.type === "error") {
-            log.warn(`Unauthorized: ${result.message}`, {
+        if (claims !== null) {
+          // Verify token
+          const userResult = await getUserMe(clientMsg.token, config);
+          if (userResult.type === "error") {
+            log.warn(`Unauthorized: ${userResult.message}`, {
               persistentID: persistentId,
               gameID: clientMsg.gameID,
             });
             ws.close(1002, "Unauthorized: user me fetch failed");
             return;
           }
-          roles = result.response.player.roles;
-          flares = result.response.player.flares;
 
-          if (allowedFlares !== undefined) {
-            const allowed =
-              allowedFlares.length === 0 ||
-              allowedFlares.some((f) => flares?.includes(f));
-            if (!allowed) {
-              log.warn(
-                "Forbidden: player without an allowed flare attempted to join game",
-              );
-              ws.close(1002, "Forbidden");
-              return;
-            }
+          isLoggedIn =
+            userResult.response.user &&
+            (userResult.response.user?.discord !== undefined ||
+              userResult.response.user?.email !== undefined);
+
+          // get player permissions
+          roles = userResult.response.player.roles;
+          flares = userResult.response.player.flares;
+        }
+
+        // Normalize username and clan tag before any rejoin/join handling.
+        // If this connection maps to an existing lobby client, we still want
+        // the latest pre-join identity to be reflected.
+        let clientUsername = clientMsg.username;
+        let clientClanTag = clientMsg.clanTag;
+
+        if (isLoggedIn) {
+          ({ username: clientUsername, clanTag: clientClanTag } =
+            privilegeRefresher
+              .get()
+              .censor(clientUsername, clientClanTag ?? null));
+        } else {
+          clientClanTag = null;
+          if (!clientUsername.match(/^Anon\d{3}$/)) {
+            clientUsername = createAnonUsername();
           }
+        }
+
+        // Try to reconnect an existing client (e.g., page refresh)
+        // If successful, skip all authorization
+        if (
+          gm.rejoinClient(ws, persistentId, clientMsg.gameID, 0, {
+            username: clientUsername,
+            clanTag: clientClanTag,
+          })
+        ) {
+          return;
         }
 
         const cosmeticResult = privilegeRefresher
@@ -482,8 +480,8 @@ export async function startWorker() {
           roles,
           flares,
           ip,
-          censoredUsername,
-          censoredClanTag,
+          clientUsername,
+          clientClanTag,
           ws,
           cosmeticResult.cosmetics,
         );


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #1636 

## Description:

Describe the PR.
Add client and server checks to prevent non-logged in users from setting a username.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

babyboucher
