### PR TITLE
Fix ranked 1v1 requeue opening matchmaking

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -728,30 +728,24 @@ class Client {
       window.location.href = "/";
     }
 
-    // Handle requeue parameter for ranked matchmaking
-    const searchParams = new URLSearchParams(window.location.search);
-    if (searchParams.has("requeue")) {
-      // Remove only the requeue parameter, preserving other params and hash
-      searchParams.delete("requeue");
-      const newUrl =
-        window.location.pathname +
-        (searchParams.toString() ? "?" + searchParams.toString() : "") +
-        window.location.hash;
-      history.replaceState(null, "", newUrl);
-      // Wait for matchmaking button to be defined, then trigger its click handler.
-      customElements.whenDefined("matchmaking-button").then(() => {
-        const matchmakingButton = document.querySelector(
-          "matchmaking-button button",
-        ) as HTMLButtonElement | null;
-        if (matchmakingButton) {
-          matchmakingButton.click();
-        } else {
-          console.warn(
-            "Requeue requested, but matchmaking button not found in DOM.",
-          );
-        }
-      });
+    if (this.consumeRequeueUrl()) {
+      document.dispatchEvent(new CustomEvent("open-matchmaking"));
     }
+  }
+
+  private consumeRequeueUrl(): boolean {
+    const searchParams = new URLSearchParams(window.location.search);
+    if (!searchParams.has("requeue")) {
+      return false;
+    }
+
+    searchParams.delete("requeue");
+    const newUrl =
+      window.location.pathname +
+      (searchParams.toString() ? `?${searchParams.toString()}` : "") +
+      window.location.hash;
+    history.replaceState(null, "", newUrl);
+    return true;
   }
 
   private async handleJoinLobby(event: CustomEvent<JoinLobbyEvent>) {


### PR DESCRIPTION
Resolves: https://discord.com/channels/1284581928254701718/1502285978121801851/1502285978121801851

## Description:

Replace the requeue button-click workaround with a direct `open-matchmaking` event
Keep consuming only the `requeue` URL parameter while preserving other query params and hash


https://github.com/user-attachments/assets/7922b4ec-1686-484b-8ce1-b417896ddc44



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:
aotumuri