### PR TITLE
Disable build hotkeys after death

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -519,10 +519,12 @@ export class InputHandler {
       }
 
       // Two-phase build keybind matching: exact code match first, then digit/Numpad alias.
-      const matchedBuild = this.resolveBuildKeybind(e.code, e.shiftKey);
-      if (matchedBuild !== null) {
-        e.preventDefault();
-        this.setGhostStructure(matchedBuild);
+      if (this.canUseBuildKeybinds()) {
+        const matchedBuild = this.resolveBuildKeybind(e.code, e.shiftKey);
+        if (matchedBuild !== null) {
+          e.preventDefault();
+          this.setGhostStructure(matchedBuild);
+        }
       }
 
       if (this.keybindMatchesEvent(e, this.keybinds.requestAlliance)) {
@@ -941,6 +943,11 @@ export class InputHandler {
         return type;
     }
     return null;
+  }
+
+  private canUseBuildKeybinds(): boolean {
+    const myPlayer = this.gameView.myPlayer?.();
+    return !this.gameView.inSpawnPhase() && myPlayer?.isAlive() === true;
   }
 
   private getPinchDistance(): number {

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -49,7 +49,10 @@ describe("InputHandler AutoUpgrade", () => {
     testSettings = new UserSettings();
     testSettings.removeCached(KEYBINDS_KEY, false);
 
-    mockGameView = { inSpawnPhase: () => false } as GameView;
+    mockGameView = {
+      inSpawnPhase: () => false,
+      myPlayer: () => ({ isAlive: () => true }),
+    } as GameView;
     mockCanvas = document.createElement("canvas");
     mockCanvas.width = 800;
     mockCanvas.height = 600;
@@ -625,6 +628,16 @@ describe("InputHandler AutoUpgrade", () => {
         new KeyboardEvent("keyup", { code: "Numpad0", key: "0" }),
       );
       expect(inputHandler["uiState"].ghostStructure).toBe(UnitType.MIRV);
+    });
+
+    test("does not set ghost structure when the player is dead", () => {
+      mockGameView.myPlayer = () => ({ isAlive: () => false });
+
+      window.dispatchEvent(
+        new KeyboardEvent("keyup", { code: "Numpad1", key: "1" }),
+      );
+
+      expect(inputHandler["uiState"].ghostStructure).toBeNull();
     });
   });
 

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -9,7 +9,7 @@ import {
 import { UIState } from "../src/client/graphics/UIState";
 import { EventBus } from "../src/core/EventBus";
 import { UnitType } from "../src/core/game/Game";
-import { GameView } from "../src/core/game/GameView";
+import { GameView, PlayerView } from "../src/core/game/GameView";
 import { KEYBINDS_KEY, UserSettings } from "../src/core/game/UserSettings";
 
 class MockPointerEvent {
@@ -631,7 +631,8 @@ describe("InputHandler AutoUpgrade", () => {
     });
 
     test("does not set ghost structure when the player is dead", () => {
-      mockGameView.myPlayer = () => ({ isAlive: () => false });
+      mockGameView.myPlayer = () =>
+        ({ isAlive: () => false }) as unknown as PlayerView;
 
       window.dispatchEvent(
         new KeyboardEvent("keyup", { code: "Numpad1", key: "1" }),


### PR DESCRIPTION
## Description:

Prevent number-key build shortcuts from opening the unit build ghost after the player has died.
Keep build hotkeys available only while the player is alive and not in spawn phase.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri