### PR TITLE
fix: resolve MIRV stuck on path not found

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -109,6 +109,10 @@ export class MirvExecution implements Execution {
       return;
     } else if (result.status === PathStatus.NEXT) {
       this.nuke.move(result.node);
+    } else if (result.status === PathStatus.NOT_FOUND) {
+      this.nuke.delete(false);
+      this.active = false;
+      return;
     }
   }
 


### PR DESCRIPTION
Resolves #4126

## Description:

Fixes a bug where the MIRV missile hangs in the air and stalls the game loop indefinitely if pathfinding fails (returning `PathStatus.NOT_FOUND`). This PR handles the path failure gracefully by deleting the MIRV unit and deactivating the execution class.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
