### PR TITLE
VSCode: small textual fix in launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,7 +4,7 @@
     {
       "type": "node",
       "request": "launch",
-      "name": "Debug Jest Tests",
+      "name": "Debug Tests",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run-script", "test"],
       "console": "integratedTerminal",


### PR DESCRIPTION
## Description:

Rename "Debug Jest Tests" to just "Debug Tests". We now use Vitest, not Jest anymore since awhile. And in case we would switch to another framework in the future, just leave its name out of the configuration name.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33