### PR TITLE
fix(server): guard lobby full WS send with readyState and try/catch

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -212,12 +212,21 @@ export class GameServer {
         clientID: client.clientID,
       });
 
-      client.ws.send(
-        JSON.stringify({
-          type: "error",
-          error: "full-lobby",
-        } satisfies ServerErrorMessage),
-      );
+      try {
+        if (client.ws.readyState === WebSocket.OPEN) {
+          client.ws.send(
+            JSON.stringify({
+              type: "error",
+              error: "full-lobby",
+            } satisfies ServerErrorMessage),
+          );
+        }
+      } catch (error) {
+        this.log.error(`error sending full-lobby message for game ${this.id}`, {
+          clientID: client.clientID,
+          error,
+        });
+      }
       return "rejected";
     }
 


### PR DESCRIPTION
Resolves #4121

## Description:

The “lobby full” rejection path sent an error over WebSocket without checking `readyState`, risking runtime exceptions when the socket was already closing/closed. Hardens the “lobby full” flow by checking `WebSocket.OPEN` and wrapping `send` in a try/catch.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
