### PR TITLE
fix(game): patch Winner Spoofing vulnerability with strict majority consensus

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -610,6 +610,9 @@ export class GameServer {
           }
           this._hasEnded = true;
         }
+      } else {
+        // Check if remaining clients have reached a winner consensus
+        this.checkWinnerConsensus();
       }
     });
     client.ws.on("error", (error: Error) => {
@@ -1263,7 +1266,7 @@ export class GameServer {
       },
     );
 
-    if (potentialWinner.ips.size * 2 < activeUniqueIPs.size) {
+    if (potentialWinner.ips.size * 2 <= activeUniqueIPs.size) {
       return;
     }
 
@@ -1276,5 +1279,27 @@ export class GameServer {
       },
     );
     this.archiveGame();
+  }
+
+  private checkWinnerConsensus() {
+    if (this.winner !== null) {
+      return;
+    }
+
+    const activeUniqueIPs = new Set(this.activeClients.map((c) => c.ip));
+
+    for (const [winnerKey, potentialWinner] of this.winnerVotes.entries()) {
+      if (potentialWinner.ips.size * 2 > activeUniqueIPs.size) {
+        this.winner = potentialWinner.winner;
+        this.log.info(
+          `Winner determined by ${potentialWinner.ips.size}/${activeUniqueIPs.size} active IPs after client disconnect`,
+          {
+            winnerKey: winnerKey,
+          },
+        );
+        this.archiveGame();
+        return;
+      }
+    }
   }
 }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -610,7 +610,7 @@ export class GameServer {
           }
           this._hasEnded = true;
         }
-      } else {
+      } else if (!this._hasEnded) {
         // Check if remaining clients have reached a winner consensus
         this.checkWinnerConsensus();
       }
