### PR TITLE
Make nations more forgiving toward humans on Easy difficulty 🕊️

### DIFF
--- a/src/core/execution/NationExecution.ts
+++ b/src/core/execution/NationExecution.ts
@@ -74,7 +74,7 @@ export class NationExecution implements Execution {
     const { difficulty } = this.mg.config().gameConfig();
     switch (difficulty) {
       case Difficulty.Easy:
-        return this.random.nextInt(65, 80); // Slower reactions
+        return this.random.nextInt(65, 100); // Slower reactions
       case Difficulty.Medium:
         return this.random.nextInt(55, 70);
       case Difficulty.Hard:

--- a/src/core/execution/nation/NationAllianceBehavior.ts
+++ b/src/core/execution/nation/NationAllianceBehavior.ts
@@ -390,9 +390,14 @@ export class NationAllianceBehavior {
     }
 
     // Betray very weak players (similar check as above but for the easier difficulties)
-    // This doesn't check for maxTroops and isn't really smart. It opens the nations up for attacks, but that's intended.
+    // This doesn't check for maxTroops and isn't really smart. It makes nations vulnerable, but that's intended.
+    // On easy, don't betray humans
     if (
       (difficulty === Difficulty.Easy || difficulty === Difficulty.Medium) &&
+      !(
+        difficulty === Difficulty.Easy &&
+        otherPlayer.type() === PlayerType.Human
+      ) &&
       this.player.troops() >= otherPlayer.troops() * 10
     ) {
       this.betray(otherPlayer);

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -88,11 +88,11 @@ export class NationMIRVBehavior {
     const { difficulty } = this.game.config().gameConfig();
     switch (difficulty) {
       case Difficulty.Easy:
-        return 1.5; // Needs larger gap to trigger
+        return 2; // Needs larger gap to trigger
       case Difficulty.Medium:
-        return 1.3;
+        return 1.5;
       case Difficulty.Hard:
-        return 1.2;
+        return 1.25;
       case Difficulty.Impossible:
         return 1.15; // Reacts to smaller gaps
       default:
@@ -104,7 +104,7 @@ export class NationMIRVBehavior {
     const { difficulty } = this.game.config().gameConfig();
     switch (difficulty) {
       case Difficulty.Easy:
-        return 15; // Needs more cities to trigger
+        return 20; // Needs more cities to trigger
       case Difficulty.Medium:
       case Difficulty.Hard:
         return 10;

--- a/src/core/execution/utils/AiAttackBehavior.ts
+++ b/src/core/execution/utils/AiAttackBehavior.ts
@@ -767,7 +767,7 @@ export class AiAttackBehavior {
 
     // Prevent attacking of humans on lower difficulties
     const { difficulty } = this.game.config().gameConfig();
-    if (difficulty === Difficulty.Easy && this.random.chance(2)) {
+    if (difficulty === Difficulty.Easy && this.random.nextInt(0, 4) !== 0) {
       return false;
     }
     if (difficulty === Difficulty.Medium && this.random.chance(4)) {


### PR DESCRIPTION
## Description:

- Nations on Easy no longer betray human allies
- Nations on Easy now attack humans only 25% of the time (down from 50%)
- Increased Easy reaction tick range (65-100, up from 65-80) so nations respond more slowly
- Raised MIRV steamroll-stop thresholds on Easy (city gap multiplier 1.5 -> 2, min leader cities 15 -> 20) and slightly tuned Medium/Hard thresholds

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
