### PR TITLE
fix: preserve null gold in DonateGoldExecution so auto-donate works (BUG-03)

### DIFF
--- a/src/core/execution/DonateGoldExecution.ts
+++ b/src/core/execution/DonateGoldExecution.ts
@@ -18,7 +18,7 @@ import {
 
 export class DonateGoldExecution implements Execution {
   private recipient: Player;
-  private gold: Gold;
+  private gold: Gold | null;
 
   private mg: Game;
   private random: PseudoRandom;
@@ -30,7 +30,7 @@ export class DonateGoldExecution implements Execution {
     private recipientID: PlayerID,
     goldNum: number | null,
   ) {
-    this.gold = toInt(goldNum ?? 0);
+    this.gold = goldNum === null ? null : toInt(goldNum);
   }
 
   init(mg: Game, ticks: number): void {

--- a/tests/Donate.test.ts
+++ b/tests/Donate.test.ts
@@ -183,6 +183,74 @@ describe("Donate troops to a non ally", () => {
   });
 });
 
+describe("Donate gold with null goldNum (auto-donate fallback)", () => {
+  it("Should auto-donate 1/3 of sender gold when goldNum is null", async () => {
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      donateGold: true,
+    });
+    const gameID: GameID = "game_id";
+
+    const donorInfo = new PlayerInfo(
+      "donor",
+      PlayerType.Human,
+      null,
+      "donor_id",
+    );
+    const recipientInfo = new PlayerInfo(
+      "recipient",
+      PlayerType.Human,
+      null,
+      "recipient_id",
+    );
+
+    game.addPlayer(donorInfo);
+    game.addPlayer(recipientInfo);
+
+    const donor = game.player(donorInfo.id);
+    const recipient = game.player(recipientInfo.id);
+
+    // Spawn both players
+    const spawnA = game.ref(0, 10);
+    const spawnB = game.ref(0, 15);
+
+    game.addExecution(
+      new SpawnExecution(gameID, donorInfo, spawnA),
+      new SpawnExecution(gameID, recipientInfo, spawnB),
+    );
+
+    // donor sends alliance request to recipient
+    const allianceRequest = donor.createAllianceRequest(recipient);
+    expect(allianceRequest).not.toBeNull();
+
+    // recipient accepts the alliance request
+    if (allianceRequest) {
+      allianceRequest.accept();
+    }
+    game.executeNextTick();
+
+    // Give donor a known amount of gold
+    donor.addGold(9000n);
+    const donorGoldBefore = donor.gold();
+    const recipientGoldBefore = recipient.gold();
+
+    // Pass null as goldNum — should trigger auto-donate of sender.gold() / 3n
+    game.addExecution(new DonateGoldExecution(donor, recipientInfo.id, null));
+
+    for (let i = 0; i < 5; i++) {
+      game.executeNextTick();
+    }
+
+    // Donor should have lost gold
+    expect(donor.gold() < donorGoldBefore).toBe(true);
+    // Recipient should have received gold
+    expect(recipient.gold() > recipientGoldBefore).toBe(true);
+    // Check donor lost roughly 1/3 of their gold
+    const donorLost = donorGoldBefore - donor.gold();
+    expect(donorLost).toBeGreaterThan(0n);
+  });
+});
+
 describe("Donate Gold to a non ally", () => {
   it("Gold should not be donated", async () => {
     const game = await setup("ocean_and_land", {


### PR DESCRIPTION
Resolves #4092

## Description:

When `goldNum` is `null` (the caller wants to auto-donate 1/3 of the sender's current gold), the constructor coerced it to `0` via `goldNum ?? 0`, producing `0n` (BigInt zero). Since `0n` is not nullish, the `??=` fallback in `init()` (`this.gold ??= sender.gold() / 3n`) never triggered — resulting in a silent zero-gold transfer where the UI confirmed success but no gold or relationship points were transferred.

This PR preserves `null` through the constructor so the `??=` operator correctly resolves the dynamic amount during `init()`. Explicit non-null amounts continue to pass through `toInt()` unchanged. Adds a test covering the null-amount path.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires