### PR TITLE
Restore dev-only localStorage pattern override

### DIFF
--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -496,7 +496,15 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
     result.flag = await resolveFlagUrl(refs.flag);
   }
 
-  if (refs.patternName && cosmetics) {
+  const devPattern = new UserSettings().getDevOnlyPattern();
+
+  if (devPattern) {
+    result.pattern = {
+      name: devPattern.name,
+      patternData: devPattern.patternData,
+      colorPalette: devPattern.colorPalette,
+    };
+  } else if (refs.patternName && cosmetics) {
     const pattern = cosmetics.patterns[refs.patternName];
 
     if (pattern) {
@@ -506,16 +514,6 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
         colorPalette: refs.patternColorPaletteName
           ? cosmetics.colorPalettes?.[refs.patternColorPaletteName]
           : undefined,
-      };
-    }
-  } else {
-    const devPattern = new UserSettings().getDevOnlyPattern();
-
-    if (devPattern) {
-      result.pattern = {
-        name: devPattern.name,
-        patternData: devPattern.patternData,
-        colorPalette: devPattern.colorPalette,
       };
     }
   }

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -239,8 +239,6 @@ export class UserSettings {
 
   // For development only. Used for testing patterns, set in the console manually.
   getDevOnlyPattern(): PlayerPattern | undefined {
-    if (process.env.GAME_ENV !== "dev") return undefined;
-
     const data = localStorage.getItem("dev-pattern") ?? undefined;
     if (data === undefined) return undefined;
     return {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -239,6 +239,8 @@ export class UserSettings {
 
   // For development only. Used for testing patterns, set in the console manually.
   getDevOnlyPattern(): PlayerPattern | undefined {
+    if (process.env.GAME_ENV !== "dev") return undefined;
+
     const data = localStorage.getItem("dev-pattern") ?? undefined;
     if (data === undefined) return undefined;
     return {


### PR DESCRIPTION
If this PR fixes an issue, link it below. If not, delete these two lines.
Resolves #(issue number)

## Description:

Restore the localStorage-driven dev pattern override for development environments


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri