### PR TITLE
fix: add sliding window reset to rate limiter totalBytes counter

### DIFF
--- a/src/server/ClientMsgRateLimiter.ts
+++ b/src/server/ClientMsgRateLimiter.ts
@@ -11,6 +11,7 @@ interface ClientBucket {
   perSecond: RateLimiter;
   perMinute: RateLimiter;
   totalBytes: number;
+  lastByteReset: number;
 }
 
 export class ClientMsgRateLimiter {
@@ -18,6 +19,15 @@ export class ClientMsgRateLimiter {
 
   check(clientID: ClientID, type: string, bytes: number): RateLimitResult {
     const bucket = this.getOrCreate(clientID);
+
+    // Reset byte counter every 60 seconds to prevent lifetime accumulation
+    // from kicking legitimate long-session players.
+    const now = Date.now();
+    if (now - bucket.lastByteReset > 60_000) {
+      bucket.totalBytes = 0;
+      bucket.lastByteReset = now;
+    }
+
     bucket.totalBytes += bytes;
 
     if (bucket.totalBytes >= TOTAL_BYTES) return "kick";
@@ -57,6 +67,7 @@ export class ClientMsgRateLimiter {
         interval: "minute",
       }),
       totalBytes: 0,
+      lastByteReset: Date.now(),
     };
     this.buckets.set(clientID, bucket);
     return bucket;


### PR DESCRIPTION
totalBytes accumulated over the entire session lifetime without any reset. In a 2-3 hour game, legitimate players would accumulate far more than the 2MB limit and get kicked.

This adds a 60-second sliding window: the byte counter resets every minute, so only sustained high-bandwidth abuse triggers the kick. Normal gameplay (~200 bytes/intent * 10/sec = 2KB/sec = 120KB/min) stays well under the 2MB per-window limit.

If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #(issue number)

## Description:

Describe the PR.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
