### PR TITLE
Restrict ArchipelagoSea to special rotation only 🗺️

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -22,6 +22,7 @@ import { getMapLandTiles } from "./MapLandTiles";
 
 const log = logger.child({});
 const ARCADE_MAPS = new Set(mapCategories.arcade);
+const SPECIAL_ONLY_MAPS = new Set<GameMapType>([GameMapType.ArchipelagoSea]);
 
 // Hard cap on player count for performance. Applied after compact-map reduction.
 const MAX_PLAYER_COUNT = 125;
@@ -509,7 +510,10 @@ export class MapPlaylist {
     const maps: GameMapType[] = [];
     (Object.keys(GameMapType) as GameMapName[]).forEach((key) => {
       const map = GameMapType[key];
-      if (type !== "special" && ARCADE_MAPS.has(map)) {
+      if (
+        type !== "special" &&
+        (ARCADE_MAPS.has(map) || SPECIAL_ONLY_MAPS.has(map))
+      ) {
         return;
       }
       let freq = frequency[key] ?? 0;


### PR DESCRIPTION
## Description:

ArchipelagoSea is a very "special" map with the extreme amount of tiny islands, and the map maker said "could there be a way to make Archipelago Sea have 5M or 25M starters more often? I feel like the map is too unorthodox to be played in normal settings"

So lets restrict it to the special rotation, like arcade maps. People expect crazy-stupid games there.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
