### PR TITLE
Team Maps Expansion: New team spawnzones for multiple maps

### DIFF
--- a/map-generator/assets/maps/aegean/info.json
+++ b/map-generator/assets/maps/aegean/info.json
@@ -121,5 +121,21 @@
       "coordinates": [1416, 1755],
       "name": "Carpathos"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 2000,
+        "width": 850,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 2000,
+        "width": 850,
+        "x": 850,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/beringsea/info.json
+++ b/map-generator/assets/maps/beringsea/info.json
@@ -121,5 +121,21 @@
       "name": "Magadan",
       "flag": "ru"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1600,
+        "width": 1375,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1600,
+        "width": 1125,
+        "x": 1375,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/beringstrait/info.json
+++ b/map-generator/assets/maps/beringstrait/info.json
@@ -11,5 +11,21 @@
       "name": "Russia",
       "flag": "ru"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 916,
+        "width": 750,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 916,
+        "width": 750,
+        "x": 750,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/bosphorusstraits/info.json
+++ b/map-generator/assets/maps/bosphorusstraits/info.json
@@ -111,5 +111,21 @@
       "name": "Esenyurt",
       "flag": "tr"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 612,
+        "width": 500,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 612,
+        "width": 500,
+        "x": 500,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/conakry/info.json
+++ b/map-generator/assets/maps/conakry/info.json
@@ -101,5 +101,21 @@
       "name": "Dioumaya",
       "flag": "gn"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1000,
+        "width": 1290,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1000,
+        "width": 1166,
+        "x": 1290,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/falklandislands/info.json
+++ b/map-generator/assets/maps/falklandislands/info.json
@@ -61,5 +61,21 @@
       "name": "San Carlos",
       "flag": "fk"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1400,
+        "width": 1050,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1400,
+        "width": 1050,
+        "x": 1050,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/gulfofstlawrence/info.json
+++ b/map-generator/assets/maps/gulfofstlawrence/info.json
@@ -131,5 +131,27 @@
       "name": "Yarmouth",
       "flag": "ca_ns"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "3": [
+      {
+        "height": 500,
+        "width": 900,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1348,
+        "width": 720,
+        "x": 900,
+        "y": 0
+      },
+      {
+        "height": 848,
+        "width": 900,
+        "x": 0,
+        "y": 500
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/pluto/info.json
+++ b/map-generator/assets/maps/pluto/info.json
@@ -81,5 +81,21 @@
       "name": "Free Pluto State",
       "flag": ""
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1300,
+        "width": 1050,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1300,
+        "width": 1050,
+        "x": 1050,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/straitofgibraltar/info.json
+++ b/map-generator/assets/maps/straitofgibraltar/info.json
@@ -33,5 +33,21 @@
       "coordinates": [1555, 258],
       "name": "Andalusia"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 651,
+        "width": 2900,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 825,
+        "width": 2900,
+        "x": 0,
+        "y": 651
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/straitofhormuz/info.json
+++ b/map-generator/assets/maps/straitofhormuz/info.json
@@ -101,5 +101,21 @@
       "name": "Al Wakrah",
       "flag": ""
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 700,
+        "width": 1300,
+        "x": 0,
+        "y": 500
+      },
+      {
+        "height": 500,
+        "width": 1800,
+        "x": 0,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/surrounded/info.json
+++ b/map-generator/assets/maps/surrounded/info.json
@@ -41,5 +41,47 @@
       "flag": "",
       "name": "Rugged Islander"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1976,
+        "width": 988,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1976,
+        "width": 988,
+        "x": 988,
+        "y": 0
+      }
+    ],
+    "4": [
+      {
+        "height": 988,
+        "width": 988,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 988,
+        "width": 988,
+        "x": 988,
+        "y": 0
+      },
+      {
+        "height": 988,
+        "width": 988,
+        "x": 0,
+        "y": 988
+      },
+      {
+        "height": 988,
+        "width": 988,
+        "x": 988,
+        "y": 988
+      }
+    ]
+  }
 }

--- a/map-generator/assets/maps/tradersdream/info.json
+++ b/map-generator/assets/maps/tradersdream/info.json
@@ -66,5 +66,21 @@
       "flag": "",
       "name": "Harborwick"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 960,
+        "width": 2200,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 960,
+        "width": 2200,
+        "x": 0,
+        "y": 960
+      }
+    ]
+  }
 }

--- a/resources/maps/aegean/manifest.json
+++ b/resources/maps/aegean/manifest.json
@@ -136,5 +136,21 @@
       "coordinates": [1416, 1755],
       "name": "Carpathos"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 2000,
