### PR TITLE
fix: resolve lobby host disconnect race condition

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -630,6 +630,19 @@ export class GameServer {
       // Remove persistentId if the game has not started to prevent going over max players
       if (!this._hasStarted) {
         this.persistentIdToClientId.delete(client.persistentID);
+        // Close lobby when host leaves before game starts
+        if (
+          !this.isPublic() &&
+          client.persistentID === this.creatorPersistentID
+        ) {
+          this.log.info("Host left due to early socket close, closing lobby", {
+            gameID: this.id,
+          });
+          for (const c of [...this.activeClients]) {
+            this.kickClient(c.clientID, KICK_REASON_HOST_LEFT);
+          }
+          this._hasEnded = true;
+        }
       }
     }
   }


### PR DESCRIPTION
Resolves #4125

## Description:

Fix a race condition in `GameServer.ts` where if the lobby host's WebSocket connection closes immediately during/before listeners are fully attached, the client is removed but the lobby is left open, orphaning any other players in the lobby. This PR adds the host-closure logic to the `readyState >= 2` safety check block to cleanly shut down private lobbies and kick remaining clients.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
