### PR TITLE
Standarize map names across info and manifest jsons

### DIFF
--- a/map-generator/assets/maps/bajacalifornia/info.json
+++ b/map-generator/assets/maps/bajacalifornia/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "bajacalifornia",
+  "name": "Baja California",
   "nations": [
     {
       "coordinates": [513, 44],

--- a/map-generator/assets/maps/greatlakes/info.json
+++ b/map-generator/assets/maps/greatlakes/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "greatlakes",
+  "name": "Great Lakes",
   "nations": [
     {
       "coordinates": [38, 326],

--- a/map-generator/assets/maps/milkyway/info.json
+++ b/map-generator/assets/maps/milkyway/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "milkyway",
+  "name": "Milky Way",
   "nations": [
     {
       "coordinates": [775, 757],

--- a/map-generator/assets/maps/southamerica/info.json
+++ b/map-generator/assets/maps/southamerica/info.json
@@ -1,5 +1,5 @@
 {
-  "name": "Americas",
+  "name": "South America",
   "nations": [
     {
       "coordinates": [438, 58],

--- a/resources/maps/bajacalifornia/manifest.json
+++ b/resources/maps/bajacalifornia/manifest.json
@@ -14,7 +14,7 @@
     "num_land_tiles": 331582,
     "width": 900
   },
-  "name": "bajacalifornia",
+  "name": "Baja California",
   "nations": [
     {
       "coordinates": [513, 44],

--- a/resources/maps/greatlakes/manifest.json
+++ b/resources/maps/greatlakes/manifest.json
@@ -14,7 +14,7 @@
     "num_land_tiles": 476275,
     "width": 1000
   },
-  "name": "greatlakes",
+  "name": "Great Lakes",
   "nations": [
     {
       "coordinates": [38, 326],

--- a/resources/maps/milkyway/manifest.json
+++ b/resources/maps/milkyway/manifest.json
@@ -14,7 +14,7 @@
     "num_land_tiles": 105978,
     "width": 750
   },
-  "name": "milkyway",
+  "name": "Milky Way",
   "nations": [
     {
       "coordinates": [775, 757],

--- a/resources/maps/southamerica/manifest.json
+++ b/resources/maps/southamerica/manifest.json
@@ -14,7 +14,7 @@
     "num_land_tiles": 342275,
     "width": 872
   },
-  "name": "Americas",
+  "name": "South America",
   "nations": [
     {
       "coordinates": [438, 58],


### PR DESCRIPTION
## Description:

Just a text change. 4 maps had inconsistencies in their names in their info.json (and by consequence the manifest). If sites extracted map names from one of these they would appear with an inconsistent name. The south america map for example was named "Americas", and appeared as such in the pathfinding playground (thats where i noticed these inconsistencies)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tri.star1011