### PR TITLE
Fix: only run the deploy action within our repository

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,8 @@ concurrency:
 
 jobs:
   deploy:
-    # Don't deploy on push if this is a fork; always deploy on schedule and workflow_dispatch
-    if: ${{( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.repository == 'openfrontio/OpenFrontIO' }}
+    # Deploy on push/schedule/workflow_dispatch (see "on:") unless this is a fork
+    if: ${{ github.repository == 'openfrontio/OpenFrontIO' }}
     # Use different logic based on event type
     name: Deploy to ${{ inputs.target_domain || 'openfront.dev' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,7 +48,7 @@ concurrency:
 jobs:
   deploy:
     # Don't deploy on push if this is a fork; always deploy on schedule and workflow_dispatch
-    if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || github.repository == 'openfrontio/OpenFrontIO' }}
+    if: ${{( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') && github.repository == 'openfrontio/OpenFrontIO' }}
     # Use different logic based on event type
     name: Deploy to ${{ inputs.target_domain || 'openfront.dev' }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description:

Fix: only run the deploy action within our repo. It was already meant to do this, but the if statement had a bug. 

This lead to errors in repos with a fork, because it would run but couldn't find the needed secrets there of course.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33