### PR TITLE
Fix: unremoved border tiles on replay catchup when worker is ahead and render queue has backlog

### DIFF
--- a/src/client/graphics/layers/TerritoryLayer.ts
+++ b/src/client/graphics/layers/TerritoryLayer.ts
@@ -537,6 +537,7 @@ export class TerritoryLayer implements Layer {
 
   paintTerritory(tile: TileRef, isBorder: boolean = false) {
     if (isBorder && !this.game.hasOwner(tile)) {
+      this.clearTile(tile);
       return;
     }
 
@@ -555,15 +556,9 @@ export class TerritoryLayer implements Layer {
       return;
     }
     const owner = this.game.owner(tile) as PlayerView;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const isHighlighted =
-      this.highlightedTerritory &&
-      this.highlightedTerritory.id() === owner.id();
     const myPlayer = this.game.myPlayer();
 
     if (this.game.isBorder(tile)) {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      const playerIsFocused = owner && this.game.focusedPlayer() === owner;
       if (myPlayer) {
         const alternativeColor = this.alternateViewColor(owner);
         this.paintTile(this.alternativeImageData, tile, alternativeColor, 255);


### PR DESCRIPTION
## Description:

`paintTerritory(tile, true)` early-return now calls `clearTile(tile)` before returning. When a neighbor-triggered repaint finds a tile that lost its owner (e.g. conquered) between being queued and being rendered, the stale border pixels are cleared instead of left behind.

As reported during a playtest for v31 and here after release: https://discord.com/channels/1284581928254701718/1379092916827324426/1500628773916250123

Also: removed dead code, unused vars `isHighlighted` and `playerIsFocused` that were left behind from old highlighting functionality.

<img width="630" height="596" alt="image" src="https://github.com/user-attachments/assets/ab964007-d582-41bb-92c5-7d762bb25291" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33