### PR TITLE
Show game ID ingame 🪪

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -185,7 +185,8 @@
     "exit_confirmation": "Are you sure you want to exit the game?",
     "bomb_direction": "Atom / Hydrogen bomb arc direction",
     "icon_alt_player_leaderboard": "Player Leaderboard Icon",
-    "icon_alt_team_leaderboard": "Team Leaderboard Icon"
+    "icon_alt_team_leaderboard": "Team Leaderboard Icon",
+    "game_id_tooltip": "Game ID"
   },
   "single_modal": {
     "random_spawn": "Random spawn",

--- a/src/client/graphics/layers/GameLeftSidebar.ts
+++ b/src/client/graphics/layers/GameLeftSidebar.ts
@@ -133,6 +133,13 @@ export class GameLeftSidebar extends LitElement implements Layer {
               height="20"
             />
           </div>
+          ${this.isLeaderboardShow || this.isTeamLeaderboardShow
+            ? html`<span
+                class="ml-auto text-[10px] text-slate-500 select-all leading-none self-start"
+                title="Game ID"
+                >${this.game?.gameID() ?? ""}</span
+              >`
+            : null}
           ${this.isTeamGame
             ? html`
                 <div

--- a/src/client/graphics/layers/GameLeftSidebar.ts
+++ b/src/client/graphics/layers/GameLeftSidebar.ts
@@ -136,7 +136,7 @@ export class GameLeftSidebar extends LitElement implements Layer {
           ${this.isLeaderboardShow || this.isTeamLeaderboardShow
             ? html`<span
                 class="ml-auto text-[10px] text-slate-500 select-all leading-none self-start"
-                title="Game ID"
+                title=${translateText("help_modal.game_id_tooltip")}
                 >${this.game?.gameID() ?? ""}</span
               >`
             : null}


### PR DESCRIPTION
## Description:

Instead of begging youtubers to share their game id to be able to debug:

Display the current game ID in the top-right corner of the in-game leaderboard panel (there was unused space)

<img width="391" height="326" alt="image" src="https://github.com/user-attachments/assets/8b0aa7c2-fc8c-48e5-ae11-edd60fd40de9" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
