### PR TITLE
Fix build: add missing adfree field to ResolveCosmetics test mock 🔧

### DIFF
--- a/tests/ResolveCosmetics.test.ts
+++ b/tests/ResolveCosmetics.test.ts
@@ -18,6 +18,7 @@ function makeUserMe(flares: string[] = []): UserMeResponse {
     user: {},
     player: {
       publicId: "test",
+      adfree: false,
       flares,
       achievements: { singleplayerMap: [] },
     },


### PR DESCRIPTION
## Description:

Commit `4d5b7c0` added `adfree: boolean` as a required field to `UserMeResponseSchema` in `ApiSchemas.ts`, but did not update the mock object in `tests/ResolveCosmetics.test.ts`. This caused `tsc --noEmit` to fail with a type overlap error, breaking the production build.

**Fix:** Add `adfree: false` to the `player` mock inside `makeUserMe()` in the test file.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
