### PR TITLE
sec: resolve 1v1 winner spoofing vulnerability via strict consensus majority

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1263,7 +1263,7 @@ export class GameServer {
       },
     );
 
-    if (potentialWinner.ips.size * 2 < activeUniqueIPs.size) {
+    if (potentialWinner.ips.size * 2 <= activeUniqueIPs.size) {
       return;
     }
 


### PR DESCRIPTION
Resolves #4136

## Description:

Fixes a critical security vulnerability where a single client could unilaterally declare themselves the winner (winner spoofing) in 1v1 ranked games. 

Previously, the consensus check `potentialWinner.ips.size * 2 < activeUniqueIPs.size` allowed 1 out of 2 votes to satisfy the consensus condition (`2 < 2` is false). This PR changes the comparison operator to `<=` so that a strict majority (2 out of 2 votes) is required to determine the winner in a 1v1 game, unless one of the players has disconnected.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory
- [X] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
