### PR TITLE
Make MIRVs take fixed time to fire regardless of launch location 🚀

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -26,6 +26,7 @@ export class MirvExecution implements Execution {
   private rangeSquared = this.range * this.range;
   private minimumSpread = 55;
   private warheadCount = 350;
+  private fixedFireTicks = 75;
 
   private baseX: number;
   private baseY: number;
@@ -50,10 +51,9 @@ export class MirvExecution implements Execution {
     this.random = new PseudoRandom(mg.ticks() + simpleHash(this.player.id()));
     this.mg = mg;
     this.targetPlayer = this.mg.owner(this.dst);
+    // Speed is recomputed in tick() once spawnTile/separateDst are known,
+    // so flight time stays constant regardless of launch location.
     this.speed = this.mg.config().defaultNukeSpeed();
-    this.pathFinder = UniversalPathFinding.Parabola(mg, {
-      increment: this.speed,
-    });
 
     // Betrayal on launch
     if (this.targetPlayer.isPlayer()) {
@@ -87,6 +87,12 @@ export class MirvExecution implements Execution {
       const y = Math.max(0, this.mg.y(this.dst) - 500) + 50;
       this.separateDst = this.mg.ref(x, y);
 
+      // Scale speed so flight time is fixed regardless of launch location.
+      this.speed = this.computeFixedTimeSpeed();
+      this.pathFinder = UniversalPathFinding.Parabola(this.mg, {
+        increment: this.speed,
+      });
+
       this.mg.displayIncomingUnit(
         this.nuke.id(),
         // TODO TranslateText
@@ -110,6 +116,24 @@ export class MirvExecution implements Execution {
     } else if (result.status === PathStatus.NEXT) {
       this.nuke.move(result.node);
     }
+  }
+
+  private computeFixedTimeSpeed(): number {
+    // Measure the actual parabolic path length, then divide by the desired
+    // tick count. A temporary fine-grained pathfinder gives a precise
+    // length estimate (cached points are spaced ~1 px apart).
+    const measure = UniversalPathFinding.Parabola(this.mg, { increment: 1 });
+    const path = measure.findPath(this.spawnTile, this.separateDst) ?? [];
+    let length = 0;
+    for (let i = 1; i < path.length; i++) {
+      const dx = this.mg.x(path[i]) - this.mg.x(path[i - 1]);
+      const dy = this.mg.y(path[i]) - this.mg.y(path[i - 1]);
+      length += Math.sqrt(dx * dx + dy * dy);
+    }
+    if (length <= 0) {
+      return this.mg.config().defaultNukeSpeed();
+    }
+    return length / this.fixedFireTicks;
   }
 
   private separate() {

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -121,7 +121,7 @@ export class MirvExecution implements Execution {
   private computeFixedTimeSpeed(): number {
     // Measure the actual parabolic path length, then divide by the desired
     // tick count. A temporary fine-grained pathfinder gives a precise
-    // length estimate (cached points are spaced ~1 px apart).
+    // length estimate.
     const measure = UniversalPathFinding.Parabola(this.mg, { increment: 1 });
     const path = measure.findPath(this.spawnTile, this.separateDst) ?? [];
     let length = 0;


### PR DESCRIPTION
## Description:

Multiple people asked for that in the game-feedback DC channel, so here is a PR for it: MIRV flight time from launch to warhead separation is now a fixed 75 ticks (enough reaction time for the targeted player?) regardless of where the launching silo sits relative to the target.

(The video was taken with just 50 ticks configured)

https://github.com/user-attachments/assets/73ea3bb8-4aa5-4f72-8229-3fa6c31f15b1

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
