### PR TITLE
Fixed playerPanel doesnt show flag | Added flag name on hover

### DIFF
--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -496,9 +496,7 @@ export class PlayerPanel extends LitElement implements Layer {
     my: PlayerView,
     myPanelClicked: boolean = false,
   ) {
-    const activeFlagPath = myPanelClicked
-      ? my.cosmetics.flag
-      : other.cosmetics.flag;
+    const activeFlagPath = myPanelClicked ? my.cosmetics.flag : other.cosmetics.flag;
     const flagCode = activeFlagPath?.match(/\/([^.]+)\./)?.[1];
 
     // Find the country based on that code
@@ -516,8 +514,13 @@ export class PlayerPanel extends LitElement implements Layer {
         ${country && activeFlagPath
           ? html`<img
               src=${activeFlagPath}
+<<<<<<< HEAD
               title=${typeof country !== "string" ? country.name : country}
               alt=${typeof country !== "string" ? country.name : country}
+=======
+              title=${typeof country!== "string"?country.name : country}
+              alt=${typeof country!== "string"?country.name : country}
+>>>>>>> 00715c0b (Fixed playerPanel doesnt show flag | Added flag name on hover)
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -491,12 +491,18 @@ export class PlayerPanel extends LitElement implements Layer {
     `;
   }
 
-  private renderIdentityRow(other: PlayerView, my: PlayerView) {
-    const flagCode = other.cosmetics.flag;
-    const country =
-      typeof flagCode === "string"
-        ? Countries.find((c) => c.code === flagCode)
-        : undefined;
+  private renderIdentityRow(
+    other: PlayerView,
+    my: PlayerView,
+    myPanelClicked: boolean = false,
+  ) {
+    const activeFlagPath = myPanelClicked ? my.cosmetics.flag : other.cosmetics.flag;
+    const flagCode = activeFlagPath?.match(/\/([^.]+)\./)?.[1];
+
+    // Find the country based on that code
+    const country = flagCode
+      ? Countries.find((c) => c.code === flagCode.split("/")[1])
+      : flagCode;
 
     const chip =
       other.type() === PlayerType.Human
@@ -505,10 +511,11 @@ export class PlayerPanel extends LitElement implements Layer {
 
     return html`
       <div class="flex items-center gap-2.5 flex-wrap">
-        ${country && typeof flagCode === "string"
+        ${country && activeFlagPath
           ? html`<img
-              src=${assetUrl(`flags/${encodeURIComponent(flagCode)}.svg`)}
-              alt=${country?.name ?? "Flag"}
+              src=${activeFlagPath}
+              title=${typeof country!== "string"?country.name : country}
+              alt=${typeof country!== "string"?country.name : country}
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";
@@ -946,7 +953,9 @@ export class PlayerPanel extends LitElement implements Layer {
                     class="p-6 flex flex-col gap-2 font-sans antialiased text-[14.5px] leading-relaxed"
                   >
                     <!-- Identity (flag, name, type, traitor, relation) -->
-                    <div class="mb-1">${this.renderIdentityRow(other, my)}</div>
+                    <div class="mb-1">
+                      ${this.renderIdentityRow(other, my, owner === my)}
+                    </div>
 
                     ${this.sendTarget
                       ? html`

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -494,11 +494,8 @@ export class PlayerPanel extends LitElement implements Layer {
   private renderIdentityRow(
     other: PlayerView,
     my: PlayerView,
-    myPanelClicked: boolean = false,
   ) {
-    const activeFlagPath = myPanelClicked
-      ? my.cosmetics.flag
-      : other.cosmetics.flag;
+    const activeFlagPath = other.cosmetics.flag
     const flagCode = activeFlagPath?.match(/\/([^.]+)\./)?.[1];
 
     // Find the country based on that code
@@ -513,11 +510,11 @@ export class PlayerPanel extends LitElement implements Layer {
 
     return html`
       <div class="flex items-center gap-2.5 flex-wrap">
-        ${country && activeFlagPath
+        ${activeFlagPath
           ? html`<img
               src=${activeFlagPath}
-              title=${typeof country !== "string" ? country.name : country}
-              alt=${typeof country !== "string" ? country.name : country}
+              title=${typeof country !== "string" ? country?.name : country}
+              alt=${typeof country !== "string" ? country?.name : country}
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";
@@ -956,7 +953,7 @@ export class PlayerPanel extends LitElement implements Layer {
                   >
                     <!-- Identity (flag, name, type, traitor, relation) -->
                     <div class="mb-1">
-                      ${this.renderIdentityRow(other, my, owner === my)}
+                      ${this.renderIdentityRow(other, my)}
                     </div>
 
                     ${this.sendTarget

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -496,7 +496,9 @@ export class PlayerPanel extends LitElement implements Layer {
     my: PlayerView,
     myPanelClicked: boolean = false,
   ) {
-    const activeFlagPath = myPanelClicked ? my.cosmetics.flag : other.cosmetics.flag;
+    const activeFlagPath = myPanelClicked
+      ? my.cosmetics.flag
+      : other.cosmetics.flag;
     const flagCode = activeFlagPath?.match(/\/([^.]+)\./)?.[1];
 
     // Find the country based on that code
@@ -514,13 +516,8 @@ export class PlayerPanel extends LitElement implements Layer {
         ${country && activeFlagPath
           ? html`<img
               src=${activeFlagPath}
-<<<<<<< HEAD
               title=${typeof country !== "string" ? country.name : country}
               alt=${typeof country !== "string" ? country.name : country}
-=======
-              title=${typeof country!== "string"?country.name : country}
-              alt=${typeof country!== "string"?country.name : country}
->>>>>>> 00715c0b (Fixed playerPanel doesnt show flag | Added flag name on hover)
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";

--- a/src/client/graphics/layers/PlayerPanel.ts
+++ b/src/client/graphics/layers/PlayerPanel.ts
@@ -496,7 +496,9 @@ export class PlayerPanel extends LitElement implements Layer {
     my: PlayerView,
     myPanelClicked: boolean = false,
   ) {
-    const activeFlagPath = myPanelClicked ? my.cosmetics.flag : other.cosmetics.flag;
+    const activeFlagPath = myPanelClicked
+      ? my.cosmetics.flag
+      : other.cosmetics.flag;
     const flagCode = activeFlagPath?.match(/\/([^.]+)\./)?.[1];
 
     // Find the country based on that code
@@ -514,8 +516,8 @@ export class PlayerPanel extends LitElement implements Layer {
         ${country && activeFlagPath
           ? html`<img
               src=${activeFlagPath}
-              title=${typeof country!== "string"?country.name : country}
-              alt=${typeof country!== "string"?country.name : country}
+              title=${typeof country !== "string" ? country.name : country}
+              alt=${typeof country !== "string" ? country.name : country}
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";


### PR DESCRIPTION
## Description:

Noticed the playerPanel should have had a flag, but it wasn't working.
Fixed plus added flag name when hovering.
Before:
<img width="200" height="300" alt="noFLag" src="https://github.com/user-attachments/assets/363cedee-b86c-4896-8bcb-91f9f2673a93" />

After:
<img width="200" height="300" alt="withFlagAndName" src="https://github.com/user-attachments/assets/2f1225a6-1b38-4c7b-84d5-91daf6e72313" />





## Please complete the following:

- [ x] Linked the relevant issue (e.g., `Resolves #123`).
- [ x] Added screenshots for any UI changes.
- [ x] Processed text through `translateText()` and added strings to `en.json`.
- [ x] Added/Updated tests in the `tests/` directory.
- [ x] Verified that `npm test` passes.
- [ x] Provided your Discord username in the PR description for communication.
## Please put your Discord username so you can be contacted if a bug or regression is found:

Boostry
