### PR TITLE
fix(core): destroy defense posts on tile capture instead of downgrading and transferring ownership (#1563)

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -57,10 +57,7 @@ export class PlayerExecution implements Execution {
 
       const captor = this.mg!.player(owner.id());
       if (u.type() === UnitType.DefensePost) {
-        u.decreaseLevel(captor);
-        if (u.isActive()) {
-          captor.captureUnit(u);
-        }
+        u.delete(true, captor);
       } else {
         captor.captureUnit(u);
       }

--- a/tests/core/executions/PlayerExecution.test.ts
+++ b/tests/core/executions/PlayerExecution.test.ts
@@ -46,7 +46,7 @@ describe("PlayerExecution", () => {
     expect(game.unitCount(UnitType.DefensePost)).toBe(0);
   });
 
-  test("DefensePost lv. 2+ is downgraded when tile owner changes", () => {
+  test("DefensePost lv. 2+ is destroyed when tile owner changes", () => {
     const tile = game.ref(50, 50);
     player.conquer(tile);
     const defensePost = player.buildUnit(UnitType.DefensePost, tile, {});
@@ -60,11 +60,8 @@ describe("PlayerExecution", () => {
     otherPlayer.conquer(tile);
     executeTicks(game, 2);
 
-    expect(defensePost.level()).toBe(1);
-    expect(game.unitCount(UnitType.DefensePost)).toBe(1);
-    expect(otherPlayer.units(UnitType.DefensePost)).toHaveLength(1);
-    expect(defensePost.owner()).toBe(otherPlayer);
-    expect(defensePost.isActive()).toBe(true);
+    expect(game.unitCount(UnitType.DefensePost)).toBe(0);
+    expect(defensePost.isActive()).toBe(false);
   });
 
   test("Non-DefensePost structures are transferred (not downgraded) when tile owner changes", () => {


### PR DESCRIPTION
## Description: 

Capturing defense posts previously demoted their level by 1, and transferred ownership to the invading player if their level was still above 0. The expected strategic behavior is that defense posts should always be destroyed (deleted) upon capture.

This fix updates PlayerExecution.ts's structure tick loop to immediately destroy the Defense Post unit via u.delete(true, captor) instead of transferring ownership. It also rewrites the corresponding unit tests in PlayerExecution.test.ts to verify the complete destruction of Defense Posts of all levels (including level 2+) when the tile owner changes.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
