### PR TITLE
conqueror receives 50% of gold when conquering a human player

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -86,6 +86,7 @@ export interface Config {
   startManpower(playerInfo: PlayerInfo): number;
   troopIncreaseRate(player: Player | PlayerView): number;
   goldAdditionRate(player: Player | PlayerView): Gold;
+  conquerGoldAmount(captured: Player): Gold;
   attackTilesPerTick(
     attckTroops: number,
     attacker: Player,

--- a/src/core/configuration/DefaultConfig.ts
+++ b/src/core/configuration/DefaultConfig.ts
@@ -512,6 +512,17 @@ export class DefaultConfig implements Config {
     return base;
   }
 
+  public conquerGoldAmount(captured: Player): Gold {
+    if (
+      captured.type() === PlayerType.Bot ||
+      captured.type() === PlayerType.Nation
+    ) {
+      return captured.gold();
+    } else {
+      return captured.gold() / 2n;
+    }
+  }
+
   private startingGoldFor(playerInfo: PlayerInfo): Gold {
     const base = BigInt(this._gameConfig.startingGold ?? 0);
     const hc = this._gameConfig.hostCheats;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -1204,6 +1204,9 @@ export class GameImpl implements Game {
     const skipGoldTransfer =
       attacksSent === 0n && conquered.type() === PlayerType.Human;
     const gold = skipGoldTransfer ? 0n : conquered.gold();
+    const goldCaptured = skipGoldTransfer
+      ? 0n
+      : this._config.conquerGoldAmount(conquered);
 
     if (skipGoldTransfer) {
       this.displayMessage(
@@ -1222,22 +1225,22 @@ export class GameImpl implements Game {
         conqueror.id(),
         gold,
         {
-          gold: renderNumber(gold),
+          gold: renderNumber(goldCaptured),
           name: conquered.displayName(),
         },
       );
-      conqueror.addGold(gold);
+      conqueror.addGold(goldCaptured);
       conquered.removeGold(gold);
 
       // Record stats
-      this.stats().goldWar(conqueror, conquered, gold);
+      this.stats().goldWar(conqueror, conquered, goldCaptured);
     }
 
     this.addUpdate({
       type: GameUpdateType.ConquestEvent,
       conquerorId: conqueror.id(),
       conqueredId: conquered.id(),
-      gold,
+      gold: goldCaptured,
     });
   }
 }

--- a/tests/ConquerGold.test.ts
+++ b/tests/ConquerGold.test.ts
@@ -1,0 +1,103 @@
+import { SpawnExecution } from "../src/core/execution/SpawnExecution";
+import { Game, Player, PlayerInfo, PlayerType } from "../src/core/game/Game";
+import { GameID } from "../src/core/Schemas";
+import { setup } from "./util/Setup";
+
+const gameID: GameID = "test_game";
+
+function addPlayerWithGold(
+  game: Game,
+  id: string,
+  type: PlayerType,
+  gold: bigint,
+): Player {
+  game.addPlayer(new PlayerInfo(id, type, null, id));
+  const player = game.player(id);
+  player.addGold(gold);
+  return player;
+}
+
+describe("DefaultConfig.conquerGoldAmount", () => {
+  let game: Game;
+
+  beforeEach(async () => {
+    game = await setup("ocean_and_land");
+  });
+
+  test("returns full gold for Bot", () => {
+    const bot = addPlayerWithGold(game, "bot", PlayerType.Bot, 1000n);
+    expect(game.config().conquerGoldAmount(bot)).toBe(1000n);
+  });
+
+  test("returns full gold for Nation", () => {
+    const nation = addPlayerWithGold(game, "nation", PlayerType.Nation, 2000n);
+    expect(game.config().conquerGoldAmount(nation)).toBe(2000n);
+  });
+
+  test("returns half gold for Human", () => {
+    const human = addPlayerWithGold(game, "human", PlayerType.Human, 1000n);
+    expect(game.config().conquerGoldAmount(human)).toBe(500n);
+  });
+});
+
+describe("Conquest gold transfer", () => {
+  let game: Game;
+  let conqueror: Player;
+
+  beforeEach(async () => {
+    game = await setup("ocean_and_land");
+    const conquerorInfo = new PlayerInfo(
+      "conqueror",
+      PlayerType.Human,
+      null,
+      "conqueror",
+    );
+    game.addPlayer(conquerorInfo);
+    game.addExecution(
+      new SpawnExecution(gameID, conquerorInfo, game.ref(0, 10)),
+    );
+    while (game.inSpawnPhase()) {
+      game.executeNextTick();
+    }
+    conqueror = game.player(conquerorInfo.id);
+  });
+
+  test("conqueror receives 100% of gold when conquering a Bot", () => {
+    const bot = addPlayerWithGold(game, "bot", PlayerType.Bot, 1000n);
+    const goldBefore = conqueror.gold();
+    game.conquerPlayer(conqueror, bot);
+    expect(conqueror.gold()).toBe(goldBefore + 1000n);
+    expect(bot.gold()).toBe(0n);
+  });
+
+  test("conqueror receives 100% of gold when conquering a Nation", () => {
+    const nation = addPlayerWithGold(game, "nation", PlayerType.Nation, 800n);
+    const goldBefore = conqueror.gold();
+    game.conquerPlayer(conqueror, nation);
+    expect(conqueror.gold()).toBe(goldBefore + 800n);
+    expect(nation.gold()).toBe(0n);
+  });
+
+  test("conqueror receives 50% of gold when conquering a Human who has attacked", () => {
+    // clientID must be non-null for stats tracking to work
+    game.addPlayer(
+      new PlayerInfo("victim", PlayerType.Human, "victim_client", "victim"),
+    );
+    const victim = game.player("victim");
+    victim.addGold(1000n);
+    // Record an attack so the gold transfer is not skipped
+    game.stats().attack(victim, game.terraNullius(), 100);
+    const goldBefore = conqueror.gold();
+    game.conquerPlayer(conqueror, victim);
+    expect(conqueror.gold()).toBe(goldBefore + 500n);
+    expect(victim.gold()).toBe(0n);
+  });
+
+  test("conqueror receives no gold when conquering a Human who never attacked", () => {
+    const victim = addPlayerWithGold(game, "afk", PlayerType.Human, 1000n);
+    const goldBefore = conqueror.gold();
+    game.conquerPlayer(conqueror, victim);
+    expect(conqueror.gold()).toBe(goldBefore);
+    expect(victim.gold()).toBe(1000n);
+  });
+});


### PR DESCRIPTION
## Description:

The motivation is to prevent snowballing players from also gaining too much gold by conquering other players

- Adds `conquerGoldAmount` to `Config`/`DefaultConfig`: returns 100% of captured gold for bots/nations, 50% for human players
- Updates `GameImpl.conquerPlayer` to use this amount for the conqueror's gold gain (the conquered player still loses their full gold)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
