### PR TITLE
fix: typo 'handline' -> 'handling' in websocket error log

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -574,7 +574,7 @@ export class GameServer {
         }
       } catch (error) {
         this.log.info(
-          `error handline websocket request in game server: ${error}`,
+          `error handling websocket request in game server: ${error}`,
           {
             clientID: client.clientID,
           },


### PR DESCRIPTION
## Description:

Fixes a typo in `GameServer.ts` - `handline` should be `handling` in the websocket error log message.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires