### PR TITLE
Map playlist tweaks 🗺️

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -149,6 +149,8 @@ const WATER_NUKES_BOOSTED_MAPS: ReadonlySet<GameMapType> = new Set([
   GameMapType.Baikal,
   GameMapType.Alps,
   GameMapType.TheBox,
+  GameMapType.Luna,
+  GameMapType.ArchipelagoSea,
 ]);
 
 // Modifiers that cannot be active at the same time.
@@ -243,10 +245,9 @@ export class MapPlaylist {
       excludedModifiers.push("isRandomSpawn");
     }
 
-    // No extreme modifiers on FourIslands - Causes 3h long stalemates
-    if (map === GameMapType.FourIslands) {
+    // No gold multi on FourIslands team games - Too high chance of 3h long stalemates
+    if (map === GameMapType.FourIslands && mode === GameMode.Team) {
       excludedModifiers.push("goldMultiplier");
-      excludedModifiers.push("startingGold25M");
     }
 
     // Hard nations modifier only applies when nations are present (not HvN, which is always hard)
@@ -529,6 +530,9 @@ export class MapPlaylist {
     if (map === GameMapType.FourIslands && Math.random() < 0.75) {
       return 4;
     }
+    if (map === GameMapType.Luna && Math.random() < 0.75) {
+      return 2;
+    }
 
     const totalWeight = TEAM_WEIGHTS.reduce((sum, w) => sum + w.weight, 0);
     const roll = Math.random() * totalWeight;
@@ -663,7 +667,8 @@ export class MapPlaylist {
     if (playerTeams === HumansVsNations) return 5 * 10;
     if (startingGold !== undefined && startingGold >= 25_000_000)
       return 150 * 10;
-    if (startingGold) return SAM_CONSTRUCTION_TICKS + 15 * 10;
+    if (startingGold !== undefined && startingGold >= 5_000_000)
+      return SAM_CONSTRUCTION_TICKS + 15 * 10;
     return 5 * 10;
   }
 


### PR DESCRIPTION
## Description:

Add Luna and ArchipelagoSea to the water-nukes-boosted maps set.

Bias Luna games towards 2 teams (75% chance), similar to how FourIslands is biased towards 4 teams.

Restrict the FourIslands gold multiplier exclusion to team games only, since the stalemate risk is team-mode-specific. Also removes the startingGold25M exclusion that was bundled with it. Reasoning: Did some data analysis to find the root cause.

1M starting gold games accidentally had 45 seconds of PVP immunity, but thats not needed.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