+        "width": 850,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 2000,
+        "width": 850,
+        "x": 850,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/beringsea/manifest.json
+++ b/resources/maps/beringsea/manifest.json
@@ -136,5 +136,21 @@
       "flag": "ru",
       "name": "Magadan"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1600,
+        "width": 1375,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1600,
+        "width": 1125,
+        "x": 1375,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/beringstrait/manifest.json
+++ b/resources/maps/beringstrait/manifest.json
@@ -26,5 +26,21 @@
       "flag": "ru",
       "name": "Russia"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 916,
+        "width": 750,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 916,
+        "width": 750,
+        "x": 750,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/bosphorusstraits/manifest.json
+++ b/resources/maps/bosphorusstraits/manifest.json
@@ -126,5 +126,21 @@
       "flag": "tr",
       "name": "Esenyurt"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 612,
+        "width": 500,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 612,
+        "width": 500,
+        "x": 500,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/conakry/manifest.json
+++ b/resources/maps/conakry/manifest.json
@@ -116,5 +116,21 @@
       "flag": "gn",
       "name": "Dioumaya"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1000,
+        "width": 1290,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1000,
+        "width": 1166,
+        "x": 1290,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/falklandislands/manifest.json
+++ b/resources/maps/falklandislands/manifest.json
@@ -76,5 +76,21 @@
       "flag": "fk",
       "name": "San Carlos"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1400,
+        "width": 1050,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1400,
+        "width": 1050,
+        "x": 1050,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/gulfofstlawrence/manifest.json
+++ b/resources/maps/gulfofstlawrence/manifest.json
@@ -146,5 +146,27 @@
       "flag": "ca_ns",
       "name": "Yarmouth"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "3": [
+      {
+        "height": 500,
+        "width": 900,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1348,
+        "width": 720,
+        "x": 900,
+        "y": 0
+      },
+      {
+        "height": 848,
+        "width": 900,
+        "x": 0,
+        "y": 500
+      }
+    ]
+  }
 }

--- a/resources/maps/pluto/manifest.json
+++ b/resources/maps/pluto/manifest.json
@@ -96,5 +96,21 @@
       "flag": "",
       "name": "Free Pluto State"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1300,
+        "width": 1050,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1300,
+        "width": 1050,
+        "x": 1050,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/straitofgibraltar/manifest.json
+++ b/resources/maps/straitofgibraltar/manifest.json
@@ -48,5 +48,21 @@
       "coordinates": [1555, 258],
       "name": "Andalusia"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 651,
+        "width": 2900,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 825,
+        "width": 2900,
+        "x": 0,
+        "y": 651
+      }
+    ]
+  }
 }

--- a/resources/maps/straitofhormuz/manifest.json
+++ b/resources/maps/straitofhormuz/manifest.json
@@ -116,5 +116,21 @@
       "flag": "",
       "name": "Al Wakrah"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 700,
+        "width": 1300,
+        "x": 0,
+        "y": 500
+      },
+      {
+        "height": 500,
+        "width": 1800,
+        "x": 0,
+        "y": 0
+      }
+    ]
+  }
 }

--- a/resources/maps/surrounded/manifest.json
+++ b/resources/maps/surrounded/manifest.json
@@ -56,5 +56,47 @@
       "flag": "",
       "name": "Rugged Islander"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 1976,
+        "width": 988,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 1976,
+        "width": 988,
+        "x": 988,
+        "y": 0
+      }
+    ],
+    "4": [
+      {
+        "height": 988,
+        "width": 988,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 988,
+        "width": 988,
+        "x": 988,
+        "y": 0
+      },
+      {
+        "height": 988,
+        "width": 988,
+        "x": 0,
+        "y": 988
+      },
+      {
+        "height": 988,
+        "width": 988,
+        "x": 988,
+        "y": 988
+      }
+    ]
+  }
 }

--- a/resources/maps/tradersdream/manifest.json
+++ b/resources/maps/tradersdream/manifest.json
@@ -81,5 +81,21 @@
       "flag": "",
       "name": "Harborwick"
     }
