### PR TITLE
Fix middle-click SAM not upgrading other buildings when SAM is unaffo…

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -655,20 +655,6 @@ export class ClientGameRunner {
       }
 
       if (upgradeUnits.length === 0) {
-        // No upgradeable buildings found. Check if there's a SAM nearby that
-        // simply can't be upgraded yet (e.g. not enough gold). If so, do
-        // nothing — don't fall through to upgrading some other building.
-        const myPlayerID = this.myPlayer!.id();
-        const nearbySam = this.gameView
-          .nearbyUnits(
-            clickedTile,
-            this.gameView.config().structureMinDist(),
-            UnitType.SAMLauncher,
-          )
-          .some(({ unit }) => unit.owner().id() === myPlayerID);
-        if (nearbySam) {
-          return;
-        }
         return;
       }
 

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -659,26 +659,21 @@ export class ClientGameRunner {
       }
 
       // If the closest upgradeable unit is a SAM, upgrade it.
-      // If the closest upgradeable unit is NOT a SAM but there's an own SAM
-      // nearby (within the same search radius), prefer doing nothing — the
-      // player most likely middle-clicked the SAM intending to upgrade it but
-      // couldn't afford it, and we must not spend gold on a different building.
+      // If the closest upgradeable unit is NOT a SAM, but actions() found a SAM
+      // entry with canUpgrade===false (SAM exists near clickedTile but can't be
+      // afforded right now), do nothing — the player intended to upgrade that
+      // SAM and we must not spend their gold on a different building.
       const bestUpgrade = findClosestBy(upgradeUnits, (u) => u.distance);
       if (!bestUpgrade) {
         return;
       }
 
       if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        const myPlayerID = this.myPlayer!.id();
-        const nearbySam = this.gameView
-          .nearbyUnits(
-            clickedTile,
-            this.gameView.config().structureMinDist(),
-            UnitType.SAMLauncher,
-          )
-          .some(({ unit }) => unit.owner().id() === myPlayerID);
-        if (nearbySam) {
-          // Clicked near a SAM that can't be upgraded — do nothing.
+        const samBlockedByGold = actions.buildableUnits.some(
+          (bu) => bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
+        );
+        if (samBlockedByGold) {
+          // A SAM near clickedTile exists but can't be upgraded yet — do nothing.
           return;
         }
       }

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -654,17 +654,55 @@ export class ClientGameRunner {
         }
       }
 
-      if (upgradeUnits.length > 0) {
-        const bestUpgrade = findClosestBy(upgradeUnits, (u) => u.distance);
-        if (bestUpgrade) {
-          this.eventBus.emit(
-            new SendUpgradeStructureIntentEvent(
-              bestUpgrade.unitId,
-              bestUpgrade.unitType,
-            ),
-          );
+      if (upgradeUnits.length === 0) {
+        // No upgradeable buildings found. Check if there's a SAM nearby that
+        // simply can't be upgraded yet (e.g. not enough gold). If so, do
+        // nothing — don't fall through to upgrading some other building.
+        const myPlayerID = this.myPlayer!.id();
+        const nearbySam = this.gameView
+          .nearbyUnits(
+            clickedTile,
+            this.gameView.config().structureMinDist(),
+            UnitType.SAMLauncher,
+          )
+          .some(({ unit }) => unit.owner().id() === myPlayerID);
+        if (nearbySam) {
+          return;
+        }
+        return;
+      }
+
+      // If the closest upgradeable unit is a SAM, upgrade it.
+      // If the closest upgradeable unit is NOT a SAM but there's an own SAM
+      // nearby (within the same search radius), prefer doing nothing — the
+      // player most likely middle-clicked the SAM intending to upgrade it but
+      // couldn't afford it, and we must not spend gold on a different building.
+      const bestUpgrade = findClosestBy(upgradeUnits, (u) => u.distance);
+      if (!bestUpgrade) {
+        return;
+      }
+
+      if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
+        const myPlayerID = this.myPlayer!.id();
+        const nearbySam = this.gameView
+          .nearbyUnits(
+            clickedTile,
+            this.gameView.config().structureMinDist(),
+            UnitType.SAMLauncher,
+          )
+          .some(({ unit }) => unit.owner().id() === myPlayerID);
+        if (nearbySam) {
+          // Clicked near a SAM that can't be upgraded — do nothing.
+          return;
         }
       }
+
+      this.eventBus.emit(
+        new SendUpgradeStructureIntentEvent(
+          bestUpgrade.unitId,
+          bestUpgrade.unitType,
+        ),
+      );
     });
   }
 

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -669,34 +669,33 @@ export class ClientGameRunner {
       }
 
       if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        // Block the upgrade only if an unaffordable own SAM is closer to
