### PR TITLE
Fix off by one error

### DIFF
--- a/src/client/ClanApi.ts
+++ b/src/client/ClanApi.ts
@@ -109,7 +109,7 @@ export async function fetchClans(
     const params = new URLSearchParams();
     params.set("page", String(page));
     params.set("limit", String(limit));
-    if (search && search.length >= 3) params.set("search", search);
+    if (search && search.length >= 2) params.set("search", search);
     const res = await clanFetch(`/clans?${params}`);
     if (!res.ok) return false;
     const json = await res.json();

--- a/tests/client/clan/ClanApiQueries.test.ts
+++ b/tests/client/clan/ClanApiQueries.test.ts
@@ -193,20 +193,6 @@ describe("fetchClans", () => {
     expect(url.searchParams.get("search")).toBe("abc");
   });
 
-  it("omits search param for 2-char query (below min length of 3)", async () => {
-    const fetchSpy = vi.fn(
-      (_input: string | URL | Request, _init?: RequestInit) =>
-        Promise.resolve(okJson(browseResponse)),
-    );
-    vi.stubGlobal("fetch", fetchSpy);
-
-    await fetchClans("AB", 1, 20);
-
-    const calledUrl = fetchSpy.mock.calls[0]![0] as string;
-    const url = new URL(calledUrl);
-    expect(url.searchParams.get("search")).toBeNull();
-  });
-
   it("omits search param when too short and non-alphanumeric", async () => {
     const fetchSpy = vi.fn(
       (_input: string | URL | Request, _init?: RequestInit) =>


### PR DESCRIPTION
## Description:

Currently it is impossible to search for 2 letter clan tags (UN, FR, EU), this is because of an off by one error present in the API

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

Babyboucher