### PR TITLE
feat: make PlayerInfoPanel available in replays

### DIFF
--- a/src/client/hud/layers/MainRadialMenu.ts
+++ b/src/client/hud/layers/MainRadialMenu.ts
@@ -25,6 +25,14 @@ const swordIcon = assetUrl("images/SwordIconWhite.svg");
 
 import { ContextMenuEvent } from "../../InputHandler";
 
+function emptyPlayerActions(): PlayerActions {
+  return {
+    canAttack: false,
+    buildableUnits: [],
+    canSendEmojiAllPlayers: false,
+  };
+}
+
 @customElement("main-radial-menu")
 export class MainRadialMenu extends LitElement implements Controller {
   private radialMenu: RadialMenu;
@@ -87,27 +95,40 @@ export class MainRadialMenu extends LitElement implements Controller {
       if (!this.game.isValidCoord(worldCoords.x, worldCoords.y)) {
         return;
       }
-      if (this.game.myPlayer() === null) {
+      const myPlayer = this.game.myPlayer();
+      const isReplay = this.game.config().isReplay();
+      if (myPlayer === null && !isReplay) {
         return;
       }
       this.clickedTile = this.game.ref(worldCoords.x, worldCoords.y);
-      this.game
-        .myPlayer()!
-        .actions(this.clickedTile)
-        .then((actions) => {
-          this.updatePlayerActions(
-            this.game.myPlayer()!,
-            actions,
-            this.clickedTile!,
-            event.x,
-            event.y,
-          );
-        });
+      if (myPlayer === null) {
+        // Replay: only show the info-only radial when right-clicking on a player
+        if (!this.game.owner(this.clickedTile).isPlayer()) {
+          return;
+        }
+        this.updatePlayerActions(
+          null,
+          emptyPlayerActions(),
+          this.clickedTile,
+          event.x,
+          event.y,
+        );
+        return;
+      }
+      myPlayer.actions(this.clickedTile).then((actions) => {
+        this.updatePlayerActions(
+          myPlayer,
+          actions,
+          this.clickedTile!,
+          event.x,
+          event.y,
+        );
+      });
     });
   }
 
   private async updatePlayerActions(
-    myPlayer: PlayerView,
+    myPlayer: PlayerView | null,
     actions: PlayerActions,
     tile: TileRef,
     screenX: number | null = null,
@@ -139,6 +160,7 @@ export class MainRadialMenu extends LitElement implements Controller {
     };
 
     const isFriendlyTarget =
+      myPlayer !== null &&
       recipient !== null &&
       recipient.isFriendly(myPlayer) &&
       !recipient.isDisconnected();
@@ -161,16 +183,11 @@ export class MainRadialMenu extends LitElement implements Controller {
 
   async tick() {
     if (!this.radialMenu.isMenuVisible() || this.clickedTile === null) return;
-    this.game
-      .myPlayer()!
-      .actions(this.clickedTile)
-      .then((actions) => {
-        this.updatePlayerActions(
-          this.game.myPlayer()!,
-          actions,
-          this.clickedTile!,
-        );
-      });
+    const myPlayer = this.game.myPlayer();
+    if (myPlayer === null) return; // replay mode: nothing to refresh
+    myPlayer.actions(this.clickedTile).then((actions) => {
+      this.updatePlayerActions(myPlayer, actions, this.clickedTile!);
+    });
   }
 
   closeMenu() {

--- a/src/client/hud/layers/MainRadialMenu.ts
+++ b/src/client/hud/layers/MainRadialMenu.ts
@@ -95,31 +95,25 @@ export class MainRadialMenu extends LitElement implements Controller {
       if (!this.game.isValidCoord(worldCoords.x, worldCoords.y)) {
         return;
       }
-      const myPlayer = this.game.myPlayer();
-      const isReplay = this.game.config().isReplay();
-      if (myPlayer === null && !isReplay) {
-        return;
-      }
-      this.clickedTile = this.game.ref(worldCoords.x, worldCoords.y);
-      if (myPlayer === null) {
-        // Replay: only show the info-only radial when right-clicking on a player
-        if (!this.game.owner(this.clickedTile).isPlayer()) {
-          return;
+      const clickedTile = this.game.ref(worldCoords.x, worldCoords.y);
+      this.clickedTile = clickedTile;
+
+      // Spectators (replay, dead, pre-spawn): skip the action radial and open
+      // the read-only PlayerPanel directly when right-clicking on a player.
+      if (this.game.isSpectator()) {
+        if (this.game.owner(clickedTile).isPlayer()) {
+          this.playerPanel.show(emptyPlayerActions(), clickedTile);
         }
-        this.updatePlayerActions(
-          null,
-          emptyPlayerActions(),
-          this.clickedTile,
-          event.x,
-          event.y,
-        );
         return;
       }
-      myPlayer.actions(this.clickedTile).then((actions) => {
+
+      const myPlayer = this.game.myPlayer();
+      if (myPlayer === null) return;
+      myPlayer.actions(clickedTile).then((actions) => {
         this.updatePlayerActions(
           myPlayer,
           actions,
-          this.clickedTile!,
+          clickedTile,
           event.x,
           event.y,
         );
@@ -128,7 +122,7 @@ export class MainRadialMenu extends LitElement implements Controller {
   }
 
   private async updatePlayerActions(
-    myPlayer: PlayerView | null,
+    myPlayer: PlayerView,
     actions: PlayerActions,
     tile: TileRef,
     screenX: number | null = null,
@@ -139,7 +133,7 @@ export class MainRadialMenu extends LitElement implements Controller {
     const tileOwner = this.game.owner(tile);
     const recipient = tileOwner.isPlayer() ? (tileOwner as PlayerView) : null;
 
-    if (myPlayer && recipient) {
+    if (recipient) {
       this.chatIntegration.setupChatModal(myPlayer, recipient);
     }
 
@@ -160,7 +154,6 @@ export class MainRadialMenu extends LitElement implements Controller {
     };
 
     const isFriendlyTarget =
-      myPlayer !== null &&
       recipient !== null &&
       recipient.isFriendly(myPlayer) &&
       !recipient.isDisconnected();
@@ -184,9 +177,10 @@ export class MainRadialMenu extends LitElement implements Controller {
   async tick() {
     if (!this.radialMenu.isMenuVisible() || this.clickedTile === null) return;
     const myPlayer = this.game.myPlayer();
-    if (myPlayer === null) return; // replay mode: nothing to refresh
-    myPlayer.actions(this.clickedTile).then((actions) => {
-      this.updatePlayerActions(myPlayer, actions, this.clickedTile!);
+    if (myPlayer === null) return;
+    const tile = this.clickedTile;
+    myPlayer.actions(tile).then((actions) => {
+      this.updatePlayerActions(myPlayer, actions, tile);
     });
   }
 

--- a/src/client/hud/layers/MainRadialMenu.ts
+++ b/src/client/hud/layers/MainRadialMenu.ts
@@ -23,6 +23,14 @@ const swordIcon = assetUrl("images/SwordIconWhite.svg");
 
 import { ContextMenuEvent } from "../../InputHandler";
 
+function emptyPlayerActions(): PlayerActions {
+  return {
+    canAttack: false,
+    buildableUnits: [],
+    canSendEmojiAllPlayers: false,
+  };
+}
+
 export class MainRadialMenu implements Controller {
   private radialMenu: RadialMenu;
 
@@ -82,27 +90,40 @@ export class MainRadialMenu implements Controller {
       if (!this.game.isValidCoord(worldCoords.x, worldCoords.y)) {
         return;
       }
-      if (this.game.myPlayer() === null) {
+      const myPlayer = this.game.myPlayer();
+      const isReplay = this.game.config().isReplay();
+      if (myPlayer === null && !isReplay) {
         return;
       }
       this.clickedTile = this.game.ref(worldCoords.x, worldCoords.y);
-      this.game
-        .myPlayer()!
-        .actions(this.clickedTile)
-        .then((actions) => {
-          this.updatePlayerActions(
-            this.game.myPlayer()!,
-            actions,
-            this.clickedTile!,
-            event.x,
-            event.y,
-          );
-        });
+      if (myPlayer === null) {
+        // Replay: only show the info-only radial when right-clicking on a player
+        if (!this.game.owner(this.clickedTile).isPlayer()) {
+          return;
+        }
+        this.updatePlayerActions(
+          null,
+          emptyPlayerActions(),
+          this.clickedTile,
+          event.x,
+          event.y,
+        );
+        return;
+      }
+      myPlayer.actions(this.clickedTile).then((actions) => {
+        this.updatePlayerActions(
+          myPlayer,
+          actions,
+          this.clickedTile!,
+          event.x,
+          event.y,
+        );
+      });
     });
   }
 
   private async updatePlayerActions(
-    myPlayer: PlayerView,
+    myPlayer: PlayerView | null,
     actions: PlayerActions,
     tile: TileRef,
     screenX: number | null = null,
@@ -134,6 +155,7 @@ export class MainRadialMenu implements Controller {
     };
 
     const isFriendlyTarget =
+      myPlayer !== null &&
       recipient !== null &&
       recipient.isFriendly(myPlayer) &&
       !recipient.isDisconnected();
@@ -156,16 +178,11 @@ export class MainRadialMenu implements Controller {
 
   async tick() {
     if (!this.radialMenu.isMenuVisible() || this.clickedTile === null) return;
-    this.game
-      .myPlayer()!
-      .actions(this.clickedTile)
-      .then((actions) => {
-        this.updatePlayerActions(
-          this.game.myPlayer()!,
-          actions,
-          this.clickedTile!,
-        );
-      });
+    const myPlayer = this.game.myPlayer();
+    if (myPlayer === null) return; // replay mode: nothing to refresh
+    myPlayer.actions(this.clickedTile).then((actions) => {
+      this.updatePlayerActions(myPlayer, actions, this.clickedTile!);
+    });
   }
 
   closeMenu() {

--- a/src/client/hud/layers/MainRadialMenu.ts
+++ b/src/client/hud/layers/MainRadialMenu.ts
@@ -90,31 +90,25 @@ export class MainRadialMenu implements Controller {
       if (!this.game.isValidCoord(worldCoords.x, worldCoords.y)) {
         return;
       }
-      const myPlayer = this.game.myPlayer();
-      const isReplay = this.game.config().isReplay();
-      if (myPlayer === null && !isReplay) {
-        return;
-      }
-      this.clickedTile = this.game.ref(worldCoords.x, worldCoords.y);
-      if (myPlayer === null) {
-        // Replay: only show the info-only radial when right-clicking on a player
-        if (!this.game.owner(this.clickedTile).isPlayer()) {
-          return;
+      const clickedTile = this.game.ref(worldCoords.x, worldCoords.y);
+      this.clickedTile = clickedTile;
+
+      // Spectators (replay, dead, pre-spawn): skip the action radial and open
+      // the read-only PlayerPanel directly when right-clicking on a player.
+      if (this.game.isSpectator()) {
+        if (this.game.owner(clickedTile).isPlayer()) {
+          this.playerPanel.show(emptyPlayerActions(), clickedTile);
         }
-        this.updatePlayerActions(
-          null,
-          emptyPlayerActions(),
-          this.clickedTile,
-          event.x,
-          event.y,
-        );
         return;
       }
-      myPlayer.actions(this.clickedTile).then((actions) => {
+
+      const myPlayer = this.game.myPlayer();
+      if (myPlayer === null) return;
+      myPlayer.actions(clickedTile).then((actions) => {
         this.updatePlayerActions(
           myPlayer,
           actions,
-          this.clickedTile!,
+          clickedTile,
           event.x,
           event.y,
         );
@@ -123,7 +117,7 @@ export class MainRadialMenu implements Controller {
   }
 
   private async updatePlayerActions(
-    myPlayer: PlayerView | null,
+    myPlayer: PlayerView,
     actions: PlayerActions,
     tile: TileRef,
     screenX: number | null = null,
@@ -134,7 +128,7 @@ export class MainRadialMenu implements Controller {
     const tileOwner = this.game.owner(tile);
     const recipient = tileOwner.isPlayer() ? (tileOwner as PlayerView) : null;
 
-    if (myPlayer && recipient) {
+    if (recipient) {
       this.chatIntegration.setupChatModal(myPlayer, recipient);
     }
 
@@ -155,7 +149,6 @@ export class MainRadialMenu implements Controller {
     };
 
     const isFriendlyTarget =
-      myPlayer !== null &&
       recipient !== null &&
       recipient.isFriendly(myPlayer) &&
       !recipient.isDisconnected();
@@ -179,9 +172,10 @@ export class MainRadialMenu implements Controller {
   async tick() {
     if (!this.radialMenu.isMenuVisible() || this.clickedTile === null) return;
     const myPlayer = this.game.myPlayer();
-    if (myPlayer === null) return; // replay mode: nothing to refresh
-    myPlayer.actions(this.clickedTile).then((actions) => {
-      this.updatePlayerActions(myPlayer, actions, this.clickedTile!);
+    if (myPlayer === null) return;
+    const tile = this.clickedTile;
+    myPlayer.actions(tile).then((actions) => {
+      this.updatePlayerActions(myPlayer, actions, tile);
     });
   }
 

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -949,7 +949,9 @@ export class PlayerPanel extends LitElement implements Controller {
                     class="p-6 flex flex-col gap-2 font-sans antialiased text-[14.5px] leading-relaxed"
                   >
                     <!-- Identity (flag, name, type, traitor, relation) -->
-                    <div class="mb-1">${this.renderIdentityRow(other, viewer)}</div>
+                    <div class="mb-1">
+                      ${this.renderIdentityRow(other, viewer)}
+                    </div>
 
                     ${this.sendTarget
                       ? html`
@@ -995,7 +997,9 @@ export class PlayerPanel extends LitElement implements Controller {
                     ${this.renderResources(other)}
 
                     <!-- Rocket direction toggle -->
-                    ${other === viewer && !isReplay ? this.renderRocketDirectionToggle() : ""}
+                    ${other === viewer && !isReplay
+                      ? this.renderRocketDirectionToggle()
+                      : ""}
 
                     <ui-divider></ui-divider>
 
@@ -1009,7 +1013,6 @@ export class PlayerPanel extends LitElement implements Controller {
 
                     <!-- Alliance time remaining -->
                     ${this.renderAllianceExpiry()}
-
                     ${isReplay
                       ? ""
                       : html`

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -867,8 +867,8 @@ export class PlayerPanel extends LitElement implements Controller {
     if (!this.isVisible) return html``;
 
     const my = this.g.myPlayer();
-    const isReplay = this.g.config().isReplay();
-    if (!my && !isReplay) return html``;
+    const isSpectator = this.g.isSpectator();
+    if (!my && !isSpectator) return html``;
     if (!this.tile) return html``;
 
     const owner = this.g.owner(this.tile);
@@ -878,7 +878,7 @@ export class PlayerPanel extends LitElement implements Controller {
       return html``;
     }
     const other = owner as PlayerView;
-    // In replay mode myPlayer() is null; use other as stand-in so read-only rendering works
+    // Spectators (replay viewers, dead, or pre-spawn) have no live player; use other as a read-only stand-in
     const viewer = my ?? other;
     const myGoldNum = viewer.gold();
     const myTroopsNum = Number(viewer.troops());
@@ -953,7 +953,7 @@ export class PlayerPanel extends LitElement implements Controller {
                       ${this.renderIdentityRow(other, viewer)}
                     </div>
 
-                    ${this.sendTarget
+                    ${this.sendTarget && !isSpectator
                       ? html`
                           <send-resource-modal
                             .open=${this.sendMode !== "none"}
@@ -974,7 +974,7 @@ export class PlayerPanel extends LitElement implements Controller {
                           ></send-resource-modal>
                         `
                       : ""}
-                    ${this.moderationTarget
+                    ${this.moderationTarget && !isSpectator
                       ? html`
                           <player-moderation-modal
                             .open=${true}
@@ -997,7 +997,7 @@ export class PlayerPanel extends LitElement implements Controller {
                     ${this.renderResources(other)}
 
                     <!-- Rocket direction toggle -->
-                    ${other === viewer && !isReplay
+                    ${other === viewer && !isSpectator
                       ? this.renderRocketDirectionToggle()
                       : ""}
 
@@ -1013,7 +1013,7 @@ export class PlayerPanel extends LitElement implements Controller {
 
                     <!-- Alliance time remaining -->
                     ${this.renderAllianceExpiry()}
-                    ${isReplay
+                    ${isSpectator
                       ? ""
                       : html`
                           <ui-divider></ui-divider>

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -867,7 +867,8 @@ export class PlayerPanel extends LitElement implements Controller {
     if (!this.isVisible) return html``;
 
     const my = this.g.myPlayer();
-    if (!my) return html``;
+    const isReplay = this.g.config().isReplay();
+    if (!my && !isReplay) return html``;
     if (!this.tile) return html``;
 
     const owner = this.g.owner(this.tile);
@@ -877,8 +878,10 @@ export class PlayerPanel extends LitElement implements Controller {
       return html``;
     }
     const other = owner as PlayerView;
-    const myGoldNum = my.gold();
-    const myTroopsNum = Number(my.troops());
+    // In replay mode myPlayer() is null; use other as stand-in so read-only rendering works
+    const viewer = my ?? other;
+    const myGoldNum = viewer.gold();
+    const myTroopsNum = Number(viewer.troops());
 
     return html`
       <style>
@@ -946,7 +949,7 @@ export class PlayerPanel extends LitElement implements Controller {
                     class="p-6 flex flex-col gap-2 font-sans antialiased text-[14.5px] leading-relaxed"
                   >
                     <!-- Identity (flag, name, type, traitor, relation) -->
-                    <div class="mb-1">${this.renderIdentityRow(other, my)}</div>
+                    <div class="mb-1">${this.renderIdentityRow(other, viewer)}</div>
 
                     ${this.sendTarget
                       ? html`
@@ -957,7 +960,7 @@ export class PlayerPanel extends LitElement implements Controller {
                               ? myTroopsNum
                               : myGoldNum}
                             .uiState=${this.uiState}
-                            .myPlayer=${my}
+                            .myPlayer=${viewer}
                             .target=${this.sendTarget}
                             .gameView=${this.g}
                             .eventBus=${this.eventBus}
@@ -973,7 +976,7 @@ export class PlayerPanel extends LitElement implements Controller {
                       ? html`
                           <player-moderation-modal
                             .open=${true}
-                            .myPlayer=${my}
+                            .myPlayer=${viewer}
                             .target=${this.moderationTarget}
                             .eventBus=${this.eventBus}
                             .isAdmin=${this.isAdminRole}
@@ -992,12 +995,12 @@ export class PlayerPanel extends LitElement implements Controller {
                     ${this.renderResources(other)}
 
                     <!-- Rocket direction toggle -->
-                    ${other === my ? this.renderRocketDirectionToggle() : ""}
+                    ${other === viewer && !isReplay ? this.renderRocketDirectionToggle() : ""}
 
                     <ui-divider></ui-divider>
 
                     <!-- Stats: betrayals / trading -->
-                    ${this.renderStats(other, my)}
+                    ${this.renderStats(other, viewer)}
 
                     <ui-divider></ui-divider>
 
@@ -1007,10 +1010,13 @@ export class PlayerPanel extends LitElement implements Controller {
                     <!-- Alliance time remaining -->
                     ${this.renderAllianceExpiry()}
 
-                    <ui-divider></ui-divider>
-
-                    <!-- Actions -->
-                    ${this.renderActions(my, other)}
+                    ${isReplay
+                      ? ""
+                      : html`
+                          <ui-divider></ui-divider>
+                          <!-- Actions -->
+                          ${this.renderActions(viewer, other)}
+                        `}
                   </div>
                 </div>
               </div>

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -882,8 +882,8 @@ export class PlayerPanel extends LitElement implements Controller {
     if (!this.isVisible) return html``;
 
     const my = this.g.myPlayer();
-    const isReplay = this.g.config().isReplay();
-    if (!my && !isReplay) return html``;
+    const isSpectator = this.g.isSpectator();
+    if (!my && !isSpectator) return html``;
     if (!this.tile) return html``;
 
     const owner = this.g.owner(this.tile);
@@ -893,7 +893,7 @@ export class PlayerPanel extends LitElement implements Controller {
       return html``;
     }
     const other = owner as PlayerView;
-    // In replay mode myPlayer() is null; use other as stand-in so read-only rendering works
+    // Spectators (replay viewers, dead, or pre-spawn) have no live player; use other as a read-only stand-in
     const viewer = my ?? other;
     const myGoldNum = viewer.gold();
     const myTroopsNum = Number(viewer.troops());
@@ -968,7 +968,7 @@ export class PlayerPanel extends LitElement implements Controller {
                       ${this.renderIdentityRow(other, viewer)}
                     </div>
 
-                    ${this.sendTarget
+                    ${this.sendTarget && !isSpectator
                       ? html`
                           <send-resource-modal
                             .open=${this.sendMode !== "none"}
@@ -989,7 +989,7 @@ export class PlayerPanel extends LitElement implements Controller {
                           ></send-resource-modal>
                         `
                       : ""}
-                    ${this.moderationTarget
+                    ${this.moderationTarget && !isSpectator
                       ? html`
                           <player-moderation-modal
                             .open=${true}
@@ -1012,7 +1012,7 @@ export class PlayerPanel extends LitElement implements Controller {
                     ${this.renderResources(other)}
 
                     <!-- Rocket direction toggle -->
-                    ${other === viewer && !isReplay
+                    ${other === viewer && !isSpectator
                       ? this.renderRocketDirectionToggle()
                       : ""}
 
@@ -1028,7 +1028,7 @@ export class PlayerPanel extends LitElement implements Controller {
 
                     <!-- Alliance time remaining -->
                     ${this.renderAllianceExpiry()}
-                    ${isReplay
+                    ${isSpectator
                       ? ""
                       : html`
                           <ui-divider></ui-divider>

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -882,7 +882,8 @@ export class PlayerPanel extends LitElement implements Controller {
     if (!this.isVisible) return html``;
 
     const my = this.g.myPlayer();
-    if (!my) return html``;
+    const isReplay = this.g.config().isReplay();
+    if (!my && !isReplay) return html``;
     if (!this.tile) return html``;
 
     const owner = this.g.owner(this.tile);
@@ -892,8 +893,10 @@ export class PlayerPanel extends LitElement implements Controller {
       return html``;
     }
     const other = owner as PlayerView;
-    const myGoldNum = my.gold();
-    const myTroopsNum = Number(my.troops());
+    // In replay mode myPlayer() is null; use other as stand-in so read-only rendering works
+    const viewer = my ?? other;
+    const myGoldNum = viewer.gold();
+    const myTroopsNum = Number(viewer.troops());
 
     return html`
       <style>
@@ -961,7 +964,7 @@ export class PlayerPanel extends LitElement implements Controller {
                     class="p-6 flex flex-col gap-2 font-sans antialiased text-[14.5px] leading-relaxed"
                   >
                     <!-- Identity (flag, name, type, traitor, relation) -->
-                    <div class="mb-1">${this.renderIdentityRow(other, my)}</div>
+                    <div class="mb-1">${this.renderIdentityRow(other, viewer)}</div>
 
                     ${this.sendTarget
                       ? html`
@@ -972,7 +975,7 @@ export class PlayerPanel extends LitElement implements Controller {
                               ? myTroopsNum
                               : myGoldNum}
                             .uiState=${this.uiState}
-                            .myPlayer=${my}
+                            .myPlayer=${viewer}
                             .target=${this.sendTarget}
                             .gameView=${this.g}
                             .eventBus=${this.eventBus}
@@ -988,7 +991,7 @@ export class PlayerPanel extends LitElement implements Controller {
                       ? html`
                           <player-moderation-modal
                             .open=${true}
-                            .myPlayer=${my}
+                            .myPlayer=${viewer}
                             .target=${this.moderationTarget}
                             .eventBus=${this.eventBus}
                             .isAdmin=${this.isAdminRole}
@@ -1007,12 +1010,12 @@ export class PlayerPanel extends LitElement implements Controller {
                     ${this.renderResources(other)}
 
                     <!-- Rocket direction toggle -->
-                    ${other === my ? this.renderRocketDirectionToggle() : ""}
+                    ${other === viewer && !isReplay ? this.renderRocketDirectionToggle() : ""}
 
                     <ui-divider></ui-divider>
 
                     <!-- Stats: betrayals / trading -->
-                    ${this.renderStats(other, my)}
+                    ${this.renderStats(other, viewer)}
 
                     <ui-divider></ui-divider>
 
@@ -1022,10 +1025,13 @@ export class PlayerPanel extends LitElement implements Controller {
                     <!-- Alliance time remaining -->
                     ${this.renderAllianceExpiry()}
 
-                    <ui-divider></ui-divider>
-
-                    <!-- Actions -->
-                    ${this.renderActions(my, other)}
+                    ${isReplay
+                      ? ""
+                      : html`
+                          <ui-divider></ui-divider>
+                          <!-- Actions -->
+                          ${this.renderActions(viewer, other)}
+                        `}
                   </div>
                 </div>
               </div>

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -964,7 +964,9 @@ export class PlayerPanel extends LitElement implements Controller {
                     class="p-6 flex flex-col gap-2 font-sans antialiased text-[14.5px] leading-relaxed"
                   >
                     <!-- Identity (flag, name, type, traitor, relation) -->
-                    <div class="mb-1">${this.renderIdentityRow(other, viewer)}</div>
+                    <div class="mb-1">
+                      ${this.renderIdentityRow(other, viewer)}
+                    </div>
 
                     ${this.sendTarget
                       ? html`
@@ -1010,7 +1012,9 @@ export class PlayerPanel extends LitElement implements Controller {
                     ${this.renderResources(other)}
 
                     <!-- Rocket direction toggle -->
-                    ${other === viewer && !isReplay ? this.renderRocketDirectionToggle() : ""}
+                    ${other === viewer && !isReplay
+                      ? this.renderRocketDirectionToggle()
+                      : ""}
 
                     <ui-divider></ui-divider>
 
@@ -1024,7 +1028,6 @@ export class PlayerPanel extends LitElement implements Controller {
 
                     <!-- Alliance time remaining -->
                     ${this.renderAllianceExpiry()}
-
                     ${isReplay
                       ? ""
                       : html`

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -35,7 +35,7 @@ const traitorIcon = assetUrl("images/TraitorIconWhite.svg");
 const xIcon = assetUrl("images/XIcon.svg");
 
 export interface MenuElementParams {
-  myPlayer: PlayerView;
+  myPlayer: PlayerView | null;
   selected: PlayerView | null;
   tile: TileRef;
   playerActions: PlayerActions;
@@ -124,7 +124,7 @@ export enum Slot {
 
 function isFriendlyTarget(params: MenuElementParams): boolean {
   const selectedPlayer = params.selected;
-  if (selectedPlayer === null) return false;
+  if (selectedPlayer === null || params.myPlayer === null) return false;
   const isFriendly = (selectedPlayer as PlayerView).isFriendly;
   if (typeof isFriendly !== "function") return false;
   return isFriendly.call(selectedPlayer, params.myPlayer);
@@ -215,7 +215,7 @@ const allyRequestElement: MenuElement = {
   icon: allianceIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleAllianceRequest(
-      params.myPlayer,
+      params.myPlayer!,
       params.selected!,
     );
     params.closeMenu();
@@ -266,7 +266,7 @@ const allyBreakElement: MenuElement = {
   icon: traitorIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleBreakAlliance(
-      params.myPlayer,
+      params.myPlayer!,
       params.selected!,
     );
     params.closeMenu();
@@ -500,8 +500,10 @@ const donateGoldRadialElement: MenuElement = {
 export const deleteUnitElement: MenuElement = {
   id: Slot.Delete,
   name: "delete",
-  cooldown: (params: MenuElementParams) => params.myPlayer.deleteUnitCooldown(),
+  cooldown: (params: MenuElementParams) =>
+    params.myPlayer?.deleteUnitCooldown() ?? 0,
   disabled: (params: MenuElementParams) => {
+    if (params.myPlayer === null) return true;
     const tileOwner = params.game.owner(params.tile);
     const isLand = params.game.isLand(params.tile);
 
@@ -549,8 +551,8 @@ export const deleteUnitElement: MenuElement = {
   ],
   action: (params: MenuElementParams) => {
     const DELETE_SELECTION_RADIUS = 5;
-    const myUnits = params.myPlayer
-      .units()
+    const myUnits = params
+      .myPlayer!.units()
       .filter(
         (unit) =>
           !unit.isUnderConstruction() &&
@@ -595,7 +597,7 @@ export const boatMenuElement: MenuElement = {
   color: COLORS.boat,
 
   action: async (params: MenuElementParams) => {
-    params.playerActionHandler.handleBoatAttack(params.myPlayer, params.tile);
+    params.playerActionHandler.handleBoatAttack(params.myPlayer!, params.tile);
 
     params.closeMenu();
   },
@@ -631,7 +633,7 @@ export const centerButtonElement: CenterButtonElement = {
       if (isFriendlyTarget(params) && !isDisconnectedTarget(params)) {
         const selectedPlayer = params.selected as PlayerView;
         const ratio = params.uiState?.attackRatio ?? 1;
-        const troopsToDonate = Math.floor(ratio * params.myPlayer.troops());
+        const troopsToDonate = Math.floor(ratio * params.myPlayer!.troops());
         if (troopsToDonate > 0) {
           params.playerActionHandler.handleDonateTroops(
             selectedPlayer,
@@ -640,7 +642,7 @@ export const centerButtonElement: CenterButtonElement = {
         }
       } else {
         params.playerActionHandler.handleAttack(
-          params.myPlayer,
+          params.myPlayer!,
           params.selected?.id() ?? null,
         );
       }
@@ -656,6 +658,9 @@ export const rootMenuElement: MenuElement = {
   icon: infoIcon,
   color: COLORS.info,
   subMenu: (params: MenuElementParams) => {
+    if (params.myPlayer === null) {
+      return [infoMenuElement];
+    }
     const isAllied = params.selected?.isAlliedWith(params.myPlayer);
     const isDisconnected = isDisconnectedTarget(params);
 

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -35,7 +35,7 @@ const traitorIcon = assetUrl("images/TraitorIconWhite.svg");
 const xIcon = assetUrl("images/XIcon.svg");
 
 export interface MenuElementParams {
-  myPlayer: PlayerView | null;
+  myPlayer: PlayerView;
   selected: PlayerView | null;
   tile: TileRef;
   playerActions: PlayerActions;
@@ -124,7 +124,7 @@ export enum Slot {
 
 function isFriendlyTarget(params: MenuElementParams): boolean {
   const selectedPlayer = params.selected;
-  if (selectedPlayer === null || params.myPlayer === null) return false;
+  if (selectedPlayer === null) return false;
   const isFriendly = (selectedPlayer as PlayerView).isFriendly;
   if (typeof isFriendly !== "function") return false;
   return isFriendly.call(selectedPlayer, params.myPlayer);
@@ -215,7 +215,7 @@ const allyRequestElement: MenuElement = {
   icon: allianceIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleAllianceRequest(
-      params.myPlayer!,
+      params.myPlayer,
       params.selected!,
     );
     params.closeMenu();
@@ -266,7 +266,7 @@ const allyBreakElement: MenuElement = {
   icon: traitorIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleBreakAlliance(
-      params.myPlayer!,
+      params.myPlayer,
       params.selected!,
     );
     params.closeMenu();
@@ -500,10 +500,8 @@ const donateGoldRadialElement: MenuElement = {
 export const deleteUnitElement: MenuElement = {
   id: Slot.Delete,
   name: "delete",
-  cooldown: (params: MenuElementParams) =>
-    params.myPlayer?.deleteUnitCooldown() ?? 0,
+  cooldown: (params: MenuElementParams) => params.myPlayer.deleteUnitCooldown(),
   disabled: (params: MenuElementParams) => {
-    if (params.myPlayer === null) return true;
     const tileOwner = params.game.owner(params.tile);
     const isLand = params.game.isLand(params.tile);
 
@@ -551,8 +549,8 @@ export const deleteUnitElement: MenuElement = {
   ],
   action: (params: MenuElementParams) => {
     const DELETE_SELECTION_RADIUS = 5;
-    const myUnits = params
-      .myPlayer!.units()
+    const myUnits = params.myPlayer
+      .units()
       .filter(
         (unit) =>
           !unit.isUnderConstruction() &&
@@ -597,7 +595,7 @@ export const boatMenuElement: MenuElement = {
   color: COLORS.boat,
 
   action: async (params: MenuElementParams) => {
-    params.playerActionHandler.handleBoatAttack(params.myPlayer!, params.tile);
+    params.playerActionHandler.handleBoatAttack(params.myPlayer, params.tile);
 
     params.closeMenu();
   },
@@ -633,7 +631,7 @@ export const centerButtonElement: CenterButtonElement = {
       if (isFriendlyTarget(params) && !isDisconnectedTarget(params)) {
         const selectedPlayer = params.selected as PlayerView;
         const ratio = params.uiState?.attackRatio ?? 1;
-        const troopsToDonate = Math.floor(ratio * params.myPlayer!.troops());
+        const troopsToDonate = Math.floor(ratio * params.myPlayer.troops());
         if (troopsToDonate > 0) {
           params.playerActionHandler.handleDonateTroops(
             selectedPlayer,
@@ -642,7 +640,7 @@ export const centerButtonElement: CenterButtonElement = {
         }
       } else {
         params.playerActionHandler.handleAttack(
-          params.myPlayer!,
+          params.myPlayer,
           params.selected?.id() ?? null,
         );
       }
@@ -658,9 +656,6 @@ export const rootMenuElement: MenuElement = {
   icon: infoIcon,
   color: COLORS.info,
   subMenu: (params: MenuElementParams) => {
-    if (params.myPlayer === null) {
-      return [infoMenuElement];
-    }
     const isAllied = params.selected?.isAlliedWith(params.myPlayer);
     const isDisconnected = isDisconnectedTarget(params);
 

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -43,7 +43,7 @@ const traitorIcon = assetUrl("images/TraitorIconWhite.svg");
 const xIcon = assetUrl("images/XIcon.svg");
 
 export interface MenuElementParams {
-  myPlayer: PlayerView;
+  myPlayer: PlayerView | null;
   selected: PlayerView | null;
   tile: TileRef;
   playerActions: PlayerActions;
@@ -133,7 +133,7 @@ export enum Slot {
 
 function isFriendlyTarget(params: MenuElementParams): boolean {
   const selectedPlayer = params.selected;
-  if (selectedPlayer === null) return false;
+  if (selectedPlayer === null || params.myPlayer === null) return false;
   const isFriendly = (selectedPlayer as PlayerView).isFriendly;
   if (typeof isFriendly !== "function") return false;
   return isFriendly.call(selectedPlayer, params.myPlayer);
@@ -224,7 +224,7 @@ const allyRequestElement: MenuElement = {
   icon: allianceIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleAllianceRequest(
-      params.myPlayer,
+      params.myPlayer!,
       params.selected!,
     );
     params.closeMenu();
@@ -275,7 +275,7 @@ const allyBreakElement: MenuElement = {
   icon: traitorIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleBreakAlliance(
-      params.myPlayer,
+      params.myPlayer!,
       params.selected!,
     );
     params.closeMenu();
@@ -623,8 +623,10 @@ const donateGoldRadialElement: MenuElement = {
 export const deleteUnitElement: MenuElement = {
   id: Slot.Delete,
   name: "delete",
-  cooldown: (params: MenuElementParams) => params.myPlayer.deleteUnitCooldown(),
+  cooldown: (params: MenuElementParams) =>
+    params.myPlayer?.deleteUnitCooldown() ?? 0,
   disabled: (params: MenuElementParams) => {
+    if (params.myPlayer === null) return true;
     const tileOwner = params.game.owner(params.tile);
     const isLand = params.game.isLand(params.tile);
 
@@ -672,8 +674,8 @@ export const deleteUnitElement: MenuElement = {
   ],
   action: (params: MenuElementParams) => {
     const DELETE_SELECTION_RADIUS = 5;
-    const myUnits = params.myPlayer
-      .units()
+    const myUnits = params
+      .myPlayer!.units()
       .filter(
         (unit) =>
           !unit.isUnderConstruction() &&
@@ -718,7 +720,7 @@ export const boatMenuElement: MenuElement = {
   color: COLORS.boat,
 
   action: async (params: MenuElementParams) => {
-    params.playerActionHandler.handleBoatAttack(params.myPlayer, params.tile);
+    params.playerActionHandler.handleBoatAttack(params.myPlayer!, params.tile);
 
     params.closeMenu();
   },
@@ -754,7 +756,7 @@ export const centerButtonElement: CenterButtonElement = {
       if (isFriendlyTarget(params) && !isDisconnectedTarget(params)) {
         const selectedPlayer = params.selected as PlayerView;
         const ratio = params.uiState?.attackRatio ?? 1;
-        const troopsToDonate = Math.floor(ratio * params.myPlayer.troops());
+        const troopsToDonate = Math.floor(ratio * params.myPlayer!.troops());
         if (troopsToDonate > 0) {
           params.playerActionHandler.handleDonateTroops(
             selectedPlayer,
@@ -763,7 +765,7 @@ export const centerButtonElement: CenterButtonElement = {
         }
       } else {
         params.playerActionHandler.handleAttack(
-          params.myPlayer,
+          params.myPlayer!,
           params.selected?.id() ?? null,
         );
       }
@@ -779,6 +781,9 @@ export const rootMenuElement: MenuElement = {
   icon: infoIcon,
   color: COLORS.info,
   subMenu: (params: MenuElementParams) => {
+    if (params.myPlayer === null) {
+      return [infoMenuElement];
+    }
     const isAllied = params.selected?.isAlliedWith(params.myPlayer);
     const isDisconnected = isDisconnectedTarget(params);
 

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -43,7 +43,7 @@ const traitorIcon = assetUrl("images/TraitorIconWhite.svg");
 const xIcon = assetUrl("images/XIcon.svg");
 
 export interface MenuElementParams {
-  myPlayer: PlayerView | null;
+  myPlayer: PlayerView;
   selected: PlayerView | null;
   tile: TileRef;
   playerActions: PlayerActions;
@@ -133,7 +133,7 @@ export enum Slot {
 
 function isFriendlyTarget(params: MenuElementParams): boolean {
   const selectedPlayer = params.selected;
-  if (selectedPlayer === null || params.myPlayer === null) return false;
+  if (selectedPlayer === null) return false;
   const isFriendly = (selectedPlayer as PlayerView).isFriendly;
   if (typeof isFriendly !== "function") return false;
   return isFriendly.call(selectedPlayer, params.myPlayer);
@@ -224,7 +224,7 @@ const allyRequestElement: MenuElement = {
   icon: allianceIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleAllianceRequest(
-      params.myPlayer!,
+      params.myPlayer,
       params.selected!,
     );
     params.closeMenu();
@@ -275,7 +275,7 @@ const allyBreakElement: MenuElement = {
   icon: traitorIcon,
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleBreakAlliance(
-      params.myPlayer!,
+      params.myPlayer,
       params.selected!,
     );
     params.closeMenu();
@@ -623,10 +623,8 @@ const donateGoldRadialElement: MenuElement = {
 export const deleteUnitElement: MenuElement = {
   id: Slot.Delete,
   name: "delete",
-  cooldown: (params: MenuElementParams) =>
-    params.myPlayer?.deleteUnitCooldown() ?? 0,
+  cooldown: (params: MenuElementParams) => params.myPlayer.deleteUnitCooldown(),
   disabled: (params: MenuElementParams) => {
-    if (params.myPlayer === null) return true;
     const tileOwner = params.game.owner(params.tile);
     const isLand = params.game.isLand(params.tile);
 
@@ -674,8 +672,8 @@ export const deleteUnitElement: MenuElement = {
   ],
   action: (params: MenuElementParams) => {
     const DELETE_SELECTION_RADIUS = 5;
-    const myUnits = params
-      .myPlayer!.units()
+    const myUnits = params.myPlayer
+      .units()
       .filter(
         (unit) =>
           !unit.isUnderConstruction() &&
@@ -720,7 +718,7 @@ export const boatMenuElement: MenuElement = {
   color: COLORS.boat,
 
   action: async (params: MenuElementParams) => {
-    params.playerActionHandler.handleBoatAttack(params.myPlayer!, params.tile);
+    params.playerActionHandler.handleBoatAttack(params.myPlayer, params.tile);
 
     params.closeMenu();
   },
@@ -756,7 +754,7 @@ export const centerButtonElement: CenterButtonElement = {
       if (isFriendlyTarget(params) && !isDisconnectedTarget(params)) {
         const selectedPlayer = params.selected as PlayerView;
         const ratio = params.uiState?.attackRatio ?? 1;
-        const troopsToDonate = Math.floor(ratio * params.myPlayer!.troops());
+        const troopsToDonate = Math.floor(ratio * params.myPlayer.troops());
         if (troopsToDonate > 0) {
           params.playerActionHandler.handleDonateTroops(
             selectedPlayer,
@@ -765,7 +763,7 @@ export const centerButtonElement: CenterButtonElement = {
         }
       } else {
         params.playerActionHandler.handleAttack(
-          params.myPlayer!,
+          params.myPlayer,
           params.selected?.id() ?? null,
         );
       }
@@ -781,9 +779,6 @@ export const rootMenuElement: MenuElement = {
   icon: infoIcon,
   color: COLORS.info,
   subMenu: (params: MenuElementParams) => {
-    if (params.myPlayer === null) {
-      return [infoMenuElement];
-    }
     const isAllied = params.selected?.isAlliedWith(params.myPlayer);
     const isDisconnected = isDisconnectedTarget(params);
 

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -1048,6 +1048,9 @@ export class GameView implements GameMap {
   config(): Config {
     return this._config;
   }
+  isSpectator(): boolean {
+    return !this.myPlayer()?.isAlive() || this._config.isReplay();
+  }
   units(...types: UnitType[]): UnitView[] {
     if (types.length === 0) {
       return Array.from(this._units.values()).filter((u) => u.isActive());

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -1108,6 +1108,9 @@ export class GameView implements GameMap {
   config(): Config {
     return this._config;
   }
+  isSpectator(): boolean {
+    return !this.myPlayer()?.isAlive() || this._config.isReplay();
+  }
   units(...types: UnitType[]): UnitView[] {
     if (types.length === 0) {
       return Array.from(this._units.values()).filter((u) => u.isActive());


### PR DESCRIPTION
 ## Description:                                                                                                                                                                                                                   
   
  Makes the PlayerInfoPanel accessible during replay playback, as suggested by @FloPinguin.                                                                                                                                         
                                                               
  Previously the panel returned empty immediately when `myPlayer()` was null (which is always the case in replays since the viewer is not an active participant). The panel now renders in a read-only mode showing all
  informational content: player name, flag, resources, alliances, betrayal count, and trading status.

  The right-click radial menu was also gated on `myPlayer !== null`, so it never opened in replays. In replay mode the radial now opens with only the **info** wedge enabled when right-clicking on a player tile, which is the
  entry point to the panel.

  Action buttons that require sending intents to the server are hidden in replay mode since they are not applicable:

  - Chat, Emoji, Target
  - Donate Troops / Donate Gold
  - Alliance Request / Break Alliance
  - Embargo / Stop-Trade buttons
  - Moderation (Kick)
  - Rocket direction toggle

  Read-only content (resources, alliances, stats) remains fully visible, which was the main motivation for this feature: being able to review alliances during a replay.

  ## Screenshots
  
<img width="448" height="343" alt="Screenshot_17" src="https://github.com/user-attachments/assets/8df4d355-83a3-4e82-8953-b9437585c706" />

Radial menu only shows info option.

<img width="936" height="540" alt="Screenshot_16" src="https://github.com/user-attachments/assets/1c27009d-b717-4942-a98e-ba970d0bedb3" />

Displays all read-only content.

  ## Please complete the following:

  - [x] I have added screenshots for all UI updates
  - [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
  - [x] I have added relevant tests to the test directory
  - [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

  Tested locally with `npm run dev:prod` against a real prod replay (`/w1/game/tvBd246s?live`).

  ## Please put your Discord username so you can be contacted if a bug or regression is found:

  sxndrexe
