### PR TITLE
Fix: CI Test failures because of too-long running test

### DIFF
--- a/tests/TranslationSystem.test.ts
+++ b/tests/TranslationSystem.test.ts
@@ -620,5 +620,5 @@ describe("Translation System", () => {
 
     expect(missingKeys).toEqual([]);
     expect(unusedKeys).toEqual([]);
-  });
+  }, 30000);
 });


### PR DESCRIPTION
## Description:

Set timeout to 30s instead of the default 5s for test  "en.json keys stay in sync with source usage". It reads almost all files and therefor can take longer to complete its run, with the growing repository.

This sometimes lead to error from vitest `Error: Test timed out in 5000ms. If this is a long-running test, pass a timeout value as the last argument or configure it globally with "testTimeout"`. A workaround was to re-run the test, sometimes it then ran fast enough to stay below the 5s timeout. But a more permanent fix is in this PR: set the timout to 30s specifically for this test.

<img width="997" height="251" alt="image" src="https://github.com/user-attachments/assets/0efb138a-fd64-461a-8109-e9e0b3f57c7a" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33