### PR TITLE
Add map voting to public lobbies

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -649,7 +649,9 @@
     "players_per_team": "of {num}",
     "started": "Started",
     "status": "Status",
-    "join_timeout": "You didn't enter the game in time."
+    "join_timeout": "You didn't enter the game in time.",
+    "upvote": "Upvote map",
+    "downvote": "Downvote map"
   },
   "matchmaking_modal": {
     "title": "1v1 Ranked Matchmaking (ALPHA)",

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -366,6 +366,38 @@ export class GameModeSelector extends LitElement {
               ></path>
             </svg>
           </span>
+          ${lobby.mapVotes
+            ? html`<span
+                class="absolute bottom-full left-2 mb-1 flex items-center gap-2 text-xs font-bold tracking-widest bg-black/70 backdrop-blur-sm px-2 py-0.5 rounded normal-case"
+              >
+                <span class="flex items-center gap-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-3.5 w-3.5 inline-block"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z"
+                    ></path>
+                  </svg>
+                  ${lobby.mapVotes.up}
+                </span>
+                <span class="flex items-center gap-1">
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    class="h-3.5 w-3.5 inline-block"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path
+                      d="M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.106-1.79l-.05-.025A4 4 0 0011.057 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z"
+                    ></path>
+                  </svg>
+                  ${lobby.mapVotes.down}
+                </span>
+              </span>`
+            : ""}
           ${mapName
             ? html`<p
                 class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -324,6 +324,10 @@ export class JoinLobbyModal extends BaseModal {
     this.lobbyCreatorClientID = null;
     this.isConnecting = true;
     this.handledJoinTimeout = false;
+    // Reset vote state before reconciling, so a stale cooldown from the
+    // previous lobby doesn't block this lobby's tally from rendering.
+    this.mapVotes = null;
+    this.clearVoteCooldown();
     this.startLobbyUpdates();
     if (lobbyInfo) {
       this.updateFromLobby(lobbyInfo);
@@ -379,6 +383,8 @@ export class JoinLobbyModal extends BaseModal {
     this.lobbyCreatorClientID = null;
     this.isConnecting = true;
     this.leaveLobbyOnClose = true;
+    this.mapVotes = null;
+    this.clearVoteCooldown();
   }
 
   disconnectedCallback() {
@@ -656,6 +662,7 @@ export class JoinLobbyModal extends BaseModal {
         <button
           type="button"
           ?disabled=${this.voteCooldownActive}
+          aria-pressed=${myVote === "up" ? "true" : "false"}
           @click=${() => this.castVote("up")}
           aria-label=${translateText("public_lobby.upvote")}
           title=${translateText("public_lobby.upvote")}
@@ -669,6 +676,7 @@ export class JoinLobbyModal extends BaseModal {
         <button
           type="button"
           ?disabled=${this.voteCooldownActive}
+          aria-pressed=${myVote === "down" ? "true" : "false"}
           @click=${() => this.castVote("down")}
           aria-label=${translateText("public_lobby.downvote")}
           title=${translateText("public_lobby.downvote")}

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -18,6 +18,7 @@ import {
   GameInfo,
   GameRecordSchema,
   LobbyInfoEvent,
+  MapVotes,
   PublicGameInfo,
 } from "../core/Schemas";
 import {
@@ -31,6 +32,7 @@ import { getApiBase } from "./Api";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
+import { SendMapVoteIntentEvent } from "./Transport";
 import { normaliseMapKey } from "./Utils";
 import { BaseModal } from "./components/BaseModal";
 import "./components/CopyButton";
@@ -55,9 +57,12 @@ export class JoinLobbyModal extends BaseModal {
   @state() private serverTimeOffset: number = 0;
   @state() private isConnecting: boolean = true;
   @state() private lobbyCreatorClientID: string | null = null;
+  @state() private mapVotes: MapVotes | null = null;
+  @state() private voteCooldownActive: boolean = false;
 
   private leaveLobbyOnClose = true;
   private countdownTimerId: number | null = null;
+  private voteCooldownTimerId: number | null = null;
   private handledJoinTimeout = false;
 
   private isPrivateLobby(): boolean {
@@ -378,6 +383,7 @@ export class JoinLobbyModal extends BaseModal {
 
   disconnectedCallback() {
     this.clearCountdownTimer();
+    this.clearVoteCooldown();
     this.stopLobbyUpdates();
     super.disconnectedCallback();
   }
@@ -604,6 +610,7 @@ export class JoinLobbyModal extends BaseModal {
         <div class="flex flex-col gap-1">
           <span class="text-lg font-bold text-white">${mapName}</span>
           <span class="text-sm text-white/60">${modeSubtitle}</span>
+          ${this.renderMapVote()}
         </div>
       </div>
       ${cards.length > 0
@@ -613,6 +620,112 @@ export class JoinLobbyModal extends BaseModal {
         : html``}
       ${this.renderDisabledUnits()} ${this.renderHostCheats()}
     `;
+  }
+
+  // Upvote/downvote control for the lobby's map. Only public lobbies vote;
+  // the live tally and the player's own vote arrive via lobby_info broadcasts.
+  private renderMapVote(): TemplateResult {
+    if (this.gameConfig?.gameType !== GameType.Public) {
+      return html``;
+    }
+    const myVote = this.mapVotes?.myVote ?? null;
+    const up = this.mapVotes?.up ?? 0;
+    const down = this.mapVotes?.down ?? 0;
+    const thumbUp = html`<svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-4 w-4"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        d="M2 10.5a1.5 1.5 0 113 0v6a1.5 1.5 0 01-3 0v-6zM6 10.333v5.43a2 2 0 001.106 1.79l.05.025A4 4 0 008.943 18h5.416a2 2 0 001.962-1.608l1.2-6A2 2 0 0015.56 8H12V4a2 2 0 00-2-2 1 1 0 00-1 1v.667a4 4 0 01-.8 2.4L6.8 7.933a4 4 0 00-.8 2.4z"
+      ></path>
+    </svg>`;
+    const thumbDown = html`<svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-4 w-4"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+    >
+      <path
+        d="M18 9.5a1.5 1.5 0 11-3 0v-6a1.5 1.5 0 013 0v6zM14 9.667v-5.43a2 2 0 00-1.106-1.79l-.05-.025A4 4 0 0011.057 2H5.64a2 2 0 00-1.962 1.608l-1.2 6A2 2 0 004.44 12H8v4a2 2 0 002 2 1 1 0 001-1v-.667a4 4 0 01.8-2.4l1.4-1.866a4 4 0 00.8-2.4z"
+      ></path>
+    </svg>`;
+    return html`
+      <div class="flex items-center gap-2 mt-1">
+        <button
+          type="button"
+          ?disabled=${this.voteCooldownActive}
+          @click=${() => this.castVote("up")}
+          aria-label=${translateText("public_lobby.upvote")}
+          title=${translateText("public_lobby.upvote")}
+          class="flex items-center gap-1 px-2 py-1 rounded-md text-sm transition-colors disabled:opacity-60 ${myVote ===
+          "up"
+            ? "bg-green-600/80 text-white"
+            : "bg-white/10 text-white/80 hover:bg-white/20"}"
+        >
+          ${thumbUp}<span>${up}</span>
+        </button>
+        <button
+          type="button"
+          ?disabled=${this.voteCooldownActive}
+          @click=${() => this.castVote("down")}
+          aria-label=${translateText("public_lobby.downvote")}
+          title=${translateText("public_lobby.downvote")}
+          class="flex items-center gap-1 px-2 py-1 rounded-md text-sm transition-colors disabled:opacity-60 ${myVote ===
+          "down"
+            ? "bg-red-600/80 text-white"
+            : "bg-white/10 text-white/80 hover:bg-white/20"}"
+        >
+          ${thumbDown}<span>${down}</span>
+        </button>
+      </div>
+    `;
+  }
+
+  private castVote(vote: "up" | "down") {
+    if (!this.eventBus || this.voteCooldownActive) {
+      return;
+    }
+    const current = this.mapVotes?.myVote ?? null;
+    // Clicking the active direction toggles the vote off.
+    const next = current === vote ? "clear" : vote;
+    // Optimistically update for instant feedback; the next lobby_info
+    // broadcast reconciles with the authoritative tally.
+    const up = this.mapVotes?.up ?? 0;
+    const down = this.mapVotes?.down ?? 0;
+    this.mapVotes = {
+      up: Math.max(
+        0,
+        up - (current === "up" ? 1 : 0) + (next === "up" ? 1 : 0),
+      ),
+      down: Math.max(
+        0,
+        down - (current === "down" ? 1 : 0) + (next === "down" ? 1 : 0),
+      ),
+      myVote: next === "clear" ? null : next,
+    };
+    this.eventBus.emit(new SendMapVoteIntentEvent(next));
+    this.startVoteCooldown();
+  }
+
+  private startVoteCooldown() {
+    this.voteCooldownActive = true;
+    if (this.voteCooldownTimerId !== null) {
+      window.clearTimeout(this.voteCooldownTimerId);
+    }
+    this.voteCooldownTimerId = window.setTimeout(() => {
+      this.voteCooldownActive = false;
+      this.voteCooldownTimerId = null;
+    }, 400);
+  }
+
+  private clearVoteCooldown() {
+    if (this.voteCooldownTimerId !== null) {
+      window.clearTimeout(this.voteCooldownTimerId);
+      this.voteCooldownTimerId = null;
+    }
+    this.voteCooldownActive = false;
   }
 
   private renderDisabledUnits(): TemplateResult {
@@ -745,6 +858,12 @@ export class JoinLobbyModal extends BaseModal {
       "lobbyCreatorClientID" in lobby
         ? (lobby.lobbyCreatorClientID ?? null)
         : null;
+
+    // Reconcile with the authoritative tally from the server. Skipped while a
+    // local cooldown is active so an in-flight optimistic vote isn't clobbered.
+    if (!this.voteCooldownActive) {
+      this.mapVotes = lobby.mapVotes ?? null;
+    }
   }
 
   private startLobbyUpdates() {

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -170,6 +170,10 @@ export class SendKickPlayerIntentEvent implements GameEvent {
   constructor(public readonly target: string) {}
 }
 
+export class SendMapVoteIntentEvent implements GameEvent {
+  constructor(public readonly vote: "up" | "down" | "clear") {}
+}
+
 export class SendUpdateGameConfigIntentEvent implements GameEvent {
   constructor(public readonly config: Partial<GameConfig>) {}
 }
@@ -260,6 +264,9 @@ export class Transport {
 
     this.eventBus.on(SendKickPlayerIntentEvent, (e) =>
       this.onSendKickPlayerIntent(e),
+    );
+    this.eventBus.on(SendMapVoteIntentEvent, (e) =>
+      this.onSendMapVoteIntent(e),
     );
 
     this.eventBus.on(SendUpdateGameConfigIntentEvent, (e) =>
@@ -637,6 +644,13 @@ export class Transport {
     this.sendIntent({
       type: "kick_player",
       target: event.target,
+    });
+  }
+
+  private onSendMapVoteIntent(event: SendMapVoteIntentEvent) {
+    this.sendIntent({
+      type: "map_vote",
+      vote: event.vote,
     });
   }
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -51,7 +51,8 @@ export type Intent =
   | KickPlayerIntent
   | TogglePauseIntent
   | UpdateGameConfigIntent
-  | StartGameIntent;
+  | StartGameIntent
+  | MapVoteIntent;
 
 export type AttackIntent = z.infer<typeof AttackIntentSchema>;
 export type CancelAttackIntent = z.infer<typeof CancelAttackIntentSchema>;
@@ -86,6 +87,7 @@ export type UpdateGameConfigIntent = z.infer<
   typeof UpdateGameConfigIntentSchema
 >;
 export type StartGameIntent = z.infer<typeof StartGameIntentSchema>;
+export type MapVoteIntent = z.infer<typeof MapVoteIntentSchema>;
 
 export type Turn = z.infer<typeof TurnSchema>;
 export type GameConfig = z.infer<typeof GameConfigSchema>;
@@ -160,6 +162,16 @@ const ClientInfoSchema = z.object({
   friends: z.array(z.string()).optional(),
 });
 
+// Tally of upvotes/downvotes for a public lobby's map. `myVote` is only
+// populated on the per-client GameInfo broadcast (the requesting client's own
+// vote); it is absent on the public lobby list.
+export const MapVotesSchema = z.object({
+  up: z.number().int().nonnegative(),
+  down: z.number().int().nonnegative(),
+  myVote: z.enum(["up", "down"]).nullable().optional(),
+});
+export type MapVotes = z.infer<typeof MapVotesSchema>;
+
 export const GameInfoSchema = z.object({
   gameID: z.string(),
   clients: z.array(ClientInfoSchema).optional(),
@@ -168,6 +180,7 @@ export const GameInfoSchema = z.object({
   serverTime: z.number(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema.optional(),
+  mapVotes: MapVotesSchema.optional(),
 });
 
 export const PublicGameInfoSchema = z.object({
@@ -176,6 +189,7 @@ export const PublicGameInfoSchema = z.object({
   startsAt: z.number().optional(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema,
+  mapVotes: MapVotesSchema.optional(),
 });
 
 export const PublicGamesSchema = z.object({
@@ -463,6 +477,14 @@ export const StartGameIntentSchema = z.object({
   type: z.literal("start_game"),
 });
 
+export const MapVoteIntentSchema = z.object({
+  type: z.literal("map_vote"),
+  // "up"/"down" cast (or switch) the player's vote for the lobby's map;
+  // "clear" removes their vote. Lobby-only; handled server-side and never
+  // relayed into the deterministic simulation.
+  vote: z.enum(["up", "down", "clear"]),
+});
+
 const IntentSchema = z.discriminatedUnion("type", [
   AttackIntentSchema,
   CancelAttackIntentSchema,
@@ -489,6 +511,7 @@ const IntentSchema = z.discriminatedUnion("type", [
   TogglePauseIntentSchema,
   UpdateGameConfigIntentSchema,
   StartGameIntentSchema,
+  MapVoteIntentSchema,
 ]);
 
 // StampedIntent = Intent with server-stamped clientID (used in turns and execution)

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -92,7 +92,10 @@ export class GameServer {
   > = new Map();
 
   // Public-lobby map votes, keyed by persistentID so each player gets one
-  // vote that survives reconnects and can be switched or cleared.
+  // vote that survives reconnects and can be switched or cleared. Tallies are
+  // an advisory signal only: persistentID is not bound to a verified human, so
+  // they are not sybil-resistant and downstream rotation logic should treat
+  // them as soft input rather than ballot-grade counts.
   private mapVotes: Map<string, "up" | "down"> = new Map();
 
   private _hasEnded = false;
@@ -523,12 +526,10 @@ export class GameServer {
               }
               case "map_vote": {
                 // Public-lobby only; recorded server-side and never relayed
-                // into the simulation. Broadcast updated tallies on change.
-                if (
-                  this.applyMapVote(client.persistentID, stampedIntent.vote)
-                ) {
-                  this.broadcastLobbyInfo();
-                }
+                // into the simulation. The updated tally rides the existing
+                // 1s lobby-info broadcast, so we don't fan out per vote
+                // (which an unprivileged client could otherwise drive).
+                this.applyMapVote(client.persistentID, stampedIntent.vote);
                 return;
               }
               case "toggle_pause": {
@@ -611,6 +612,9 @@ export class GameServer {
       if (!this._hasStarted) {
         // Remove persistentId if the game has not started to prevent going over max players
         this.persistentIdToClientId.delete(client.persistentID);
+        // Drop the leaver's map vote so the tally and the start() summary
+        // reflect only players still present.
+        this.mapVotes.delete(client.persistentID);
         // Close lobby when host leaves before game starts
         if (
           !this.isPublic() &&
@@ -644,6 +648,7 @@ export class GameServer {
       // Remove persistentId if the game has not started to prevent going over max players
       if (!this._hasStarted) {
         this.persistentIdToClientId.delete(client.persistentID);
+        this.mapVotes.delete(client.persistentID);
       }
     }
   }
@@ -658,21 +663,23 @@ export class GameServer {
     return this.activeClients.length;
   }
 
-  // Records a player's map vote. Only accepted for public lobbies still in the
-  // Lobby phase. "up"/"down" set (and overwrite) the vote, "clear" removes it.
-  // Returns true if the vote was accepted (i.e. state may have changed).
+  // Records a player's map vote. Accepted only while a public lobby is still
+  // waiting (not yet prestarted/started/ended). "up"/"down" set (or switch)
+  // the vote, "clear" removes it. Returns true only if the tally changed.
   public applyMapVote(
     persistentID: string,
     vote: "up" | "down" | "clear",
   ): boolean {
-    if (!this.isPublic() || this.phase() !== GamePhase.Lobby) {
+    if (!this.isPublic() || this.hasStarted() || this._hasEnded) {
       return false;
     }
     if (vote === "clear") {
-      this.mapVotes.delete(persistentID);
-    } else {
-      this.mapVotes.set(persistentID, vote);
+      return this.mapVotes.delete(persistentID);
     }
+    if (this.mapVotes.get(persistentID) === vote) {
+      return false;
+    }
+    this.mapVotes.set(persistentID, vote);
     return true;
   }
 
@@ -1101,6 +1108,8 @@ export class GameServer {
     }
 
     this.kickedPersistentIds.add(clientToKick.persistentID);
+    // Drop any map vote from the kicked player so the tally stays accurate.
+    this.mapVotes.delete(clientToKick.persistentID);
 
     const client = this.activeClients.find((c) => c.clientID === clientID);
     if (client) {

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -91,6 +91,10 @@ export class GameServer {
     { winner: ClientSendWinnerMessage; ips: Set<string> }
   > = new Map();
 
+  // Public-lobby map votes, keyed by persistentID so each player gets one
+  // vote that survives reconnects and can be switched or cleared.
+  private mapVotes: Map<string, "up" | "down"> = new Map();
+
   private _hasEnded = false;
 
   private lobbyInfoIntervalId: ReturnType<typeof setInterval> | null = null;
@@ -517,6 +521,16 @@ export class GameServer {
                 this.start();
                 return;
               }
+              case "map_vote": {
+                // Public-lobby only; recorded server-side and never relayed
+                // into the simulation. Broadcast updated tallies on change.
+                if (
+                  this.applyMapVote(client.persistentID, stampedIntent.vote)
+                ) {
+                  this.broadcastLobbyInfo();
+                }
+                return;
+              }
               case "toggle_pause": {
                 // Only lobby creator can pause/resume
                 if (client.clientID !== this.lobbyCreatorID) {
@@ -644,6 +658,37 @@ export class GameServer {
     return this.activeClients.length;
   }
 
+  // Records a player's map vote. Only accepted for public lobbies still in the
+  // Lobby phase. "up"/"down" set (and overwrite) the vote, "clear" removes it.
+  // Returns true if the vote was accepted (i.e. state may have changed).
+  public applyMapVote(
+    persistentID: string,
+    vote: "up" | "down" | "clear",
+  ): boolean {
+    if (!this.isPublic() || this.phase() !== GamePhase.Lobby) {
+      return false;
+    }
+    if (vote === "clear") {
+      this.mapVotes.delete(persistentID);
+    } else {
+      this.mapVotes.set(persistentID, vote);
+    }
+    return true;
+  }
+
+  private mapVoteTally(): { up: number; down: number } {
+    let up = 0;
+    let down = 0;
+    for (const vote of this.mapVotes.values()) {
+      if (vote === "up") {
+        up++;
+      } else {
+        down++;
+      }
+    }
+    return { up, down };
+  }
+
   public numDesyncedClients(): number {
     return this.outOfSyncClients.size;
   }
@@ -715,9 +760,20 @@ export class GameServer {
     const lobbyInfo = this.gameInfo();
     this.activeClients.forEach((c) => {
       if (c.ws.readyState === WebSocket.OPEN) {
+        // Attach this recipient's own vote so the client can highlight it.
+        // Clone the tally per client so myVote is never shared across sends.
+        const lobby = lobbyInfo.mapVotes
+          ? {
+              ...lobbyInfo,
+              mapVotes: {
+                ...lobbyInfo.mapVotes,
+                myVote: this.mapVotes.get(c.persistentID) ?? null,
+              },
+            }
+          : lobbyInfo;
         const msg = JSON.stringify({
           type: "lobby_info",
-          lobby: lobbyInfo,
+          lobby,
           myClientID: c.clientID,
         } satisfies ServerLobbyInfoMessage);
         c.ws.send(msg);
@@ -734,6 +790,17 @@ export class GameServer {
     // Set last ping to start so we don't immediately stop the game
     // if no client connects/pings.
     this.lastPingUpdate = Date.now();
+
+    // Emit a structured summary of the lobby's map votes so rotation
+    // frequency can be informed by aggregating these across games.
+    if (this.isPublic()) {
+      this.log.info("map_vote_summary", {
+        gameID: this.id,
+        gameMap: this.gameConfig.gameMap,
+        ...this.mapVoteTally(),
+        numClients: this.numClients(),
+      });
+    }
 
     const friendsFor = this.buildFriendsLookup();
 
@@ -986,6 +1053,8 @@ export class GameServer {
       startsAt: this.startsAt,
       serverTime: Date.now(),
       publicGameType: this.publicGameType,
+      // Counts only here; per-client myVote is attached in broadcastLobbyInfo.
+      mapVotes: this.isPublic() ? this.mapVoteTally() : undefined,
     };
   }
 

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -93,6 +93,8 @@ export class WorkerLobbyService {
           startsAt: gi.startsAt,
           gameConfig: gi.gameConfig,
           publicGameType: gi.publicGameType!,
+          // Counts only (gameInfo() never sets myVote in the base tally).
+          mapVotes: gi.mapVotes,
         } satisfies PublicGameInfo;
       });
     process.send?.({ type: "lobbyList", lobbies } satisfies WorkerLobbyList);

--- a/tests/MapVoteSchema.test.ts
+++ b/tests/MapVoteSchema.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import {
+  ClientMessageSchema,
+  GameInfoSchema,
+  MapVoteIntentSchema,
+  MapVotesSchema,
+  PublicGameInfoSchema,
+} from "../src/core/Schemas";
+
+describe("MapVoteIntentSchema", () => {
+  it("accepts up, down and clear votes", () => {
+    for (const vote of ["up", "down", "clear"]) {
+      expect(
+        MapVoteIntentSchema.safeParse({ type: "map_vote", vote }).success,
+      ).toBe(true);
+    }
+  });
+
+  it("rejects unknown vote values", () => {
+    expect(
+      MapVoteIntentSchema.safeParse({ type: "map_vote", vote: "sideways" })
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects a missing vote field", () => {
+    expect(MapVoteIntentSchema.safeParse({ type: "map_vote" }).success).toBe(
+      false,
+    );
+  });
+
+  it("round-trips as an intent client message", () => {
+    const result = ClientMessageSchema.safeParse({
+      type: "intent",
+      intent: { type: "map_vote", vote: "up" },
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("MapVotesSchema", () => {
+  it("accepts a counts-only tally", () => {
+    expect(MapVotesSchema.safeParse({ up: 3, down: 1 }).success).toBe(true);
+  });
+
+  it("accepts an optional myVote, including null", () => {
+    expect(
+      MapVotesSchema.safeParse({ up: 0, down: 0, myVote: "down" }).success,
+    ).toBe(true);
+    expect(
+      MapVotesSchema.safeParse({ up: 0, down: 0, myVote: null }).success,
+    ).toBe(true);
+  });
+
+  it("rejects negative or non-integer counts", () => {
+    expect(MapVotesSchema.safeParse({ up: -1, down: 0 }).success).toBe(false);
+    expect(MapVotesSchema.safeParse({ up: 1.5, down: 0 }).success).toBe(false);
+  });
+
+  it("rejects an invalid myVote", () => {
+    expect(
+      MapVotesSchema.safeParse({ up: 0, down: 0, myVote: "clear" }).success,
+    ).toBe(false);
+  });
+});
+
+describe("lobby info schemas accept optional mapVotes", () => {
+  it("GameInfoSchema parses with and without mapVotes", () => {
+    const base = { gameID: "abc", serverTime: 123 };
+    expect(GameInfoSchema.safeParse(base).success).toBe(true);
+    expect(
+      GameInfoSchema.safeParse({
+        ...base,
+        mapVotes: { up: 2, down: 1, myVote: "up" },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("PublicGameInfoSchema parses with and without mapVotes", () => {
+    const base = { gameID: "abc", numClients: 0, publicGameType: "ffa" };
+    expect(PublicGameInfoSchema.safeParse(base).success).toBe(true);
+    expect(
+      PublicGameInfoSchema.safeParse({ ...base, mapVotes: { up: 5, down: 0 } })
+        .success,
+    ).toBe(true);
+  });
+});

--- a/tests/server/MapVote.test.ts
+++ b/tests/server/MapVote.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GameType } from "../../src/core/game/Game";
+import { GameServer } from "../../src/server/GameServer";
+
+describe("GameServer map voting", () => {
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  // A public lobby whose start time is in the future, so phase() === Lobby.
+  function publicLobby(): GameServer {
+    return new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      { gameType: GameType.Public, gameMap: "plains", gameMapSize: 100 } as any,
+      undefined,
+      Date.now() + 60_000,
+      "ffa",
+    );
+  }
+
+  it("records an upvote and surfaces it in gameInfo()", () => {
+    const game = publicLobby();
+    expect(game.applyMapVote("p1", "up")).toBe(true);
+    expect(game.gameInfo().mapVotes).toEqual({ up: 1, down: 0 });
+  });
+
+  it("switches a vote instead of double counting", () => {
+    const game = publicLobby();
+    game.applyMapVote("p1", "up");
+    game.applyMapVote("p1", "down");
+    expect(game.gameInfo().mapVotes).toEqual({ up: 0, down: 1 });
+  });
+
+  it("clears a vote", () => {
+    const game = publicLobby();
+    game.applyMapVote("p1", "up");
+    game.applyMapVote("p1", "clear");
+    expect(game.gameInfo().mapVotes).toEqual({ up: 0, down: 0 });
+  });
+
+  it("counts one vote per distinct persistentID", () => {
+    const game = publicLobby();
+    game.applyMapVote("p1", "up");
+    game.applyMapVote("p2", "up");
+    game.applyMapVote("p3", "down");
+    expect(game.gameInfo().mapVotes).toEqual({ up: 2, down: 1 });
+  });
+
+  it("does not surface mapVotes for private lobbies", () => {
+    const game = new GameServer("private-game", mockLogger, Date.now(), {
+      gameType: GameType.Private,
+      gameMap: "plains",
+      gameMapSize: 100,
+    } as any);
+    expect(game.applyMapVote("p1", "up")).toBe(false);
+    expect(game.gameInfo().mapVotes).toBeUndefined();
+  });
+
+  it("rejects votes once the lobby has left the Lobby phase", () => {
+    // startsAt in the past => phase() is no longer Lobby.
+    const game = new GameServer(
+      "started-game",
+      mockLogger,
+      Date.now(),
+      { gameType: GameType.Public, gameMap: "plains", gameMapSize: 100 } as any,
+      undefined,
+      Date.now() - 60_000,
+      "ffa",
+    );
+    expect(game.applyMapVote("p1", "up")).toBe(false);
+    expect(game.gameInfo().mapVotes).toEqual({ up: 0, down: 0 });
+  });
+});

--- a/tests/server/MapVote.test.ts
+++ b/tests/server/MapVote.test.ts
@@ -65,18 +65,37 @@ describe("GameServer map voting", () => {
     expect(game.gameInfo().mapVotes).toBeUndefined();
   });
 
-  it("rejects votes once the lobby has left the Lobby phase", () => {
-    // startsAt in the past => phase() is no longer Lobby.
-    const game = new GameServer(
-      "started-game",
-      mockLogger,
-      Date.now(),
-      { gameType: GameType.Public, gameMap: "plains", gameMapSize: 100 } as any,
-      undefined,
-      Date.now() - 60_000,
-      "ffa",
-    );
+  it("rejects votes once the lobby has started", () => {
+    const game = publicLobby();
+    // prestart() flips the lobby out of the waiting state.
+    game.prestart();
     expect(game.applyMapVote("p1", "up")).toBe(false);
+    expect(game.gameInfo().mapVotes).toEqual({ up: 0, down: 0 });
+  });
+
+  it("treats re-sending the same vote as a no-op", () => {
+    const game = publicLobby();
+    expect(game.applyMapVote("p1", "up")).toBe(true);
+    expect(game.applyMapVote("p1", "up")).toBe(false);
+    expect(game.applyMapVote("p1", "clear")).toBe(true);
+    expect(game.applyMapVote("p1", "clear")).toBe(false);
+  });
+
+  it("drops a player's vote when they are kicked before start", () => {
+    const game = publicLobby();
+    const client = {
+      clientID: "c1",
+      persistentID: "p1",
+      username: "u1",
+      clanTag: null,
+      friends: [],
+      ws: { readyState: 1, send: () => {}, close: () => {} },
+    } as any;
+    (game as any).allClients.set("c1", client);
+    (game as any).activeClients = [client];
+    game.applyMapVote("p1", "up");
+    expect(game.gameInfo().mapVotes).toEqual({ up: 1, down: 0 });
+    game.kickClient("c1");
     expect(game.gameInfo().mapVotes).toEqual({ up: 0, down: 0 });
   });
 });


### PR DESCRIPTION
Resolves #2999

## Description:

Adds map voting to public lobbies so players can upvote or downvote the upcoming map, giving us a signal that can inform map rotation frequency.

It works through a new lobby-only `map_vote` intent (up / down / clear) added to `Schemas.ts`. The intent is handled entirely server-side in `GameServer` and is never relayed into the deterministic simulation, exactly like the existing `kick_player` and `start_game` lobby intents. Votes are stored in memory per `GameServer`, keyed by `persistentID`, so each player gets one vote that survives reconnects and can be switched or cleared. This mirrors the existing `winnerVotes` pattern, so no new persistence or storage is introduced (the server has no DB), and votes are dropped when a player disconnects or is kicked before the game starts so the tally only reflects players still present.

Tallies are surfaced two ways. On `GameInfo` we send the counts plus the recipient's own `myVote` (attached per-client in `broadcastLobbyInfo`, so each player sees their own selection highlighted). On `PublicGameInfo` we send counts only, propagated through the existing Worker→Master `lobbyList` broadcast so the lobby browser can show them.

Casting happens in `JoinLobbyModal` over the existing authenticated game WebSocket, because the `/lobbies` browser socket is broadcast-only and terminates any client that sends on it, so it cannot receive votes. That means the lobby-browser cards (`GameModeSelector`) show read-only counts, and the actual up/down buttons live in the join/waiting modal. Votes are accepted only while a public lobby is still waiting, they reuse the existing per-client intent rate limiter, and the client debounces clicks (~400ms) with optimistic feedback that reconciles on the next `lobby_info`. The tally rides that existing once-per-second `lobby_info` broadcast rather than fanning out synchronously per vote.

A structured `map_vote_summary` is logged at game start for offline rotation analysis. Live `MapPlaylist.FREQUENCY` is intentionally not auto-tuned from raw votes, since the tally is an advisory signal and isn't sybil-resistant for anonymous players.

### Screenshots

Read-only vote counts on a lobby-browser card:

![Lobby card vote counts](https://raw.githubusercontent.com/stfn-c/OpenFrontIO/media/1-lobby-card-vote-counts.png)

Vote buttons in the join/waiting modal:

![Join modal vote buttons](https://raw.githubusercontent.com/stfn-c/OpenFrontIO/media/2-join-modal-vote-buttons.png)

After upvoting (highlighted, count incremented):

![Join modal after upvoting](https://raw.githubusercontent.com/stfn-c/OpenFrontIO/media/3-join-modal-upvoted.png)

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

stfn-c
