### PR TITLE
Optimize Max Troops leaderboard

### DIFF
--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -80,7 +80,8 @@ export class Leaderboard extends LitElement implements Controller {
     const maxTroopsMap = new Map<PlayerID, number>();
     const maxTroopsCalc = (p: PlayerView) => this.game!.config().maxTroops(p);
     const maxTroops = (p: PlayerView) => {
-      if (p.id() in maxTroopsMap) return maxTroopsMap.get(p.id())!;
+      const potential = maxTroopsMap.get(p.id());
+      if (potential !== undefined) return potential;
       const result = maxTroopsCalc(p);
       maxTroopsMap.set(p.id(), result);
       return result;

--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -1,6 +1,7 @@
 import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { PlayerID } from "src/core/game/Game";
 import { renderTroops, translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
 import { GameView, PlayerView } from "../../../core/game/GameView";
@@ -78,6 +79,11 @@ export class Leaderboard extends LitElement implements Controller {
 
     const maxTroops = (p: PlayerView) => this.game!.config().maxTroops(p);
 
+    const maxTroopsMap = new Map<PlayerID, number>();
+    for (const player of sorted) {
+      maxTroopsMap.set(player.id(), maxTroops(player));
+    }
+
     switch (this._sortKey) {
       case "gold":
         sorted = sorted.sort((a, b) =>
@@ -85,7 +91,9 @@ export class Leaderboard extends LitElement implements Controller {
         );
         break;
       case "maxtroops":
-        sorted = sorted.sort((a, b) => compare(maxTroops(a), maxTroops(b)));
+        sorted = sorted.sort((a, b) =>
+          compare(maxTroopsMap.get(a.id())!, maxTroopsMap.get(b.id())!),
+        );
         break;
       default:
         sorted = sorted.sort((a, b) =>
@@ -102,7 +110,7 @@ export class Leaderboard extends LitElement implements Controller {
       : alivePlayers;
 
     this.players = playersToShow.map((player, index) => {
-      const maxTroops = this.game!.config().maxTroops(player);
+      const maxTroops = maxTroopsMap.get(player.id())!;
       return {
         name: player.displayName(),
         position: index + 1,
@@ -132,7 +140,7 @@ export class Leaderboard extends LitElement implements Controller {
       }
 
       if (myPlayer.isAlive()) {
-        const myPlayerMaxTroops = this.game!.config().maxTroops(myPlayer);
+        const myPlayerMaxTroops = maxTroopsMap.get(myPlayer.id())!;
         this.players.pop();
         this.players.push({
           name: myPlayer.displayName(),
@@ -274,7 +282,7 @@ export class Leaderboard extends LitElement implements Controller {
       </div>
 
       <button
-        class="mt-2 p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm 
+        class="mt-2 p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm
         border rounded-md border-slate-500 transition-colors
         text-white mx-auto block hover:bg-white/10 bg-gray-700/50"
         @click=${() => {

--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -77,12 +77,14 @@ export class Leaderboard extends LitElement implements Controller {
     const compare = (a: number, b: number) =>
       this._sortOrder === "asc" ? a - b : b - a;
 
-    const maxTroops = (p: PlayerView) => this.game!.config().maxTroops(p);
-
     const maxTroopsMap = new Map<PlayerID, number>();
-    for (const player of sorted) {
-      maxTroopsMap.set(player.id(), maxTroops(player));
-    }
+    const maxTroopsCalc = (p: PlayerView) => this.game!.config().maxTroops(p);
+    const maxTroops = (p: PlayerView) => {
+      if (p.id() in maxTroopsMap) return maxTroopsMap.get(p.id())!;
+      const result = maxTroopsCalc(p);
+      maxTroopsMap.set(p.id(), result);
+      return result;
+    };
 
     switch (this._sortKey) {
       case "gold":
@@ -91,6 +93,11 @@ export class Leaderboard extends LitElement implements Controller {
         );
         break;
       case "maxtroops":
+        for (const player of sorted) {
+          maxTroopsMap.set(player.id(), maxTroopsCalc(player));
+        }
+
+        // We know that these exist in the map so we can omit the check
         sorted = sorted.sort((a, b) =>
           compare(maxTroopsMap.get(a.id())!, maxTroopsMap.get(b.id())!),
         );
@@ -110,7 +117,6 @@ export class Leaderboard extends LitElement implements Controller {
       : alivePlayers;
 
     this.players = playersToShow.map((player, index) => {
-      const maxTroops = maxTroopsMap.get(player.id())!;
       return {
         name: player.displayName(),
         position: index + 1,
@@ -118,7 +124,7 @@ export class Leaderboard extends LitElement implements Controller {
           player.numTilesOwned() / numTilesWithoutFallout,
         ),
         gold: renderNumber(player.gold()),
-        maxTroops: renderTroops(maxTroops),
+        maxTroops: renderTroops(maxTroops(player)),
         isMyPlayer: player === myPlayer,
         isOnSameTeam:
           myPlayer !== null &&
@@ -140,7 +146,6 @@ export class Leaderboard extends LitElement implements Controller {
       }
 
       if (myPlayer.isAlive()) {
-        const myPlayerMaxTroops = maxTroopsMap.get(myPlayer.id())!;
         this.players.pop();
         this.players.push({
           name: myPlayer.displayName(),
@@ -149,7 +154,7 @@ export class Leaderboard extends LitElement implements Controller {
             myPlayer.numTilesOwned() / this.game.numLandTiles(),
           ),
           gold: renderNumber(myPlayer.gold()),
-          maxTroops: renderTroops(myPlayerMaxTroops),
+          maxTroops: renderTroops(maxTroops(myPlayer)),
           isMyPlayer: true,
           isOnSameTeam: true,
           player: myPlayer,


### PR DESCRIPTION
Cache maxTroops for each playerID
This significantly speeds up leaderboard calculations (especially when maxtroops is selected)

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

icyhenryt
