### PR TITLE
fix: Show full store item names instead of truncating them

### DIFF
--- a/src/client/components/CosmeticContainer.ts
+++ b/src/client/components/CosmeticContainer.ts
@@ -404,7 +404,7 @@ export class CosmeticContainer extends LitElement {
     if (this.name) {
       this._nameEl ??= document.createElement("div");
       const cfg = rarityConfig[this.rarity] ?? fallback;
-      this._nameEl.className = `text-xs font-bold uppercase tracking-wider text-center truncate w-full`;
+      this._nameEl.className = `text-xs font-bold uppercase tracking-wider text-center whitespace-normal break-words w-full`;
       this._nameEl.style.color = cfg.nameColor;
       this._nameEl.title = this.name;
       this._nameEl.textContent = this.name;


### PR DESCRIPTION
## Description:

The store item cards were truncating names with an ellipsis. This change updates the cosmetic card name label to wrap instead of truncating, so the full name is always shown.

before
<img width="748" height="363" alt="スクリーンショット 2026-05-04 10 26 58" src="https://github.com/user-attachments/assets/32030be3-6e92-4ca6-8117-451c0ae75582" />

after
<img width="756" height="585" alt="スクリーンショット 2026-05-04 10 27 30" src="https://github.com/user-attachments/assets/20e0fd36-dea4-4236-852b-ca5a2cd7e0f5" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri