### PR TITLE
fix(client): guard leaderboard percentage against division-by-zero under heavy fallout

### DIFF
--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -107,7 +107,9 @@ export class Leaderboard extends LitElement implements Controller {
         name: player.displayName(),
         position: index + 1,
         score: formatPercentage(
-          player.numTilesOwned() / numTilesWithoutFallout,
+          numTilesWithoutFallout > 0
+            ? player.numTilesOwned() / numTilesWithoutFallout
+            : 0,
         ),
         gold: renderNumber(player.gold()),
         maxTroops: renderTroops(maxTroops),
@@ -138,7 +140,9 @@ export class Leaderboard extends LitElement implements Controller {
           name: myPlayer.displayName(),
           position: place,
           score: formatPercentage(
-            myPlayer.numTilesOwned() / this.game.numLandTiles(),
+            numTilesWithoutFallout > 0
+              ? myPlayer.numTilesOwned() / numTilesWithoutFallout
+              : 0,
           ),
           gold: renderNumber(myPlayer.gold()),
           maxTroops: renderTroops(myPlayerMaxTroops),


### PR DESCRIPTION
Resolves #4123

## Description:

The leaderboard “your rank” row computed territory percentage using all land tiles, while other rows used “land without fallout”, leading to inconsistent percentages after heavy nuking. Aligns the leaderboard “your rank” percentage with the rest of the leaderboard, and guards both calculations against division-by-zero when all tiles have fallout.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
