### PR TITLE
Open custom lobbies to the public

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -527,7 +527,7 @@
     "error": "Error"
   },
   "private_lobby": {
-    "title": "Join Private Lobby",
+    "title": "Join Custom Lobby",
     "enter_id": "Enter Lobby ID",
     "join_lobby": "Join Lobby",
     "not_found": "Lobby not found. Please check the ID and try again.",
@@ -573,7 +573,7 @@
     "tag_invalid_chars": "Clan tag can only contain letters and numbers."
   },
   "host_modal": {
-    "title": "Create Private Lobby",
+    "title": "Create Custom Lobby",
     "mode": "Mode",
     "team_count": "Number of Teams",
     "options_title": "Options",
@@ -616,7 +616,12 @@
     "starting_gold": "Starting Gold (Millions)",
     "starting_gold_placeholder": "5",
     "host_cheats": "Host Cheats",
-    "leave_confirmation": "Are you sure you want to leave the lobby?"
+    "leave_confirmation": "Are you sure you want to leave the lobby?",
+    "open_to_public_title": "Open to Public",
+    "open_to_public_desc": "Allow anyone to find and join this lobby from the main menu.",
+    "open_to_public_active": "Open to Public",
+    "open_button": "Open to Public",
+    "close_to_public_button": "Close to Public"
   },
   "team_colors": {
     "red": "Red",
@@ -644,7 +649,18 @@
   },
   "game_mode": {
     "ffa": "Free for All",
-    "teams": "Teams"
+    "team": "Teams",
+    "teams": "Teams",
+    "special": "Special"
+  },
+  "join_lobby": {
+    "open_custom_section_title": "Open Custom Lobbies",
+    "no_open_custom_lobbies": "No open custom lobbies at the moment.",
+    "players_label": "players",
+    "join_button": "Join",
+    "expand": "Show details",
+    "collapse": "Hide details",
+    "no_custom_options": "Default settings"
   },
   "mode_selector": {
     "teams_title": "Teams",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -5,6 +5,12 @@
     "svg": "uk_us_flag",
     "lang_code": "en"
   },
+  "units": {
+    "second_short": "s",
+    "minute_short": "m",
+    "minute": "min",
+    "million_short": "M"
+  },
   "common": {
     "not_logged_in": "Not logged in",
     "close": "Close",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -656,13 +656,11 @@
   "game_mode": {
     "ffa": "Free for All",
     "team": "Teams",
-    "teams": "Teams",
-    "special": "Special"
+    "teams": "Teams"
   },
   "join_lobby": {
     "open_custom_section_title": "Open Custom Lobbies",
     "no_open_custom_lobbies": "No open custom lobbies at the moment.",
-    "players_label": "players",
     "join_button": "Join",
     "expand": "Show details",
     "collapse": "Hide details",

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -81,6 +81,13 @@ export class GameModeSelector extends LitElement {
     );
     this.requestUpdate();
 
+    const joinModal = document.querySelector(
+      "join-lobby-modal",
+    ) as JoinLobbyModal | null;
+    if (joinModal) {
+      joinModal.openLobbies = lobbies.openLobbies ?? [];
+    }
+
     const allGames = Object.values(lobbies.games ?? {}).flat();
     for (const game of allGames) {
       const mapType = game.gameConfig?.gameMap as GameMapType;

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -607,6 +607,7 @@ export class HostLobbyModal extends BaseModal {
     this.hostCheatGoldMultiplierValue = undefined;
     this.hostCheatStartingGold = false;
     this.hostCheatStartingGoldValue = undefined;
+    this.openToPublicType = null;
 
     this.leaveLobbyOnClose = true;
   }

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -86,6 +86,7 @@ export class HostLobbyModal extends BaseModal {
   @state() private hostCheatStartingGold: boolean = false;
   @state() private hostCheatStartingGoldValue: number | undefined = undefined;
   @state() private lobbyCreatorClientID: string = "";
+  @state() private openToPublicType: "ffa" | "team" | "special" | null = null;
 
   @property({ attribute: false }) eventBus: EventBus | null = null;
   // Timers for debouncing slider changes
@@ -104,6 +105,8 @@ export class HostLobbyModal extends BaseModal {
     if (lobby.clients) {
       this.clients = lobby.clients;
     }
+    this.openToPublicType =
+      (lobby.openCustomType as "ffa" | "team" | "special" | null) ?? null;
   };
 
   private getRandomString(): string {
@@ -398,6 +401,8 @@ export class HostLobbyModal extends BaseModal {
             .nationCount=${this.nations}
             .onKickPlayer=${(clientID: string) => this.kickPlayer(clientID)}
           ></lobby-player-view>
+
+          ${this.renderOpenToPublicSection()}
         </div>
 
         <!-- Player List / footer -->
@@ -415,6 +420,71 @@ export class HostLobbyModal extends BaseModal {
         </div>
       </div>
     `;
+  }
+
+  private renderOpenToPublicSection() {
+    return html`
+      <div class="mt-10 pt-6 border-t border-white/10">
+        <div class="flex flex-col gap-3">
+          <div>
+            <h3 class="text-sm font-bold text-white uppercase tracking-widest">
+              ${translateText("host_modal.open_to_public_title")}
+            </h3>
+            <p class="text-xs text-white/50 mt-1">
+              ${translateText("host_modal.open_to_public_desc")}
+            </p>
+          </div>
+
+          ${this.openToPublicType !== null
+            ? html`
+                <div
+                  class="flex items-center justify-between gap-3 px-4 py-3 rounded-xl border border-green-500/30 bg-green-500/10"
+                >
+                  <span
+                    class="text-sm font-bold text-green-400 uppercase tracking-widest"
+                  >
+                    ${translateText("host_modal.open_to_public_active")}
+                  </span>
+                  <button
+                    class="px-4 py-2 text-xs font-bold uppercase tracking-widest text-white bg-white/10 hover:bg-white/20 rounded-lg transition-all"
+                    @click=${this.closeToPublic}
+                  >
+                    ${translateText("host_modal.close_to_public_button")}
+                  </button>
+                </div>
+              `
+            : html`
+                <button
+                  class="w-full py-3 text-sm font-bold uppercase tracking-widest text-white bg-blue-600 hover:bg-blue-500 rounded-xl transition-all"
+                  @click=${this.openToPublic}
+                >
+                  ${translateText("host_modal.open_button")}
+                </button>
+              `}
+        </div>
+      </div>
+    `;
+  }
+
+  private openToPublic() {
+    const publicGameType = this.gameMode === GameMode.Team ? "team" : "ffa";
+    this.dispatchEvent(
+      new CustomEvent("open-to-public", {
+        detail: { publicGameType },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private closeToPublic() {
+    this.dispatchEvent(
+      new CustomEvent("open-to-public", {
+        detail: { publicGameType: null },
+        bubbles: true,
+        composed: true,
+      }),
+    );
   }
 
   protected onOpen(): void {
@@ -932,6 +1002,7 @@ export class HostLobbyModal extends BaseModal {
         detail: {
           config: {
             gameMap: this.selectedMap,
+            useRandomMap: this.useRandomMap,
             gameMapSize: this.compactMap
               ? GameMapSize.Compact
               : GameMapSize.Normal,

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -44,6 +44,7 @@ export class JoinLobbyModal extends BaseModal {
   @query("#lobbyIdInput") private lobbyIdInput!: HTMLInputElement;
 
   @property({ attribute: false }) eventBus: EventBus | null = null;
+  @property({ attribute: false }) openLobbies: PublicGameInfo[] = [];
 
   @state() private players: ClientInfo[] = [];
   @state() private playerCount: number = 0;
@@ -55,6 +56,7 @@ export class JoinLobbyModal extends BaseModal {
   @state() private serverTimeOffset: number = 0;
   @state() private isConnecting: boolean = true;
   @state() private lobbyCreatorClientID: string | null = null;
+  @state() private expandedLobbies: Set<string> = new Set();
 
   private leaveLobbyOnClose = true;
   private countdownTimerId: number | null = null;
@@ -218,7 +220,8 @@ export class JoinLobbyModal extends BaseModal {
 
   private renderJoinForm() {
     return html`
-      <form @submit=${this.joinLobbyFromInput} class="custom-scrollbar p-6 space-y-4 mr-1">
+      <div class="custom-scrollbar p-6 space-y-6 mr-1">
+        <form @submit=${this.joinLobbyFromInput}>
           <div class="flex flex-col gap-3">
             <div class="flex gap-2">
               <input
@@ -255,9 +258,311 @@ export class JoinLobbyModal extends BaseModal {
               submit
             ></o-button>
           </div>
-        </div>
-      </form>
+        </form>
+
+        ${this.renderOpenLobbies()}
+      </div>
     `;
+  }
+
+  private renderOpenLobbies() {
+    return html`
+      <div class="border-t border-white/10 pt-5">
+        <h3
+          class="text-xs font-bold uppercase tracking-widest text-white/40 mb-3"
+        >
+          ${translateText("join_lobby.open_custom_section_title")}
+        </h3>
+        ${this.openLobbies.length === 0
+          ? html`<p class="text-xs text-white/30 text-center py-4">
+              ${translateText("join_lobby.no_open_custom_lobbies")}
+            </p>`
+          : html`<div class="flex flex-col gap-2">
+              ${this.openLobbies.map((lobby) =>
+                this.renderOpenLobbyCard(lobby),
+              )}
+            </div>`}
+      </div>
+    `;
+  }
+
+  private gameModeLabel(lobby: PublicGameInfo): string {
+    const c = lobby.gameConfig;
+    const isTeam = c?.gameMode === GameMode.Team;
+    if (!isTeam || !c) return translateText("game_mode.ffa");
+    if (c.playerTeams === HumansVsNations) {
+      return translateText("host_modal.teams_Humans Vs Nations");
+    }
+    if (typeof c.playerTeams === "string") {
+      return translateText("host_modal.teams_" + c.playerTeams);
+    }
+    if (typeof c.playerTeams === "number") {
+      return translateText("public_lobby.teams", { num: c.playerTeams });
+    }
+    return translateText("game_mode.team");
+  }
+
+  private readonly randomMapThumbnail = assetUrl("images/RandomMap.webp");
+
+  private renderOpenLobbyCard(lobby: PublicGameInfo) {
+    // ===================================================================
+    // EXPLICIT ISOLATED RANDOM BYPASS — do not touch / do not merge with
+    // the normal map resolution logic below. If the host selected Random,
+    // force name and thumbnail directly: no lookup, no fallback, no resolve.
+    // ===================================================================
+    const isRandomMap = lobby.gameConfig?.useRandomMap === true;
+
+    let mapName: string;
+    let thumbnailUrl: string;
+    if (isRandomMap) {
+      mapName = translateText("map.random");
+      thumbnailUrl = this.randomMapThumbnail;
+    } else {
+      // ----- Normal map logic (unchanged) -----
+      const mapKey = lobby.gameConfig?.gameMap;
+      mapName = getMapName(mapKey) ?? mapKey ?? "";
+      thumbnailUrl = mapKey
+        ? assetUrl(
+            `maps/${encodeURIComponent(normaliseMapKey(mapKey))}/thumbnail.webp`,
+          )
+        : this.randomMapThumbnail;
+    }
+
+    const playerCount = lobby.numClients;
+    const maxPlayers = lobby.gameConfig?.maxPlayers ?? 0;
+    const categoryLabel = this.gameModeLabel(lobby);
+    const isExpanded = this.expandedLobbies.has(lobby.gameID);
+
+    return html`
+      <div
+        class="rounded-xl border border-white/10 bg-white/5 overflow-hidden transition-all"
+      >
+        <!-- Main row -->
+        <div class="flex items-center gap-3 px-3 py-3">
+          <!-- Map thumbnail -->
+          <img
+            src=${thumbnailUrl}
+            alt=${mapName}
+            class="w-16 h-12 rounded-lg object-cover border border-white/10 shrink-0"
+            @error=${(e: Event) => {
+              if (!isRandomMap) {
+                (e.target as HTMLImageElement).src = this.randomMapThumbnail;
+              }
+            }}
+          />
+
+          <!-- Map name + mode -->
+          <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+            <span class="text-sm font-bold text-white truncate"
+              >${mapName}</span
+            >
+            <span
+              class="text-[10px] font-bold uppercase tracking-widest text-white/40"
+              >${categoryLabel}</span
+            >
+          </div>
+
+          <!-- Player count + join + expand -->
+          <div class="flex items-center gap-2 shrink-0">
+            <div class="flex items-center gap-1 text-white/60">
+              <svg
+                class="w-4 h-4"
+                fill="currentColor"
+                viewBox="0 0 20 20"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"
+                ></path>
+              </svg>
+              <span class="text-xs font-bold">
+                ${maxPlayers > 0 ? `${playerCount}/${maxPlayers}` : playerCount}
+              </span>
+            </div>
+            <button
+              class="px-3 py-1.5 text-xs font-bold uppercase tracking-widest text-white bg-blue-600 hover:bg-blue-500 rounded-lg transition-all"
+              @click=${() => this.joinOpenLobby(lobby.gameID)}
+            >
+              ${translateText("join_lobby.join_button")}
+            </button>
+            <button
+              class="flex items-center justify-center w-7 h-7 rounded-lg border border-white/10 bg-white/5 hover:bg-white/15 text-white/60 hover:text-white transition-all"
+              @click=${() => this.toggleLobbyExpanded(lobby.gameID)}
+              aria-label=${isExpanded
+                ? translateText("join_lobby.collapse")
+                : translateText("join_lobby.expand")}
+            >
+              <svg
+                class="w-3.5 h-3.5 transition-transform ${isExpanded
+                  ? "rotate-90"
+                  : ""}"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2.5"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  d="M9 5l7 7-7 7"
+                ></path>
+              </svg>
+            </button>
+          </div>
+        </div>
+
+        <!-- Expandable details -->
+        ${isExpanded && lobby.gameConfig
+          ? this.renderOpenLobbyDetails(lobby.gameConfig)
+          : html``}
+      </div>
+    `;
+  }
+
+  private renderOpenLobbyDetails(c: GameConfig): TemplateResult {
+    const isTeam = c.gameMode === GameMode.Team;
+    const isCompact =
+      c.gameMapSize === GameMapSize.Compact || c.publicGameModifiers?.isCompact;
+
+    const tags: string[] = [];
+
+    if (c.difficulty !== Difficulty.Easy)
+      tags.push(translateText(`difficulty.${c.difficulty.toLowerCase()}`));
+    if (c.instantBuild) tags.push(translateText("host_modal.instant_build"));
+    if (c.randomSpawn) tags.push(translateText("host_modal.random_spawn"));
+    if (c.infiniteGold) tags.push(translateText("host_modal.infinite_gold"));
+    if (c.infiniteTroops) tags.push(translateText("host_modal.infinite_troops"));
+    if (c.disableAlliances)
+      tags.push(
+        translateText("public_game_modifier.disable_alliances_label"),
+      );
+    if (c.waterNukes)
+      tags.push(translateText("public_game_modifier.water_nukes_label"));
+    if (isCompact) tags.push(translateText("host_modal.compact_map"));
+    if ((isTeam && !c.donateGold) || (!isTeam && c.donateGold))
+      tags.push(
+        `${translateText("host_modal.donate_gold")}: ${translateText(c.donateGold ? "common.enabled" : "common.disabled")}`,
+      );
+    if ((isTeam && !c.donateTroops) || (!isTeam && c.donateTroops))
+      tags.push(
+        `${translateText("host_modal.donate_troops")}: ${translateText(c.donateTroops ? "common.enabled" : "common.disabled")}`,
+      );
+    if (c.maxTimerValue)
+      tags.push(
+        `${translateText("private_lobby.game_length")}: ${c.maxTimerValue} min`,
+      );
+    if (c.spawnImmunityDuration && Math.round(c.spawnImmunityDuration / 10) !== 5) {
+      const s = Math.round(c.spawnImmunityDuration / 10);
+      const val =
+        s < 60
+          ? `${s}s`
+          : s % 60 > 0
+            ? `${Math.floor(s / 60)}m ${s % 60}s`
+            : `${Math.floor(s / 60)} min`;
+      tags.push(`${translateText("private_lobby.pvp_immunity")}: ${val}`);
+    }
+    if (c.startingGold)
+      tags.push(
+        `${translateText("private_lobby.starting_gold")}: ${parseFloat((c.startingGold / 1_000_000).toPrecision(12))}M`,
+      );
+    if (c.goldMultiplier)
+      tags.push(
+        `${translateText("host_modal.gold_multiplier")}: x${c.goldMultiplier}`,
+      );
+    if (c.bots !== (isCompact ? 100 : 400))
+      tags.push(`${translateText("host_modal.bots")} ${c.bots}`);
+    if (c.nations === "disabled")
+      tags.push(
+        `${translateText("host_modal.nations")}: ${translateText("common.disabled")}`,
+      );
+
+    const unitKeys: Record<string, string> = {
+      City: "unit_type.city",
+      Port: "unit_type.port",
+      "Defense Post": "unit_type.defense_post",
+      "SAM Launcher": "unit_type.sam_launcher",
+      "Missile Silo": "unit_type.missile_silo",
+      Warship: "unit_type.warship",
+      Factory: "unit_type.factory",
+      "Atom Bomb": "unit_type.atom_bomb",
+      "Hydrogen Bomb": "unit_type.hydrogen_bomb",
+      MIRV: "unit_type.mirv",
+      "Trade Ship": "player_stats_table.unit.trade",
+      Transport: "player_stats_table.unit.trans",
+      "MIRV Warhead": "player_stats_table.unit.mirvw",
+    };
+    const disabledUnits = c.disabledUnits ?? [];
+
+    if (tags.length === 0 && disabledUnits.length === 0) {
+      return html`
+        <div class="px-3 pb-3 pt-1">
+          <p class="text-xs text-white/30">
+            ${translateText("join_lobby.no_custom_options")}
+          </p>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="px-3 pb-3 border-t border-white/10 pt-3 space-y-2">
+        ${tags.length > 0
+          ? html`
+              <div class="flex flex-wrap gap-1.5">
+                ${tags.map(
+                  (tag) => html`
+                    <span
+                      class="px-2 py-0.5 bg-white/10 text-white/70 text-[10px] font-bold rounded-md border border-white/10"
+                    >
+                      ${tag}
+                    </span>
+                  `,
+                )}
+              </div>
+            `
+          : html``}
+        ${disabledUnits.length > 0
+          ? html`
+              <div class="flex flex-wrap gap-1.5">
+                ${disabledUnits.map((unit) => {
+                  const key = unitKeys[unit];
+                  const name = key ? translateText(key) : unit;
+                  return html`
+                    <span
+                      class="px-2 py-0.5 bg-red-500/20 text-red-300 text-[10px] font-bold rounded-md border border-red-500/30"
+                    >
+                      ${name}
+                    </span>
+                  `;
+                })}
+              </div>
+            `
+          : html``}
+      </div>
+    `;
+  }
+
+  private toggleLobbyExpanded(gameID: string) {
+    const next = new Set(this.expandedLobbies);
+    if (next.has(gameID)) {
+      next.delete(gameID);
+    } else {
+      next.add(gameID);
+    }
+    this.expandedLobbies = next;
+  }
+
+  private async joinOpenLobby(gameID: string) {
+    this.startTrackingLobby(gameID);
+    try {
+      const gameExists = await this.checkActiveLobby(gameID);
+      if (!gameExists) {
+        this.resetTrackingState();
+        this.showMessage(translateText("private_lobby.not_found"), "red");
+      }
+    } catch {
+      this.resetTrackingState();
+      this.showMessage(translateText("private_lobby.error"), "red");
+    }
   }
 
   protected onOpen(args?: Record<string, unknown>): void {
@@ -374,6 +679,7 @@ export class JoinLobbyModal extends BaseModal {
     this.lobbyCreatorClientID = null;
     this.isConnecting = true;
     this.leaveLobbyOnClose = true;
+    this.expandedLobbies = new Set();
   }
 
   disconnectedCallback() {
@@ -410,11 +716,15 @@ export class JoinLobbyModal extends BaseModal {
     if (!this.gameConfig) return html``;
 
     const c = this.gameConfig;
-    const mapName = getMapName(c.gameMap);
-    const normalizedMap = normaliseMapKey(c.gameMap);
-    const thumbnailUrl = assetUrl(
-      `maps/${encodeURIComponent(normalizedMap)}/thumbnail.webp`,
-    );
+    const isRandomMap = c.useRandomMap === true;
+    const mapName = isRandomMap
+      ? translateText("map.random")
+      : (getMapName(c.gameMap) ?? c.gameMap);
+    const thumbnailUrl = isRandomMap
+      ? this.randomMapThumbnail
+      : assetUrl(
+          `maps/${encodeURIComponent(normaliseMapKey(c.gameMap))}/thumbnail.webp`,
+        );
     const isTeam = c.gameMode === GameMode.Team;
 
     let modeSubtitle: string;
@@ -598,7 +908,9 @@ export class JoinLobbyModal extends BaseModal {
           alt=${mapName ?? c.gameMap}
           class="w-20 h-20 rounded-lg object-cover border border-white/10 shrink-0"
           @error=${(e: Event) => {
-            (e.target as HTMLImageElement).style.display = "none";
+            if (!isRandomMap) {
+              (e.target as HTMLImageElement).src = this.randomMapThumbnail;
+            }
           }}
         />
         <div class="flex flex-col gap-1">

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -448,7 +448,7 @@ export class JoinLobbyModal extends BaseModal {
       );
     if (c.maxTimerValue)
       tags.push(
-        `${translateText("private_lobby.game_length")}: ${c.maxTimerValue} min`,
+        `${translateText("private_lobby.game_length")}: ${c.maxTimerValue} ${translateText("units.minute")}`,
       );
     if (
       c.spawnImmunityDuration &&
@@ -457,15 +457,15 @@ export class JoinLobbyModal extends BaseModal {
       const s = Math.round(c.spawnImmunityDuration / 10);
       const val =
         s < 60
-          ? `${s}s`
+          ? `${s}${translateText("units.second_short")}`
           : s % 60 > 0
-            ? `${Math.floor(s / 60)}m ${s % 60}s`
-            : `${Math.floor(s / 60)} min`;
+            ? `${Math.floor(s / 60)}${translateText("units.minute_short")} ${s % 60}${translateText("units.second_short")}`
+            : `${Math.floor(s / 60)} ${translateText("units.minute")}`;
       tags.push(`${translateText("private_lobby.pvp_immunity")}: ${val}`);
     }
     if (c.startingGold)
       tags.push(
-        `${translateText("private_lobby.starting_gold")}: ${parseFloat((c.startingGold / 1_000_000).toPrecision(12))}M`,
+        `${translateText("private_lobby.starting_gold")}: ${parseFloat((c.startingGold / 1_000_000).toPrecision(12))}${translateText("units.million_short")}`,
       );
     if (c.goldMultiplier)
       tags.push(

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -473,6 +473,8 @@ export class JoinLobbyModal extends BaseModal {
       );
     if (c.bots !== (isCompact ? 100 : 400))
       tags.push(`${translateText("host_modal.bots")} ${c.bots}`);
+    if (typeof c.nations === "number")
+      tags.push(`${translateText("host_modal.nations")}: ${c.nations}`);
     if (c.nations === "disabled")
       tags.push(
         `${translateText("host_modal.nations")}: ${translateText("common.disabled")}`,
@@ -557,11 +559,13 @@ export class JoinLobbyModal extends BaseModal {
     this.startTrackingLobby(gameID);
     try {
       const gameExists = await this.checkActiveLobby(gameID);
+      if (this.currentLobbyId !== gameID) return;
       if (!gameExists) {
         this.resetTrackingState();
         this.showMessage(translateText("private_lobby.not_found"), "red");
       }
     } catch {
+      if (this.currentLobbyId !== gameID) return;
       this.resetTrackingState();
       this.showMessage(translateText("private_lobby.error"), "red");
     }

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -431,11 +431,10 @@ export class JoinLobbyModal extends BaseModal {
     if (c.instantBuild) tags.push(translateText("host_modal.instant_build"));
     if (c.randomSpawn) tags.push(translateText("host_modal.random_spawn"));
     if (c.infiniteGold) tags.push(translateText("host_modal.infinite_gold"));
-    if (c.infiniteTroops) tags.push(translateText("host_modal.infinite_troops"));
+    if (c.infiniteTroops)
+      tags.push(translateText("host_modal.infinite_troops"));
     if (c.disableAlliances)
-      tags.push(
-        translateText("public_game_modifier.disable_alliances_label"),
-      );
+      tags.push(translateText("public_game_modifier.disable_alliances_label"));
     if (c.waterNukes)
       tags.push(translateText("public_game_modifier.water_nukes_label"));
     if (isCompact) tags.push(translateText("host_modal.compact_map"));
@@ -451,7 +450,10 @@ export class JoinLobbyModal extends BaseModal {
       tags.push(
         `${translateText("private_lobby.game_length")}: ${c.maxTimerValue} min`,
       );
-    if (c.spawnImmunityDuration && Math.round(c.spawnImmunityDuration / 10) !== 5) {
+    if (
+      c.spawnImmunityDuration &&
+      Math.round(c.spawnImmunityDuration / 10) !== 5
+    ) {
       const s = Math.round(c.spawnImmunityDuration / 10);
       const val =
         s < 60

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -54,6 +54,7 @@ import { TerritoryPatternsModal } from "./TerritoryPatternsModal";
 import { TokenLoginModal } from "./TokenLoginModal";
 import {
   SendKickPlayerIntentEvent,
+  SendOpenToPublicIntentEvent,
   SendStartGameEvent,
   SendUpdateGameConfigIntentEvent,
 } from "./Transport";
@@ -225,6 +226,7 @@ declare global {
     userMeResponse: CustomEvent<UserMeResponse | false>;
     "leave-lobby": CustomEvent;
     "update-game-config": CustomEvent;
+    "open-to-public": CustomEvent<{ publicGameType: string | null }>;
   }
 
   // Fixes the globalThis.addEventListener errors
@@ -380,6 +382,10 @@ class Client {
     document.addEventListener(
       "update-game-config",
       this.handleUpdateGameConfig.bind(this),
+    );
+    document.addEventListener(
+      "open-to-public",
+      this.handleOpenToPublic.bind(this),
     );
     document.addEventListener(
       "open-matchmaking",
@@ -1025,6 +1031,22 @@ class Client {
     // Forward to eventBus if available
     if (this.eventBus) {
       this.eventBus.emit(new SendUpdateGameConfigIntentEvent(config));
+    }
+  }
+
+  private handleOpenToPublic(
+    event: CustomEvent<{ publicGameType: string | null }>,
+  ) {
+    if (this.eventBus) {
+      this.eventBus.emit(
+        new SendOpenToPublicIntentEvent(
+          event.detail.publicGameType as
+            | "ffa"
+            | "team"
+            | "special"
+            | null,
+        ),
+      );
     }
   }
 

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1040,11 +1040,7 @@ class Client {
     if (this.eventBus) {
       this.eventBus.emit(
         new SendOpenToPublicIntentEvent(
-          event.detail.publicGameType as
-            | "ffa"
-            | "team"
-            | "special"
-            | null,
+          event.detail.publicGameType as "ffa" | "team" | "special" | null,
         ),
       );
     }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1037,13 +1037,18 @@ class Client {
   private handleOpenToPublic(
     event: CustomEvent<{ publicGameType: string | null }>,
   ) {
-    if (this.eventBus) {
-      this.eventBus.emit(
-        new SendOpenToPublicIntentEvent(
-          event.detail.publicGameType as "ffa" | "team" | "special" | null,
-        ),
-      );
+    if (!this.eventBus) return;
+    const raw = event.detail.publicGameType;
+    const validTypes = ["ffa", "team", "special"] as const;
+    const isValid =
+      raw === null || (validTypes as readonly string[]).includes(raw);
+    if (!isValid) {
+      console.error(`[open-to-public] invalid publicGameType: ${raw}`);
+      return;
     }
+    this.eventBus.emit(
+      new SendOpenToPublicIntentEvent(raw as "ffa" | "team" | "special" | null),
+    );
   }
 
   private async getTurnstileToken(

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -22,6 +22,7 @@ import {
   ClientSendWinnerMessage,
   GameConfig,
   Intent,
+  PublicGameType,
   ServerMessage,
   ServerMessageSchema,
   Winner,
@@ -176,6 +177,10 @@ export class SendUpdateGameConfigIntentEvent implements GameEvent {
 
 export class SendStartGameEvent implements GameEvent {}
 
+export class SendOpenToPublicIntentEvent implements GameEvent {
+  constructor(public readonly publicGameType: PublicGameType | null) {}
+}
+
 export class Transport {
   private socket: WebSocket | null = null;
 
@@ -267,6 +272,10 @@ export class Transport {
     );
 
     this.eventBus.on(SendStartGameEvent, () => this.onSendStartGame());
+
+    this.eventBus.on(SendOpenToPublicIntentEvent, (e) =>
+      this.onSendOpenToPublicIntent(e),
+    );
   }
 
   private startPing() {
@@ -649,6 +658,13 @@ export class Transport {
 
   private onSendStartGame() {
     this.sendIntent({ type: "start_game" });
+  }
+
+  private onSendOpenToPublicIntent(event: SendOpenToPublicIntentEvent) {
+    this.sendIntent({
+      type: "open_to_public",
+      publicGameType: event.publicGameType,
+    });
   }
 
   private sendIntent(intent: Intent) {

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -1,6 +1,7 @@
 import IntlMessageFormat from "intl-messageformat";
 import {
   Duos,
+  GameMapType,
   GameMode,
   HumansVsNations,
   MessageType,
@@ -16,6 +17,10 @@ import { Platform } from "./Platform";
 export const TUTORIAL_VIDEO_URL = "https://www.youtube.com/embed/EN2oOog3pSs";
 
 export function normaliseMapKey(mapName: string): string {
+  const enumKey = Object.keys(GameMapType).find(
+    (k) => GameMapType[k as keyof typeof GameMapType] === mapName,
+  );
+  if (enumKey) return enumKey.toLowerCase();
   return mapName.toLowerCase().replace(/[\s.]+/g, "");
 }
 

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -149,6 +149,7 @@ export const PlayerStatsTreeSchema = z.object({
   Singleplayer: GameModeStatsSchema.optional(),
   Public: GameModeStatsSchema.optional(),
   Private: GameModeStatsSchema.optional(),
+  Custom: GameModeStatsSchema.optional(),
   Ranked: z.partialRecord(z.enum(RankedType), PlayerStatsLeafSchema).optional(),
 });
 export type PlayerStatsTree = z.infer<typeof PlayerStatsTreeSchema>;

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -168,7 +168,7 @@ export const GameInfoSchema = z.object({
   serverTime: z.number(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema.optional(),
-  openCustomType: PublicGameTypeSchema.optional(),
+  openCustomType: PublicGameTypeSchema.nullable().optional(),
 });
 
 export const PublicGameInfoSchema = z.object({

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -51,7 +51,8 @@ export type Intent =
   | KickPlayerIntent
   | TogglePauseIntent
   | UpdateGameConfigIntent
-  | StartGameIntent;
+  | StartGameIntent
+  | OpenToPublicIntent;
 
 export type AttackIntent = z.infer<typeof AttackIntentSchema>;
 export type CancelAttackIntent = z.infer<typeof CancelAttackIntentSchema>;
@@ -86,6 +87,7 @@ export type UpdateGameConfigIntent = z.infer<
   typeof UpdateGameConfigIntentSchema
 >;
 export type StartGameIntent = z.infer<typeof StartGameIntentSchema>;
+export type OpenToPublicIntent = z.infer<typeof OpenToPublicIntentSchema>;
 
 export type Turn = z.infer<typeof TurnSchema>;
 export type GameConfig = z.infer<typeof GameConfigSchema>;
@@ -166,6 +168,7 @@ export const GameInfoSchema = z.object({
   serverTime: z.number(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema.optional(),
+  openCustomType: PublicGameTypeSchema.optional(),
 });
 
 export const PublicGameInfoSchema = z.object({
@@ -179,6 +182,7 @@ export const PublicGameInfoSchema = z.object({
 export const PublicGamesSchema = z.object({
   serverTime: z.number(),
   games: z.record(PublicGameTypeSchema, z.array(PublicGameInfoSchema)),
+  openLobbies: z.array(PublicGameInfoSchema).optional(),
 });
 
 export class LobbyInfoEvent implements GameEvent {
@@ -253,6 +257,7 @@ export const GameConfigSchema = z.object({
   disableAlliances: z.boolean().nullable().optional(),
   waterNukes: z.boolean().nullable().optional(),
   randomSpawn: z.boolean(),
+  useRandomMap: z.boolean().optional(),
   maxPlayers: z.number().optional(),
   maxTimerValue: z.number().int().min(1).max(120).nullable().optional(), // In minutes
   spawnImmunityDuration: z.number().int().min(0).nullable().optional(), // In ticks
@@ -459,6 +464,12 @@ export const StartGameIntentSchema = z.object({
   type: z.literal("start_game"),
 });
 
+export const OpenToPublicIntentSchema = z.object({
+  type: z.literal("open_to_public"),
+  // null closes the lobby to public; non-null opens it under the given category
+  publicGameType: PublicGameTypeSchema.nullable(),
+});
+
 const IntentSchema = z.discriminatedUnion("type", [
   AttackIntentSchema,
   CancelAttackIntentSchema,
@@ -485,6 +496,7 @@ const IntentSchema = z.discriminatedUnion("type", [
   TogglePauseIntentSchema,
   UpdateGameConfigIntentSchema,
   StartGameIntentSchema,
+  OpenToPublicIntentSchema,
 ]);
 
 // StampedIntent = Intent with server-stamped clientID (used in turns and execution)

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -273,6 +273,7 @@ export enum GameType {
   Singleplayer = "Singleplayer",
   Public = "Public",
   Private = "Private",
+  Custom = "Custom",
 }
 export const isGameType = (value: unknown): value is GameType =>
   isEnumValue(GameType, value);

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -28,6 +28,13 @@ export class GameManager {
     );
   }
 
+  public openCustomLobbies(): GameServer[] {
+    return Array.from(this.games.values()).filter(
+      (g) =>
+        g.phase() === GamePhase.Lobby && g.openCustomLobbyType() !== null,
+    );
+  }
+
   joinClient(
     client: Client,
     gameID: GameID,

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -30,8 +30,7 @@ export class GameManager {
 
   public openCustomLobbies(): GameServer[] {
     return Array.from(this.games.values()).filter(
-      (g) =>
-        g.phase() === GamePhase.Lobby && g.openCustomLobbyType() !== null,
+      (g) => g.phase() === GamePhase.Lobby && g.openCustomLobbyType() !== null,
     );
   }
 

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -4,7 +4,7 @@ import WebSocket from "ws";
 import { z } from "zod";
 import { isAdminRole } from "../core/ApiSchemas";
 import { GameEnv } from "../core/configuration/Config";
-import { GameType } from "../core/game/Game";
+import { GameMode, GameType } from "../core/game/Game";
 import {
   ClientID,
   ClientMessageSchema,
@@ -13,6 +13,7 @@ import {
   GameInfo,
   GameStartInfo,
   GameStartInfoSchema,
+  OpenToPublicIntent,
   PlayerRecord,
   PublicGameType,
   ServerDesyncSchema,
@@ -93,6 +94,11 @@ export class GameServer {
 
   private visibleAt?: number;
 
+  // When set, this private lobby is open for anyone to join via the custom list.
+  // Null means the lobby is closed to public. Once set to non-null at least once,
+  // gameConfig.gameType is permanently set to GameType.Custom.
+  private openCustomType: PublicGameType | null = null;
+
   constructor(
     public readonly id: string,
     readonly log_: Logger,
@@ -117,6 +123,9 @@ export class GameServer {
   public updateGameConfig(gameConfig: Partial<GameConfig>): void {
     if (gameConfig.gameMap !== undefined) {
       this.gameConfig.gameMap = gameConfig.gameMap;
+    }
+    if (gameConfig.useRandomMap !== undefined) {
+      this.gameConfig.useRandomMap = gameConfig.useRandomMap;
     }
     if (gameConfig.gameMapSize !== undefined) {
       this.gameConfig.gameMapSize = gameConfig.gameMapSize;
@@ -482,6 +491,54 @@ export class GameServer {
                 );
 
                 this.updateGameConfig(stampedIntent.config);
+                // Keep openCustomType in sync with gameMode when open to public
+                if (
+                  this.openCustomType !== null &&
+                  stampedIntent.config.gameMode !== undefined
+                ) {
+                  this.openCustomType =
+                    stampedIntent.config.gameMode === GameMode.Team
+                      ? "team"
+                      : "ffa";
+                }
+                return;
+              }
+              case "open_to_public": {
+                if (client.clientID !== this.lobbyCreatorID) {
+                  this.log.warn(`Only lobby creator can open lobby to public`, {
+                    clientID: client.clientID,
+                    creatorID: this.lobbyCreatorID,
+                    gameID: this.id,
+                  });
+                  return;
+                }
+                if (this.isPublic()) {
+                  this.log.warn(
+                    `Cannot open a system-managed public game to public`,
+                    { gameID: this.id },
+                  );
+                  return;
+                }
+                if (this.hasStarted()) {
+                  this.log.warn(
+                    `Cannot change visibility after game has started`,
+                    { gameID: this.id },
+                  );
+                  return;
+                }
+                const intent = stampedIntent as StampedIntent &
+                  OpenToPublicIntent;
+                this.openCustomType = intent.publicGameType;
+                if (intent.publicGameType !== null) {
+                  // Permanently mark as Custom once opened to public
+                  this.gameConfig.gameType = GameType.Custom;
+                  this.log.info(`Lobby opened to public`, {
+                    gameID: this.id,
+                    category: intent.publicGameType,
+                  });
+                } else {
+                  this.log.info(`Lobby closed to public`, { gameID: this.id });
+                }
                 return;
               }
               case "start_game": {
@@ -961,12 +1018,17 @@ export class GameServer {
       gameConfig: this.gameConfig,
       startsAt: this.startsAt,
       serverTime: Date.now(),
-      publicGameType: this.publicGameType,
+      publicGameType: this.publicGameType ?? this.openCustomType ?? undefined,
+      openCustomType: this.openCustomType ?? undefined,
     };
   }
 
   public isPublic(): boolean {
     return this.gameConfig.gameType === GameType.Public;
+  }
+
+  public openCustomLobbyType(): PublicGameType | null {
+    return this.openCustomType;
   }
 
   public kickClient(

--- a/src/server/IPCBridgeSchema.ts
+++ b/src/server/IPCBridgeSchema.ts
@@ -23,6 +23,7 @@ export type MasterMessage = z.infer<typeof MasterMessageSchema>;
 const WorkerLobbyListSchema = z.object({
   type: z.literal("lobbyList"),
   lobbies: z.array(PublicGameInfoSchema),
+  openLobbies: z.array(PublicGameInfoSchema).optional(),
 });
 
 const WorkerReadySchema = z.object({

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -22,6 +22,8 @@ export class MasterLobbyService {
   private readonly workers = new Map<number, Worker>();
   // Worker id => the lobbies it owns.
   private readonly workerLobbies = new Map<number, PublicGameInfo[]>();
+  // Worker id => open custom lobbies it owns.
+  private readonly workerOpenLobbies = new Map<number, PublicGameInfo[]>();
   private readonly readyWorkers = new Set<number>();
   private started = false;
 
@@ -47,6 +49,7 @@ export class MasterLobbyService {
           break;
         case "lobbyList":
           this.workerLobbies.set(workerId, msg.lobbies);
+          this.workerOpenLobbies.set(workerId, msg.openLobbies ?? []);
           break;
       }
     });
@@ -55,6 +58,7 @@ export class MasterLobbyService {
   removeWorker(workerId: number) {
     this.workers.delete(workerId);
     this.workerLobbies.delete(workerId);
+    this.workerOpenLobbies.delete(workerId);
     this.readyWorkers.delete(workerId);
   }
 
@@ -108,11 +112,13 @@ export class MasterLobbyService {
   }
 
   private broadcastLobbies() {
+    const openLobbies = Array.from(this.workerOpenLobbies.values()).flat();
     const msg = {
       type: "lobbiesBroadcast",
       publicGames: {
         serverTime: Date.now(),
         games: this.getAllLobbies(),
+        openLobbies,
       },
     } satisfies MasterLobbiesBroadcast;
     for (const [workerId, worker] of this.workers.entries()) {

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -99,6 +99,7 @@ export class WorkerLobbyService {
     const openLobbies = this.gm
       .openCustomLobbies()
       .map((g) => g.gameInfo())
+      .filter((gi) => gi.openCustomType != null)
       .map((gi) => {
         return {
           gameID: gi.gameID,

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -95,7 +95,25 @@ export class WorkerLobbyService {
           publicGameType: gi.publicGameType!,
         } satisfies PublicGameInfo;
       });
-    process.send?.({ type: "lobbyList", lobbies } satisfies WorkerLobbyList);
+
+    const openLobbies = this.gm
+      .openCustomLobbies()
+      .map((g) => g.gameInfo())
+      .map((gi) => {
+        return {
+          gameID: gi.gameID,
+          numClients: gi.clients?.length ?? 0,
+          startsAt: gi.startsAt,
+          gameConfig: gi.gameConfig,
+          publicGameType: gi.openCustomType!,
+        } satisfies PublicGameInfo;
+      });
+
+    process.send?.({
+      type: "lobbyList",
+      lobbies,
+      openLobbies,
+    } satisfies WorkerLobbyList);
   }
 
   private setupUpgradeHandler() {

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -99,7 +99,9 @@ export class WorkerLobbyService {
     const openLobbies = this.gm
       .openCustomLobbies()
       .map((g) => g.gameInfo())
-      .filter((gi) => gi.openCustomType != null)
+      .filter(
+        (gi) => gi.openCustomType !== null && gi.openCustomType !== undefined,
+      )
       .map((gi) => {
         return {
           gameID: gi.gameID,


### PR DESCRIPTION
<img width="752" height="114" alt="PUBLIC-LOBBIES" src="https://github.com/user-attachments/assets/ff6208e1-6bd2-4328-822b-02cdffb71c8d" />

## Description:

Adds the ability for hosts to open their custom lobbies to the public, allowing other players to discover and join them without needing an invite link.
This PR eliminates "private" lobbies and they are now called **CUSTOM LOBBIES,** since they can be either private or public.

**Host side (HostLobbyModal):**
- New "Open to public" / "Close to public" toggle button in the lobby
- Button state updates in real time and reflects the current visibility of the lobby

**Player side (JoinLobbyModal):**
- New "Open lobbies" section listing all publicly open custom games
- Each card shows: map thumbnail, map name, game mode (FFA / Teams with team count), player count, and a Join button
- Clicking a card expands a dropdown with the full game config details before joining
- All fields update in real time as the host changes settings

**Improvements:**
- Random map: when the host selects "Random", viewers see "Random" + the random map thumbnail instead of the resolved map
- Missing thumbnails for unknown/future maps now fall back to the random map thumbnail instead of hiding the image

> **OPTION TO OPEN THE GAME TO THE PUBLIC IN THE CONFIGURATOR OF A CUSTOM LOBBY**
>
> <img width="745" height="648" alt="createcustomlobby" src="https://github.com/user-attachments/assets/5c1fe8a4-0215-43f7-bc52-db6ab70cedbb" />

> **HOW THE LIST OF PUBLIC ITEMS LOOKS**
>
><img width="740" height="645" alt="joincustomlobby" src="https://github.com/user-attachments/assets/8596cf3a-cd9c-4402-a780-c01312c32fbd" />

> **HOW THE LIST OF PUBLIC ITEMS LOOKS (extended item details)**
>
><img width="743" height="646" alt="joincustomlobby_options" src="https://github.com/user-attachments/assets/9ba05646-47b5-40dd-948b-5212851aa235" />


The text, in general, about how the game is opened to the public, what appears in the public game list, etc. I leave it up to you what you want to include; if you want, tell me on Discord and we can discuss it further.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

sardidefcon