### PR TITLE
Fix broken logo in README 🖼️

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="resources/images/OpenFrontLogoDark.svg">
-    <source media="(prefers-color-scheme: light)" srcset="resources/images/OpenFrontLogo.svg">
-    <img src="resources/images/OpenFrontLogo.svg" alt="OpenFrontIO Logo" width="300">
+    <source media="(prefers-color-scheme: dark)" srcset="proprietary/images/OpenFrontLogoDark.svg">
+    <source media="(prefers-color-scheme: light)" srcset="proprietary/images/OpenFrontLogo.svg">
+    <img src="proprietary/images/OpenFrontLogo.svg" alt="OpenFrontIO Logo" width="300">
   </picture>
 </p>
 


### PR DESCRIPTION
## Description:

The README referenced `resources/images/OpenFrontLogo.svg` and `resources/images/OpenFrontLogoDark.svg`, but those files do not exist at that path. The actual logo SVGs live under `proprietary/images/`. Updated all three `<picture>` element references to point to the correct directory so the logo renders properly on GitHub.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
