### PR TITLE
Add building upgrades section and missing icons to Help Modal

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -186,7 +186,12 @@
     "bomb_direction": "Atom / Hydrogen bomb arc direction",
     "icon_alt_player_leaderboard": "Player Leaderboard Icon",
     "icon_alt_team_leaderboard": "Team Leaderboard Icon",
-    "game_id_tooltip": "Game ID"
+    "game_id_tooltip": "Game ID",
+    "upgrade_title": "Building Upgrades",
+    "upgrade_desc": "Upgrade your buildings to increase their health and defense.",
+    "upgrade_health": "Most buildings can be upgraded to significantly increase their Max Health.",
+    "upgrade_economy": "Upgrading Cities increases your resource generation and Gold income.",
+    "upgrade_defense": "Upgrading defensive structures increases their attack damage and operational range."
   },
   "single_modal": {
     "random_spawn": "Random spawn",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -187,11 +187,11 @@
     "icon_alt_player_leaderboard": "Player Leaderboard Icon",
     "icon_alt_team_leaderboard": "Team Leaderboard Icon",
     "game_id_tooltip": "Game ID",
-    "upgrade_title": "Building Upgrades",
-    "upgrade_desc": "Upgrade your buildings to increase their health and defense.",
-    "upgrade_health": "Most buildings can be upgraded to significantly increase their Max Health.",
-    "upgrade_economy": "Upgrading Cities increases your resource generation and Gold income.",
-    "upgrade_defense": "Upgrading defensive structures increases their attack damage and operational range."
+    "upgrade_title": "Building Mechanics",
+    "upgrade_desc": "Buildings can be military (square icons) or economic (round icons). All buildings cost Gold and some have specific placement requirements, such as Ports which must be built near water.",
+    "upgrade_health": "Buildings (except Defense Posts) are transferred to the conquering player if their territory changes owners.",
+    "upgrade_economy": "Players can destroy their own buildings through the radial menu (30s timer).",
+    "upgrade_defense": "Nukes will destroy all buildings within their explosion radius."
   },
   "single_modal": {
     "random_spawn": "Random spawn",

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -762,6 +762,8 @@ export class HelpModal extends BaseModal {
                   <li class="flex items-center gap-3">
                     <img
                       src=${assetUrl("images/BuildIconWhite.svg")}
+                      alt=""
+                      aria-hidden="true"
                       class="w-8 h-8 scale-75 origin-left"
                     />
                     <span>${translateText("help_modal.upgrade_health")}</span>
@@ -769,6 +771,8 @@ export class HelpModal extends BaseModal {
                   <li class="flex items-center gap-3">
                     <img
                       src=${assetUrl("images/DonateGoldIconWhite.svg")}
+                      alt=""
+                      aria-hidden="true"
                       class="w-8 h-8 scale-75 origin-left"
                     />
                     <span>${translateText("help_modal.upgrade_economy")}</span>
@@ -776,6 +780,8 @@ export class HelpModal extends BaseModal {
                   <li class="flex items-center gap-3">
                     <img
                       src=${assetUrl("images/InfoIcon.svg")}
+                      alt=""
+                      aria-hidden="true"
                       class="w-8 h-8 scale-75 origin-left"
                     />
                     <span>${translateText("help_modal.upgrade_defense")}</span>

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -761,7 +761,7 @@ export class HelpModal extends BaseModal {
                 <ul class="space-y-3">
                   <li class="flex items-center gap-3">
                     <img
-                      src=${assetUrl("images/BuildIconWhite.svg")}
+                      src=${assetUrl("images/CityIconWhite.svg")}
                       alt=""
                       aria-hidden="true"
                       class="w-8 h-8 scale-75 origin-left"
@@ -770,7 +770,7 @@ export class HelpModal extends BaseModal {
                   </li>
                   <li class="flex items-center gap-3">
                     <img
-                      src=${assetUrl("images/DonateGoldIconWhite.svg")}
+                      src=${assetUrl("images/TargetIconWhite.svg")}
                       alt=""
                       aria-hidden="true"
                       class="w-8 h-8 scale-75 origin-left"
@@ -779,7 +779,7 @@ export class HelpModal extends BaseModal {
                   </li>
                   <li class="flex items-center gap-3">
                     <img
-                      src=${assetUrl("images/InfoIcon.svg")}
+                      src=${assetUrl("images/NukeIconWhite.svg")}
                       alt=""
                       aria-hidden="true"
                       class="w-8 h-8 scale-75 origin-left"

--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -720,6 +720,71 @@ export class HelpModal extends BaseModal {
             </div>
           </section>
 
+          <!-- Building Upgrades Section -->
+          <section class="mb-8">
+            <div class="flex items-center gap-3 mb-6">
+              <!-- Set the icon color to blue to match the rest of the UI -->
+              <div class="text-blue-400">
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="24"
+                  height="24"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-width="2"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                >
+                  <polyline points="18 15 12 9 6 15"></polyline>
+                </svg>
+              </div>
+              <h3
+                class="text-xl font-bold uppercase tracking-widest text-white/90"
+              >
+                ${translateText("help_modal.upgrade_title")}
+              </h3>
+              <div
+                class="flex-1 h-px bg-gradient-to-r from-blue-500/50 to-transparent"
+              ></div>
+            </div>
+
+            <div
+              class="bg-black/20 rounded-xl border border-white/10 p-6 flex flex-col md:flex-row gap-6 hover:bg-white/5 transition-colors"
+            >
+              <div class="text-white/70 text-sm w-full">
+                <p class="mb-4 leading-relaxed">
+                  ${translateText("help_modal.upgrade_desc")}
+                </p>
+
+                <!-- List of upgrades with missing icons populated -->
+                <ul class="space-y-3">
+                  <li class="flex items-center gap-3">
+                    <img
+                      src=${assetUrl("images/BuildIconWhite.svg")}
+                      class="w-8 h-8 scale-75 origin-left"
+                    />
+                    <span>${translateText("help_modal.upgrade_health")}</span>
+                  </li>
+                  <li class="flex items-center gap-3">
+                    <img
+                      src=${assetUrl("images/DonateGoldIconWhite.svg")}
+                      class="w-8 h-8 scale-75 origin-left"
+                    />
+                    <span>${translateText("help_modal.upgrade_economy")}</span>
+                  </li>
+                  <li class="flex items-center gap-3">
+                    <img
+                      src=${assetUrl("images/InfoIcon.svg")}
+                      class="w-8 h-8 scale-75 origin-left"
+                    />
+                    <span>${translateText("help_modal.upgrade_defense")}</span>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </section>
+
           <!-- Info/Ally Panels Section -->
           <section class="mb-8">
             <div class="flex items-center gap-3 mb-6">


### PR DESCRIPTION
## Description:
Resolves #1478

This PR overhauls the Help Modal to better encompass the state of the game, specifically addressing the missing information regarding building mechanics and missing icons requested in the issue. 

**Changes made:**
- Added a new "Building Mechanics" section to `HelpModal.ts`, matching the existing Tailwind CSS styling.
- Replaced flat text blocks with scalable SVG icons (`CityIconWhite.svg`, `TargetIconWhite.svg`, `NukeIconWhite.svg`) to visually illustrate Conquest, Destruction, and Nuke rules.
- Modernized the layout of the Radial Menu and Build Menu sections using Tailwind CSS grids, hover states, and glassmorphism effects for a cleaner UI.
- Registered all new UI strings via `translateText()` and properly nested them under the `help_modal` object in `en.json`.
- Verified mechanics text against the official OpenFront Wiki.

## Screenshots
<img width="1065" height="376" alt="image" src="https://github.com/user-attachments/assets/de61f695-02f7-487a-9c1e-77d7049c80a9" />
<img width="815" height="583" alt="99e14677-71e4-41d1-95e9-26e1f05888d3" src="https://github.com/user-attachments/assets/24a57424-3561-4c10-a99e-faf6086f75ca" />
<img width="530" height="619" alt="1adcbe47-a76d-49c3-85db-87b6de707703" src="https://github.com/user-attachments/assets/e5ba043f-815a-452b-bde7-05ef5b60ae14" />

## Checklist
- [x] I have linked the relevant issue
- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

Please put your Discord username so you can be contacted if a bug or regression is found:
ambatukam0336## Description:
Resolves #1478

This PR overhauls the Help Modal to better encompass the state of the game, specifically addressing the missing information regarding building mechanics and missing icons requested in the issue. 

**Changes made:**
- Added a new "Building Mechanics" section to `HelpModal.ts`, matching the existing Tailwind CSS styling.
- Replaced flat text blocks with scalable SVG icons (`CityIconWhite.svg`, `TargetIconWhite.svg`, `NukeIconWhite.svg`) to visually illustrate Conquest, Destruction, and Nuke rules.
- Modernized the layout of the Radial Menu and Build Menu sections using Tailwind CSS grids, hover states, and glassmorphism effects for a cleaner UI.
- Registered all new UI strings via `translateText()` and properly nested them under the `help_modal` object in `en.json`.
- Verified mechanics text against the official OpenFront Wiki.

### Screenshots
<img width="1072" height="358" alt="822da8ce-65fc-48e0-a603-adf7eab95d60" src="https://github.com/user-attachments/assets/a9d6a1c3-cd80-45ba-9c16-0aa62163fba5" />
<img width="815" height="583" alt="99e14677-71e4-41d1-95e9-26e1f05888d3" src="https://github.com/user-attachments/assets/24a57424-3561-4c10-a99e-faf6086f75ca" />
<img width="530" height="619" alt="1adcbe47-a76d-49c3-85db-87b6de707703" src="https://github.com/user-attachments/assets/e5ba043f-815a-452b-bde7-05ef5b60ae14" />

### Checklist
- [x] I have linked the relevant issue
- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

Please put your Discord username so you can be contacted if a bug or regression is found:
ambatukam0336