-  ]
+  ],
+  "teamGameSpawnAreas": {
+    "2": [
+      {
+        "height": 960,
+        "width": 2200,
+        "x": 0,
+        "y": 0
+      },
+      {
+        "height": 960,
+        "width": 2200,
+        "x": 0,
+        "y": 960
+      }
+    ]
+  }
 }

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -130,6 +130,18 @@ const SPECIAL_TEAM_MAPS: ReadonlyMap<GameMapType, TeamCountConfig> = new Map([
   [GameMapType.Baikal, 2],
   [GameMapType.FourIslands, 4],
   [GameMapType.Luna, 2],
+  [GameMapType.StraitOfGibraltar, 2],
+  [GameMapType.StraitOfHormuz, 2],
+  [GameMapType.Aegean, 2],
+  [GameMapType.BeringSea, 2],
+  [GameMapType.BeringStrait, 2],
+  [GameMapType.BosphorusStraits, 2],
+  [GameMapType.Conakry, 2],
+  [GameMapType.Pluto, 2],
+  [GameMapType.FalklandIslands, 2],
+  [GameMapType.TradersDream, 2],
+  [GameMapType.Surrounded, 4],
+  [GameMapType.GulfOfStLawrence, 3],
 ]);
 
 type ModifierKey =


### PR DESCRIPTION
## Description:

Lets give Teams and HvN gamemodes some attention. Adds team spawnzones to the following maps, and boosts them to appear more frequently as this gamemode:

- Straitofgibraltar - 2 teams
- Aegean - 2 teams
- Beringsea - 2 teams
- Beringstrait - 2 teams
- Bosphorusstraits - 2 teams
- Conakry - 2 teams
- Falklandislands - 2 teams
- Straitofhormuz - 2 teams
- Tradersdream - 2 teams
- Surrounded - 2 teams & 4 teams
- Pluto - 2 teams
- Gulf of St. Lawrence - 3 teams

These maps (especially the ones for 2 teams) are all very symmetrical and would be nice gift for the playerbase, which enjoys these kind of games like FourIslands4Teams and Baikal2Teams. This is also nice for HvN, as it centralizes the players and gives them a better chance at defeating the nations.

Screenshots of the maps with the new team spawnzones:


<img width="1320" height="486" alt="Captura de pantalla 2026-05-28 001558" src="https://github.com/user-attachments/assets/e0b4bea6-d1b7-4793-a995-ec2a139a5af6" />
<img width="1177" height="528" alt="Captura de pantalla 2026-05-28 001913" src="https://github.com/user-attachments/assets/28ec5bf8-3a02-4660-ba62-3edbcabeaf51" />
<img width="1147" height="531" alt="Captura de pantalla 2026-05-28 002032" src="https://github.com/user-attachments/assets/b148f1ae-473a-4505-b0f4-ca8820fbbb55" />
<img width="1219" height="536" alt="Captura de pantalla 2026-05-28 002348" src="https://github.com/user-attachments/assets/89af4d27-eadf-447c-9bde-d0dcfe1ff757" />
<img width="923" height="524" alt="Captura de pantalla 2026-05-28 002704" src="https://github.com/user-attachments/assets/50ad1b11-1685-41fb-b14d-088a2f0db88b" />
<img width="1307" height="456" alt="Captura de pantalla 2026-05-28 002859" src="https://github.com/user-attachments/assets/4ef18da9-336a-4698-8af0-2769467148b4" />
<img width="1219" height="548" alt="Captura de pantalla 2026-05-28 003134" src="https://github.com/user-attachments/assets/d0a514bf-e6e6-43f6-89b7-2168bc395010" />
<img width="1200" height="538" alt="Captura de pantalla 2026-05-28 003449" src="https://github.com/user-attachments/assets/c1672296-db4d-4baf-9992-4bb380fab4e9" />
<img width="1032" height="501" alt="Captura de pantalla 2026-05-28 003650" src="https://github.com/user-attachments/assets/8dd5ee07-3ac3-4f03-a56e-31c01d612655" />
<img width="1074" height="525" alt="Captura de pantalla 2026-05-28 003951" src="https://github.com/user-attachments/assets/e140706b-3f1c-4e09-b70c-efc3e6536c60" />
<img width="914" height="513" alt="Captura de pantalla 2026-05-28 004632" src="https://github.com/user-attachments/assets/e0dd6820-62f4-48b6-8356-df20c0e6ed8f" />
<img width="988" height="509" alt="Captura de pantalla 2026-05-28 005518" src="https://github.com/user-attachments/assets/0da95c41-1191-4de4-a3ce-873839c00605" />
<img width="986" height="514" alt="Captura de pantalla 2026-05-28 000505" src="https://github.com/user-attachments/assets/4eb20c73-56ba-4f9f-90af-8a047aa399eb" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

tri.star1011