-        // clickedTile than the best candidate — meaning the player clicked on
-        // the SAM, not on the other building. If the SAM is farther away, the
-        // click was intentionally on the other building and we should proceed.
-        const hasBlockedSamEntry = actions.buildableUnits.some(
-          (bu) => bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
-        );
-        if (hasBlockedSamEntry) {
-          const myPlayerID = this.myPlayer!.id();
-          const closestSam = this.gameView
-            .nearbyUnits(
-              clickedTile,
-              this.gameView.config().structureMinDist(),
-              UnitType.SAMLauncher,
-            )
-            .filter(({ unit }) => unit.owner().id() === myPlayerID)
-            .sort((a, b) => a.distSquared - b.distSquared)[0];
+        // Block the upgrade only if the closest own SAM to clickedTile is
+        // unaffordable AND is at least as close as the best candidate.
+        // This means the player clicked on the SAM intending to upgrade it,
+        // not on the other building.
+        const myPlayerID = this.myPlayer!.id();
+        const closestSam = this.gameView
+          .nearbyUnits(
+            clickedTile,
+            this.gameView.config().structureMinDist(),
+            UnitType.SAMLauncher,
+          )
+          .filter(({ unit }) => unit.owner().id() === myPlayerID)
+          .sort((a, b) => a.distSquared - b.distSquared)[0];
 
-          if (closestSam) {
-            const samDist = this.gameView.manhattanDist(
-              clickedTile,
-              closestSam.unit.tile(),
-            );
-            if (samDist <= bestUpgrade.distance) {
-              // SAM is at least as close as the best candidate — player clicked
-              // on the SAM, not on the other building. Do nothing.
-              return;
-            }
+        if (closestSam) {
+          const samDist = this.gameView.manhattanDist(
+            clickedTile,
+            closestSam.unit.tile(),
+          );
+          // canUpgrade===false for SAMLauncher means the SAM exists near
+          // clickedTile but can't be afforded (buildableUnits uses the same
+          // structureMinDist radius to find it).
+          const samIsUnaffordable = actions.buildableUnits.some(
+            (bu) => bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
+          );
+          if (samIsUnaffordable && samDist <= bestUpgrade.distance) {
+            return;
           }
         }
       }

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -658,44 +658,38 @@ export class ClientGameRunner {
         return;
       }
 
-      // If the closest upgradeable unit is a SAM, upgrade it.
-      // If the closest upgradeable unit is NOT a SAM, but actions() found a SAM
-      // entry with canUpgrade===false (SAM exists near clickedTile but can't be
-      // afforded right now), do nothing — the player intended to upgrade that
-      // SAM and we must not spend their gold on a different building.
+      // Upgrade the closest affordable building. But if there's an unaffordable
+      // building (any type) that's closer to clickedTile than the best candidate,
+      // do nothing — the player clicked on that unaffordable building intending
+      // to upgrade it, and we must not spend their gold on a different building.
       const bestUpgrade = findClosestBy(upgradeUnits, (u) => u.distance);
       if (!bestUpgrade) {
         return;
       }
 
-      if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        // Block the upgrade only if the closest own SAM to clickedTile is
-        // unaffordable AND is at least as close as the best candidate.
-        // This means the player clicked on the SAM intending to upgrade it,
-        // not on the other building.
-        const myPlayerID = this.myPlayer!.id();
-        const closestSam = this.gameView
-          .nearbyUnits(
-            clickedTile,
-            this.gameView.config().structureMinDist(),
-            UnitType.SAMLauncher,
-          )
-          .filter(({ unit }) => unit.owner().id() === myPlayerID)
-          .sort((a, b) => a.distSquared - b.distSquared)[0];
+      // Check if any unaffordable building is closer than bestUpgrade
+      for (const bu of actions.buildableUnits) {
+        if (bu.canUpgrade === false && bu.type !== bestUpgrade.unitType) {
+          const myPlayerID = this.myPlayer!.id();
+          const closestOfType = this.gameView
+            .nearbyUnits(
+              clickedTile,
+              this.gameView.config().structureMinDist(),
+              bu.type,
+            )
+            .filter(({ unit }) => unit.owner().id() === myPlayerID)
+            .sort((a, b) => a.distSquared - b.distSquared)[0];
 
-        if (closestSam) {
-          const samDist = this.gameView.manhattanDist(
-            clickedTile,
-            closestSam.unit.tile(),
-          );
-          // canUpgrade===false for SAMLauncher means the SAM exists near
-          // clickedTile but can't be afforded (buildableUnits uses the same
-          // structureMinDist radius to find it).
-          const samIsUnaffordable = actions.buildableUnits.some(
-            (bu) => bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
-          );
-          if (samIsUnaffordable && samDist <= bestUpgrade.distance) {
-            return;
+          if (closestOfType) {
+            const dist = this.gameView.manhattanDist(
+              clickedTile,
+              closestOfType.unit.tile(),
+            );
+            if (dist <= bestUpgrade.distance) {
+              // An unaffordable building of type bu.type is at least as close
+              // as bestUpgrade — player clicked on it, not on bestUpgrade.
+              return;
+            }
           }
         }
       }

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -669,12 +669,35 @@ export class ClientGameRunner {
       }
 
       if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        const samBlockedByGold = actions.buildableUnits.some(
+        // Block the upgrade only if an unaffordable own SAM is closer to
+        // clickedTile than the best candidate — meaning the player clicked on
+        // the SAM, not on the other building. If the SAM is farther away, the
+        // click was intentionally on the other building and we should proceed.
+        const hasBlockedSamEntry = actions.buildableUnits.some(
           (bu) => bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
         );
-        if (samBlockedByGold) {
-          // A SAM near clickedTile exists but can't be upgraded yet — do nothing.
-          return;
+        if (hasBlockedSamEntry) {
+          const myPlayerID = this.myPlayer!.id();
+          const closestSam = this.gameView
+            .nearbyUnits(
+              clickedTile,
+              this.gameView.config().structureMinDist(),
+              UnitType.SAMLauncher,
+            )
+            .filter(({ unit }) => unit.owner().id() === myPlayerID)
+            .sort((a, b) => a.distSquared - b.distSquared)[0];
+
+          if (closestSam) {
+            const samDist = this.gameView.manhattanDist(
+              clickedTile,
+              closestSam.unit.tile(),
+            );
+            if (samDist <= bestUpgrade.distance) {
+              // SAM is at least as close as the best candidate — player clicked
+              // on the SAM, not on the other building. Do nothing.
+              return;
+            }
+          }
         }
       }
 

--- a/tests/FindAndUpgradeNearestBuilding.test.ts
+++ b/tests/FindAndUpgradeNearestBuilding.test.ts
@@ -4,6 +4,13 @@ import { EventBus } from "../src/core/EventBus";
 import { UnitType } from "../src/core/game/Game";
 import { TileRef } from "../src/core/game/GameMap";
 
+/**
+ * NOTE: The `findAndUpgradeNearestBuilding` function below is a test-local
+ * mirror of `ClientGameRunner.findAndUpgradeNearestBuilding` (src/client/ClientGameRunner.ts).
+ * If you change the production logic, update this stub accordingly so the
+ * tests remain meaningful.
+ */
+
 // Minimal tile ref for testing
 const TILE = 42 as TileRef;
 const PLAYER_ID = "player-1";
@@ -67,15 +74,6 @@ function makeRunner(buildableUnits: any[], allUnits: any[], nearbySams: any[]) {
       }
 
       if (upgradeUnits.length === 0) {
-        const myPlayerID = this.myPlayer!.id();
-        const nearbySam = this.gameView
-          .nearbyUnits(
-            tile,
-            this.gameView.config().structureMinDist(),
-            UnitType.SAMLauncher,
-          )
-          .some(({ unit }: any) => unit.owner().id() === myPlayerID);
-        if (nearbySam) return;
         return;
       }
 

--- a/tests/FindAndUpgradeNearestBuilding.test.ts
+++ b/tests/FindAndUpgradeNearestBuilding.test.ts
@@ -16,6 +16,7 @@ const TILE = 42 as TileRef;
 const PLAYER_ID = "player-1";
 const SEARCH_RADIUS = 15;
 
+/** Creates a minimal unit view stub for testing. */
 function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
   return {
     id: () => id,
@@ -25,6 +26,12 @@ function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
   };
 }
 
+/**
+ * Builds a minimal ClientGameRunner stub with mocked dependencies.
+ * @param buildableUnits - list returned by myPlayer.actions()
+ * @param allUnits - units returned by gameView.units()
+ * @param nearbySams - units returned by gameView.nearbyUnits() for SAMLauncher queries
+ */
 function makeRunner(buildableUnits: any[], allUnits: any[], nearbySams: any[]) {
   const eventBus = new EventBus();
   const emitSpy = vi.spyOn(eventBus, "emit");

--- a/tests/FindAndUpgradeNearestBuilding.test.ts
+++ b/tests/FindAndUpgradeNearestBuilding.test.ts
@@ -1,0 +1,263 @@
+import { describe, expect, test, vi } from "vitest";
+import { SendUpgradeStructureIntentEvent } from "../src/client/Transport";
+import { EventBus } from "../src/core/EventBus";
+import { UnitType } from "../src/core/game/Game";
+import { TileRef } from "../src/core/game/GameMap";
+
+// Minimal tile ref for testing
+const TILE = 42 as TileRef;
+const PLAYER_ID = "player-1";
+const SEARCH_RADIUS = 15;
+
+function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
+  return {
+    id: () => id,
+    type: () => type,
+    tile: () => tile,
+    owner: () => ({ id: () => ownerID }),
+  };
+}
+
+function makeRunner(buildableUnits: any[], allUnits: any[], nearbySams: any[]) {
+  const eventBus = new EventBus();
+  const emitSpy = vi.spyOn(eventBus, "emit");
+
+  const myPlayer = {
+    id: () => PLAYER_ID,
+    actions: vi.fn().mockResolvedValue({ buildableUnits }),
+  };
+
+  const gameView = {
+    units: () => allUnits,
+    manhattanDist: (_a: TileRef, _b: TileRef) => 5,
+    nearbyUnits: vi.fn().mockReturnValue(nearbySams),
+    config: () => ({ structureMinDist: () => SEARCH_RADIUS }),
+  };
+
+  // Minimal stub of ClientGameRunner exposing only what we need
+  const runner = {
+    myPlayer,
+    gameView,
+    eventBus,
+    findAndUpgradeNearestBuilding: async function (tile: TileRef) {
+      const actions = await this.myPlayer!.actions(tile, []);
+      const upgradeUnits: {
+        unitId: number;
+        unitType: UnitType;
+        distance: number;
+      }[] = [];
+
+      for (const bu of actions.buildableUnits) {
+        if (bu.canUpgrade !== false) {
+          const existingUnit = this.gameView
+            .units()
+            .find((unit: any) => unit.id() === bu.canUpgrade);
+          if (existingUnit) {
+            const distance = this.gameView.manhattanDist(
+              tile,
+              existingUnit.tile(),
+            );
+            upgradeUnits.push({
+              unitId: bu.canUpgrade,
+              unitType: bu.type,
+              distance,
+            });
+          }
+        }
+      }
+
+      if (upgradeUnits.length === 0) {
+        const myPlayerID = this.myPlayer!.id();
+        const nearbySam = this.gameView
+          .nearbyUnits(
+            tile,
+            this.gameView.config().structureMinDist(),
+            UnitType.SAMLauncher,
+          )
+          .some(({ unit }: any) => unit.owner().id() === myPlayerID);
+        if (nearbySam) return;
+        return;
+      }
+
+      // findClosestBy equivalent — pick minimum distance
+      const bestUpgrade = upgradeUnits.reduce((a, b) =>
+        a.distance <= b.distance ? a : b,
+      );
+
+      if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
+        const myPlayerID = this.myPlayer!.id();
+        const nearbySam = this.gameView
+          .nearbyUnits(
+            tile,
+            this.gameView.config().structureMinDist(),
+            UnitType.SAMLauncher,
+          )
+          .some(({ unit }: any) => unit.owner().id() === myPlayerID);
+        if (nearbySam) return;
+      }
+
+      this.eventBus.emit(
+        new SendUpgradeStructureIntentEvent(
+          bestUpgrade.unitId,
+          bestUpgrade.unitType,
+        ),
+      );
+    },
+  };
+
+  return { runner, emitSpy };
+}
+
+describe("findAndUpgradeNearestBuilding", () => {
+  describe("no SAM nearby", () => {
+    test("upgrades DefensePost when it is the only upgradeable building", async () => {
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
+      const buildableUnits = [{ type: UnitType.DefensePost, canUpgrade: 1 }];
+      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost], []);
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ unitId: 1, unitType: UnitType.DefensePost }),
+      );
+    });
+
+    test("does nothing when no buildings are upgradeable", async () => {
+      const buildableUnits = [
+        { type: UnitType.DefensePost, canUpgrade: false },
+      ];
+      const { runner, emitSpy } = makeRunner(buildableUnits, [], []);
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("SAM nearby — the bug scenario", () => {
+    test("does NOT upgrade DefensePost when own SAM is nearby but unaffordable", async () => {
+      // SAM exists on the map but canUpgrade=false (not enough gold)
+      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID);
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
+
+      // Only DefensePost is upgradeable (SAM excluded due to insufficient gold)
+      const buildableUnits = [
+        { type: UnitType.SAMLauncher, canUpgrade: false },
+        { type: UnitType.DefensePost, canUpgrade: 1 },
+      ];
+
+      // nearbyUnits returns the SAM
+      const nearbySams = [{ unit: samUnit }];
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [defensePost],
+        nearbySams,
+      );
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).not.toHaveBeenCalled();
+    });
+
+    test("upgrades SAM when it IS affordable and is the closest upgradeable building", async () => {
+      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID);
+      const buildableUnits = [{ type: UnitType.SAMLauncher, canUpgrade: 10 }];
+      const nearbySams = [{ unit: samUnit }];
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [samUnit],
+        nearbySams,
+      );
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ unitId: 10, unitType: UnitType.SAMLauncher }),
+      );
+    });
+
+    test("does not upgrade enemy SAM nearby — upgrades own DefensePost instead", async () => {
+      const enemySam = makeUnit(10, UnitType.SAMLauncher, "enemy-player");
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
+      const buildableUnits = [{ type: UnitType.DefensePost, canUpgrade: 1 }];
+
+      // nearbyUnits returns an enemy SAM — should not block the upgrade
+      const nearbySams = [{ unit: enemySam }];
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [defensePost],
+        nearbySams,
+      );
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ unitId: 1, unitType: UnitType.DefensePost }),
+      );
+    });
+  });
+
+  describe("multiple upgradeable buildings", () => {
+    test("picks the closest upgradeable building when no SAM nearby", async () => {
+      const defensePost = makeUnit(
+        1,
+        UnitType.DefensePost,
+        PLAYER_ID,
+        10 as TileRef,
+      );
+      const factory = makeUnit(2, UnitType.Factory, PLAYER_ID, 20 as TileRef);
+      const buildableUnits = [
+        { type: UnitType.DefensePost, canUpgrade: 1 },
+        { type: UnitType.Factory, canUpgrade: 2 },
+      ];
+
+      // Override manhattanDist to return different distances
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [defensePost, factory],
+        [],
+      );
+      runner.gameView.manhattanDist = (a: TileRef, b: TileRef) =>
+        b === (10 as TileRef) ? 3 : 8;
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ unitId: 1, unitType: UnitType.DefensePost }),
+      );
+    });
+
+    test("upgrades SAM when both SAM and DefensePost are upgradeable and SAM is nearby", async () => {
+      const samUnit = makeUnit(
+        10,
+        UnitType.SAMLauncher,
+        PLAYER_ID,
+        5 as TileRef,
+      );
+      const defensePost = makeUnit(
+        1,
+        UnitType.DefensePost,
+        PLAYER_ID,
+        20 as TileRef,
+      );
+      const buildableUnits = [
+        { type: UnitType.SAMLauncher, canUpgrade: 10 },
+        { type: UnitType.DefensePost, canUpgrade: 1 },
+      ];
+      const nearbySams = [{ unit: samUnit }];
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [samUnit, defensePost],
+        nearbySams,
+      );
+      runner.gameView.manhattanDist = (a: TileRef, b: TileRef) =>
+        b === (5 as TileRef) ? 2 : 10;
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ unitId: 10, unitType: UnitType.SAMLauncher }),
+      );
+    });
+  });
+});