@@ -1257,8 +1257,11 @@ export class GameServer {
     potentialWinner.ips.add(client.ip);
 
     const activeUniqueIPs = new Set(this.activeClients.map((c) => c.ip));
+    const activeVotes = [...potentialWinner.ips].filter((ip) =>
+      activeUniqueIPs.has(ip),
+    ).length;
 
-    const ratio = `${potentialWinner.ips.size}/${activeUniqueIPs.size}`;
+    const ratio = `${activeVotes}/${activeUniqueIPs.size}`;
     this.log.info(
       `received winner vote ${clientMsg.winner}, ${ratio} votes for this winner`,
       {
@@ -1266,14 +1269,14 @@ export class GameServer {
       },
     );
 
-    if (potentialWinner.ips.size * 2 <= activeUniqueIPs.size) {
+    if (activeVotes * 2 <= activeUniqueIPs.size) {
       return;
     }
 
     // Vote succeeded
     this.winner = potentialWinner.winner;
     this.log.info(
-      `Winner determined by ${potentialWinner.ips.size}/${activeUniqueIPs.size} active IPs`,
+      `Winner determined by ${activeVotes}/${activeUniqueIPs.size} active IPs`,
       {
         winnerKey: winnerKey,
       },
@@ -1282,17 +1285,23 @@ export class GameServer {
   }
 
   private checkWinnerConsensus() {
-    if (this.winner !== null) {
+    if (this.winner !== null || this._hasEnded) {
       return;
     }
 
     const activeUniqueIPs = new Set(this.activeClients.map((c) => c.ip));
+    if (activeUniqueIPs.size === 0) {
+      return;
+    }
 
     for (const [winnerKey, potentialWinner] of this.winnerVotes.entries()) {
-      if (potentialWinner.ips.size * 2 > activeUniqueIPs.size) {
+      const activeVotes = [...potentialWinner.ips].filter((ip) =>
+        activeUniqueIPs.has(ip),
+      ).length;
+      if (activeVotes * 2 > activeUniqueIPs.size) {
         this.winner = potentialWinner.winner;
         this.log.info(
-          `Winner determined by ${potentialWinner.ips.size}/${activeUniqueIPs.size} active IPs after client disconnect`,
+          `Winner determined by ${activeVotes}/${activeUniqueIPs.size} active IPs after client disconnect`,
           {
             winnerKey: winnerKey,
           },

--- a/tests/server/WinnerConsensus.test.ts
+++ b/tests/server/WinnerConsensus.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/core/Schemas", async () => {
+  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
+  return {
+    ...actual,
+    GameStartInfoSchema: {
+      safeParse: (data: any) => ({ success: true, data: data }),
+    },
+    ServerPrestartMessageSchema: {
+      safeParse: (data: any) => ({ success: true, data: data }),
+    },
+    ClientMessageSchema: {
+      safeParse: (data: any) => ({ success: true, data: data }),
+    },
+  };
+});
+
+import { GameType } from "../../src/core/game/Game";
+import { Client } from "../../src/server/Client";
+import { GameServer } from "../../src/server/GameServer";
+
+function makeMockWs() {
+  const handlers: Record<string, (...args: any[]) => any> = {};
+  return {
+    on: (event: string, handler: (...args: any[]) => any) => {
+      handlers[event] = handler;
+    },
+    removeAllListeners: (_event: string) => {},
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    trigger: (event: string, ...args: any[]) => handlers[event]?.(...args),
+  };
+}
+
+function makeClient(
+  clientID: string,
+  persistentID: string,
+  ip: string = "127.0.0.1",
+): { client: Client; ws: ReturnType<typeof makeMockWs> } {
+  const ws = makeMockWs();
+  const client = new Client(
+    clientID,
+    persistentID,
+    null,
+    null,
+    undefined,
+    ip,
+    "TestUser",
+    null,
+    ws as any,
+    undefined,
+    undefined,
+    [],
+  );
+  return { client, ws };
+}
+
+describe("GameServer - winner consensus validation", () => {
+  let mockLogger: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  function makeGame() {
+    const game = new GameServer("test-game", mockLogger, Date.now(), {
+      gameType: GameType.Private,
+    } as any);
+    // Mock archiveGame so we don't hit external calls
+    (game as any).archiveGame = vi.fn();
+    return game;
+  }
+
+  it("1v1 match with two active players does not allow winner spoofing by a single player", async () => {
+    const game = makeGame();
+    // Simulate game starting so start logic is covered
+    game.start();
+
+    const { client: playerA, ws: wsA } = makeClient(
+      "cid-a",
+      "pid-a",
+      "1.1.1.1",
+    );
+    const { client: playerB } = makeClient("cid-b", "pid-b", "2.2.2.2");
+
+    game.joinClient(playerA);
+    game.joinClient(playerB);
+
+    // Player A votes for themselves as winner
+    await wsA.trigger(
+      "message",
+      JSON.stringify({
+        type: "winner",
+        winner: ["player", "cid-a"],
+        allPlayersStats: {},
+      }),
+    );
+
+    // Expect no winner determined yet (requires consensus or disconnect)
+    expect((game as any).winner).toBeNull();
+    expect((game as any).archiveGame).not.toHaveBeenCalled();
+  });
+
+  it("1v1 match with two active players determines winner when both agree", async () => {
+    const game = makeGame();
+    game.start();
+
+    const { client: playerA, ws: wsA } = makeClient(
+      "cid-a",
+      "pid-a",
+      "1.1.1.1",
+    );
+    const { client: playerB, ws: wsB } = makeClient(
+      "cid-b",
+      "pid-b",
+      "2.2.2.2",
+    );
+
+    game.joinClient(playerA);
+    game.joinClient(playerB);
+
+    // Both vote for player A
+    const winnerMsg = {
+      type: "winner",
+      winner: ["player", "cid-a"],
+      allPlayersStats: {},
+    };
+
+    await wsA.trigger("message", JSON.stringify(winnerMsg));
+    expect((game as any).winner).toBeNull();
+
+    await wsB.trigger("message", JSON.stringify(winnerMsg));
+
+    // Consensus reached!
+    expect((game as any).winner).toBeDefined();
+    expect((game as any).winner).not.toBeNull();
+    expect((game as any).winner?.winner).toEqual(["player", "cid-a"]);
+    expect((game as any).archiveGame).toHaveBeenCalledOnce();
+  });
+
+  it("when player B disconnects, player A's pending winner vote is immediately processed and resolved", async () => {
+    const game = makeGame();
+    game.start();
+
+    const { client: playerA, ws: wsA } = makeClient(
+      "cid-a",
+      "pid-a",
+      "1.1.1.1",
+    );
+    const { client: playerB, ws: wsB } = makeClient(
+      "cid-b",
+      "pid-b",
+      "2.2.2.2",
+    );
+
+    game.joinClient(playerA);
+    game.joinClient(playerB);
+
+    // Player A votes for themselves
+    await wsA.trigger(
+      "message",
+      JSON.stringify({
+        type: "winner",
+        winner: ["player", "cid-a"],
+        allPlayersStats: {},
+      }),
+    );
+    expect((game as any).winner).toBeNull();
+
+    // Player B disconnects
+    await wsB.trigger("close");
+
+    // The single remaining player A has the strict majority (1/1)
+    expect((game as any).winner).toBeDefined();
+    expect((game as any).winner).not.toBeNull();
+    expect((game as any).winner?.winner).toEqual(["player", "cid-a"]);
+    expect((game as any).archiveGame).toHaveBeenCalledOnce();
+  });
+
+  it("prevents Sybil attacks: multiple connections from the same IP are collapsed into one vote", async () => {
+    const game = makeGame();
+    game.start();
+
+    // Player A and their clone connect from the same IP
+    const { client: playerA, ws: wsA } = makeClient(
+      "cid-a",
+      "pid-a",
+      "1.1.1.1",
+    );
+    const { client: playerAClone, ws: wsAClone } = makeClient(
+      "cid-a-clone",
+      "pid-a-clone",
+      "1.1.1.1",
+    );
+    const { client: playerB } = makeClient("cid-b", "pid-b", "2.2.2.2");
+
+    game.joinClient(playerA);
+    game.joinClient(playerAClone);
+    game.joinClient(playerB);
+
+    // Both A and their clone vote for A
+    const winnerMsg = {
+      type: "winner",
+      winner: ["player", "cid-a"],
+      allPlayersStats: {},
+    };
+
+    await wsA.trigger("message", JSON.stringify(winnerMsg));
+    await wsAClone.trigger("message", JSON.stringify(winnerMsg));
+
+    // Even though there are 2 votes, since they share the same IP, they collapse to 1 unique IP vote.
+    // Out of 2 unique active IPs ("1.1.1.1" and "2.2.2.2"), 1 vote does not make a strict majority (1 * 2 <= 2).
+    expect((game as any).winner).toBeNull();
+    expect((game as any).archiveGame).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Resolves #3958

## Description:

This PR fixes a critical "Winner Spoofing" vulnerability in 1v1 matches. Previously, a malicious client could send a `winner` message to force an immediate win because the voting logic (`potentialWinner.ips.size * 2 < activeUniqueIPs.size`) failed to return in a 1v1 scenario (1 * 2 < 2 evaluates to false), bypassing intended consensus. 

The logic has been updated to require a **strict majority** consensus (`potentialWinner.ips.size * 2 <= activeUniqueIPs.size`). In a 1v1 game, a single vote will no longer trigger an immediate win. Furthermore, to prevent legitimate wins from being stuck if a losing player rage-quits before voting, a new `checkWinnerConsensus()` routine runs on client disconnects to automatically declare a win if the remaining votes constitute a strict majority.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
