### PR TITLE
Fix for v30: do not show "Not logged in" on flag modal on CrazyGames

### DIFF
--- a/src/client/components/NotLoggedInWarning.ts
+++ b/src/client/components/NotLoggedInWarning.ts
@@ -34,7 +34,7 @@ export class NotLoggedInWarning extends LitElement {
   render() {
     if (this.linked) return html``;
 
-    return html`<div class="flex items-center">
+    return html`<div class="no-crazygames flex items-center">
       <button
         class="px-4 py-2 text-xs font-bold uppercase tracking-wider transition-colors duration-200 rounded-lg bg-red-500/20 text-red-400 border border-red-500/30 cursor-pointer hover:bg-red-500/30"
         data-i18n="common.not_logged_in"


### PR DESCRIPTION
## Description:

Fix for v30 and main.

Do not show "Not logged in" on the FlagInputModal in CrazyGames, since our own login should not work there. It was added in https://github.com/openfrontio/OpenFrontIO/pull/3521 in v30 so this fix is needed for production too.

<img width="1415" height="797" alt="image" src="https://github.com/user-attachments/assets/ef839e08-827d-4eea-b5aa-8aca6357ad07" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33