### PR TITLE
fix: render spawn highlight on 1/5 frames instead of 4/5

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -167,7 +167,7 @@ export class TerritoryLayer implements Layer {
   }
 
   private spawnHighlight() {
-    if (this.game.ticks() % 5 === 0) {
+    if (this.game.ticks() % 5 !== 0) {
       return;
     }
 


### PR DESCRIPTION

Resolves #3590

## Description:
The spawnHighlight() function in TerritoryLayer.ts was using `=== 0` 
as the condition to return early, which caused the spawn highlight to 
render on 4 out of every 5 frames instead of the intended 1 out of 5. 
Changed `=== 0` to `!== 0` so the function skips rendering on 4/5 
frames, improving performance especially on large maps.


## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x ] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced