### PR TITLE
Adjust troop loss calculations and troop limits

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -672,7 +672,7 @@ export class DefaultConfig implements Config {
       const altAttackerLoss =
         1.3 * defenderTroopLoss * (mag / 100) * traitorMod;
       const attackerTroopLoss =
-        0.7 * currentAttackerLoss + 0.3 * altAttackerLoss;
+        0.4 * currentAttackerLoss + 0.6 * altAttackerLoss;
 
       return {
         attackerTroopLoss,
@@ -768,7 +768,7 @@ export class DefaultConfig implements Config {
     const maxTroops =
       player.type() === PlayerType.Human && this.infiniteTroops()
         ? 1_000_000_000
-        : 2 * (Math.pow(player.numTilesOwned(), 0.6) * 1000 + 50000) +
+        : 2 * (Math.pow(player.numTilesOwned(), 0.7) * 1000 + 50000) +
           player
             .units(UnitType.City)
             .map((city) => city.level())
@@ -800,7 +800,7 @@ export class DefaultConfig implements Config {
   troopIncreaseRate(player: Player): number {
     const max = this.maxTroops(player);
 
-    let toAdd = 10 + Math.pow(player.troops(), 0.73) / 4;
+    let toAdd = 10 + Math.pow(player.troops(), 0.8) / 4;
 
     const ratio = 1 - player.troops() / max;
     toAdd *= ratio;


### PR DESCRIPTION
## Description:

I think this fixes the stalemate issue mentioned in the previous PR without restoring the attack loss "bug". I tried making very small adjustments (possibly too small?) to meet the goal of very gradually changing the feel of the game. 

If stalemate is still an issue, would recommend boosting the toAdd parameter. I think the issue is not that attack losses are too high relative to defender, but rather that large attackers get nerfed so much by this formula. Going up to .8 from .73 is a roughly 10% boost in troop growth for an attacker that is 4x the size of a defender. Not sure anyone will notice, but it adds up over game time.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
