### PR TITLE
Feature/custom colors and leaderboard

### DIFF
--- a/src/client/ColorInput.ts
+++ b/src/client/ColorInput.ts
@@ -1,0 +1,108 @@
+import { LitElement, html } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { UserSettings } from "../core/game/UserSettings";
+
+export const COLOR_MODE_CHANGED_EVENT = "color-mode-changed";
+
+/**
+ * A small button that sits next to the Skin/Pattern button on the main menu.
+ * Clicking it cycles through color modes: Random → Custom → Team.
+ * In "custom" mode a native color picker is also shown.
+ */
+@customElement("color-input")
+export class ColorInput extends LitElement {
+  @state() private mode: "random" | "custom" | "team" = "random";
+  @state() private primaryColor = "#2196f3";
+
+  private userSettings = new UserSettings();
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    this.mode = this.userSettings.colorMode();
+    this.primaryColor = this.userSettings.customPrimaryColor();
+  }
+
+  private cycleMode() {
+    const next: Record<string, "random" | "custom" | "team"> = {
+      random: "custom",
+      custom: "team",
+      team: "random",
+    };
+    const newMode = next[this.mode];
+    this.mode = newMode;
+    this.userSettings.setColorMode(newMode);
+    window.dispatchEvent(new CustomEvent(COLOR_MODE_CHANGED_EVENT));
+  }
+
+  private onColorChange(e: Event) {
+    const color = (e.target as HTMLInputElement).value;
+    this.primaryColor = color;
+    this.userSettings.setCustomPrimaryColor(color);
+    // Use a slightly darker shade as secondary color
+    this.userSettings.setCustomSecondaryColor(color);
+    window.dispatchEvent(new CustomEvent(COLOR_MODE_CHANGED_EVENT));
+  }
+
+  private modeLabel(): string {
+    if (this.mode === "custom") return "Custom";
+    if (this.mode === "team") return "Team";
+    return "Random";
+  }
+
+  private modeIcon(): string {
+    if (this.mode === "custom") return "🎨";
+    if (this.mode === "team") return "🤝";
+    return "🎲";
+  }
+
+  render() {
+    return html`
+      <div class="relative flex flex-col items-center gap-1 h-full">
+        <!-- Main button — same style as pattern-input -->
+        <button
+          id="color-input-btn"
+          title="Color Mode: ${this.modeLabel()} (click to change)"
+          class="pattern-btn m-0 p-0 w-full h-full flex cursor-pointer flex-col justify-center items-center focus:outline-none focus:ring-0 transition-all duration-200 hover:scale-105 bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:shadow-[var(--shadow-action-card-hover)] rounded-lg overflow-hidden gap-1"
+          @click=${this.cycleMode}
+        >
+          ${this.mode === "custom"
+            ? html`
+                <div
+                  class="w-7 h-7 rounded-md border-2 border-white/30"
+                  style="background:${this.primaryColor}"
+                ></div>
+                <span class="text-[7px] leading-tight font-black text-white uppercase">Custom</span>
+              `
+            : this.mode === "team"
+            ? html`
+                <span class="text-xl leading-none">🤝</span>
+                <span class="text-[7px] leading-tight font-black text-white uppercase">Team</span>
+              `
+            : html`
+                <span class="text-xl leading-none">🎲</span>
+                <span class="text-[7px] leading-tight font-black text-white uppercase">Random</span>
+              `}
+        </button>
+
+        <!-- Hidden native color picker — only shown in custom mode -->
+        ${this.mode === "custom"
+          ? html`
+              <input
+                type="color"
+                id="color-input-picker"
+                .value=${this.primaryColor}
+                @input=${this.onColorChange}
+                title="Pick your territory color"
+                class="absolute bottom-0 left-0 w-full h-1 opacity-0 cursor-pointer"
+                style="height:100%;top:0;"
+              />
+            `
+          : ""}
+      </div>
+    `;
+  }
+}

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -8,6 +8,7 @@ import "./components/baseComponents/setting/SettingNumber";
 import "./components/baseComponents/setting/SettingSelect";
 import "./components/baseComponents/setting/SettingSlider";
 import "./components/baseComponents/setting/SettingToggle";
+import "./components/baseComponents/setting/SettingColor";
 import { BaseModal } from "./components/BaseModal";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { Platform } from "./Platform";
@@ -306,6 +307,19 @@ export class UserSettingModal extends BaseModal {
       "🏳️ Territory Patterns:",
       this.userSettings.territoryPatterns() ? "ON" : "OFF",
     );
+  }
+
+  private toggleCustomColorsEnabled() {
+    this.userSettings.toggleCustomColorsEnabled();
+    this.requestUpdate();
+  }
+
+  private handleCustomPrimaryColor(e: CustomEvent<{ value: string }>) {
+    this.userSettings.setCustomPrimaryColor(e.detail.value);
+  }
+
+  private handleCustomSecondaryColor(e: CustomEvent<{ value: string }>) {
+    this.userSettings.setCustomSecondaryColor(e.detail.value);
   }
 
   private toggleGoToPlayer() {
@@ -840,6 +854,33 @@ export class UserSettingModal extends BaseModal {
         .checked=${this.userSettings.territoryPatterns()}
         @change=${this.toggleTerritoryPatterns}
       ></setting-toggle>
+
+      <!-- 🎨 Custom Territory Colors -->
+      <setting-toggle
+        label="Custom Territory Colors"
+        description="Override lobby settings and use your own colors"
+        id="custom-colors-toggle"
+        .checked=${this.userSettings.customColorsEnabled()}
+        @change=${this.toggleCustomColorsEnabled}
+      ></setting-toggle>
+
+      ${this.userSettings.customColorsEnabled()
+        ? html`
+            <setting-color
+              label="Primary Color"
+              description="The main fill color of your territory"
+              .value=${this.userSettings.customPrimaryColor()}
+              @change=${this.handleCustomPrimaryColor}
+            ></setting-color>
+            
+            <setting-color
+              label="Secondary Color"
+              description="The color of your borders"
+              .value=${this.userSettings.customSecondaryColor()}
+              @change=${this.handleCustomSecondaryColor}
+            ></setting-color>
+          `
+        : ""}
 
       <!-- 🔍 Go to player -->
       <setting-toggle

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -8,7 +8,6 @@ import "./components/baseComponents/setting/SettingNumber";
 import "./components/baseComponents/setting/SettingSelect";
 import "./components/baseComponents/setting/SettingSlider";
 import "./components/baseComponents/setting/SettingToggle";
-import "./components/baseComponents/setting/SettingColor";
 import { BaseModal } from "./components/BaseModal";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { Platform } from "./Platform";
@@ -307,19 +306,6 @@ export class UserSettingModal extends BaseModal {
       "🏳️ Territory Patterns:",
       this.userSettings.territoryPatterns() ? "ON" : "OFF",
     );
-  }
-
-  private toggleCustomColorsEnabled() {
-    this.userSettings.toggleCustomColorsEnabled();
-    this.requestUpdate();
-  }
-
-  private handleCustomPrimaryColor(e: CustomEvent<{ value: string }>) {
-    this.userSettings.setCustomPrimaryColor(e.detail.value);
-  }
-
-  private handleCustomSecondaryColor(e: CustomEvent<{ value: string }>) {
-    this.userSettings.setCustomSecondaryColor(e.detail.value);
   }
 
   private toggleGoToPlayer() {
@@ -854,33 +840,6 @@ export class UserSettingModal extends BaseModal {
         .checked=${this.userSettings.territoryPatterns()}
         @change=${this.toggleTerritoryPatterns}
       ></setting-toggle>
-
-      <!-- 🎨 Custom Territory Colors -->
-      <setting-toggle
-        label="Custom Territory Colors"
-        description="Override lobby settings and use your own colors"
-        id="custom-colors-toggle"
-        .checked=${this.userSettings.customColorsEnabled()}
-        @change=${this.toggleCustomColorsEnabled}
-      ></setting-toggle>
-
-      ${this.userSettings.customColorsEnabled()
-        ? html`
-            <setting-color
-              label="Primary Color"
-              description="The main fill color of your territory"
-              .value=${this.userSettings.customPrimaryColor()}
-              @change=${this.handleCustomPrimaryColor}
-            ></setting-color>
-            
-            <setting-color
-              label="Secondary Color"
-              description="The color of your borders"
-              .value=${this.userSettings.customSecondaryColor()}
-              @change=${this.handleCustomSecondaryColor}
-            ></setting-color>
-          `
-        : ""}
 
       <!-- 🔍 Go to player -->
       <setting-toggle

--- a/src/client/components/PlayPage.ts
+++ b/src/client/components/PlayPage.ts
@@ -1,10 +1,28 @@
 import { LitElement, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { assetUrl } from "../../core/AssetUrls";
+import { UserSettings } from "../../core/game/UserSettings";
+import "./baseComponents/setting/SettingToggle";
+import "./baseComponents/setting/SettingColor";
 import "./NewsBox";
 
 @customElement("play-page")
 export class PlayPage extends LitElement {
+  private userSettings = new UserSettings();
+
+  private toggleCustomColorsEnabled() {
+    this.userSettings.toggleCustomColorsEnabled();
+    this.requestUpdate();
+  }
+
+  private handleCustomPrimaryColor(e: CustomEvent<{ value: string }>) {
+    this.userSettings.setCustomPrimaryColor(e.detail.value);
+  }
+
+  private handleCustomSecondaryColor(e: CustomEvent<{ value: string }>) {
+    this.userSettings.setCustomSecondaryColor(e.detail.value);
+  }
+
   createRenderRoot() {
     return this;
   }
@@ -111,6 +129,35 @@ export class PlayPage extends LitElement {
               show-select-label
               class="flex-1 h-full"
             ></flag-input>
+          </div>
+
+          <!-- Custom Colors: full width row -->
+          <div class="lg:col-span-2 px-2 py-2 bg-surface border-y border-white/10 lg:rounded-xl lg:border-y-0">
+            <setting-toggle
+              label="Custom Territory Colors"
+              description="Override lobby settings and use your own colors"
+              id="custom-colors-toggle-main"
+              .checked=${this.userSettings.customColorsEnabled()}
+              @change=${this.toggleCustomColorsEnabled}
+            ></setting-toggle>
+
+            ${this.userSettings.customColorsEnabled()
+              ? html`
+                  <setting-color
+                    label="Primary Color"
+                    description="The main fill color of your territory"
+                    .value=${this.userSettings.customPrimaryColor()}
+                    @change=${this.handleCustomPrimaryColor}
+                  ></setting-color>
+                  
+                  <setting-color
+                    label="Secondary Color"
+                    description="The color of your borders"
+                    .value=${this.userSettings.customSecondaryColor()}
+                    @change=${this.handleCustomSecondaryColor}
+                  ></setting-color>
+                `
+              : ""}
           </div>
         </div>
 

--- a/src/client/components/PlayPage.ts
+++ b/src/client/components/PlayPage.ts
@@ -1,28 +1,11 @@
 import { LitElement, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { assetUrl } from "../../core/AssetUrls";
-import { UserSettings } from "../../core/game/UserSettings";
-import "./baseComponents/setting/SettingToggle";
-import "./baseComponents/setting/SettingColor";
+import "../ColorInput";
 import "./NewsBox";
 
 @customElement("play-page")
 export class PlayPage extends LitElement {
-  private userSettings = new UserSettings();
-
-  private toggleCustomColorsEnabled() {
-    this.userSettings.toggleCustomColorsEnabled();
-    this.requestUpdate();
-  }
-
-  private handleCustomPrimaryColor(e: CustomEvent<{ value: string }>) {
-    this.userSettings.setCustomPrimaryColor(e.detail.value);
-  }
-
-  private handleCustomSecondaryColor(e: CustomEvent<{ value: string }>) {
-    this.userSettings.setCustomSecondaryColor(e.detail.value);
-  }
-
   createRenderRoot() {
     return this;
   }
@@ -109,6 +92,11 @@ export class PlayPage extends LitElement {
                 adaptive-size
                 class="shrink-0 lg:hidden"
               ></pattern-input>
+              <!-- Color mode button (mobile) -->
+              <color-input
+                id="color-input-mobile"
+                class="shrink-0 lg:hidden h-10 w-10"
+              ></color-input>
               <flag-input
                 id="flag-input-mobile"
                 show-select-label
@@ -117,47 +105,23 @@ export class PlayPage extends LitElement {
             </div>
           </div>
 
-          <!-- Skin + flag: right col -->
+          <!-- Skin + Color + Flag: right col (desktop) -->
           <div class="hidden lg:flex h-[60px] gap-2">
             <pattern-input
               id="pattern-input-desktop"
               show-select-label
               class="flex-1 h-full"
             ></pattern-input>
+            <!-- Color mode button (desktop) — sits right next to skin -->
+            <color-input
+              id="color-input-desktop"
+              class="h-full w-[60px]"
+            ></color-input>
             <flag-input
               id="flag-input-desktop"
               show-select-label
               class="flex-1 h-full"
             ></flag-input>
-          </div>
-
-          <!-- Custom Colors: full width row -->
-          <div class="lg:col-span-2 px-2 py-2 bg-surface border-y border-white/10 lg:rounded-xl lg:border-y-0">
-            <setting-toggle
-              label="Custom Territory Colors"
-              description="Override lobby settings and use your own colors"
-              id="custom-colors-toggle-main"
-              .checked=${this.userSettings.customColorsEnabled()}
-              @change=${this.toggleCustomColorsEnabled}
-            ></setting-toggle>
-
-            ${this.userSettings.customColorsEnabled()
-              ? html`
-                  <setting-color
-                    label="Primary Color"
-                    description="The main fill color of your territory"
-                    .value=${this.userSettings.customPrimaryColor()}
-                    @change=${this.handleCustomPrimaryColor}
-                  ></setting-color>
-                  
-                  <setting-color
-                    label="Secondary Color"
-                    description="The color of your borders"
-                    .value=${this.userSettings.customSecondaryColor()}
-                    @change=${this.handleCustomSecondaryColor}
-                  ></setting-color>
-                `
-              : ""}
           </div>
         </div>
 

--- a/src/client/components/baseComponents/setting/SettingColor.ts
+++ b/src/client/components/baseComponents/setting/SettingColor.ts
@@ -1,0 +1,53 @@
+import { LitElement, html } from "lit";
+import { customElement, property } from "lit/decorators.js";
+
+@customElement("setting-color")
+export class SettingColor extends LitElement {
+  @property() label = "Color";
+  @property() description = "";
+  @property() value = "#000000";
+
+  createRenderRoot() {
+    return this;
+  }
+
+  private handleChange(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.value = input.value;
+    
+    // Dispatch an event so the parent component can listen to it
+    this.dispatchEvent(new CustomEvent("change", {
+      detail: { value: this.value },
+      bubbles: true,
+      composed: true
+    }));
+  }
+
+  render() {
+    return html`
+      <label
+        class="flex flex-row items-center justify-between w-full p-4 bg-white/5 border border-white/10 rounded-xl hover:bg-white/10 transition-all gap-4 cursor-pointer"
+      >
+        <div class="flex flex-col flex-1 min-w-0 mr-4">
+          <div class="text-white font-bold text-base block mb-1">
+            ${this.label}
+          </div>
+          <div class="text-white/50 text-sm leading-snug">
+            ${this.description}
+          </div>
+        </div>
+
+        <div class="relative shrink-0 flex items-center gap-2">
+          <div class="text-xs font-mono text-white/50">${this.value}</div>
+          <input
+            type="color"
+            class="h-8 w-8 cursor-pointer rounded-md bg-transparent border-0 p-0"
+            .value=${this.value}
+            @input=${this.handleChange}
+            @change=${this.handleChange}
+          />
+        </div>
+      </label>
+    `;
+  }
+}

--- a/src/client/graphics/layers/Leaderboard.ts
+++ b/src/client/graphics/layers/Leaderboard.ts
@@ -14,6 +14,8 @@ interface Entry {
   score: string;
   gold: string;
   maxTroops: string;
+  betrayals: string;
+  alliances: string;
   isMyPlayer: boolean;
   isOnSameTeam: boolean;
   player: PlayerView;
@@ -30,7 +32,10 @@ export class Leaderboard extends LitElement implements Layer {
   private showTopFive = true;
 
   @state()
-  private _sortKey: "tiles" | "gold" | "maxtroops" = "tiles";
+  private _viewState: "default" | "alliances" = "default";
+
+  @state()
+  private _sortKey: "tiles" | "gold" | "maxtroops" | "betrayals" | "alliances" = "tiles";
 
   @state()
   private _sortOrder: "asc" | "desc" = "desc";
@@ -57,7 +62,7 @@ export class Leaderboard extends LitElement implements Layer {
     this.updateLeaderboard();
   }
 
-  private setSort(key: "tiles" | "gold" | "maxtroops") {
+  private setSort(key: "tiles" | "gold" | "maxtroops" | "betrayals" | "alliances") {
     if (this._sortKey === key) {
       this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
     } else {
@@ -87,6 +92,12 @@ export class Leaderboard extends LitElement implements Layer {
       case "maxtroops":
         sorted = sorted.sort((a, b) => compare(maxTroops(a), maxTroops(b)));
         break;
+      case "betrayals":
+        sorted = sorted.sort((a, b) => compare(a.betrayals(), b.betrayals()));
+        break;
+      case "alliances":
+        sorted = sorted.sort((a, b) => compare(a.alliances().length, b.alliances().length));
+        break;
       default:
         sorted = sorted.sort((a, b) =>
           compare(a.numTilesOwned(), b.numTilesOwned()),
@@ -102,7 +113,7 @@ export class Leaderboard extends LitElement implements Layer {
       : alivePlayers;
 
     this.players = playersToShow.map((player, index) => {
-      const maxTroops = this.game!.config().maxTroops(player);
+      const pMaxTroops = this.game!.config().maxTroops(player);
       return {
         name: player.displayName(),
         position: index + 1,
@@ -110,7 +121,9 @@ export class Leaderboard extends LitElement implements Layer {
           player.numTilesOwned() / numTilesWithoutFallout,
         ),
         gold: renderNumber(player.gold()),
-        maxTroops: renderTroops(maxTroops),
+        maxTroops: renderTroops(pMaxTroops),
+        betrayals: player.betrayals().toString(),
+        alliances: player.alliances().length.toString(),
         isMyPlayer: player === myPlayer,
         isOnSameTeam:
           myPlayer !== null &&
@@ -142,6 +155,8 @@ export class Leaderboard extends LitElement implements Layer {
           ),
           gold: renderNumber(myPlayer.gold()),
           maxTroops: renderTroops(myPlayerMaxTroops),
+          betrayals: myPlayer.betrayals().toString(),
+          alliances: myPlayer.alliances().length.toString(),
           isMyPlayer: true,
           isOnSameTeam: true,
           player: myPlayer,
@@ -199,28 +214,38 @@ export class Leaderboard extends LitElement implements Layer {
                   : "⬇️"
                 : ""}
             </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("gold")}
-            >
-              ${translateText("leaderboard.gold")}
-              ${this._sortKey === "gold"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("maxtroops")}
-            >
-              ${translateText("leaderboard.maxtroops")}
-              ${this._sortKey === "maxtroops"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
+            
+            ${this._viewState === "default" ? html`
+              <div
+                class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+                @click=${() => this.setSort("gold")}
+              >
+                ${translateText("leaderboard.gold")}
+                ${this._sortKey === "gold" ? (this._sortOrder === "asc" ? "⬆️" : "⬇️") : ""}
+              </div>
+              <div
+                class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+                @click=${() => this.setSort("maxtroops")}
+              >
+                ${translateText("leaderboard.maxtroops")}
+                ${this._sortKey === "maxtroops" ? (this._sortOrder === "asc" ? "⬆️" : "⬇️") : ""}
+              </div>
+            ` : html`
+              <div
+                class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+                @click=${() => this.setSort("betrayals")}
+              >
+                Betrayals
+                ${this._sortKey === "betrayals" ? (this._sortOrder === "asc" ? "⬆️" : "⬇️") : ""}
+              </div>
+              <div
+                class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+                @click=${() => this.setSort("alliances")}
+              >
+                Alliances
+                ${this._sortKey === "alliances" ? (this._sortOrder === "asc" ? "⬆️" : "⬇️") : ""}
+              </div>
+            `}
           </div>
 
           ${repeat(
@@ -257,39 +282,53 @@ export class Leaderboard extends LitElement implements Layer {
                 >
                   ${player.score}
                 </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.gold}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.maxTroops}
-                </div>
+                
+                ${this._viewState === "default" ? html`
+                  <div class="py-1 md:py-2 text-center ${index < this.players.length - 1 ? "border-b border-slate-500" : ""}">
+                    ${player.gold}
+                  </div>
+                  <div class="py-1 md:py-2 text-center ${index < this.players.length - 1 ? "border-b border-slate-500" : ""}">
+                    ${player.maxTroops}
+                  </div>
+                ` : html`
+                  <div class="py-1 md:py-2 text-center ${index < this.players.length - 1 ? "border-b border-slate-500" : ""}">
+                    ${player.betrayals}
+                  </div>
+                  <div class="py-1 md:py-2 text-center ${index < this.players.length - 1 ? "border-b border-slate-500" : ""}">
+                    ${player.alliances}
+                  </div>
+                `}
               </div>
             `,
           )}
         </div>
       </div>
 
-      <button
-        class="mt-2 p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm 
-        border rounded-md border-slate-500 transition-colors
-        text-white mx-auto block hover:bg-white/10 bg-gray-700/50"
-        @click=${() => {
-          this.showTopFive = !this.showTopFive;
-          this.updateLeaderboard();
-        }}
-      >
-        ${this.showTopFive ? "+" : "-"}
-      </button>
+      <div class="flex justify-center gap-2 mt-2">
+        <button
+          class="p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm border rounded-md border-slate-500 transition-colors text-white block hover:bg-white/10 bg-gray-700/50"
+          @click=${() => {
+            this.showTopFive = !this.showTopFive;
+            this.updateLeaderboard();
+          }}
+        >
+          ${this.showTopFive ? "+" : "-"}
+        </button>
+        <button
+          class="p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm border rounded-md border-slate-500 transition-colors text-white block hover:bg-white/10 bg-gray-700/50"
+          @click=${() => {
+            this._viewState = this._viewState === "default" ? "alliances" : "default";
+            if (this._viewState === "alliances" && (this._sortKey === "gold" || this._sortKey === "maxtroops")) {
+              this._sortKey = "tiles";
+            } else if (this._viewState === "default" && (this._sortKey === "betrayals" || this._sortKey === "alliances")) {
+              this._sortKey = "tiles";
+            }
+            this.updateLeaderboard();
+          }}
+        >
+          ${this._viewState === "default" ? "Show Alliances" : "Show Stats"}
+        </button>
+      </div>
     `;
   }
 }

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -265,28 +265,37 @@ export class PlayerView {
       } satisfies ColorPalette;
     }
 
+    const isMyPlayer = this.game.myClientID() === this.data.clientID;
+
     if (this.team() === null) {
-      this._territoryColor = colord(
-        this.cosmetics.color?.color ??
-          pattern?.colorPalette?.primaryColor ??
-          defaultTerritoryColor.toHex(),
-      );
+      if (isMyPlayer && userSettings.customColorsEnabled()) {
+        this._territoryColor = colord(userSettings.customPrimaryColor());
+      } else {
+        this._territoryColor = colord(
+          this.cosmetics.color?.color ??
+            pattern?.colorPalette?.primaryColor ??
+            defaultTerritoryColor.toHex(),
+        );
+      }
     } else {
       this._territoryColor = defaultTerritoryColor;
     }
 
     this._structureColors = theme.structureColors(this._territoryColor);
 
-    const maybeFocusedBorderColor =
-      this.game.myClientID() === this.data.clientID
+    const maybeFocusedBorderColor = isMyPlayer
         ? theme.focusedBorderColor()
         : defaultBorderColor;
 
-    this._borderColor = new Colord(
-      pattern?.colorPalette?.secondaryColor ??
-        this.cosmetics.color?.color ??
-        maybeFocusedBorderColor.toHex(),
-    );
+    if (isMyPlayer && userSettings.customColorsEnabled()) {
+      this._borderColor = new Colord(userSettings.customSecondaryColor());
+    } else {
+      this._borderColor = new Colord(
+        pattern?.colorPalette?.secondaryColor ??
+          this.cosmetics.color?.color ??
+          maybeFocusedBorderColor.toHex(),
+      );
+    }
 
     // Pre-compute all border color variants once
     const baseRgb = this._borderColor.toRgb();
@@ -619,6 +628,9 @@ export class PlayerView {
 
   isTraitor(): boolean {
     return this.data.isTraitor;
+  }
+  betrayals(): number {
+    return this.data.betrayals;
   }
   getTraitorRemainingTicks(): number {
     return Math.max(0, this.data.traitorRemainingTicks ?? 0);

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -268,11 +268,11 @@ export class PlayerView {
     const isMyPlayer = this.game.myClientID() === this.data.clientID;
     const colorMode = isMyPlayer ? userSettings.colorMode() : "random";
 
-    if (colorMode === "custom") {
-      // Always use user's chosen color, even if in a team
+    if (colorMode === "custom" && this.team() === null) {
+      // Custom color only in solo/FFA — team games always use assigned team color
       this._territoryColor = colord(userSettings.customPrimaryColor());
-    } else if (colorMode === "team") {
-      // Force team color (default game behavior, team always wins)
+    } else if (colorMode === "team" || this.team() !== null) {
+      // Force team color (default game behavior)
       this._territoryColor = defaultTerritoryColor;
     } else {
       // "random" — normal game logic
@@ -293,7 +293,7 @@ export class PlayerView {
         ? theme.focusedBorderColor()
         : defaultBorderColor;
 
-    if (colorMode === "custom") {
+    if (colorMode === "custom" && this.team() === null) {
       this._borderColor = new Colord(userSettings.customSecondaryColor());
     } else {
       this._borderColor = new Colord(

--- a/src/core/game/GameView.ts
+++ b/src/core/game/GameView.ts
@@ -266,19 +266,25 @@ export class PlayerView {
     }
 
     const isMyPlayer = this.game.myClientID() === this.data.clientID;
+    const colorMode = isMyPlayer ? userSettings.colorMode() : "random";
 
-    if (this.team() === null) {
-      if (isMyPlayer && userSettings.customColorsEnabled()) {
-        this._territoryColor = colord(userSettings.customPrimaryColor());
-      } else {
+    if (colorMode === "custom") {
+      // Always use user's chosen color, even if in a team
+      this._territoryColor = colord(userSettings.customPrimaryColor());
+    } else if (colorMode === "team") {
+      // Force team color (default game behavior, team always wins)
+      this._territoryColor = defaultTerritoryColor;
+    } else {
+      // "random" — normal game logic
+      if (this.team() === null) {
         this._territoryColor = colord(
           this.cosmetics.color?.color ??
             pattern?.colorPalette?.primaryColor ??
             defaultTerritoryColor.toHex(),
         );
+      } else {
+        this._territoryColor = defaultTerritoryColor;
       }
-    } else {
-      this._territoryColor = defaultTerritoryColor;
     }
 
     this._structureColors = theme.structureColors(this._territoryColor);
@@ -287,7 +293,7 @@ export class PlayerView {
         ? theme.focusedBorderColor()
         : defaultBorderColor;
 
-    if (isMyPlayer && userSettings.customColorsEnabled()) {
+    if (colorMode === "custom") {
       this._borderColor = new Colord(userSettings.customSecondaryColor());
     } else {
       this._borderColor = new Colord(

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -237,6 +237,30 @@ export class UserSettings {
     this.setBool(DARK_MODE_KEY, !this.darkMode());
   }
 
+  customColorsEnabled() {
+    return this.getBool("settings.customColorsEnabled", false);
+  }
+
+  toggleCustomColorsEnabled() {
+    this.setBool("settings.customColorsEnabled", !this.customColorsEnabled());
+  }
+
+  customPrimaryColor(): string {
+    return this.getString("settings.customPrimaryColor", "#2196f3");
+  }
+
+  setCustomPrimaryColor(color: string): void {
+    this.setString("settings.customPrimaryColor", color);
+  }
+
+  customSecondaryColor(): string {
+    return this.getString("settings.customSecondaryColor", "#1565c0");
+  }
+
+  setCustomSecondaryColor(color: string): void {
+    this.setString("settings.customSecondaryColor", color);
+  }
+
   // For development only. Used for testing patterns, set in the console manually.
   getDevOnlyPattern(): PlayerPattern | undefined {
     const data = localStorage.getItem("dev-pattern") ?? undefined;

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -237,12 +237,24 @@ export class UserSettings {
     this.setBool(DARK_MODE_KEY, !this.darkMode());
   }
 
-  customColorsEnabled() {
-    return this.getBool("settings.customColorsEnabled", false);
+  // Color mode: "random" = game default, "custom" = user picks, "team" = always use team color
+  colorMode(): "random" | "custom" | "team" {
+    const val = this.getString("settings.colorMode", "random");
+    if (val === "custom" || val === "team") return val;
+    return "random";
+  }
+
+  setColorMode(mode: "random" | "custom" | "team"): void {
+    this.setString("settings.colorMode", mode);
+  }
+
+  // Keep legacy helpers so GameView still compiles
+  customColorsEnabled(): boolean {
+    return this.colorMode() === "custom";
   }
 
   toggleCustomColorsEnabled() {
-    this.setBool("settings.customColorsEnabled", !this.customColorsEnabled());
+    this.setColorMode(this.colorMode() === "custom" ? "random" : "custom");
   }
 
   customPrimaryColor(): string {


### PR DESCRIPTION
## Description:

Adds two new features to improve the gameplay experience:

**1. Custom Territory Colors**
- A new color button on the main menu (next to the Skin button) lets players choose their territory color
- Cycles through 3 modes: 🎲 Random (default), 🎨 Custom (pick your own color), 🤝 Team (use team color)
- Custom color is ignored in team games — team colors always take priority

**2. Alliance Stats on Leaderboard**
- A "Show Alliances" button on the leaderboard swaps Gold/Troops columns for:
  - **Betrayals** — how many times a player broke an alliance
  - **Alliances** — how many active alliances they currently have
- Both columns are sortable

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Discord: 100_snankes_93529
