### PR TITLE
Fix public lobby max player bypass

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -548,6 +548,10 @@ export class GameServer {
       this.activeClients = this.activeClients.filter(
         (c) => c.clientID !== client.clientID,
       );
+      // Remove persistentId if the game has not started to prevent going over max players
+      if (!this._hasStarted) {
+        this.persistentIdToClientId.delete(client.persistentID);
+      }
       // Close lobby when host leaves before game starts
       if (
         !this._hasStarted &&

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -548,23 +548,23 @@ export class GameServer {
       this.activeClients = this.activeClients.filter(
         (c) => c.clientID !== client.clientID,
       );
-      // Remove persistentId if the game has not started to prevent going over max players
+
       if (!this._hasStarted) {
+        // Remove persistentId if the game has not started to prevent going over max players
         this.persistentIdToClientId.delete(client.persistentID);
-      }
-      // Close lobby when host leaves before game starts
-      if (
-        !this._hasStarted &&
-        !this.isPublic() &&
-        client.persistentID === this.creatorPersistentID
-      ) {
-        this.log.info("Host left, closing lobby", {
-          gameID: this.id,
-        });
-        for (const c of [...this.activeClients]) {
-          this.kickClient(c.clientID, KICK_REASON_HOST_LEFT);
+        // Close lobby when host leaves before game starts
+        if (
+          !this.isPublic() &&
+          client.persistentID === this.creatorPersistentID
+        ) {
+          this.log.info("Host left, closing lobby", {
+            gameID: this.id,
+          });
+          for (const c of [...this.activeClients]) {
+            this.kickClient(c.clientID, KICK_REASON_HOST_LEFT);
+          }
+          this._hasEnded = true;
         }
-        this._hasEnded = true;
       }
     });
     client.ws.on("error", (error: Error) => {
@@ -582,6 +582,10 @@ export class GameServer {
       this.activeClients = this.activeClients.filter(
         (c) => c.clientID !== client.clientID,
       );
+      // Remove persistentId if the game has not started to prevent going over max players
+      if (!this._hasStarted) {
+        this.persistentIdToClientId.delete(client.persistentID);
+      }
     }
   }
 


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #3649

## Description:

Removes the persistentIdToClientId for Clients that leave before the game starts. This prevents the rejoin path from being taken which ignores max player count. See issue for details on why this is important.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

babyboucher
