### PR TITLE
Adjust troop calculation formulas (part 2)

### DIFF
--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -814,7 +814,7 @@ export class DefaultConfig implements Config {
     const maxTroops =
       player.type() === PlayerType.Human && this.hasInfiniteTroopsFor(player)
         ? 1_000_000_000
-        : 2 * (Math.pow(player.numTilesOwned(), 0.7) * 1000 + 50000) +
+        : 2 * (Math.pow(player.numTilesOwned(), 0.8) * 170 + 50000) +
           player
             .units(UnitType.City)
             .filter((u) => !u.isUnderConstruction())
@@ -847,7 +847,7 @@ export class DefaultConfig implements Config {
   troopIncreaseRate(player: Player): number {
     const max = this.maxTroops(player);
 
-    let toAdd = 10 + Math.pow(player.troops(), 0.8) / 4;
+    let toAdd = 10 + Math.pow(player.troops(), 0.8) / 8;
 
     const ratio = 1 - player.troops() / max;
     toAdd *= ratio;


### PR DESCRIPTION

## Description:

I forgot to adjust the constants appropriately. This fixes the bug from the previous adjustment. Max troop and troop growth numbers should be roughly similar to the previous version, but rebalanced to benefit larger nations (which were nerfed by the attack casualty change).

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

1brucben
