### PR TITLE
fix(client): prevent map clicks when clicking UI overlays to dismiss menus (#1086)

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -642,6 +642,10 @@ export class InputHandler {
   }
 
   onPointerUp(event: PointerEvent) {
+    if (!this.pointerDown) {
+      return;
+    }
+
     if (event.button === 1) {
       event.preventDefault();
       return;

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -251,6 +251,7 @@ describe("InputHandler AutoUpgrade", () => {
       });
       inputHandler["lastPointerDownX"] = 149;
       inputHandler["lastPointerDownY"] = 249;
+      inputHandler["pointerDown"] = true;
 
       inputHandler["onPointerUp"](pointerEvent);
 

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -268,6 +268,31 @@ describe("InputHandler AutoUpgrade", () => {
       expect(emittedTypes).not.toContain("ContextMenuEvent");
     });
 
+    test("should ignore pointerup when pointerDown is false during spawn phase", () => {
+      mockGameView.inSpawnPhase = () => true;
+      const mockEmit = vi.spyOn(eventBus, "emit");
+
+      inputHandler["userSettings"].leftClickOpensMenu = () => true;
+
+      const pointerEvent = new PointerEvent("pointerup", {
+        button: 0,
+        clientX: 150,
+        clientY: 250,
+      });
+      inputHandler["lastPointerDownX"] = 149;
+      inputHandler["lastPointerDownY"] = 249;
+      inputHandler["pointerDown"] = false;
+
+      inputHandler["onPointerUp"](pointerEvent);
+
+      const emittedTypes = mockEmit.mock.calls.map(
+        (call) => call[0].constructor.name,
+      );
+      expect(emittedTypes).not.toContain("MouseUpEvent");
+      expect(emittedTypes).not.toContain("ContextMenuEvent");
+      expect(mockEmit).not.toHaveBeenCalled();
+    });
+
     test("should suppress/ignore context menu events during spawn phase", () => {
       mockGameView.inSpawnPhase = () => true;
       const mockEmit = vi.spyOn(eventBus, "emit");


### PR DESCRIPTION
## Description: 

Clicking outside the radial menu, emoji table, or other UI overlays to dismiss them fired a window pointerup event, triggering an unintended attack or map click event on the underlying cell.

This fix introduces a pointerDown state machine check in InputHandler.ts's onPointerUp method. Pointer release events on the window are now ignored unless a valid pointerdown event had actually initiated on the game canvas. If a user clicks a UI overlay, the canvas pointerdown does not fire, and the release event is cleanly swallowed instead of triggering an attack.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
