### PR TITLE
fix: resolve trade ship source port destruction logic flaw

### DIFF
--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -73,7 +73,10 @@ export class TradeShipExecution implements Execution {
 
     // If a player captures another player's port while trading we should delete
     // the ship.
-    if (dstPortOwner.id() === this.srcPort.owner().id()) {
+    if (
+      this.srcPort.isActive() &&
+      dstPortOwner.id() === this.srcPort.owner().id()
+    ) {
       this.tradeShip.delete(false);
       this.active = false;
       return;
@@ -81,7 +84,9 @@ export class TradeShipExecution implements Execution {
 
     if (
       !this.wasCaptured &&
-      (!this._dstPort.isActive() || !tradeShipOwner.canTrade(dstPortOwner))
+      (!this._dstPort.isActive() ||
+        !this.srcPort.isActive() ||
+        !tradeShipOwner.canTrade(dstPortOwner))
     ) {
       this.tradeShip.delete(false);
       this.active = false;


### PR DESCRIPTION
Resolves #4132

## Description:

Ensures that if the source port of a trade ship is destroyed during its transit, the trade ship is deleted and the execution ends. Previously, the trade ship would proceed and complete the trade even if the source port was non-existent, rewarding gold to its owner.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
