### PR TITLE
Fix game ID display for team games 🪪

### DIFF
--- a/src/client/graphics/layers/GameLeftSidebar.ts
+++ b/src/client/graphics/layers/GameLeftSidebar.ts
@@ -133,13 +133,6 @@ export class GameLeftSidebar extends LitElement implements Layer {
               height="20"
             />
           </div>
-          ${this.isLeaderboardShow || this.isTeamLeaderboardShow
-            ? html`<span
-                class="ml-auto text-[10px] text-slate-500 select-all leading-none self-start"
-                title=${translateText("help_modal.game_id_tooltip")}
-                >${this.game?.gameID() ?? ""}</span
-              >`
-            : null}
           ${this.isTeamGame
             ? html`
                 <div
@@ -170,6 +163,13 @@ export class GameLeftSidebar extends LitElement implements Layer {
                   />
                 </div>
               `
+            : null}
+          ${this.isLeaderboardShow || this.isTeamLeaderboardShow
+            ? html`<span
+                class="ml-auto text-[10px] text-slate-500 select-all leading-none self-start"
+                title=${translateText("help_modal.game_id_tooltip")}
+                >${this.game?.gameID() ?? ""}</span
+              >`
             : null}
         </div>
         ${this.isPlayerTeamLabelVisible


### PR DESCRIPTION
## Description:

Game ID display was looking weird in team games...

Before:

<img width="389" height="321" alt="image" src="https://github.com/user-attachments/assets/cf39b490-cfba-4c3a-86af-8f9498380eae" />

After:

<img width="394" height="323" alt="image" src="https://github.com/user-attachments/assets/9e828169-b267-4627-85eb-548dca224a8a" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
