### PR TITLE
Forward game tick errors from worker to client 🐛

### DIFF
--- a/src/core/worker/Worker.worker.ts
+++ b/src/core/worker/Worker.worker.ts
@@ -60,6 +60,9 @@ async function drain(): Promise<void> {
     const batch: GameUpdateViewData[] = [];
     const onTickUpdate = (gu: GameUpdateViewData | ErrorUpdate) => {
       if (!("updates" in gu)) {
+        if ("errMsg" in gu) {
+          sendMessage({ type: "game_error", error: gu } as WorkerMessage);
+        }
         return;
       }
       batch.push(gu);

--- a/src/core/worker/WorkerClient.ts
+++ b/src/core/worker/WorkerClient.ts
@@ -53,6 +53,11 @@ export class WorkerClient {
           }
         }
         break;
+      case "game_error":
+        if (this.gameUpdateCallback && message.error) {
+          this.gameUpdateCallback(message.error);
+        }
+        break;
 
       case "initialized":
       default:

--- a/src/core/worker/WorkerMessages.ts
+++ b/src/core/worker/WorkerMessages.ts
@@ -7,7 +7,7 @@ import {
   PlayerProfile,
 } from "../game/Game";
 import { TileRef } from "../game/GameMap";
-import { GameUpdateViewData } from "../game/GameUpdates";
+import { ErrorUpdate, GameUpdateViewData } from "../game/GameUpdates";
 import { ClientID, GameStartInfo, Turn } from "../Schemas";
 
 export type WorkerMessageType =
@@ -16,6 +16,7 @@ export type WorkerMessageType =
   | "turn"
   | "game_update"
   | "game_update_batch"
+  | "game_error"
   | "player_actions"
   | "player_actions_result"
   | "player_buildables"
@@ -60,6 +61,11 @@ export interface GameUpdateMessage extends BaseWorkerMessage {
 export interface GameUpdateBatchMessage extends BaseWorkerMessage {
   type: "game_update_batch";
   gameUpdates: GameUpdateViewData[];
+}
+
+export interface GameErrorMessage extends BaseWorkerMessage {
+  type: "game_error";
+  error: ErrorUpdate;
 }
 
 export interface PlayerActionsMessage extends BaseWorkerMessage {
@@ -147,6 +153,7 @@ export type WorkerMessage =
   | InitializedMessage
   | GameUpdateMessage
   | GameUpdateBatchMessage
+  | GameErrorMessage
   | PlayerActionsResultMessage
   | PlayerBuildablesResultMessage
   | PlayerProfileResultMessage


### PR DESCRIPTION
## Description:

Currently there is a "Game tick error: Invalid coordinates: NaN,NaN" error which crashes the game rarely.
Maybe introduced by water nukes, I'm not sure.
To properly debug it when it happens again, lets print the stacktrace:

- Game tick errors (`ErrorUpdate`) were silently dropped in the web worker's `drain()` function, so the client's error modal never displayed
- Added a `"game_error"` worker message type to forward `ErrorUpdate` from the worker to the main thread
- The client now receives the full error message and stack trace via the existing `showErrorModal` dialog

<img width="1147" height="402" alt="image" src="https://github.com/user-attachments/assets/1b5dcc02-2903-41c9-bf0e-75f22cb7811a" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
