### PR TITLE
Fix hostCheats check not disabling

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -175,9 +175,7 @@ export class GameServer {
     if (gameConfig.waterNukes !== undefined) {
       this.gameConfig.waterNukes = gameConfig.waterNukes ?? undefined;
     }
-    if (gameConfig.hostCheats !== undefined) {
-      this.gameConfig.hostCheats = gameConfig.hostCheats;
-    }
+    this.gameConfig.hostCheats = gameConfig.hostCheats;
   }
 
   private isKicked(clientID: ClientID): boolean {


### PR DESCRIPTION
## Description:

Currently if you deselect Host cheats, any active host cheats will still be active. This fixes it so if you deselect Host cheats, all the cheats are disabled.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

babyboucher
