### PR TITLE
fix: guard hostCheats assignment in updateGameConfig()

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -177,7 +177,9 @@ export class GameServer {
     if (gameConfig.waterNukes !== undefined) {
       this.gameConfig.waterNukes = gameConfig.waterNukes ?? undefined;
     }
-    this.gameConfig.hostCheats = gameConfig.hostCheats;
+    if (gameConfig.hostCheats !== undefined) {
+      this.gameConfig.hostCheats = gameConfig.hostCheats;
+    }
   }
 
   private isKicked(clientID: ClientID): boolean {


### PR DESCRIPTION
## Description:

The hostCheats configuration assignment in updateGameConfig() was lacking an undefined check, causing existing configs to be overwritten when the client sends a partial update. Added a proper check to ensure partial updates do not wipe out existing configurations.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires