### PR TITLE
Fix GitHub translation key category

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -39,6 +39,7 @@
     "join": "Join Lobby",
     "solo": "Solo",
     "game_info": "Game info",
+    "github": "GitHub",
     "wiki": "Wiki",
     "privacy_policy": "Privacy Policy",
     "terms_of_service": "Terms of Service",
@@ -56,7 +57,6 @@
     "go_to_troubleshooting": "Go to our troubleshooting page"
   },
   "news": {
-    "github_link": "on GitHub",
     "title": "Release Notes"
   },
   "troubleshooting": {

--- a/src/client/components/Footer.ts
+++ b/src/client/components/Footer.ts
@@ -24,7 +24,7 @@ export class Footer extends LitElement {
           >
             <img
               src=${assetUrl("icons/github-mark-white.svg")}
-              data-i18n-alt="news.github_link"
+              data-i18n-alt="main.github"
               class="h-6 w-6 lg:h-7 lg:w-7 object-contain pointer-events-none"
               draggable="false"
             />


### PR DESCRIPTION
## Description:

The GitHub translation key was incorrectly categorized under news even though it is used on the main page.
This changes its category to main.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri