### PR TITLE
fix(core): clamp trajectory index to 0 when trajectory is empty

### DIFF
--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -479,6 +479,10 @@ export class UnitImpl implements Unit {
   }
 
   setTrajectoryIndex(i: number): void {
+    if (this._trajectory.length === 0) {
+      this._trajectoryIndex = 0;
+      return;
+    }
     const max = this._trajectory.length - 1;
     this._trajectoryIndex = i < 0 ? 0 : i > max ? max : i;
   }

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -268,4 +268,20 @@ describe("SAM", () => {
 
     expect(sam.missileTimerQueue()).toHaveLength(0);
   });
+
+  test("setTrajectoryIndex keeps index at zero for empty trajectories", async () => {
+    const nuke = attacker.buildUnit(UnitType.AtomBomb, game.ref(1, 1), {
+      targetTile: game.ref(2, 1),
+      trajectory: [],
+    });
+
+    expect(() => nuke.setTrajectoryIndex(-1)).not.toThrow();
+    expect(nuke.trajectoryIndex()).toBe(0);
+
+    expect(() => nuke.setTrajectoryIndex(0)).not.toThrow();
+    expect(nuke.trajectoryIndex()).toBe(0);
+
+    expect(() => nuke.setTrajectoryIndex(5)).not.toThrow();
+    expect(nuke.trajectoryIndex()).toBe(0);
+  });
 });


### PR DESCRIPTION
Resolves #4122

## Description:

Nuke trajectories could end up with an index of `-1` if the trajectory array was empty, breaking assumptions in downstream logic. Safely clamps the unit trajectory index to `0` when the trajectory is empty, and adds a regression test.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
