### PR TITLE
chore(cursor): add run-openfront-game agent skill

### DIFF
--- a/.cursor/skills/run-openfront-game/SKILL.md
+++ b/.cursor/skills/run-openfront-game/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: run-openfront-game
+description: >-
+  Starts OpenFrontIO locally via npm scripts (Vite client + dev game server).
+  Use when the user wants to run, start, launch, or play the game in
+  development; when debugging client/server together; or when they ask for
+  local dev URLs or how to connect to staging/production APIs from a dev build.
+---
+
+# Run OpenFrontIO locally
+
+## Before first run
+
+From the repository root:
+
+1. Install dependencies with the project’s pinned install command (not plain `npm install`):
+
+   ```bash
+   npm run inst
+   ```
+
+2. If the user already ran `npm install` successfully, skip reinstall unless they changed `package-lock.json` or hit dependency errors.
+
+## Default: full local dev stack
+
+Runs the Vite dev client and the TypeScript game server with `GAME_ENV=dev`:
+
+```bash
+npm run dev
+```
+
+- Long-running: run in the background and tell the user how to open the app (Vite prints the local URL in the terminal; typically `http://localhost:5173` unless configured otherwise).
+- To avoid auto-opening a browser (if the project or environment does this), set `SKIP_BROWSER_OPEN=true` in the environment before starting.
+
+## Common variants
+
+| Goal | Command |
+|------|---------|
+| Client only (hot reload, no local game server) | `npm run start:client` |
+| Server only (dev settings) | `npm run start:server-dev` |
+| Dev client + server, API pointed at **staging** | `npm run dev:staging` |
+| Dev client + server, API pointed at **production** | `npm run dev:prod` |
+| Production build then run server (tunnel-style flow) | `npm run tunnel` |
+
+`start:server` runs the server without forcing `GAME_ENV=dev` (see `package.json` scripts for exact behavior).
+
+## After start
+
+- If something fails, read the terminal output: port conflicts, missing env files, or Node version issues are the usual causes.
+- For replay or API-specific workflows mentioned in the repo README, follow README guidance (commit alignment for production replays, etc.).

--- a/.cursor/skills/run-openfront-game/SKILL.md
+++ b/.cursor/skills/run-openfront-game/SKILL.md
@@ -34,13 +34,13 @@ npm run dev
 
 ## Common variants
 
-| Goal | Command |
-|------|---------|
-| Client only (hot reload, no local game server) | `npm run start:client` |
-| Server only (dev settings) | `npm run start:server-dev` |
-| Dev client + server, API pointed at **staging** | `npm run dev:staging` |
-| Dev client + server, API pointed at **production** | `npm run dev:prod` |
-| Production build then run server (tunnel-style flow) | `npm run tunnel` |
+| Goal                                                 | Command                    |
+| ---------------------------------------------------- | -------------------------- |
+| Client only (hot reload, no local game server)       | `npm run start:client`     |
+| Server only (dev settings)                           | `npm run start:server-dev` |
+| Dev client + server, API pointed at **staging**      | `npm run dev:staging`      |
+| Dev client + server, API pointed at **production**   | `npm run dev:prod`         |
+| Production build then run server (tunnel-style flow) | `npm run tunnel`           |
 
 `start:server` runs the server without forcing `GAME_ENV=dev` (see `package.json` scripts for exact behavior).
 

--- a/.cursor/skills/run-openfront-game/SKILL.md
+++ b/.cursor/skills/run-openfront-game/SKILL.md
@@ -29,7 +29,7 @@ Runs the Vite dev client and the TypeScript game server with `GAME_ENV=dev`:
 npm run dev
 ```
 
-- Long-running: run in the background and tell the user how to open the app (Vite prints the local URL in the terminal; typically `http://localhost:5173` unless configured otherwise).
+- Long-running: run in the background and tell the user how to open the app (Vite prints the local URL in the terminal; this repo sets port **9000** in `vite.config.ts`, e.g. `http://localhost:9000`).
 - To avoid auto-opening a browser (if the project or environment does this), set `SKIP_BROWSER_OPEN=true` in the environment before starting.
 
 ## Common variants


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.

## Description:

Adds a Cursor agent skill at `.cursor/skills/run-openfront-game/SKILL.md` for running OpenFrontIO locally (`npm run inst`, `npm run dev`, and common script variants). This change is documentation only; there are no UI or runtime code changes.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

(Contact via GitHub if needed.)
