### PR TITLE
Dependabot: check for go dependency security updates too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,17 @@ updates:
     groups:
       updates:
         applies-to: version-updates
-        patterns: ["*"] #wildcard, needs brackets as bugfix apparently
+        patterns: ["*"] # wildcard, needs brackets as bugfix apparently
       security:
         applies-to: security-updates
         patterns: ["*"]
+  - package-ecosystem: "gomod"
+    directory: "/map-generator"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 0 # exclude version updates
+    groups:
+      golang:
+        applies-to: security-updates
+        patterns:
+          - ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,7 +21,4 @@ updates:
     groups:
       golang:
         applies-to: security-updates
-    groups:
-      golang:
-        applies-to: security-updates
         patterns: ["*"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,5 +21,7 @@ updates:
     groups:
       golang:
         applies-to: security-updates
-        patterns:
-          - ["*"]
+    groups:
+      golang:
+        applies-to: security-updates
+        patterns: ["*"]


### PR DESCRIPTION
## Description:

Let dependabot also check for security updates for go dependencies periodically. 

Even though we only use go in map-generator and it's only one dependency currently, still good to catch security updates.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33