### PR TITLE
Feat/auto copy lobby code 

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { copyToClipboard, translateText } from "../client/Utils";
+import { translateText } from "../client/Utils";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import { EventBus } from "../core/EventBus";
 import {
@@ -22,7 +22,7 @@ import { generateID } from "../core/Util";
 import { getPlayToken } from "./Auth";
 import "./components/baseComponents/Modal";
 import { BaseModal } from "./components/BaseModal";
-import "./components/CopyButton";
+import { CopyButton } from "./components/CopyButton";
 import "./components/GameConfigSettings";
 import "./components/LobbyPlayerView";
 import "./components/ToggleInputCard";
@@ -377,7 +377,8 @@ export class HostLobbyModal extends BaseModal {
         crazyGamesSDK.showInviteButton(this.lobbyId);
         const url = await this.constructUrl();
         this.updateHistory(url);
-        await copyToClipboard(url);
+        await this.updateComplete;
+        (this.querySelector("copy-button") as CopyButton)?.handleCopy();
       })
       .then(() => {
         this.dispatchEvent(

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -367,9 +367,13 @@ export class HostLobbyModal extends BaseModal {
     // Note: clientID will be assigned by server when we join the lobby
     // lobbyCreatorClientID stays empty until then
 
-    // Start building the URL in parallel with the server call so the config is
-    // ready to use as soon as the lobby is confirmed — avoids a serial wait.
-    const urlPromise = this.constructUrl();
+    // Copy immediately so the host can share the link without waiting for the
+    // server. If lobby creation fails, clear the clipboard to avoid a dead link.
+    void this.constructUrl().then(async (url) => {
+      this.updateHistory(url);
+      await this.updateComplete;
+      void (this.querySelector("copy-button") as CopyButton)?.handleCopy();
+    });
 
     // Pass auth token for creator identification (server extracts persistentID from it)
     createLobby(this.lobbyId)
@@ -379,13 +383,6 @@ export class HostLobbyModal extends BaseModal {
           throw new Error(`Invalid lobby ID format: ${this.lobbyId}`);
         }
         crazyGamesSDK.showInviteButton(this.lobbyId);
-        // Only copy after server confirms the lobby exists to avoid sharing a
-        // stale URL for a lobby that failed to create. Config is cached by now
-        // so the await is instant.
-        const url = await urlPromise;
-        this.updateHistory(url);
-        await this.updateComplete;
-        void (this.querySelector("copy-button") as CopyButton)?.handleCopy();
       })
       .then(() => {
         this.dispatchEvent(
@@ -398,6 +395,10 @@ export class HostLobbyModal extends BaseModal {
             composed: true,
           }),
         );
+      })
+      .catch(() => {
+        // Clear clipboard so the host doesn't accidentally share a dead link
+        void navigator.clipboard.writeText("").catch(() => {});
       });
     if (this.modalEl) {
       this.modalEl.onClose = () => {

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -367,6 +367,14 @@ export class HostLobbyModal extends BaseModal {
     // Note: clientID will be assigned by server when we join the lobby
     // lobbyCreatorClientID stays empty until then
 
+    // Build URL immediately (lobbyId is known locally before server confirms)
+    const urlPromise = this.constructUrl();
+    urlPromise.then(async (url) => {
+      this.updateHistory(url);
+      await this.updateComplete;
+      (this.querySelector("copy-button") as CopyButton)?.handleCopy();
+    });
+
     // Pass auth token for creator identification (server extracts persistentID from it)
     createLobby(this.lobbyId)
       .then(async (lobby) => {
@@ -375,10 +383,6 @@ export class HostLobbyModal extends BaseModal {
           throw new Error(`Invalid lobby ID format: ${this.lobbyId}`);
         }
         crazyGamesSDK.showInviteButton(this.lobbyId);
-        const url = await this.constructUrl();
-        this.updateHistory(url);
-        await this.updateComplete;
-        (this.querySelector("copy-button") as CopyButton)?.handleCopy();
       })
       .then(() => {
         this.dispatchEvent(

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -367,13 +367,9 @@ export class HostLobbyModal extends BaseModal {
     // Note: clientID will be assigned by server when we join the lobby
     // lobbyCreatorClientID stays empty until then
 
-    // Build & copy URL immediately — lobbyId is generated locally so we don't
-    // need to wait for the server round-trip before sharing the invite link.
-    void this.constructUrl().then(async (url) => {
-      this.updateHistory(url);
-      await this.updateComplete;
-      (this.querySelector("copy-button") as CopyButton)?.handleCopy();
-    });
+    // Start building the URL in parallel with the server call so the config is
+    // ready to use as soon as the lobby is confirmed — avoids a serial wait.
+    const urlPromise = this.constructUrl();
 
     // Pass auth token for creator identification (server extracts persistentID from it)
     createLobby(this.lobbyId)
@@ -383,6 +379,13 @@ export class HostLobbyModal extends BaseModal {
           throw new Error(`Invalid lobby ID format: ${this.lobbyId}`);
         }
         crazyGamesSDK.showInviteButton(this.lobbyId);
+        // Only copy after server confirms the lobby exists to avoid sharing a
+        // stale URL for a lobby that failed to create. Config is cached by now
+        // so the await is instant.
+        const url = await urlPromise;
+        this.updateHistory(url);
+        await this.updateComplete;
+        void (this.querySelector("copy-button") as CopyButton)?.handleCopy();
       })
       .then(() => {
         this.dispatchEvent(

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -1,6 +1,6 @@
 import { html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { translateText } from "../client/Utils";
+import { copyToClipboard, translateText } from "../client/Utils";
 import { getServerConfigFromClient } from "../core/configuration/ConfigLoader";
 import { EventBus } from "../core/EventBus";
 import {
@@ -377,6 +377,7 @@ export class HostLobbyModal extends BaseModal {
         crazyGamesSDK.showInviteButton(this.lobbyId);
         const url = await this.constructUrl();
         this.updateHistory(url);
+        await copyToClipboard(url);
       })
       .then(() => {
         this.dispatchEvent(

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -367,9 +367,9 @@ export class HostLobbyModal extends BaseModal {
     // Note: clientID will be assigned by server when we join the lobby
     // lobbyCreatorClientID stays empty until then
 
-    // Build URL immediately (lobbyId is known locally before server confirms)
-    const urlPromise = this.constructUrl();
-    urlPromise.then(async (url) => {
+    // Build & copy URL immediately — lobbyId is generated locally so we don't
+    // need to wait for the server round-trip before sharing the invite link.
+    void this.constructUrl().then(async (url) => {
       this.updateHistory(url);
       await this.updateComplete;
       (this.querySelector("copy-button") as CopyButton)?.handleCopy();

--- a/src/client/components/CopyButton.ts
+++ b/src/client/components/CopyButton.ts
@@ -83,7 +83,7 @@ export class CopyButton extends LitElement {
     return await this.buildCopyUrl();
   }
 
-  private async handleCopy() {
+  async handleCopy() {
     const text = await this.resolveCopyText();
     if (!text) {
       alert("Error copying game id");


### PR DESCRIPTION
Resolves #3757

## Description:

Simple patch that would remove an extra click that users have to do each time they create a private lobby. On top of the existing button, the game link will automatically be copied to the clipboard when clicking "Create Lobby". 


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

zixer._