--- a/tests/FindAndUpgradeNearestBuilding.test.ts
+++ b/tests/FindAndUpgradeNearestBuilding.test.ts
@@ -14,7 +14,6 @@ import { TileRef } from "../src/core/game/GameMap";
 // Minimal tile ref for testing
 const TILE = 42 as TileRef;
 const PLAYER_ID = "player-1";
-const SEARCH_RADIUS = 15;
 
 /** Creates a minimal unit view stub for testing. */
 function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
@@ -28,11 +27,12 @@ function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
 
 /**
  * Builds a minimal ClientGameRunner stub with mocked dependencies.
- * @param buildableUnits - list returned by myPlayer.actions()
+ * @param buildableUnits - list returned by myPlayer.actions(); set canUpgrade to
+ *   a unit id to mark it upgradeable, or false to mark it as existing but blocked
+ *   (e.g. insufficient gold).
  * @param allUnits - units returned by gameView.units()
- * @param nearbySams - units returned by gameView.nearbyUnits() for SAMLauncher queries
  */
-function makeRunner(buildableUnits: any[], allUnits: any[], nearbySams: any[]) {
+function makeRunner(buildableUnits: any[], allUnits: any[]) {
   const eventBus = new EventBus();
   const emitSpy = vi.spyOn(eventBus, "emit");
 
@@ -44,11 +44,9 @@ function makeRunner(buildableUnits: any[], allUnits: any[], nearbySams: any[]) {
   const gameView = {
     units: () => allUnits,
     manhattanDist: (_a: TileRef, _b: TileRef) => 5,
-    nearbyUnits: vi.fn().mockReturnValue(nearbySams),
-    config: () => ({ structureMinDist: () => SEARCH_RADIUS }),
   };
 
-  // Minimal stub of ClientGameRunner exposing only what we need
+  // Mirrors ClientGameRunner.findAndUpgradeNearestBuilding
   const runner = {
     myPlayer,
     gameView,
@@ -90,15 +88,13 @@ function makeRunner(buildableUnits: any[], allUnits: any[], nearbySams: any[]) {
       );
 
       if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        const myPlayerID = this.myPlayer!.id();
-        const nearbySam = this.gameView
-          .nearbyUnits(
-            tile,
-            this.gameView.config().structureMinDist(),
-            UnitType.SAMLauncher,
-          )
-          .some(({ unit }: any) => unit.owner().id() === myPlayerID);
-        if (nearbySam) return;
+        // If actions() returned a SAM entry with canUpgrade===false, a SAM
+        // exists near clickedTile but can't be afforded — do nothing.
+        const samBlockedByGold = actions.buildableUnits.some(
+          (bu: any) =>
+            bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
+        );
+        if (samBlockedByGold) return;
       }
 
       this.eventBus.emit(
@@ -118,7 +114,7 @@ describe("findAndUpgradeNearestBuilding", () => {
     test("upgrades DefensePost when it is the only upgradeable building", async () => {
       const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
       const buildableUnits = [{ type: UnitType.DefensePost, canUpgrade: 1 }];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost], []);
+      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost]);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -131,7 +127,7 @@ describe("findAndUpgradeNearestBuilding", () => {
       const buildableUnits = [
         { type: UnitType.DefensePost, canUpgrade: false },
       ];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [], []);
+      const { runner, emitSpy } = makeRunner(buildableUnits, []);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -141,38 +137,24 @@ describe("findAndUpgradeNearestBuilding", () => {
 
   describe("SAM nearby — the bug scenario", () => {
     test("does NOT upgrade DefensePost when own SAM is nearby but unaffordable", async () => {
-      // SAM exists on the map but canUpgrade=false (not enough gold)
-      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID);
       const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
 
-      // Only DefensePost is upgradeable (SAM excluded due to insufficient gold)
+      // SAM has canUpgrade=false (exists near tile but gold insufficient)
       const buildableUnits = [
         { type: UnitType.SAMLauncher, canUpgrade: false },
         { type: UnitType.DefensePost, canUpgrade: 1 },
       ];
-
-      // nearbyUnits returns the SAM
-      const nearbySams = [{ unit: samUnit }];
-      const { runner, emitSpy } = makeRunner(
-        buildableUnits,
-        [defensePost],
-        nearbySams,
-      );
+      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost]);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
       expect(emitSpy).not.toHaveBeenCalled();
     });
 
-    test("upgrades SAM when it IS affordable and is the closest upgradeable building", async () => {
+    test("upgrades SAM when it IS affordable", async () => {
       const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID);
       const buildableUnits = [{ type: UnitType.SAMLauncher, canUpgrade: 10 }];
-      const nearbySams = [{ unit: samUnit }];
-      const { runner, emitSpy } = makeRunner(
-        buildableUnits,
-        [samUnit],
-        nearbySams,
-      );
+      const { runner, emitSpy } = makeRunner(buildableUnits, [samUnit]);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -181,18 +163,11 @@ describe("findAndUpgradeNearestBuilding", () => {
       );
     });
 
-    test("does not upgrade enemy SAM nearby — upgrades own DefensePost instead", async () => {
-      const enemySam = makeUnit(10, UnitType.SAMLauncher, "enemy-player");
+    test("upgrades DefensePost when no SAM entry exists in buildableUnits at all", async () => {
+      // No SAM in buildableUnits means no SAM near this tile — normal upgrade
       const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
       const buildableUnits = [{ type: UnitType.DefensePost, canUpgrade: 1 }];
-
-      // nearbyUnits returns an enemy SAM — should not block the upgrade
-      const nearbySams = [{ unit: enemySam }];
-      const { runner, emitSpy } = makeRunner(
-        buildableUnits,
-        [defensePost],
-        nearbySams,
-      );
+      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost]);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -216,13 +191,11 @@ describe("findAndUpgradeNearestBuilding", () => {
         { type: UnitType.Factory, canUpgrade: 2 },
       ];
 
-      // Override manhattanDist to return different distances
-      const { runner, emitSpy } = makeRunner(
-        buildableUnits,
-        [defensePost, factory],
-        [],
-      );
-      runner.gameView.manhattanDist = (a: TileRef, b: TileRef) =>
+      const { runner, emitSpy } = makeRunner(buildableUnits, [
+        defensePost,
+        factory,
+      ]);
+      runner.gameView.manhattanDist = (_a: TileRef, b: TileRef) =>
         b === (10 as TileRef) ? 3 : 8;
 
       await runner.findAndUpgradeNearestBuilding(TILE);
@@ -232,7 +205,7 @@ describe("findAndUpgradeNearestBuilding", () => {
       );
     });
 
-    test("upgrades SAM when both SAM and DefensePost are upgradeable and SAM is nearby", async () => {
+    test("upgrades SAM when both SAM and DefensePost are upgradeable and SAM is closer", async () => {
       const samUnit = makeUnit(
         10,
         UnitType.SAMLauncher,
@@ -249,13 +222,11 @@ describe("findAndUpgradeNearestBuilding", () => {
         { type: UnitType.SAMLauncher, canUpgrade: 10 },
         { type: UnitType.DefensePost, canUpgrade: 1 },
       ];
-      const nearbySams = [{ unit: samUnit }];
-      const { runner, emitSpy } = makeRunner(
-        buildableUnits,
-        [samUnit, defensePost],
-        nearbySams,
-      );
-      runner.gameView.manhattanDist = (a: TileRef, b: TileRef) =>
+      const { runner, emitSpy } = makeRunner(buildableUnits, [
+        samUnit,
+        defensePost,
+      ]);
+      runner.gameView.manhattanDist = (_a: TileRef, b: TileRef) =>
         b === (5 as TileRef) ? 2 : 10;
 
       await runner.findAndUpgradeNearestBuilding(TILE);

--- a/tests/FindAndUpgradeNearestBuilding.test.ts
+++ b/tests/FindAndUpgradeNearestBuilding.test.ts
@@ -95,28 +95,25 @@ function makeRunner(
         a.distance <= b.distance ? a : b,
       );
 
-      if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        const hasBlockedSamEntry = actions.buildableUnits.some(
-          (bu: any) =>
-            bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
-        );
-        if (hasBlockedSamEntry) {
+      // Check if any unaffordable building is closer than bestUpgrade
+      for (const bu of actions.buildableUnits) {
+        if (bu.canUpgrade === false && bu.type !== bestUpgrade.unitType) {
           const myPlayerID = this.myPlayer!.id();
-          const closestSam = this.gameView
+          const closestOfType = this.gameView
             .nearbyUnits(
               tile,
               this.gameView.config().structureMinDist(),
-              UnitType.SAMLauncher,
+              bu.type,
             )
             .filter(({ unit }: any) => unit.owner().id() === myPlayerID)
             .sort((a: any, b: any) => a.distSquared - b.distSquared)[0];
 
-          if (closestSam) {
-            const samDist = this.gameView.manhattanDist(
+          if (closestOfType) {
+            const dist = this.gameView.manhattanDist(
               tile,
-              closestSam.unit.tile(),
+              closestOfType.unit.tile(),
             );
-            if (samDist <= bestUpgrade.distance) {
+            if (dist <= bestUpgrade.distance) {
               return;
             }
           }
@@ -218,6 +215,41 @@ describe("findAndUpgradeNearestBuilding", () => {
       expect(emitSpy).toHaveBeenCalledWith(
         expect.objectContaining({ unitId: 1, unitType: UnitType.DefensePost }),
       );
+    });
+
+    test("does NOT upgrade Factory when unaffordable City is closer (Evan's scenario)", async () => {
+      // City at tile 5 (dist=2, costs 1M), Factory at tile 20 (dist=10, costs 500K)
+      // Player clicked near the City — should do nothing
+      const cityTile = 5 as TileRef;
+      const factoryTile = 20 as TileRef;
+      const cityUnit = makeUnit(10, UnitType.City, PLAYER_ID, cityTile);
+      const factoryUnit = makeUnit(1, UnitType.Factory, PLAYER_ID, factoryTile);
+
+      const buildableUnits = [
+        { type: UnitType.City, canUpgrade: false },
+        { type: UnitType.Factory, canUpgrade: 1 },
+      ];
+      const distMap = new Map<TileRef, number>([
+        [cityTile, 2],
+        [factoryTile, 10],
+      ]);
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [factoryUnit],
+        [],
+        distMap,
+      );
+      // Mock nearbyUnits to return city when queried for City type
+      runner.gameView.nearbyUnits = vi.fn((tile, radius, type) => {
+        if (type === UnitType.City) {
+          return [{ unit: cityUnit, distSquared: 4 }];
+        }
+        return [];
+      });
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).not.toHaveBeenCalled();
     });
 
     test("upgrades SAM when it IS affordable", async () => {

--- a/tests/FindAndUpgradeNearestBuilding.test.ts
+++ b/tests/FindAndUpgradeNearestBuilding.test.ts
@@ -11,9 +11,9 @@ import { TileRef } from "../src/core/game/GameMap";
  * tests remain meaningful.
  */
 
-// Minimal tile ref for testing
 const TILE = 42 as TileRef;
 const PLAYER_ID = "player-1";
+const SEARCH_RADIUS = 15;
 
 /** Creates a minimal unit view stub for testing. */
 function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
@@ -27,12 +27,19 @@ function makeUnit(id: number, type: UnitType, ownerID: string, tile = TILE) {
 
 /**
  * Builds a minimal ClientGameRunner stub with mocked dependencies.
- * @param buildableUnits - list returned by myPlayer.actions(); set canUpgrade to
- *   a unit id to mark it upgradeable, or false to mark it as existing but blocked
+ * @param buildableUnits - list returned by myPlayer.actions(); canUpgrade is a
+ *   unit id when upgradeable, or false when the unit exists but is blocked
  *   (e.g. insufficient gold).
  * @param allUnits - units returned by gameView.units()
+ * @param nearbySamUnits - own SAM units returned by gameView.nearbyUnits()
+ * @param distanceMap - optional map of unit tile → manhattanDist from clickedTile
  */
-function makeRunner(buildableUnits: any[], allUnits: any[]) {
+function makeRunner(
+  buildableUnits: any[],
+  allUnits: any[],
+  nearbySamUnits: { unit: ReturnType<typeof makeUnit>; distSquared: number }[],
+  distanceMap: Map<TileRef, number> = new Map(),
+) {
   const eventBus = new EventBus();
   const emitSpy = vi.spyOn(eventBus, "emit");
 
@@ -43,7 +50,9 @@ function makeRunner(buildableUnits: any[], allUnits: any[]) {
 
   const gameView = {
     units: () => allUnits,
-    manhattanDist: (_a: TileRef, _b: TileRef) => 5,
+    manhattanDist: (_a: TileRef, b: TileRef) => distanceMap.get(b) ?? 5,
+    nearbyUnits: vi.fn().mockReturnValue(nearbySamUnits),
+    config: () => ({ structureMinDist: () => SEARCH_RADIUS }),
   };
 
   // Mirrors ClientGameRunner.findAndUpgradeNearestBuilding
@@ -82,19 +91,36 @@ function makeRunner(buildableUnits: any[], allUnits: any[]) {
         return;
       }
 
-      // findClosestBy equivalent — pick minimum distance
       const bestUpgrade = upgradeUnits.reduce((a, b) =>
         a.distance <= b.distance ? a : b,
       );
 
       if (bestUpgrade.unitType !== UnitType.SAMLauncher) {
-        // If actions() returned a SAM entry with canUpgrade===false, a SAM
-        // exists near clickedTile but can't be afforded — do nothing.
-        const samBlockedByGold = actions.buildableUnits.some(
+        const hasBlockedSamEntry = actions.buildableUnits.some(
           (bu: any) =>
             bu.type === UnitType.SAMLauncher && bu.canUpgrade === false,
         );
-        if (samBlockedByGold) return;
+        if (hasBlockedSamEntry) {
+          const myPlayerID = this.myPlayer!.id();
+          const closestSam = this.gameView
+            .nearbyUnits(
+              tile,
+              this.gameView.config().structureMinDist(),
+              UnitType.SAMLauncher,
+            )
+            .filter(({ unit }: any) => unit.owner().id() === myPlayerID)
+            .sort((a: any, b: any) => a.distSquared - b.distSquared)[0];
+
+          if (closestSam) {
+            const samDist = this.gameView.manhattanDist(
+              tile,
+              closestSam.unit.tile(),
+            );
+            if (samDist <= bestUpgrade.distance) {
+              return;
+            }
+          }
+        }
       }
 
       this.eventBus.emit(
@@ -114,7 +140,7 @@ describe("findAndUpgradeNearestBuilding", () => {
     test("upgrades DefensePost when it is the only upgradeable building", async () => {
       const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
       const buildableUnits = [{ type: UnitType.DefensePost, canUpgrade: 1 }];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost]);
+      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost], []);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -127,7 +153,7 @@ describe("findAndUpgradeNearestBuilding", () => {
       const buildableUnits = [
         { type: UnitType.DefensePost, canUpgrade: false },
       ];
-      const { runner, emitSpy } = makeRunner(buildableUnits, []);
+      const { runner, emitSpy } = makeRunner(buildableUnits, [], []);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -136,38 +162,56 @@ describe("findAndUpgradeNearestBuilding", () => {
   });
 
   describe("SAM nearby — the bug scenario", () => {
-    test("does NOT upgrade DefensePost when own SAM is nearby but unaffordable", async () => {
-      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
+    test("does NOT upgrade DefensePost when unaffordable SAM is closer to click", async () => {
+      // SAM is at tile 5 (dist=2), DefensePost at tile 20 (dist=10)
+      // Player clicked near the SAM — should do nothing
+      const samTile = 5 as TileRef;
+      const dpTile = 20 as TileRef;
+      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID, samTile);
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID, dpTile);
 
-      // SAM has canUpgrade=false (exists near tile but gold insufficient)
       const buildableUnits = [
         { type: UnitType.SAMLauncher, canUpgrade: false },
         { type: UnitType.DefensePost, canUpgrade: 1 },
       ];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost]);
+      const distMap = new Map<TileRef, number>([
+        [samTile, 2],
+        [dpTile, 10],
+      ]);
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [defensePost],
+        [{ unit: samUnit, distSquared: 4 }],
+        distMap,
+      );
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
       expect(emitSpy).not.toHaveBeenCalled();
     });
 
-    test("upgrades SAM when it IS affordable", async () => {
-      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID);
-      const buildableUnits = [{ type: UnitType.SAMLauncher, canUpgrade: 10 }];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [samUnit]);
+    test("DOES upgrade DefensePost when unaffordable SAM is farther than DefensePost", async () => {
+      // DefensePost at tile 5 (dist=2), SAM at tile 20 (dist=10)
+      // Player clicked near the DefensePost — should upgrade it
+      const samTile = 20 as TileRef;
+      const dpTile = 5 as TileRef;
+      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID, samTile);
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID, dpTile);
 
-      await runner.findAndUpgradeNearestBuilding(TILE);
-
-      expect(emitSpy).toHaveBeenCalledWith(
-        expect.objectContaining({ unitId: 10, unitType: UnitType.SAMLauncher }),
+      const buildableUnits = [
+        { type: UnitType.SAMLauncher, canUpgrade: false },
+        { type: UnitType.DefensePost, canUpgrade: 1 },
+      ];
+      const distMap = new Map<TileRef, number>([
+        [samTile, 10],
+        [dpTile, 2],
+      ]);
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [defensePost],
+        [{ unit: samUnit, distSquared: 100 }],
+        distMap,
       );
-    });
-
-    test("upgrades DefensePost when no SAM entry exists in buildableUnits at all", async () => {
-      // No SAM in buildableUnits means no SAM near this tile — normal upgrade
-      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID);
-      const buildableUnits = [{ type: UnitType.DefensePost, canUpgrade: 1 }];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [defensePost]);
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -175,28 +219,40 @@ describe("findAndUpgradeNearestBuilding", () => {
         expect.objectContaining({ unitId: 1, unitType: UnitType.DefensePost }),
       );
     });
+
+    test("upgrades SAM when it IS affordable", async () => {
+      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID);
+      const buildableUnits = [{ type: UnitType.SAMLauncher, canUpgrade: 10 }];
+      const { runner, emitSpy } = makeRunner(buildableUnits, [samUnit], []);
+
+      await runner.findAndUpgradeNearestBuilding(TILE);
+
+      expect(emitSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ unitId: 10, unitType: UnitType.SAMLauncher }),
+      );
+    });
   });
 
   describe("multiple upgradeable buildings", () => {
     test("picks the closest upgradeable building when no SAM nearby", async () => {
-      const defensePost = makeUnit(
-        1,
-        UnitType.DefensePost,
-        PLAYER_ID,
-        10 as TileRef,
-      );
-      const factory = makeUnit(2, UnitType.Factory, PLAYER_ID, 20 as TileRef);
+      const dpTile = 10 as TileRef;
+      const factoryTile = 20 as TileRef;
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID, dpTile);
+      const factory = makeUnit(2, UnitType.Factory, PLAYER_ID, factoryTile);
       const buildableUnits = [
         { type: UnitType.DefensePost, canUpgrade: 1 },
         { type: UnitType.Factory, canUpgrade: 2 },
       ];
-
-      const { runner, emitSpy } = makeRunner(buildableUnits, [
-        defensePost,
-        factory,
+      const distMap = new Map<TileRef, number>([
+        [dpTile, 3],
+        [factoryTile, 8],
       ]);
-      runner.gameView.manhattanDist = (_a: TileRef, b: TileRef) =>
-        b === (10 as TileRef) ? 3 : 8;
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [defensePost, factory],
+        [],
+        distMap,
+      );
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 
@@ -206,28 +262,24 @@ describe("findAndUpgradeNearestBuilding", () => {
     });
 
     test("upgrades SAM when both SAM and DefensePost are upgradeable and SAM is closer", async () => {
-      const samUnit = makeUnit(
-        10,
-        UnitType.SAMLauncher,
-        PLAYER_ID,
-        5 as TileRef,
-      );
-      const defensePost = makeUnit(
-        1,
-        UnitType.DefensePost,
-        PLAYER_ID,
-        20 as TileRef,
-      );
+      const samTile = 5 as TileRef;
+      const dpTile = 20 as TileRef;
+      const samUnit = makeUnit(10, UnitType.SAMLauncher, PLAYER_ID, samTile);
+      const defensePost = makeUnit(1, UnitType.DefensePost, PLAYER_ID, dpTile);
       const buildableUnits = [
         { type: UnitType.SAMLauncher, canUpgrade: 10 },
         { type: UnitType.DefensePost, canUpgrade: 1 },
       ];
-      const { runner, emitSpy } = makeRunner(buildableUnits, [
-        samUnit,
-        defensePost,
+      const distMap = new Map<TileRef, number>([
+        [samTile, 2],
+        [dpTile, 10],
       ]);
-      runner.gameView.manhattanDist = (_a: TileRef, b: TileRef) =>
-        b === (5 as TileRef) ? 2 : 10;
+      const { runner, emitSpy } = makeRunner(
+        buildableUnits,
+        [samUnit, defensePost],
+        [],
+        distMap,
+      );
 
       await runner.findAndUpgradeNearestBuilding(TILE);
 


### PR DESCRIPTION
Resolves #3511

## Description:
When middle-clicking a SAM launcher you own, the game calls findAndUpgradeNearestBuilding which queries all upgradeable structures near the clicked tile. If you can't afford the SAM upgrade, canUpgrade is false for the SAM (because canBuildUnitType returns false when gold < cost), so the SAM is excluded from the candidates list. If a nearby building (e.g. a Factory) can be upgraded, it gets picked as the "nearest" target and is upgraded instead — spending gold the player was saving for the SAM.

The fix: after finding the best upgrade candidate, check if there's an owned SAM within the same search radius as the clicked tile. If there is, but the best candidate is not a SAM (meaning the SAM couldn't be afforded), do nothing instead of upgrading the other building. This ensures middle-clicking a SAM either upgrades it or takes no action.

##Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

fghjk_60845