### PR TITLE
feat(lobby): highlight local player name in lobby list

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -79,6 +79,7 @@ export class HostLobbyModal extends BaseModal {
   @state() private useRandomMap: boolean = false;
   @state() private disabledUnits: UnitType[] = [];
   @state() private lobbyCreatorClientID: string = "";
+  @state() private myClientID: string = "";
 
   @property({ attribute: false }) eventBus: EventBus | null = null;
   // Timers for debouncing slider changes
@@ -94,6 +95,7 @@ export class HostLobbyModal extends BaseModal {
       return;
     }
     this.lobbyCreatorClientID = lobby.lobbyCreatorClientID ?? "";
+    this.myClientID = event.myClientID;
     if (lobby.clients) {
       this.clients = lobby.clients;
     }
@@ -328,7 +330,7 @@ export class HostLobbyModal extends BaseModal {
             .gameMode=${this.gameMode}
             .clients=${this.clients}
             .lobbyCreatorClientID=${this.lobbyCreatorClientID}
-            .currentClientID=${this.lobbyCreatorClientID}
+            .currentClientID=${this.myClientID}
             .teamCount=${this.teamCount}
             .nationCount=${this.nations}
             .onKickPlayer=${(clientID: string) => this.kickPlayer(clientID)}
@@ -370,7 +372,8 @@ export class HostLobbyModal extends BaseModal {
     this.startLobbyUpdates();
     this.lobbyId = generateID();
     // Note: clientID will be assigned by server when we join the lobby
-    // lobbyCreatorClientID stays empty until then
+    this.lobbyCreatorClientID = "";
+    this.myClientID = "";
 
     // Pass auth token for creator identification (server extracts persistentID from it)
     createLobby(this.lobbyId)
@@ -463,6 +466,7 @@ export class HostLobbyModal extends BaseModal {
     this.lobbyId = "";
     this.clients = [];
     this.lobbyCreatorClientID = "";
+    this.myClientID = "";
     this.goldMultiplier = false;
     this.goldMultiplierValue = undefined;
     this.startingGold = false;

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -1,4 +1,4 @@
-import { LitElement, html } from "lit";
+import { LitElement, html, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { PastelTheme } from "../../core/configuration/PastelTheme";
@@ -123,13 +123,11 @@ export class LobbyTeamView extends LitElement {
           (c) => c.clientID ?? c.username,
           (client) => {
             const displayName = this.getClientDisplayName(client);
+            const self = this.isCurrentPlayer(client);
             return html`<div
-              class="px-2 py-1 rounded-sm mb-1 text-xs text-white border
-                ${this.isCurrentPlayer(client)
-                ? "bg-sky-600/20 border-sky-500/40"
-                : "bg-gray-700/70 border-transparent"}"
+              class="px-2 py-1 rounded-sm mb-1 text-xs border bg-gray-700/70 border-transparent"
             >
-              ${displayName}
+              ${this.renderHighlightedDisplayName(displayName, self)}
             </div>`;
           },
         )}
@@ -176,7 +174,10 @@ export class LobbyTeamView extends LitElement {
             ? "current-player"
             : ""}"
         >
-          <span class="text-white">${displayName}</span>
+          ${this.renderHighlightedDisplayName(
+            displayName,
+            this.isCurrentPlayer(client),
+          )}
           ${client.clientID === this.lobbyCreatorClientID
             ? html`<span class="host-badge"
                 >(${translateText("host_modal.host_badge")})</span
@@ -239,13 +240,13 @@ export class LobbyTeamView extends LitElement {
                 (p) => p.clientID ?? p.username,
                 (p) => {
                   const displayName = this.getClientDisplayName(p);
+                  const self = this.isCurrentPlayer(p);
                   return html` <div
-                    class="px-2 py-1 rounded-sm text-xs flex items-center justify-between border
-                      ${this.isCurrentPlayer(p)
-                      ? "bg-sky-600/20 border-sky-500/40"
-                      : "bg-gray-700/70 border-transparent"}"
+                    class="px-2 py-1 rounded-sm text-xs flex items-center justify-between border bg-gray-700/70 border-transparent min-w-0"
                   >
-                    <span class="truncate text-white">${displayName}</span>
+                    <span class="truncate min-w-0"
+                      >${this.renderHighlightedDisplayName(displayName, self)}</span
+                    >
                     ${p.clientID === this.lobbyCreatorClientID
                       ? html`<span class="ml-2 text-[11px] text-green-300"
                           >(${translateText("host_modal.host_badge")})</span
@@ -382,6 +383,16 @@ export class LobbyTeamView extends LitElement {
 
   private isCurrentPlayer(client: ClientInfo): boolean {
     return !!this.currentClientID && client.clientID === this.currentClientID;
+  }
+
+  private renderHighlightedDisplayName(
+    displayName: string,
+    isSelf: boolean,
+  ): TemplateResult {
+    if (isSelf) {
+      return html`<span class="lobby-self-name-highlight">${displayName}</span>`;
+    }
+    return html`<span class="text-white">${displayName}</span>`;
   }
 
   private teamContainsCurrentPlayer(preview: TeamPreviewData): boolean {

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, TemplateResult } from "lit";
+import { html, LitElement, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { PastelTheme } from "../../core/configuration/PastelTheme";
@@ -245,7 +245,10 @@ export class LobbyTeamView extends LitElement {
                     class="px-2 py-1 rounded-sm text-xs flex items-center justify-between border bg-gray-700/70 border-transparent min-w-0"
                   >
                     <span class="truncate min-w-0"
-                      >${this.renderHighlightedDisplayName(displayName, self)}</span
+                      >${this.renderHighlightedDisplayName(
+                        displayName,
+                        self,
+                      )}</span
                     >
                     ${p.clientID === this.lobbyCreatorClientID
                       ? html`<span class="ml-2 text-[11px] text-green-300"
@@ -390,7 +393,9 @@ export class LobbyTeamView extends LitElement {
     isSelf: boolean,
   ): TemplateResult {
     if (isSelf) {
-      return html`<span class="lobby-self-name-highlight">${displayName}</span>`;
+      return html`<span class="lobby-self-name-highlight"
+        >${displayName}</span
+      >`;
     }
     return html`<span class="text-white">${displayName}</span>`;
   }

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -304,8 +304,17 @@ label.option-card:hover {
 }
 
 .player-tag.current-player {
-  background: rgba(14, 165, 233, 0.15);
-  border: 1px solid rgba(14, 165, 233, 0.4);
+  background: #2a2a2a;
+  border: 1px solid rgba(14, 165, 233, 0.55);
+}
+
+.lobby-self-name-highlight {
+  display: inline;
+  border-radius: 4px;
+  padding: 2px 6px;
+  background: rgba(14, 165, 233, 0.35);
+  color: #fff;
+  font-weight: 600;
 }
 
 #bots-count,


### PR DESCRIPTION
## Description:
Highlights the current player's display name in the multiplayer lobby so it is easy to spot in the player list.

## Changes
- Add \.lobby-self-name-highlight\ (marker-style background on the name only) for the local client in FFA and team lobby layouts in \LobbyPlayerView\.
- Host lobby uses \LobbyInfoEvent.myClientID\ as \currentClientID\ (aligned with join flow); state is cleared when opening/closing the host modal.
- Team-mode player rows use a single neutral row style; the name highlight carries the emphasis. FFA \.player-tag.current-player\ uses a stronger border with neutral fill to avoid competing with the name highlight.

## Testing
- Join a private or public lobby and confirm your username shows the highlight; other players do not.
- In team mode, confirm highlight in the left player list and inside team cards.