### PR TITLE
Sound error fixed

### DIFF
--- a/src/client/graphics/layers/GameRightSidebar.ts
+++ b/src/client/graphics/layers/GameRightSidebar.ts
@@ -1,3 +1,4 @@
+import { Howler } from "howler";
 import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { assetUrl } from "../../../core/AssetUrls";
@@ -174,13 +175,32 @@ export class GameRightSidebar extends LitElement implements Layer {
     this.eventBus.emit(new PauseGameIntentEvent(this.isPaused));
   }
 
+  private resumeAudioContext() {
+    if (Howler.ctx?.state === "suspended") {
+      void Howler.ctx.resume();
+    }
+  }
+
   private async onExitButtonClick() {
     const isAlive = this.game.myPlayer()?.isAlive();
     if (isAlive) {
       const isConfirmed = confirm(
         translateText("help_modal.exit_confirmation"),
       );
-      if (!isConfirmed) return;
+      if (!isConfirmed) {
+        // The native confirm() dialog asynchronously blurs the window, which
+        // makes Chrome suspend Howler's Web Audio context *after* confirm()
+        // returns (it is still "running" synchronously here). On confirm we
+        // reload so it doesn't matter, but on cancel we must resume it once
+        // the suspend has landed, or music and sound effects stay silent for
+        // the rest of the game. Resume on focus return (fast path) plus a
+        // timeout fallback in case the suspend lands after the focus event.
+        window.addEventListener("focus", () => this.resumeAudioContext(), {
+          once: true,
+        });
+        setTimeout(() => this.resumeAudioContext(), 1000);
+        return;
+      }
     }
     await crazyGamesSDK.requestMidgameAd();
     await crazyGamesSDK.gameplayStop();


### PR DESCRIPTION
## Description:

**Sound bug fixed: When the button to exit a game is clicked and the action is canceled in the confirmation dialog, the background music and sound effects stop playing for the rest of the game.**

Clicking "Exit" brings up a native browser confirmation dialog. This dialog causes the window to lose focus, and the browser takes the opportunity to suspend Howler's audio context. The curious thing is that this suspension doesn't happen while the dialog is open, but right after closing it. If you confirmed, it wasn't noticeable because the page reloaded anyway. But if you canceled, you were left in the game with the audio suspended, and nothing could reactivate it, so the music and sound effects were muted for the rest of the game.

Canceling simply resumes the audio if it was paused. Since the pause occurs a moment late, it's not enough to do it immediately; we do it when the window regains focus (which is precisely when the dialogue closes) and, **just in case**, with a short timer backup. This way, the sound returns automatically and the game continues normally.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

sardidefcon
