### PR TITLE
sec(server): block direct IP requests bypassing Cloudflare proxy in p…

### DIFF
--- a/src/server/Cloudflare.ts
+++ b/src/server/Cloudflare.ts
@@ -1,0 +1,102 @@
+import net from "net";
+
+export const CLOUDFLARE_IPV4_CIDRS = [
+  "173.245.48.0/20",
+  "103.21.244.0/22",
+  "103.22.200.0/22",
+  "103.31.4.0/22",
+  "141.101.64.0/18",
+  "108.162.192.0/18",
+  "190.93.240.0/20",
+  "188.114.96.0/20",
+  "197.234.240.0/22",
+  "198.41.128.0/17",
+  "162.158.0.0/15",
+  "104.16.0.0/13",
+  "104.24.0.0/14",
+  "172.64.0.0/13",
+  "131.0.72.0/22",
+];
+
+export const CLOUDFLARE_IPV6_CIDRS = [
+  "2400:cb00::/32",
+  "2606:4700::/32",
+  "2803:f800::/32",
+  "2405:b500::/32",
+  "2405:8100::/32",
+  "2a06:98c0::/29",
+  "2c0f:f248::/32",
+];
+
+function ip4ToInt(ip: string): number {
+  const parts = ip.split(".").map((part) => parseInt(part, 10));
+  return (
+    ((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3]
+  );
+}
+
+function checkIPv4InCIDR(ip: string, cidr: string): boolean {
+  const [range, bitsStr] = cidr.split("/");
+  const bits = parseInt(bitsStr, 10);
+  const ipInt = ip4ToInt(ip);
+  const rangeInt = ip4ToInt(range);
+  const mask = bits === 0 ? 0 : (~0 << (32 - bits)) >>> 0;
+  return (ipInt & mask) === (rangeInt & mask);
+}
+
+function ip6ToBigInt(ip: string): bigint {
+  let fullIp = ip;
+  if (ip.includes("::")) {
+    const parts = ip.split("::");
+    const left = parts[0] ? parts[0].split(":") : [];
+    const right = parts[1] ? parts[1].split(":") : [];
+    const missingCount = 8 - (left.length + right.length);
+    const middle = Array(missingCount).fill("0");
+    fullIp = [...left, ...middle, ...right].join(":");
+  }
+  const parts = fullIp
+    .split(":")
+    .map((part) => (part === "" ? 0n : BigInt(parseInt(part, 16))));
+  let result = 0n;
+  for (const part of parts) {
+    result = (result << 16n) + part;
+  }
+  return result;
+}
+
+function checkIPv6InCIDR(ip: string, cidr: string): boolean {
+  const [range, bitsStr] = cidr.split("/");
+  const bits = parseInt(bitsStr, 10);
+  const ipVal = ip6ToBigInt(ip);
+  const rangeVal = ip6ToBigInt(range);
+  const mask =
+    bits === 0 ? 0n : ((1n << 128n) - 1n) ^ ((1n << BigInt(128 - bits)) - 1n);
+  return (ipVal & mask) === (rangeVal & mask);
+}
+
+export function isCloudflareIp(ip: string): boolean {
+  if (!ip) return false;
+  // Convert mapped IPv4 address (e.g. ::ffff:173.245.48.5) to standard IPv4
+  if (ip.startsWith("::ffff:")) {
+    ip = ip.substring(7);
+  }
+  if (net.isIPv4(ip)) {
+    return CLOUDFLARE_IPV4_CIDRS.some((cidr) => checkIPv4InCIDR(ip, cidr));
+  }
+  if (net.isIPv6(ip)) {
+    return CLOUDFLARE_IPV6_CIDRS.some((cidr) => checkIPv6InCIDR(ip, cidr));
+  }
+  return false;
+}
+
+export function isLoopbackIp(ip: string): boolean {
+  if (!ip) return false;
+  if (ip.startsWith("::ffff:")) {
+    ip = ip.substring(7);
+  }
+  return ip === "127.0.0.1" || ip === "::1" || ip === "localhost";
+}
+
+export function isCloudflareOrLoopbackIp(ip: string): boolean {
+  return isLoopbackIp(ip) || isCloudflareIp(ip);
+}

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -14,6 +14,8 @@ import { renderAppShell } from "./RenderHtml";
 import { ServerEnv } from "./ServerEnv";
 import { applyStaticAssetCacheControl } from "./StaticAssetCache";
 
+import { isCloudflareOrLoopbackIp } from "./Cloudflare";
+
 const playlist = new MapPlaylist();
 let lobbyService: MasterLobbyService;
 
@@ -60,14 +62,25 @@ app.set("trust proxy", 3);
 
 if (ServerEnv.env() === GameEnv.Prod || ServerEnv.env() === GameEnv.Preprod) {
   app.use((req, res, next) => {
-    const host = req.headers.host ?? "";
-    const isIpHost = /^[0-9.:]+$/.test(host);
-    const hasCfHeader = Boolean(req.headers["cf-connecting-ip"]);
-
-    if (isIpHost || !hasCfHeader) {
-      log.warn(`Bypassed Cloudflare proxy. Host: ${host}`);
+    const clientIp = req.socket.remoteAddress ?? "";
+    if (!isCloudflareOrLoopbackIp(clientIp)) {
+      log.warn(
+        `Bypassed Cloudflare proxy. Direct connection from non-Cloudflare IP: ${clientIp}`,
+      );
       return res.status(403).send("Forbidden: Direct IP access is blocked.");
     }
+
+    const host = req.headers.host ?? "";
+    const isIpHost = /^[0-9.:]+$/.test(host);
+    if (
+      isIpHost &&
+      !clientIp.includes("127.0.0.1") &&
+      !clientIp.includes("::1")
+    ) {
+      log.warn(`Bypassed Cloudflare proxy. Host header was an IP: ${host}`);
+      return res.status(403).send("Forbidden: Direct IP access is blocked.");
+    }
+
     next();
   });
 }

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -57,6 +57,21 @@ app.use(
 );
 
 app.set("trust proxy", 3);
+
+if (ServerEnv.env() === GameEnv.Prod || ServerEnv.env() === GameEnv.Preprod) {
+  app.use((req, res, next) => {
+    const host = req.headers.host ?? "";
+    const isIpHost = /^[0-9.:]+$/.test(host);
+    const hasCfHeader = Boolean(req.headers["cf-connecting-ip"]);
+
+    if (isIpHost || !hasCfHeader) {
+      log.warn(`Bypassed Cloudflare proxy. Host: ${host}`);
+      return res.status(403).send("Forbidden: Direct IP access is blocked.");
+    }
+    next();
+  });
+}
+
 app.use(
   rateLimit({
     windowMs: 1000, // 1 second

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -24,6 +24,7 @@ import { registerGamePreviewRoute } from "./GamePreviewRoute";
 import { getUserMe, verifyClientToken } from "./jwt";
 import { logger } from "./Logger";
 
+import { isCloudflareOrLoopbackIp } from "./Cloudflare";
 import { MapPlaylist } from "./MapPlaylist";
 import { setNoStoreHeaders } from "./NoStoreHeaders";
 import { startPolling } from "./PollingLoop";
@@ -106,14 +107,25 @@ export async function startWorker() {
 
   if (ServerEnv.env() === GameEnv.Prod || ServerEnv.env() === GameEnv.Preprod) {
     app.use((req, res, next) => {
-      const host = req.headers.host ?? "";
-      const isIpHost = /^[0-9.:]+$/.test(host);
-      const hasCfHeader = Boolean(req.headers["cf-connecting-ip"]);
-
-      if (isIpHost || !hasCfHeader) {
-        log.warn(`Bypassed Cloudflare proxy. Host: ${host}`);
+      const clientIp = req.socket.remoteAddress ?? "";
+      if (!isCloudflareOrLoopbackIp(clientIp)) {
+        log.warn(
+          `Bypassed Cloudflare proxy. Direct connection from non-Cloudflare IP: ${clientIp}`,
+        );
         return res.status(403).send("Forbidden: Direct IP access is blocked.");
       }
+
+      const host = req.headers.host ?? "";
+      const isIpHost = /^[0-9.:]+$/.test(host);
+      if (
+        isIpHost &&
+        !clientIp.includes("127.0.0.1") &&
+        !clientIp.includes("::1")
+      ) {
+        log.warn(`Bypassed Cloudflare proxy. Host header was an IP: ${host}`);
+        return res.status(403).send("Forbidden: Direct IP access is blocked.");
+      }
+
       next();
     });
   }

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -103,6 +103,21 @@ export async function startWorker() {
   });
 
   app.set("trust proxy", 3);
+
+  if (ServerEnv.env() === GameEnv.Prod || ServerEnv.env() === GameEnv.Preprod) {
+    app.use((req, res, next) => {
+      const host = req.headers.host ?? "";
+      const isIpHost = /^[0-9.:]+$/.test(host);
+      const hasCfHeader = Boolean(req.headers["cf-connecting-ip"]);
+
+      if (isIpHost || !hasCfHeader) {
+        log.warn(`Bypassed Cloudflare proxy. Host: ${host}`);
+        return res.status(403).send("Forbidden: Direct IP access is blocked.");
+      }
+      next();
+    });
+  }
+
   app.use(compression());
 
   app.use(
@@ -277,8 +292,24 @@ export async function startWorker() {
     }
   });
 
-  // WebSocket handling
   wss.on("connection", (ws: WebSocket, req) => {
+    if (
+      ServerEnv.env() === GameEnv.Prod ||
+      ServerEnv.env() === GameEnv.Preprod
+    ) {
+      const host = req.headers.host ?? "";
+      const isIpHost = /^[0-9.:]+$/.test(host);
+      const hasCfHeader = Boolean(req.headers["cf-connecting-ip"]);
+
+      if (isIpHost || !hasCfHeader) {
+        log.warn(
+          `WebSocket connection bypassed Cloudflare proxy. Host: ${host}`,
+        );
+        ws.close(1002, "Forbidden");
+        return;
+      }
+    }
+
     ws.on("message", async (message: string) => {
       const ip = getClientIp(req);
 

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -1,6 +1,8 @@
 import http from "http";
 import { WebSocket, WebSocketServer } from "ws";
+import { GameEnv } from "../core/configuration/Config";
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
+import { isCloudflareOrLoopbackIp } from "./Cloudflare";
 import { GameManager } from "./GameManager";
 import {
   MasterMessageSchema,
@@ -8,6 +10,7 @@ import {
   WorkerReady,
 } from "./IPCBridgeSchema";
 import { logger } from "./Logger";
+import { ServerEnv } from "./ServerEnv";
 
 export class WorkerLobbyService {
   private readonly lobbiesWss: WebSocketServer;
@@ -100,6 +103,36 @@ export class WorkerLobbyService {
 
   private setupUpgradeHandler() {
     this.server.on("upgrade", (request, socket, head) => {
+      if (
+        ServerEnv.env() === GameEnv.Prod ||
+        ServerEnv.env() === GameEnv.Preprod
+      ) {
+        const clientIp = (socket as any).remoteAddress ?? "";
+        if (!isCloudflareOrLoopbackIp(clientIp)) {
+          this.log.warn(
+            `WebSocket upgrade rejected: Bypassed Cloudflare proxy. Remote IP: ${clientIp}`,
+          );
+          socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+          socket.destroy();
+          return;
+        }
+
+        const host = request.headers.host ?? "";
+        const isIpHost = /^[0-9.:]+$/.test(host);
+        if (
+          isIpHost &&
+          !clientIp.includes("127.0.0.1") &&
+          !clientIp.includes("::1")
+        ) {
+          this.log.warn(
+            `WebSocket upgrade rejected: Bypassed Cloudflare proxy. Host header was an IP: ${host}`,
+          );
+          socket.write("HTTP/1.1 403 Forbidden\r\n\r\n");
+          socket.destroy();
+          return;
+        }
+      }
+
       const pathname = request.url ?? "";
       if (pathname === "/lobbies" || pathname.endsWith("/lobbies")) {
         this.lobbiesWss.handleUpgrade(request, socket, head, (ws) => {

--- a/tests/server/Cloudflare.test.ts
+++ b/tests/server/Cloudflare.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import {
+  isCloudflareIp,
+  isCloudflareOrLoopbackIp,
+  isLoopbackIp,
+} from "../../src/server/Cloudflare";
+
+describe("Cloudflare IP Validation", () => {
+  describe("isLoopbackIp", () => {
+    test("identifies standard loopback IPs", () => {
+      expect(isLoopbackIp("127.0.0.1")).toBe(true);
+      expect(isLoopbackIp("::1")).toBe(true);
+      expect(isLoopbackIp("::ffff:127.0.0.1")).toBe(true);
+      expect(isLoopbackIp("localhost")).toBe(true);
+    });
+
+    test("returns false for non-loopback IPs", () => {
+      expect(isLoopbackIp("8.8.8.8")).toBe(false);
+      expect(isLoopbackIp("192.168.1.1")).toBe(false);
+      expect(isLoopbackIp("")).toBe(false);
+    });
+  });
+
+  describe("isCloudflareIp", () => {
+    test("returns true for valid Cloudflare IPv4 addresses", () => {
+      expect(isCloudflareIp("173.245.48.5")).toBe(true);
+      expect(isCloudflareIp("::ffff:173.245.48.5")).toBe(true);
+      expect(isCloudflareIp("103.21.244.1")).toBe(true);
+      expect(isCloudflareIp("104.16.0.2")).toBe(true);
+      expect(isCloudflareIp("172.64.0.9")).toBe(true);
+    });
+
+    test("returns true for valid Cloudflare IPv6 addresses", () => {
+      expect(isCloudflareIp("2400:cb00:0000:0000:0000:0000:0000:0001")).toBe(
+        true,
+      );
+      expect(isCloudflareIp("2400:cb00::1")).toBe(true);
+      expect(isCloudflareIp("2606:4700::ffff")).toBe(true);
+    });
+
+    test("returns false for non-Cloudflare IPs", () => {
+      expect(isCloudflareIp("8.8.8.8")).toBe(false);
+      expect(isCloudflareIp("1.1.1.1")).toBe(false);
+      expect(isCloudflareIp("192.168.1.1")).toBe(false);
+      expect(isCloudflareIp("2001:4860:4860::8888")).toBe(false);
+      expect(isCloudflareIp("")).toBe(false);
+    });
+  });
+
+  describe("isCloudflareOrLoopbackIp", () => {
+    test("returns true for both loopback and Cloudflare IPs", () => {
+      expect(isCloudflareOrLoopbackIp("127.0.0.1")).toBe(true);
+      expect(isCloudflareOrLoopbackIp("173.245.48.5")).toBe(true);
+    });
+
+    test("returns false for regular external IPs", () => {
+      expect(isCloudflareOrLoopbackIp("8.8.8.8")).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Resolves #4096

## Description:

Prevent attackers from bypassing Cloudflare's DDoS scrubbing, WAF rules, and rate limiting by accessing the origin server directly via its IP address.

Previously, direct connections to the origin IP were fully accepted on all HTTP and WebSocket surfaces. This PR secures the application against proxy bypasses using transport-layer TCP source validation against Cloudflare's official CIDR ranges:

1. Added TCP socket IP validation middleware in both Master.ts and Worker.ts for production and preproduction environments — validates `req.socket.remoteAddress` against hardcoded Cloudflare CIDR blocks (unforgeable at the application layer).
2. Added the same validation to the WebSocket `upgrade` event handler in WorkerLobbyService.ts, rejecting bypass attempts before the WebSocket handshake allocates a connection pool slot.
3. Added a secondary Host-header IP check as defense-in-depth for loopback-exempt paths.
4. Extracted all CIDR logic into a new `Cloudflare.ts` module with 60 lines of unit tests covering IPv4, IPv6, mapped addresses, and loopback.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires