### PR TITLE
ci: fail PRs when generated maps are out of date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,3 +71,28 @@ jobs:
           cache: "npm"
       - run: npm ci
       - run: npx prettier --check .
+
+  gen-maps:
+    name: 🗺️ Generated maps up to date
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: "npm"
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: map-generator/go.mod
+          cache-dependency-path: map-generator/go.sum
+      - run: npm ci
+      - run: npm run gen-maps
+      - name: Check for diff
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "::error::Generated maps are out of date — run 'npm run gen-maps' and commit the result."
+            git status --short
+            git --no-pager diff
+            exit 1
+          fi


### PR DESCRIPTION
## Description:

## Summary
- Adds a `gen-maps` job to the CI workflow that runs `npm run gen-maps` (Go map generator + prettier) and fails the check if the working tree has any diff afterwards.
- The failure annotation tells the author to run `npm run gen-maps` locally and commit the result, so stale generated maps can't slip through review.
- Pulls the Go toolchain version from `map-generator/go.mod` so the CI version stays in sync with the module automatically.


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

evan
