### PR TITLE
fix: correct error message for clan tag length (BUG-07)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -573,6 +573,7 @@
     "invalid_chars": "Username can only contain letters, numbers, spaces, and underscores.",
     "tag": "TAG",
     "tag_too_short": "Clan tag must be 2-5 alphanumeric characters.",
+    "tag_too_long": "Clan tag cannot exceed 5 characters.",
     "tag_invalid_chars": "Clan tag can only contain letters and numbers."
   },
   "host_modal": {

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -58,7 +58,7 @@ export function validateClanTag(clanTag: string): {
     return { isValid: false, error: translateText("username.tag_too_short") };
   }
   if (clanTag.length > MAX_CLAN_TAG_LENGTH) {
-    return { isValid: false, error: translateText("username.tag_too_short") };
+    return { isValid: false, error: translateText("username.tag_too_long") };
   }
 
   const parsed = ClanTagSchema.safeParse(clanTag);

--- a/tests/Censor.test.ts
+++ b/tests/Censor.test.ts
@@ -63,7 +63,7 @@ describe("username.ts functions", () => {
     test("rejects too long clan tag", () => {
       const res = validateClanTag("A".repeat(MAX_CLAN_TAG_LENGTH + 1));
       expect(res.isValid).toBe(false);
-      expect(res.error).toBe("username.tag_too_short");
+      expect(res.error).toBe("username.tag_too_long");
     });
 
     test("accepts valid clan tag", () => {


### PR DESCRIPTION
## Description:

The code was checking `clanTag.length > MAX_CLAN_TAG_LENGTH` but returning `"tag_too_short"`. This fix corrects the error message to something more appropriate or ensures the logic matches the message.

**Fix:** Corrected the error message key from `"tag_too_short"` to `"tag_too_long"` when the length exceeds the maximum.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires