### PR TITLE
chore: add Steam wishlist banner to news feed

### DIFF
--- a/resources/news.json
+++ b/resources/news.json
@@ -1,5 +1,12 @@
 [
   {
+    "id": "steam-wishlist-2026",
+    "title": "OpenFront is on Steam!",
+    "description": "Enjoying the game? Wishlist OpenFront on Steam and help us grow! 🎮",
+    "url": "https://store.steampowered.com/app/3560670/OpenFront",
+    "type": "announcement"
+  },
+  {
     "id": "firefox-performance-issues-2026",
     "title": "Firefox Performance Issues",
     "descriptionTranslationKey": "news_box.firefox_warning",


### PR DESCRIPTION
## Description:
I felt like this is a no-brainer, adding the steam webpage so people wishlist it, this boosts visibility and people can discover the game from steam

<img width="978" height="113" alt="image" src="https://github.com/user-attachments/assets/6e1ff33c-6e10-485f-adef-bc692800ec84" />
Clicking it links to the steam Openfront storefront

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

zixer._
