### PR TITLE
fix: remove double x() dereference in MIRV separation point calc

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -82,7 +82,7 @@ export class MirvExecution implements Execution {
       });
       this.mg.stats().bombLaunch(this.player, this.targetPlayer, UnitType.MIRV);
       const x = Math.floor(
-        (this.mg.x(this.dst) + this.mg.x(this.mg.x(this.nuke.tile()))) / 2,
+        (this.mg.x(this.dst) + this.mg.x(this.nuke.tile())) / 2,
       );
       const y = Math.max(0, this.mg.y(this.dst) - 500) + 50;
       this.separateDst = this.mg.ref(x, y);


### PR DESCRIPTION
mg.x() takes a TileRef and returns a number (x coordinate). The code was calling mg.x(mg.x(tile)), feeding the numeric result back into x() which expects a TileRef. This produces an incorrect midpoint for MIRV warhead separation, causing warheads to spread from a wrong position on the map.

If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #(issue number)

## Description:

Describe the PR.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
