### PR TITLE
[small fix] Add "TEAMING PROHIBITED" label to FFA games

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -772,7 +772,8 @@
     "peace_time": "4min Peace",
     "peace_time_label": "PVP Immunity",
     "water_nukes": "Water Nukes",
-    "water_nukes_label": "Water Nukes"
+    "water_nukes_label": "Water Nukes",
+    "teaming_prohibited": "Teaming Prohibited"
   },
   "select_lang": {
     "title": "Select Language"

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -302,6 +302,13 @@ export class GameModeSelector extends LitElement {
       modifierLabels.sort((a, b) => a.length - b.length);
     }
 
+    // Add "TEAMING PROHIBITED" label to FFA games
+    if (lobby.gameConfig?.gameMode === GameMode.FFA) {
+      modifierLabels.unshift(
+        translateText("public_game_modifier.teaming_prohibited"),
+      );
+    }
+
     return html`
       <button
         @click=${() => this.validateAndJoin(lobby)}


### PR DESCRIPTION
Resolves #3900 

## Description:

Add "TEAMING PROHIBITED" label to FFA games, clearly communicating to new users that teaming is not allowed.

<img width="737" height="284" alt="2026-05-30_11-42" src="https://github.com/user-attachments/assets/64291afe-3b09-431e-8cde-fbed7ca62d6e" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

goose126
