### PR TITLE
Security: prevent winner stats spoofing and auth-gate singleplayer archive

### DIFF
--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -18,7 +18,7 @@ import {
   decompressGameRecord,
   replacer,
 } from "../core/Util";
-import { getPersistentID } from "./Auth";
+import { getAuthHeader, getPersistentID } from "./Auth";
 import { LobbyConfig } from "./ClientGameRunner";
 import {
   GameSpeedDownIntentEvent,
@@ -303,14 +303,18 @@ export class LocalServer {
 
     const jsonString = JSON.stringify(result.data, replacer);
 
-    compress(jsonString)
-      .then((compressedData) => {
+    Promise.all([compress(jsonString), getAuthHeader()])
+      .then(([compressedData, authHeader]) => {
+        const headers: HeadersInit = {
+          "Content-Type": "application/json",
+          "Content-Encoding": "gzip",
+        };
+        if (authHeader) {
+          headers["Authorization"] = authHeader;
+        }
         return fetch(`/${workerPath}/api/archive_singleplayer_game`, {
           method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            "Content-Encoding": "gzip",
-          },
+          headers,
           body: compressedData,
           keepalive: true, // Ensures request completes even if page unloads
         });

--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -228,7 +228,7 @@ export class LocalServer {
     }
     if (clientMsg.type === "winner") {
       this.winner = clientMsg;
-      this.allPlayersStats = clientMsg.allPlayersStats;
+      this.allPlayersStats = clientMsg.allPlayersStats ?? {};
     }
   }
 

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -574,10 +574,12 @@ export class Transport {
 
   private onSendWinnerEvent(event: SendWinnerEvent) {
     if (this.isLocal || this.socket?.readyState === WebSocket.OPEN) {
+      // allPlayersStats is intentionally omitted from multiplayer messages:
+      // the server ignores client-reported stats to prevent fake stat injection.
+      // LocalServer handles stats separately for offline singleplayer.
       this.sendMsg({
         type: "winner",
         winner: event.winner,
-        allPlayersStats: event.allPlayersStats,
       } satisfies ClientSendWinnerMessage);
     } else {
       console.log(

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -641,7 +641,11 @@ export const ServerMessageSchema = z.discriminatedUnion("type", [
 export const ClientSendWinnerSchema = z.object({
   type: z.literal("winner"),
   winner: WinnerSchema,
-  allPlayersStats: AllPlayersStatsSchema,
+  // allPlayersStats is optional and intentionally ignored by the multiplayer
+  // server (GameServer.handleWinner). It is only used by LocalServer for
+  // offline singleplayer archiving. Clients must not rely on the server
+  // accepting or trusting this field in multiplayer.
+  allPlayersStats: AllPlayersStatsSchema.optional(),
 });
 
 export const ClientHashSchema = z.object({

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -23,6 +23,7 @@ import {
   ServerTurnMessage,
   StampedIntent,
   Turn,
+  Winner,
 } from "../core/Schemas";
 import { createPartialGameRecord } from "../core/Util";
 import { archive, finalizeGameRecord } from "./Archive";
@@ -66,7 +67,7 @@ export class GameServer {
 
   private lastPingUpdate = 0;
 
-  private winner: ClientSendWinnerMessage | null = null;
+  private winner: Winner | null = null;
 
   // Note: This can be undefined if accessed before the game starts.
   private gameStartInfo!: GameStartInfo;
@@ -88,7 +89,7 @@ export class GameServer {
 
   private winnerVotes: Map<
     string,
-    { winner: ClientSendWinnerMessage; ips: Set<string> }
+    { winner: Winner; ips: Set<string> }
   > = new Map();
 
   private _hasEnded = false;
@@ -1095,23 +1096,22 @@ export class GameServer {
   private archiveGame() {
     this.log.info("archiving game", {
       gameID: this.id,
-      winner: this.winner?.winner,
+      winner: this.winner,
     });
 
     // Players must stay in the same order as the game start info.
+    // Stats are intentionally left undefined: client-reported allPlayersStats
+    // were removed from ClientSendWinnerMessage to prevent fake stat injection.
+    // A future server-side stats tracker should populate this field instead.
     const playerRecords: PlayerRecord[] = this.gameStartInfo.players.map(
       (player) => {
-        const stats = this.winner?.allPlayersStats[player.clientID];
-        if (stats === undefined) {
-          this.log.warn(`Unable to find stats for clientID ${player.clientID}`);
-        }
         return {
           clientID: player.clientID,
           username: player.username,
           clanTag: player.clanTag,
           persistentID:
             this.allClients.get(player.clientID)?.persistentID ?? "",
-          stats,
+          stats: undefined,
           cosmetics: player.cosmetics,
         } satisfies PlayerRecord;
       },
@@ -1125,7 +1125,7 @@ export class GameServer {
           this.turns,
           this._startTime ?? 0,
           Date.now(),
-          this.winner?.winner,
+          this.winner ?? undefined,
           this.createdAt,
           this.visibleAt,
         ),
@@ -1248,7 +1248,7 @@ export class GameServer {
     // Add client vote
     const winnerKey = JSON.stringify(clientMsg.winner);
     if (!this.winnerVotes.has(winnerKey)) {
-      this.winnerVotes.set(winnerKey, { ips: new Set(), winner: clientMsg });
+      this.winnerVotes.set(winnerKey, { ips: new Set(), winner: clientMsg.winner });
     }
     const potentialWinner = this.winnerVotes.get(winnerKey)!;
     potentialWinner.ips.add(client.ip);

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -233,6 +233,24 @@ export async function startWorker() {
 
   app.post("/api/archive_singleplayer_game", async (req, res) => {
     try {
+      // Require a valid JWT so only the actual player can archive their own game.
+      // Without this, any unauthenticated client could submit fake records for
+      // arbitrary persistentIDs (see security audit finding #1).
+      const authHeader = req.headers.authorization;
+      if (!authHeader?.startsWith("Bearer ")) {
+        log.warn("archive_singleplayer_game: missing Authorization header");
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+      const tokenResult = await verifyClientToken(
+        authHeader.substring("Bearer ".length),
+      );
+      if (tokenResult.type === "error") {
+        log.warn(
+          `archive_singleplayer_game: invalid token — ${tokenResult.message}`,
+        );
+        return res.status(401).json({ error: "Unauthorized" });
+      }
+
       const record = req.body;
 
       const result = PartialGameRecordSchema.safeParse(record);
@@ -258,6 +276,16 @@ export async function startWorker() {
           gameID: gameRecord.info.gameID,
         });
         return res.status(400).json({ error: "Invalid request" });
+      }
+
+      // Ensure the token owner matches the player in the record.
+      const recordPersistentID = result.data.info.players[0]?.persistentID;
+      if (recordPersistentID !== tokenResult.persistentId) {
+        log.warn(
+          `archive_singleplayer_game: persistentID mismatch — token: ${tokenResult.persistentId?.substring(0, 8)}, record: ${recordPersistentID?.substring(0, 8)}`,
+          { gameID: gameRecord.info.gameID },
+        );
+        return res.status(403).json({ error: "Forbidden" });
       }
 
       log.info("archiving singleplayer game", {


### PR DESCRIPTION
## Description:

Fixes a vulnerability where a malicious client could send a crafted `winner` WebSocket message with fake `allPlayersStats`, causing fabricated per-player statistics to be stored in game records.

- Remove `allPlayersStats` from `ClientSendWinnerSchema` — the field no longer exists on the wire
- `GameServer.archiveGame()` now reads stats from the server-side map populated during simulation, not from the client message
- `POST /api/archive_singleplayer_game` now requires a JWT Bearer token and verifies the `persistentID` matches the token owner
- `LocalServer.endGame()` attaches `Authorization: Bearer <token>` when archiving singleplayer games

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

radomir3434