### PR TITLE
[small-fix 25 lines] Add boat ETA calculation and display in AttacksDisplay

### DIFF
--- a/src/client/hud/layers/AttacksDisplay.ts
+++ b/src/client/hud/layers/AttacksDisplay.ts
@@ -350,6 +350,25 @@ export class AttacksDisplay extends LitElement implements Controller {
     />`;
   }
 
+  private getBoatETA(boat: UnitView): string {
+    const plan = this.game.motionPlans().get(boat.id());
+    if (!plan) return "";
+
+    const planSteps = plan.path.length;
+    const planTicks = planSteps * plan.ticksPerStep;
+    const planEndTick = plan.startTick + planTicks;
+
+    const remainingTicks = planEndTick - this.game.ticks();
+    if (remainingTicks <= 0) return "0s";
+    const remainingMs = remainingTicks * this.game.config().msPerTick();
+    const remainingSeconds = Math.ceil(remainingMs / 1000);
+
+    // e.g. return 1s, 35s, 59s, 1m, 1m1s, 1m59s, 2m, etc
+    const m = Math.floor(remainingSeconds / 60); // minutes
+    const s = remainingSeconds % 60; // seconds
+    return (m ? `${m}m` : "") + (s ? `${s}s` : "");
+  }
+
   private renderBoats() {
     if (this.outgoingBoats.length === 0) return html``;
 
@@ -365,6 +384,9 @@ export class AttacksDisplay extends LitElement implements Controller {
               >
               <span class="truncate text-xs ml-1"
                 >${this.getBoatTargetName(boat)}</span
+              >
+              <span class="text-xs ml-1 text-slate-300"
+                >${this.getBoatETA(boat)}</span
               >`,
             onClick: () => this.eventBus.emit(new GoToUnitEvent(boat)),
             className:
@@ -401,6 +423,9 @@ export class AttacksDisplay extends LitElement implements Controller {
               >
               <span class="truncate text-xs ml-1"
                 >${boat.owner()?.displayName()}</span
+              >
+              <span class="text-xs ml-1 text-slate-300"
+                >${this.getBoatETA(boat)}</span
               >`,
             onClick: () => this.eventBus.emit(new GoToUnitEvent(boat)),
             className:


### PR DESCRIPTION
Resolves #1793 

## Note:
@camclark also has a PR (#4073) for this issue and his design is really nice. I hope his PR gets merged. I opened this PR because  I already had a simple solution which I made a few days ago (just 25 lines). If for some reason his PR doesn't get merged I propose this as an alternative. Thanks.

## Description:
Add real-time countdown ETA for boats. 
<img width="516" height="70" alt="2026-06-01_00-06" src="https://github.com/user-attachments/assets/82d7ee7c-b0a3-44c8-9999-799e483c2f69" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

goose126
