### PR TITLE
Remove directory-URL branch from buildAssetUrl

### DIFF
--- a/src/core/AssetUrls.ts
+++ b/src/core/AssetUrls.ts
@@ -63,14 +63,6 @@ export function buildAssetUrl(
     return directUrl;
   }
 
-  const directoryPrefix = `${normalizedPath}/`;
-  const hasNestedAssets = Object.keys(assetManifest).some((manifestPath) =>
-    manifestPath.startsWith(directoryPrefix),
-  );
-  if (hasNestedAssets) {
-    return `/_assets/${encodeAssetPath(normalizedPath)}`;
-  }
-
   return `/${encodeAssetPath(normalizedPath)}`;
 }
 

--- a/tests/AssetUrls.test.ts
+++ b/tests/AssetUrls.test.ts
@@ -10,7 +10,11 @@ describe("AssetUrls", () => {
     ).toBe("/_assets/images/Favicon.hash.svg");
   });
 
-  test("maps directory prefixes into the hashed asset namespace", () => {
+  test("falls back to the unversioned path when manifest has no match", () => {
+    expect(buildAssetUrl("images/unknown.svg", {})).toBe("/images/unknown.svg");
+  });
+
+  test("falls back to the unversioned path for directory-like paths", () => {
     const manifest = {
       "maps/britanniaclassic/manifest.json":
         "/_assets/maps/britanniaclassic/manifest.hash.json",
@@ -18,14 +22,10 @@ describe("AssetUrls", () => {
         "/_assets/maps/britanniaclassic/map.hash.bin",
     };
 
-    expect(buildAssetUrl("maps", manifest)).toBe("/_assets/maps");
+    expect(buildAssetUrl("maps", manifest)).toBe("/maps");
     expect(buildAssetUrl("maps/britanniaclassic", manifest)).toBe(
-      "/_assets/maps/britanniaclassic",
+      "/maps/britanniaclassic",
     );
-  });
-
-  test("falls back to the unversioned path when manifest has no match", () => {
-    expect(buildAssetUrl("images/unknown.svg", {})).toBe("/images/unknown.svg");
   });
 
   test("rejects dot segments in asset paths", () => {


### PR DESCRIPTION
## Description:

buildAssetUrl had a middle branch that, when called with a directory-ish path (e.g. assetUrl("maps")), would check whether any manifest entry had that prefix and return an unhashed /_assets/<path> URL. This was wrong:

* The /_assets/ prefix implies a managed, hashed asset — but the returned URL is neither. It won't exist on R2 after the migration.
* It defeats cache-busting, since no hash is applied.
* It encourages callers to reconstruct asset paths by hand via string concatenation, bypassing the manifest as the single source of truth. Renaming or reorganizing an asset directory would silently break callers the manifest can't help locate.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
