### PR TITLE
fix(render): prevent trade-friendly ships from visually rendering as angry red warships (#3843)

### DIFF
--- a/src/client/render/gl/shaders/unit/unit.frag.glsl
+++ b/src/client/render/gl/shaders/unit/unit.frag.glsl
@@ -60,10 +60,10 @@ void main() {
   //   0 = normal
   //   1 = flicker (nukes/warheads — cycling hot colors)
   //   2 = angry (warships attacking — solid red territory band)
-  if (vFlags > 1.5) {
+  if (abs(vFlags - FLAG_ANGRY) < 0.1) {
     // Angry: solid red territory band
     territoryColor = uAngryColor;
-  } else if (vFlags > 0.5) {
+  } else if (abs(vFlags - FLAG_FLICKER) < 0.1) {
     // Flicker: cycle through hot colors, offset by position hash
     float phase = fract(uTick * uFlickerSpeed + vHash);
     int idx = int(phase * 4.0) % 4;


### PR DESCRIPTION
## Description: 

The unit fragment shader (unit.frag.glsl) checked vFlags > 1.5 to colorize warships in their attacking/angry solid red territory band (FLAG_ANGRY = 2.0). However, trade-friendly ships use FLAG_TRADE_FRIENDLY = 3.0 which also matched this condition, causing friendly/trade-allied ships to incorrectly render as hostile/angry warships in normal camera view.

This fix refactors unit.frag.glsl to use precise float range queries via abs() to verify FLAG_ANGRY and FLAG_FLICKER flags specifically, preventing the trade-friendly flag from triggering the angry-red colorization.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
