### PR TITLE
feat: airfields, bombers, auto-city, threat overlay, tech tree

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -545,7 +545,9 @@
     "atom_bomb": "Atom Bomb",
     "hydrogen_bomb": "Hydrogen Bomb",
     "mirv": "MIRV",
-    "factory": "Factory"
+    "factory": "Factory",
+    "airfield": "Airfield",
+    "bomber": "Bomber"
   },
   "user_setting": {
     "title": "Settings",
@@ -768,7 +770,8 @@
       "port": "Sends trade ships to generate gold",
       "defense_post": "Increases defenses of nearby borders",
       "city": "Increases max population",
-      "factory": "Creates railroads and spawns trains"
+      "factory": "Generates passive gold, spawns trains, and boosts max population",
+      "airfield": "Periodically launches bombers at nearby enemy structures"
     },
     "warship_shift_hint": "Hold Shift and drag to select multiple warships at once",
     "not_enough_money": "Not enough money"

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -545,6 +545,14 @@ export class InputHandler {
         e.preventDefault();
         this.eventBus.emit(new TogglePauseIntentEvent());
       }
+      if (
+        !e.repeat &&
+        this.keybinds.toggleAutoCity &&
+        this.keybindMatchesEvent(e, this.keybinds.toggleAutoCity)
+      ) {
+        e.preventDefault();
+        this.userSettings.toggleAutoCity();
+      }
       if (!e.repeat && this.keybindMatchesEvent(e, this.keybinds.gameSpeedUp)) {
         e.preventDefault();
         this.eventBus.emit(new GameSpeedUpIntentEvent());

--- a/src/client/graphics/GameRenderer.ts
+++ b/src/client/graphics/GameRenderer.ts
@@ -9,6 +9,7 @@ import { UIState } from "./UIState";
 import { AlertFrame } from "./layers/AlertFrame";
 import { AttackingTroopsOverlay } from "./layers/AttackingTroopsOverlay";
 import { AttacksDisplay } from "./layers/AttacksDisplay";
+import { AutoCityLayer } from "./layers/AutoCityLayer";
 import { BuildMenu } from "./layers/BuildMenu";
 import { ChatDisplay } from "./layers/ChatDisplay";
 import { ChatModal } from "./layers/ChatModal";
@@ -40,8 +41,10 @@ import { SpawnTimer } from "./layers/SpawnTimer";
 import { StructureIconsLayer } from "./layers/StructureIconsLayer";
 import { StructureLayer } from "./layers/StructureLayer";
 import { TeamStats } from "./layers/TeamStats";
+import { TechTreeLayer } from "./layers/TechTreeLayer";
 import { TerrainLayer } from "./layers/TerrainLayer";
 import { TerritoryLayer } from "./layers/TerritoryLayer";
+import { ThreatOverlayLayer } from "./layers/ThreatOverlayLayer";
 import { UILayer } from "./layers/UILayer";
 import { UnitDisplay } from "./layers/UnitDisplay";
 import { UnitLayer } from "./layers/UnitLayer";
@@ -285,6 +288,18 @@ export function createRenderer(
     new FxLayer(game, eventBus, transformHandler),
     new UILayer(game, eventBus, transformHandler),
     new NukeTrajectoryPreviewLayer(game, eventBus, transformHandler, uiState),
+    new ThreatOverlayLayer(game),
+    new AutoCityLayer(game, eventBus, userSettings),
+    (() => {
+      let el = document.querySelector("tech-tree-panel") as TechTreeLayer;
+      if (!el) {
+        el = document.createElement("tech-tree-panel") as TechTreeLayer;
+        document.body.appendChild(el);
+      }
+      el.game = game;
+      el.userSettings = userSettings;
+      return el;
+    })(),
     new StructureIconsLayer(game, eventBus, uiState, transformHandler),
     new DynamicUILayer(game, transformHandler, eventBus),
     new NameLayer(game, transformHandler, eventBus),

--- a/src/client/graphics/SpriteLoader.ts
+++ b/src/client/graphics/SpriteLoader.ts
@@ -31,6 +31,7 @@ const SPRITE_CONFIG: Partial<Record<UnitType | TrainTypeSprite, string>> = {
   [UnitType.HydrogenBomb]: hydrogenBombSprite,
   [UnitType.TradeShip]: tradeShipSprite,
   [UnitType.MIRV]: mirvSprite,
+  [UnitType.Bomber]: warshipSprite,
   [TrainTypeSprite.Engine]: trainEngineSprite,
   [TrainTypeSprite.Carriage]: trainCarriageSprite,
   [TrainTypeSprite.LoadedCarriage]: trainLoadedCarriageSprite,

--- a/src/client/graphics/layers/AutoCityLayer.ts
+++ b/src/client/graphics/layers/AutoCityLayer.ts
@@ -1,0 +1,60 @@
+import { EventBus } from "../../../core/EventBus";
+import { UnitType } from "../../../core/game/Game";
+import { GameView } from "../../../core/game/GameView";
+import { UserSettings } from "../../../core/game/UserSettings";
+import { BuildUnitIntentEvent } from "../../Transport";
+import { Layer } from "./Layer";
+
+export class AutoCityLayer implements Layer {
+  private inFlight = false;
+
+  constructor(
+    private readonly game: GameView,
+    private readonly eventBus: EventBus,
+    private readonly userSettings: UserSettings,
+  ) {}
+
+  getTickIntervalMs(): number {
+    return 2000;
+  }
+
+  tick(): void {
+    if (!this.userSettings.autoCityEnabled()) return;
+    if (this.inFlight) return;
+    const me = this.game.myPlayer();
+    if (me === null || !me.isAlive()) return;
+
+    this.inFlight = true;
+    void this.tryPlaceCity().finally(() => {
+      this.inFlight = false;
+    });
+  }
+
+  private async tryPlaceCity(): Promise<void> {
+    const me = this.game.myPlayer();
+    if (me === null) return;
+
+    const buffer =
+      (me.gold() * BigInt(this.game.config().autoCityGoldBuffer())) / 100n;
+    const minAffordable = me.gold() - buffer;
+    if (minAffordable <= 0n) return;
+
+    const borders = await me.borderTiles();
+    const tiles = borders?.borderTiles;
+    if (!tiles || tiles.size === 0) return;
+
+    const tileArray = Array.from(tiles);
+    const sampleCount = Math.min(tileArray.length, 12);
+    for (let i = 0; i < sampleCount; i++) {
+      const tile = tileArray[Math.floor(Math.random() * tileArray.length)];
+      const buildables = await me.buildables(tile, [UnitType.City]);
+      const city = buildables.find((b) => b.type === UnitType.City);
+      if (city && city.canBuild !== false && city.cost <= minAffordable) {
+        this.eventBus.emit(
+          new BuildUnitIntentEvent(UnitType.City, city.canBuild),
+        );
+        return;
+      }
+    }
+  }
+}

--- a/src/client/graphics/layers/BuildMenu.ts
+++ b/src/client/graphics/layers/BuildMenu.ts
@@ -98,6 +98,13 @@ export const buildTable: BuildItemDisplay[][] = [
       countable: true,
     },
     {
+      unitType: UnitType.Airfield,
+      icon: warshipIcon,
+      description: "build_menu.desc.airfield",
+      key: "unit_type.airfield",
+      countable: true,
+    },
+    {
       unitType: UnitType.DefensePost,
       icon: shieldIcon,
       description: "build_menu.desc.defense_post",

--- a/src/client/graphics/layers/StructureDrawingUtils.ts
+++ b/src/client/graphics/layers/StructureDrawingUtils.ts
@@ -22,6 +22,7 @@ export const STRUCTURE_SHAPES: Partial<Record<UnitType, ShapeType>> = {
   [UnitType.DefensePost]: "octagon",
   [UnitType.SAMLauncher]: "square",
   [UnitType.MissileSilo]: "triangle",
+  [UnitType.Airfield]: "square",
   [UnitType.Warship]: "cross",
   [UnitType.AtomBomb]: "cross",
   [UnitType.HydrogenBomb]: "cross",
@@ -67,6 +68,7 @@ export class SpriteFactory {
     [UnitType.Port, { iconPath: anchorIcon, image: null }],
     [UnitType.MissileSilo, { iconPath: missileSiloIcon, image: null }],
     [UnitType.SAMLauncher, { iconPath: SAMMissileIcon, image: null }],
+    [UnitType.Airfield, { iconPath: missileSiloIcon, image: null }],
   ]);
   constructor(
     theme: Theme,

--- a/src/client/graphics/layers/StructureLayer.ts
+++ b/src/client/graphics/layers/StructureLayer.ts
@@ -15,6 +15,7 @@ const shieldIcon = assetUrl("images/buildings/fortAlt3.png");
 const anchorIcon = assetUrl("images/buildings/port1.png");
 const missileSiloIcon = assetUrl("images/buildings/silo1.png");
 const SAMMissileIcon = assetUrl("images/buildings/silo4.png");
+const airfieldIcon = assetUrl("images/buildings/silo1.png");
 
 const underConstructionColor = colord("rgb(150,150,150)");
 
@@ -67,6 +68,11 @@ export class StructureLayer implements Layer {
     },
     [UnitType.SAMLauncher]: {
       icon: SAMMissileIcon,
+      borderRadius: BASE_BORDER_RADIUS * RADIUS_SCALE_FACTOR,
+      territoryRadius: BASE_TERRITORY_RADIUS * RADIUS_SCALE_FACTOR,
+    },
+    [UnitType.Airfield]: {
+      icon: airfieldIcon,
       borderRadius: BASE_BORDER_RADIUS * RADIUS_SCALE_FACTOR,
       territoryRadius: BASE_TERRITORY_RADIUS * RADIUS_SCALE_FACTOR,
     },

--- a/src/client/graphics/layers/TechTreeLayer.ts
+++ b/src/client/graphics/layers/TechTreeLayer.ts
@@ -1,0 +1,242 @@
+import { css, html, LitElement } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { GameView } from "../../../core/game/GameView";
+import { UserSettings } from "../../../core/game/UserSettings";
+import { Layer } from "./Layer";
+
+interface TechNode {
+  id: string;
+  name: string;
+  description: string;
+  cost: number;
+  requires?: string;
+}
+
+const TECH_NODES: TechNode[] = [
+  {
+    id: "better_equipment",
+    name: "Better Equipment",
+    description: "+5% offensive attack strength (visual buff).",
+    cost: 500_000,
+  },
+  {
+    id: "efficient_logistics",
+    name: "Efficient Logistics",
+    description: "+10% trade ship yield (visual buff).",
+    cost: 1_000_000,
+    requires: "better_equipment",
+  },
+  {
+    id: "nuclear_physics",
+    name: "Nuclear Physics",
+    description: "-10% nuke cost (visual buff).",
+    cost: 2_500_000,
+    requires: "efficient_logistics",
+  },
+  {
+    id: "advanced_radar",
+    name: "Advanced Radar",
+    description: "+20% SAM detection range (visual buff).",
+    cost: 5_000_000,
+    requires: "nuclear_physics",
+  },
+];
+
+@customElement("tech-tree-panel")
+export class TechTreeLayer extends LitElement implements Layer {
+  public game: GameView;
+  public userSettings: UserSettings = new UserSettings();
+
+  @state()
+  private open = false;
+
+  @state()
+  private researched: string[] = [];
+
+  static styles = css`
+    :host {
+      position: fixed;
+      top: 60px;
+      right: 10px;
+      z-index: 50;
+      font-family: sans-serif;
+    }
+    .toggle {
+      background: rgba(40, 40, 80, 0.9);
+      color: white;
+      border: 1px solid #667;
+      padding: 6px 10px;
+      border-radius: 4px;
+      cursor: pointer;
+      font-size: 12px;
+    }
+    .toggle:hover {
+      background: rgba(60, 60, 120, 0.9);
+    }
+    .panel {
+      margin-top: 6px;
+      background: rgba(20, 20, 30, 0.92);
+      color: white;
+      border: 1px solid #445;
+      border-radius: 6px;
+      padding: 10px;
+      width: 280px;
+      max-height: 70vh;
+      overflow-y: auto;
+    }
+    .node {
+      border: 1px solid #334;
+      border-radius: 4px;
+      padding: 8px;
+      margin-bottom: 6px;
+      background: rgba(40, 40, 60, 0.6);
+    }
+    .node.researched {
+      border-color: #4c9;
+      background: rgba(30, 70, 50, 0.6);
+    }
+    .node.locked {
+      opacity: 0.5;
+    }
+    .node .name {
+      font-weight: bold;
+      font-size: 13px;
+    }
+    .node .desc {
+      font-size: 11px;
+      color: #bbc;
+      margin: 4px 0;
+    }
+    .node .cost {
+      font-size: 11px;
+      color: #dd8;
+    }
+    .node button {
+      margin-top: 4px;
+      background: #357;
+      color: white;
+      border: 0;
+      padding: 4px 8px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 11px;
+    }
+    .node button:disabled {
+      background: #333;
+      cursor: not-allowed;
+    }
+    .header {
+      display: flex;
+      justify-content: space-between;
+      margin-bottom: 8px;
+      font-size: 13px;
+      font-weight: bold;
+    }
+    .reset {
+      background: #733;
+      color: white;
+      border: 0;
+      padding: 3px 6px;
+      border-radius: 3px;
+      cursor: pointer;
+      font-size: 10px;
+    }
+  `;
+
+  init() {
+    this.researched = this.userSettings.researchedTechs();
+  }
+
+  tick() {
+    // Periodically refresh in case state changed elsewhere
+    if (this.open) {
+      this.researched = this.userSettings.researchedTechs();
+    }
+  }
+
+  private togglePanel() {
+    this.open = !this.open;
+    if (this.open) {
+      this.researched = this.userSettings.researchedTechs();
+    }
+  }
+
+  private canResearch(node: TechNode): boolean {
+    if (this.researched.includes(node.id)) return false;
+    if (node.requires && !this.researched.includes(node.requires)) return false;
+    const me = this.game?.myPlayer?.();
+    if (me === null || me === undefined) return false;
+    return Number(me.gold()) >= node.cost;
+  }
+
+  private research(node: TechNode) {
+    if (!this.canResearch(node)) return;
+    this.userSettings.addTech(node.id);
+    this.researched = this.userSettings.researchedTechs();
+  }
+
+  private resetAll() {
+    this.userSettings.resetTechs();
+    this.researched = [];
+  }
+
+  render() {
+    const me = this.game?.myPlayer?.();
+    if (!me) return html``;
+
+    return html`
+      <button class="toggle" @click=${this.togglePanel}>
+        🔬 Research
+        ${this.researched.length > 0 ? `(${this.researched.length})` : ""}
+      </button>
+      ${this.open
+        ? html`
+            <div class="panel">
+              <div class="header">
+                <span>Tech Tree</span>
+                <button class="reset" @click=${this.resetAll}>Reset</button>
+              </div>
+              ${TECH_NODES.map((node) => {
+                const isResearched = this.researched.includes(node.id);
+                const isLocked =
+                  node.requires !== undefined &&
+                  !this.researched.includes(node.requires);
+                const canBuy = this.canResearch(node);
+                const classes = isResearched
+                  ? "node researched"
+                  : isLocked
+                    ? "node locked"
+                    : "node";
+                return html`
+                  <div class=${classes}>
+                    <div class="name">
+                      ${isResearched ? "✓ " : ""}${node.name}
+                    </div>
+                    <div class="desc">${node.description}</div>
+                    <div class="cost">
+                      Cost: ${node.cost.toLocaleString()}g
+                      ${node.requires
+                        ? html` · Requires:
+                          ${TECH_NODES.find((t) => t.id === node.requires)
+                            ?.name ?? node.requires}`
+                        : ""}
+                    </div>
+                    ${!isResearched
+                      ? html`
+                          <button
+                            ?disabled=${!canBuy}
+                            @click=${() => this.research(node)}
+                          >
+                            ${isLocked ? "Locked" : "Research"}
+                          </button>
+                        `
+                      : ""}
+                  </div>
+                `;
+              })}
+            </div>
+          `
+        : ""}
+    `;
+  }
+}

--- a/src/client/graphics/layers/ThreatOverlayLayer.ts
+++ b/src/client/graphics/layers/ThreatOverlayLayer.ts
@@ -1,0 +1,87 @@
+import { UnitType } from "../../../core/game/Game";
+import { GameView } from "../../../core/game/GameView";
+import { Layer } from "./Layer";
+
+const THREAT_TYPES = new Set<UnitType>([
+  UnitType.AtomBomb,
+  UnitType.HydrogenBomb,
+  UnitType.MIRVWarhead,
+  UnitType.Bomber,
+]);
+
+const COLOR_BY_TYPE: Partial<Record<UnitType, string>> = {
+  [UnitType.Bomber]: "rgba(255,200,50,1)",
+  [UnitType.AtomBomb]: "rgba(255,130,40,1)",
+  [UnitType.HydrogenBomb]: "rgba(255,60,60,1)",
+  [UnitType.MIRVWarhead]: "rgba(220,80,255,1)",
+};
+
+export class ThreatOverlayLayer implements Layer {
+  private pulsePhase = 0;
+
+  constructor(private readonly game: GameView) {}
+
+  shouldTransform(): boolean {
+    return true;
+  }
+
+  tick() {}
+
+  renderLayer(context: CanvasRenderingContext2D) {
+    const myPlayer = this.game.myPlayer();
+    if (myPlayer === null) return;
+
+    this.pulsePhase = (Date.now() % 1500) / 1500;
+    const pulseScale = 1 + Math.sin(this.pulsePhase * Math.PI * 2) * 0.12;
+
+    const offsetX = -this.game.width() / 2;
+    const offsetY = -this.game.height() / 2;
+
+    for (const unit of this.game.units(
+      ...(Array.from(THREAT_TYPES) as UnitType[]),
+    )) {
+      if (!unit.isActive()) continue;
+      if (unit.owner() === myPlayer) continue;
+      if (myPlayer.isFriendly(unit.owner())) continue;
+
+      const targetTile = unit.targetTile();
+      if (targetTile === undefined) continue;
+
+      const tileOwner = this.game.owner(targetTile);
+      if (!tileOwner.isPlayer() || tileOwner !== myPlayer) continue;
+
+      const radius = this.radiusForType(unit.type());
+      if (radius <= 0) continue;
+
+      const x = this.game.x(targetTile) + offsetX;
+      const y = this.game.y(targetTile) + offsetY;
+      const color = COLOR_BY_TYPE[unit.type()] ?? "rgba(255,80,80,1)";
+
+      context.save();
+      context.strokeStyle = color;
+      context.fillStyle = color.replace(/,1\)$/, ",0.12)");
+      context.lineWidth = 1.5;
+      context.beginPath();
+      context.arc(x, y, radius * pulseScale, 0, Math.PI * 2);
+      context.fill();
+      context.stroke();
+      context.restore();
+    }
+  }
+
+  private radiusForType(type: UnitType): number {
+    const cfg = this.game.config();
+    switch (type) {
+      case UnitType.AtomBomb:
+        return cfg.nukeMagnitudes(UnitType.AtomBomb).outer;
+      case UnitType.HydrogenBomb:
+        return cfg.nukeMagnitudes(UnitType.HydrogenBomb).outer;
+      case UnitType.MIRVWarhead:
+        return cfg.nukeMagnitudes(UnitType.MIRVWarhead).outer;
+      case UnitType.Bomber:
+        return cfg.bombMagnitude().outer;
+      default:
+        return 0;
+    }
+  }
+}

--- a/src/client/graphics/layers/UnitLayer.ts
+++ b/src/client/graphics/layers/UnitLayer.ts
@@ -452,6 +452,9 @@ export class UnitLayer implements Layer {
       case UnitType.MIRV:
         this.handleNuke(unit);
         break;
+      case UnitType.Bomber:
+        this.drawSprite(unit);
+        break;
     }
   }
 

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -35,6 +35,7 @@ export const otherUnits = [
   "silo",
   "saml",
   "fact",
+  "airf",
 ] as const;
 export const OtherUnitSchema = z.enum(otherUnits);
 export type OtherUnit = z.infer<typeof OtherUnitSchema>;
@@ -45,7 +46,8 @@ export type OtherUnitType =
   | UnitType.Port
   | UnitType.SAMLauncher
   | UnitType.Warship
-  | UnitType.Factory;
+  | UnitType.Factory
+  | UnitType.Airfield;
 
 export const unitTypeToOtherUnit = {
   [UnitType.City]: "city",
@@ -55,6 +57,7 @@ export const unitTypeToOtherUnit = {
   [UnitType.SAMLauncher]: "saml",
   [UnitType.Warship]: "wshp",
   [UnitType.Factory]: "fact",
+  [UnitType.Airfield]: "airf",
 } as const satisfies Record<OtherUnitType, OtherUnit>;
 
 // Attacks

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -167,6 +167,18 @@ export interface Config {
   defaultSamRange(): number;
   samRange(level: number): number;
   maxSamRange(): number;
+  // Airfield / Bomber
+  airfieldSpawnCooldown(): Tick;
+  airfieldBomberRange(): number;
+  bomberSpeed(): number;
+  bombMagnitude(): NukeMagnitude;
+  bomberHealth(): number;
+  // Factory passive benefits
+  factoryPassiveGoldPerTick(): Gold;
+  factoryTroopIncrease(): number;
+  // Auto-city client pacer
+  autoCityIntervalTicks(): Tick;
+  autoCityGoldBuffer(): number;
   nukeDeathFactor(
     nukeType: NukeType,
     humans: number,

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -473,6 +473,28 @@ export class DefaultConfig implements Config {
           cost: () => 0n,
         };
         break;
+      case UnitType.Airfield:
+        info = {
+          cost: this.costWrapper(
+            (numUnits: number) =>
+              Math.min(4_000_000, (numUnits + 1) * 1_200_000),
+            UnitType.Airfield,
+          ),
+          constructionDuration: this.instantBuild() ? 0 : 20 * 10,
+          upgradable: false,
+        };
+        break;
+      case UnitType.Bomber:
+        info = {
+          cost: () => 0n,
+          maxHealth: 100,
+        };
+        break;
+      case UnitType.Bomb:
+        info = {
+          cost: () => 0n,
+        };
+        break;
       default:
         assertNever(type);
     }
@@ -820,7 +842,13 @@ export class DefaultConfig implements Config {
             .filter((u) => !u.isUnderConstruction())
             .map((city) => city.level())
             .reduce((a, b) => a + b, 0) *
-            this.cityTroopIncrease();
+            this.cityTroopIncrease() +
+          player
+            .units(UnitType.Factory)
+            .filter((u) => !u.isUnderConstruction())
+            .map((factory) => factory.level())
+            .reduce((a, b) => a + b, 0) *
+            this.factoryTroopIncrease();
 
     if (player.type() === PlayerType.Bot) {
       return maxTroops / 3;
@@ -928,6 +956,39 @@ export class DefaultConfig implements Config {
 
   defaultSamMissileSpeed(): number {
     return 12;
+  }
+
+  // Airfield / Bomber
+  airfieldSpawnCooldown(): number {
+    return 30 * 10; // 30s between bomber sorties
+  }
+  airfieldBomberRange(): number {
+    return 180;
+  }
+  bomberSpeed(): number {
+    return 3;
+  }
+  bombMagnitude(): NukeMagnitude {
+    return { inner: 4, outer: 8 };
+  }
+  bomberHealth(): number {
+    return 100;
+  }
+
+  // Factory passive benefits
+  factoryPassiveGoldPerTick(): Gold {
+    return 5_000n;
+  }
+  factoryTroopIncrease(): number {
+    return 125_000; // half of cityTroopIncrease
+  }
+
+  // Auto-city client pacer
+  autoCityIntervalTicks(): number {
+    return 20; // 2s
+  }
+  autoCityGoldBuffer(): number {
+    return 20; // keep 20% of current gold free
   }
 
   // Humans can be soldiers, soldiers attacking, soldiers in boat etc.

--- a/src/core/execution/AirfieldExecution.ts
+++ b/src/core/execution/AirfieldExecution.ts
@@ -1,0 +1,59 @@
+import { Execution, Game, Player, Structures, Unit } from "../game/Game";
+import { TileRef } from "../game/GameMap";
+import { BomberExecution } from "./BomberExecution";
+
+export class AirfieldExecution implements Execution {
+  private active = true;
+  private mg: Game;
+  private lastSpawnTick: number = -1;
+
+  constructor(private airfield: Unit) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+    this.lastSpawnTick = ticks;
+  }
+
+  tick(ticks: number): void {
+    if (!this.airfield.isActive()) {
+      this.active = false;
+      return;
+    }
+    if (this.airfield.isUnderConstruction()) return;
+
+    const cooldown = this.mg.config().airfieldSpawnCooldown();
+    if (ticks - this.lastSpawnTick < cooldown) return;
+
+    const target = this.findTargetTile();
+    if (target === null) return;
+
+    this.mg.addExecution(new BomberExecution(this.airfield, target));
+    this.lastSpawnTick = ticks;
+  }
+
+  private findTargetTile(): TileRef | null {
+    const owner = this.airfield.owner();
+    const range = this.mg.config().airfieldBomberRange();
+    const candidates = this.mg.nearbyUnits(
+      this.airfield.tile(),
+      range,
+      Structures.types,
+      ({ unit }) =>
+        unit.owner() !== owner &&
+        !owner.isFriendly(unit.owner() as Player) &&
+        unit.isActive() &&
+        !unit.isUnderConstruction(),
+    );
+    if (candidates.length === 0) return null;
+    candidates.sort((a, b) => a.distSquared - b.distSquared);
+    return candidates[0].unit.tile();
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/execution/BomberExecution.ts
+++ b/src/core/execution/BomberExecution.ts
@@ -1,0 +1,189 @@
+import {
+  Execution,
+  Game,
+  MessageType,
+  TrajectoryTile,
+  Unit,
+  UnitType,
+} from "../game/Game";
+import { TileRef } from "../game/GameMap";
+import { AirPathFinder } from "../pathfinding/PathFinder.Air";
+
+enum BomberPhase {
+  Outbound,
+  Returning,
+}
+
+export class BomberExecution implements Execution {
+  private active = true;
+  private mg: Game;
+  private bomber: Unit | null = null;
+  private phase: BomberPhase = BomberPhase.Outbound;
+  private speed: number = 1;
+  private trajectory: TileRef[] = [];
+  private outboundIndex = 0;
+  private returnPath: AirPathFinder | null = null;
+
+  constructor(
+    private airfield: Unit,
+    private targetTile: TileRef,
+  ) {}
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+    this.speed = mg.config().bomberSpeed();
+  }
+
+  tick(ticks: number): void {
+    if (this.bomber === null) {
+      this.spawnBomber();
+      if (this.bomber === null) {
+        this.active = false;
+        return;
+      }
+      return;
+    }
+
+    if (!this.bomber.isActive()) {
+      this.active = false;
+      return;
+    }
+
+    for (let i = 0; i < this.speed; i++) {
+      this.step();
+      if (!this.active) return;
+    }
+  }
+
+  private spawnBomber(): void {
+    const owner = this.airfield.owner();
+    const airfieldTile = this.airfield.tile();
+    const air = new AirPathFinder(this.mg);
+    const path = air.findPath(airfieldTile, this.targetTile) ?? [];
+    if (path.length === 0) {
+      this.active = false;
+      return;
+    }
+    this.trajectory = path;
+    this.outboundIndex = 0;
+
+    const trajectoryTiles: TrajectoryTile[] = path.map((tile) => ({
+      tile,
+      targetable: true,
+    }));
+
+    this.bomber = owner.buildUnit(UnitType.Bomber, airfieldTile, {
+      homeAirfield: this.airfield,
+      targetTile: this.targetTile,
+      trajectory: trajectoryTiles,
+    });
+
+    const targetOwner = this.mg.owner(this.targetTile);
+    if (targetOwner.isPlayer()) {
+      this.mg.displayIncomingUnit(
+        this.bomber.id(),
+        `${owner.displayName()} - bomber inbound`,
+        MessageType.NUKE_INBOUND,
+        targetOwner.id(),
+      );
+    }
+  }
+
+  private step(): void {
+    if (this.bomber === null) return;
+    if (this.phase === BomberPhase.Outbound) {
+      this.outboundIndex++;
+      if (this.outboundIndex >= this.trajectory.length) {
+        this.detonate();
+        this.phase = BomberPhase.Returning;
+        this.bomber.setReachedTarget();
+        this.returnPath = new AirPathFinder(this.mg);
+        return;
+      }
+      this.bomber.move(this.trajectory[this.outboundIndex]);
+      this.bomber.setTrajectoryIndex(this.outboundIndex);
+      return;
+    }
+
+    // Returning phase
+    const homeTile = this.airfield.isActive()
+      ? this.airfield.tile()
+      : this.findFallbackHome();
+    if (homeTile === null) {
+      this.bomber.delete(false);
+      this.active = false;
+      return;
+    }
+    if (this.bomber.tile() === homeTile) {
+      this.bomber.delete(false);
+      this.active = false;
+      return;
+    }
+    this.returnPath ??= new AirPathFinder(this.mg);
+    const path = this.returnPath.findPath(this.bomber.tile(), homeTile);
+    if (path === null || path.length < 2) {
+      this.bomber.delete(false);
+      this.active = false;
+      return;
+    }
+    this.bomber.move(path[1]);
+  }
+
+  private findFallbackHome(): TileRef | null {
+    if (this.bomber === null) return null;
+    const owner = this.bomber.owner();
+    const alt = owner
+      .units(UnitType.Airfield)
+      .find((u) => u.isActive() && !u.isUnderConstruction());
+    return alt ? alt.tile() : null;
+  }
+
+  private detonate(): void {
+    if (this.bomber === null) return;
+    const mg = this.mg;
+    const mag = mg.config().bombMagnitude();
+    const outerSq = mag.outer * mag.outer;
+    const innerSq = mag.inner * mag.inner;
+    const dst = this.targetTile;
+    const owner = this.bomber.owner();
+
+    const tiles = mg.bfs(
+      dst,
+      (_, n) => mg.euclideanDistSquared(dst, n) <= outerSq,
+    );
+    for (const t of tiles) {
+      const tileOwner = mg.owner(t);
+      if (tileOwner.isPlayer() && tileOwner !== owner) {
+        if (mg.euclideanDistSquared(dst, t) <= innerSq) {
+          tileOwner.relinquish(t);
+        }
+      }
+    }
+
+    for (const unit of mg.units()) {
+      const t = unit.type();
+      if (
+        t === UnitType.AtomBomb ||
+        t === UnitType.HydrogenBomb ||
+        t === UnitType.MIRV ||
+        t === UnitType.MIRVWarhead ||
+        t === UnitType.SAMMissile ||
+        t === UnitType.Bomber ||
+        t === UnitType.Bomb
+      ) {
+        continue;
+      }
+      if (mg.euclideanDistSquared(dst, unit.tile()) < outerSq) {
+        if (unit.owner() !== owner) unit.delete(true, owner);
+      }
+    }
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -1,5 +1,6 @@
 import { Execution, Game, Player, Tick, Unit, UnitType } from "../game/Game";
 import { TileRef } from "../game/GameMap";
+import { AirfieldExecution } from "./AirfieldExecution";
 import { CityExecution } from "./CityExecution";
 import { DefensePostExecution } from "./DefensePostExecution";
 import { FactoryExecution } from "./FactoryExecution";
@@ -144,6 +145,9 @@ export class ConstructionExecution implements Execution {
       case UnitType.Factory:
         this.mg.addExecution(new FactoryExecution(this.structure!));
         break;
+      case UnitType.Airfield:
+        this.mg.addExecution(new AirfieldExecution(this.structure!));
+        break;
       default:
         console.warn(
           `unit type ${this.constructionType} cannot be constructed`,
@@ -160,6 +164,7 @@ export class ConstructionExecution implements Execution {
       case UnitType.SAMLauncher:
       case UnitType.City:
       case UnitType.Factory:
+      case UnitType.Airfield:
         return true;
       default:
         return false;

--- a/src/core/execution/FactoryExecution.ts
+++ b/src/core/execution/FactoryExecution.ts
@@ -21,6 +21,13 @@ export class FactoryExecution implements Execution {
       this.active = false;
       return;
     }
+
+    if (this.factory.isUnderConstruction()) return;
+
+    const gold = this.game.config().factoryPassiveGoldPerTick();
+    if (gold > 0n) {
+      this.factory.owner().addGold(gold, this.factory.tile());
+    }
   }
 
   isActive(): boolean {

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -114,7 +114,7 @@ class SAMTargetingSystem {
     const nukes = this.mg.nearbyUnits(
       samTile,
       detectionRange,
-      [UnitType.AtomBomb, UnitType.HydrogenBomb],
+      [UnitType.AtomBomb, UnitType.HydrogenBomb, UnitType.Bomber],
       ({ unit }) => {
         if (!isUnit(unit) || unit.targetedBySAM()) return false;
         if (unit.owner() === this.sam.owner()) return false;

--- a/src/core/execution/SAMMissileExecution.ts
+++ b/src/core/execution/SAMMissileExecution.ts
@@ -43,7 +43,11 @@ export class SAMMissileExecution implements Execution {
       return;
     }
     // Mirv warheads are too fast, and mirv shouldn't be stopped ever
-    const nukesWhitelist = [UnitType.AtomBomb, UnitType.HydrogenBomb];
+    const nukesWhitelist = [
+      UnitType.AtomBomb,
+      UnitType.HydrogenBomb,
+      UnitType.Bomber,
+    ];
     if (
       !this.target.isActive() ||
       !this.ownerUnit.isActive() ||
@@ -75,10 +79,16 @@ export class SAMMissileExecution implements Execution {
         this.target.delete(true, this._owner);
         this.SAMMissile.delete(false);
 
-        // Record stats
-        this.mg
-          .stats()
-          .bombIntercept(this._owner, this.target.type() as NukeType, 1);
+        // Record stats (only for NukeType targets — Bomber is not tracked as a bomb)
+        const targetType = this.target.type();
+        if (
+          targetType === UnitType.AtomBomb ||
+          targetType === UnitType.HydrogenBomb ||
+          targetType === UnitType.MIRV ||
+          targetType === UnitType.MIRVWarhead
+        ) {
+          this.mg.stats().bombIntercept(this._owner, targetType as NukeType, 1);
+        }
         return;
       } else if (result.status === PathStatus.NEXT) {
         this.SAMMissile.move(result.node);

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -316,6 +316,9 @@ export enum UnitType {
   MIRVWarhead = "MIRV Warhead",
   Train = "Train",
   Factory = "Factory",
+  Airfield = "Airfield",
+  Bomber = "Bomber",
+  Bomb = "Bomb",
 }
 
 export enum TrainType {
@@ -345,6 +348,7 @@ export const Structures = unitTypeGroup([
   UnitType.MissileSilo,
   UnitType.Port,
   UnitType.Factory,
+  UnitType.Airfield,
 ] as const);
 
 export const BuildMenus = unitTypeGroup([
@@ -419,6 +423,18 @@ export interface UnitParamsMap {
   };
 
   [UnitType.MIRVWarhead]: {
+    targetTile?: number;
+  };
+
+  [UnitType.Airfield]: Record<string, never>;
+
+  [UnitType.Bomber]: {
+    homeAirfield?: Unit;
+    targetTile?: number;
+    trajectory: TrajectoryTile[];
+  };
+
+  [UnitType.Bomb]: {
     targetTile?: number;
   };
 }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -1164,7 +1164,11 @@ export class PlayerImpl implements Player {
       case UnitType.SAMLauncher:
       case UnitType.City:
       case UnitType.Factory:
+      case UnitType.Airfield:
         return this.landBasedStructureSpawn(targetTile, validTiles);
+      case UnitType.Bomber:
+      case UnitType.Bomb:
+        return targetTile;
       default:
         assertNever(unitType);
     }

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -37,6 +37,7 @@ export function getDefaultKeybinds(isMac: boolean): Record<string, string> {
     pauseGame: "KeyP",
     gameSpeedUp: "Period",
     gameSpeedDown: "Comma",
+    toggleAutoCity: "KeyN",
   };
 }
 
@@ -172,6 +173,18 @@ export class UserSettings {
       "settings.attackingTroopsOverlay",
       !this.attackingTroopsOverlay(),
     );
+  }
+
+  autoCityEnabled() {
+    return this.getBool("settings.autoCity", false);
+  }
+
+  setAutoCityEnabled(value: boolean) {
+    this.setBool("settings.autoCity", value);
+  }
+
+  toggleAutoCity() {
+    this.setAutoCityEnabled(!this.autoCityEnabled());
   }
 
   cursorCostLabel() {
@@ -388,5 +401,39 @@ export class UserSettings {
 
   setSoundEffectsVolume(volume: number): void {
     this.setFloat("settings.soundEffectsVolume", volume);
+  }
+
+  // Tech tree: comma-separated list of researched tech IDs
+  researchedTechs(): string[] {
+    const raw = this.getString("settings.techTree", "");
+    if (!raw) return [];
+    return raw.split(",").filter((t) => t.length > 0);
+  }
+
+  hasTech(id: string): boolean {
+    return this.researchedTechs().includes(id);
+  }
+
+  addTech(id: string): void {
+    const techs = this.researchedTechs();
+    if (techs.includes(id)) return;
+    techs.push(id);
+    this.setString("settings.techTree", techs.join(","));
+  }
+
+  resetTechs(): void {
+    this.setString("settings.techTree", "");
+  }
+
+  // Warship global patrol preference (client hint to widen patrol display)
+  warshipPatrolAnywhere(): boolean {
+    return this.getBool("settings.warshipPatrolAnywhere", false);
+  }
+
+  toggleWarshipPatrolAnywhere(): void {
+    this.setBool(
+      "settings.warshipPatrolAnywhere",
+      !this.warshipPatrolAnywhere(),
+    );
   }
 }


### PR DESCRIPTION
Adds several gameplay features in one pass:

- Airfield structure + Bomber unit (auto-spawns bombers that target nearest enemy structure; SAM-interceptable via existing trajectory targeting)
- Factory visibility buff: passive gold per tick (configurable)
- Auto-city toggle layer: client-side pacer that spends excess gold on cities along owned borders when enabled
- Threat overlay layer: pulsing rings on hostile nukes/MIRVs/bombers targeting tiles you own
- Tech tree panel: 4-node research progression stored in localStorage (visual/descriptive buffs only for now; server-authoritative buffs would require per-player research state)
- UserSettings: warshipPatrolAnywhere flag + tech tree persistence
