### PR TITLE
security: remove duplicate express.json() middleware (SEC-04)

### DIFF
--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -104,7 +104,6 @@ export async function startWorker() {
 
   app.set("trust proxy", 3);
   app.use(compression());
-  app.use(express.json());
 
   app.use(
     express.static(path.join(__dirname, "../../out"), {


### PR DESCRIPTION
## Description:

The app had `express.json()` registered twice in `app.ts`. This can cause issues with body parsing and is redundant.

**Fix:** Removed the second call to `app.use(express.json())`.

## Please complete the following:

- [x] I have added screenshots for all UI updates (N/A - no UI changes)
- [x] I process any text displayed to the user through translateText() (N/A)
- [x] I have added relevant tests to the test directory (N/A - existing tests pass)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced
## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires