### PR TITLE
Fix missing boat sprite icon in attacks panel

### DIFF
--- a/src/client/hud/GameRenderer.ts
+++ b/src/client/hud/GameRenderer.ts
@@ -2,9 +2,6 @@ import { EventBus } from "../../core/EventBus";
 import { GameView } from "../../core/game/GameView";
 import { UserSettings } from "../../core/game/UserSettings";
 import { Controller } from "../Controller";
-import { GameStartingModal } from "../GameStartingModal";
-import { TransformHandler } from "../TransformHandler";
-import { UIState } from "../UIState";
 import { AttackingTroopsController } from "../controllers/AttackingTroopsController";
 import { BuildPreviewController } from "../controllers/BuildPreviewController";
 import { HoverHighlightController } from "../controllers/HoverHighlightController";
@@ -12,7 +9,10 @@ import { SoundEffectController } from "../controllers/SoundEffectController";
 import { StructureHighlightController } from "../controllers/StructureHighlightController";
 import { ViewModeController } from "../controllers/ViewModeController";
 import { WarshipSelectionController } from "../controllers/WarshipSelectionController";
+import { GameStartingModal } from "../GameStartingModal";
 import { GameView as WebGLGameView } from "../render/gl";
+import { TransformHandler } from "../TransformHandler";
+import { UIState } from "../UIState";
 import { FrameProfiler } from "./FrameProfiler";
 import { ActionableEvents } from "./layers/ActionableEvents";
 import { AlertFrame } from "./layers/AlertFrame";
@@ -41,6 +41,7 @@ import { SpawnTimer } from "./layers/SpawnTimer";
 import { TeamStats } from "./layers/TeamStats";
 import { UnitDisplay } from "./layers/UnitDisplay";
 import { WinModal } from "./layers/WinModal";
+import { loadAllSprites } from "./SpriteLoader";
 
 export function createRenderer(
   inputEl: HTMLElement,
@@ -350,6 +351,10 @@ export class GameRenderer {
   ) {}
 
   initialize() {
+    loadAllSprites().catch((err) =>
+      console.error("Failed to preload sprites:", err),
+    );
+
     this.layers.forEach((l) => l.init?.());
 
     window.addEventListener("resize", () =>

--- a/src/client/hud/layers/AttacksDisplay.ts
+++ b/src/client/hud/layers/AttacksDisplay.ts
@@ -23,7 +23,7 @@ import {
 } from "../../Transport";
 import { UIState } from "../../UIState";
 import { renderTroops, translateText } from "../../Utils";
-import { getColoredSprite } from "../SpriteLoader";
+import { getColoredSprite, loadAllSprites } from "../SpriteLoader";
 const soldierIcon = assetUrl("images/SoldierIcon.svg");
 const swordIcon = assetUrl("images/SwordIcon.svg");
 
@@ -47,7 +47,14 @@ export class AttacksDisplay extends LitElement implements Controller {
     return this;
   }
 
-  init() {}
+  init() {
+    // Preload the unit sprites so boat rows can render their tinted icon.
+    // This previously ran from a deleted canvas layer, leaving the sprite
+    // map empty (see issue #4100).
+    loadAllSprites().catch((err) =>
+      console.error("Failed to preload attack display sprites:", err),
+    );
+  }
 
   tick() {
     this.active = true;

--- a/src/client/hud/layers/AttacksDisplay.ts
+++ b/src/client/hud/layers/AttacksDisplay.ts
@@ -23,7 +23,7 @@ import {
 } from "../../Transport";
 import { UIState } from "../../UIState";
 import { renderTroops, translateText } from "../../Utils";
-import { getColoredSprite, loadAllSprites } from "../SpriteLoader";
+import { getColoredSprite } from "../SpriteLoader";
 const soldierIcon = assetUrl("images/SoldierIcon.svg");
 const swordIcon = assetUrl("images/SwordIcon.svg");
 
@@ -47,11 +47,7 @@ export class AttacksDisplay extends LitElement implements Controller {
     return this;
   }
 
-  init() {
-    loadAllSprites().catch((err) =>
-      console.error("Failed to preload attack display sprites:", err),
-    );
-  }
+  init() {}
 
   tick() {
     this.active = true;

--- a/src/client/hud/layers/AttacksDisplay.ts
+++ b/src/client/hud/layers/AttacksDisplay.ts
@@ -48,9 +48,6 @@ export class AttacksDisplay extends LitElement implements Controller {
   }
 
   init() {
-    // Preload the unit sprites so boat rows can render their tinted icon.
-    // This previously ran from a deleted canvas layer, leaving the sprite
-    // map empty (see issue #4100).
     loadAllSprites().catch((err) =>
       console.error("Failed to preload attack display sprites:", err),
     );


### PR DESCRIPTION
Resolves #4100

## Description:

The boat row in the attacks panel (bottom-right UI) rendered an empty slot where the tinted boat sprite icon should appear, for both incoming and outgoing transport boats.

Root cause: `loadAllSprites()` in `SpriteLoader.ts` was never called. It was previously invoked by a canvas layer that has since been deleted, so the sprite map stayed empty. As a result `getColoredSprite()` threw, `AttacksDisplay.getBoatSpriteDataURL()` caught the error and returned `""`, and the icon rendered blank.

This fix calls `loadAllSprites()` from `AttacksDisplay.init()` (currently the only consumer of the sprite loader), so the sprite map is populated at startup.

### Demo after fix:
<img width="800" height="572" alt="CleanShot 2026-06-03 at 18 51 01" src="https://github.com/user-attachments/assets/e64a1ef7-da48-4662-a8c4-7234a8307730" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — no user-facing text added; only a console error log)
- [x] I have added relevant tests to the test directory (smoke tested locally, see demo recording above)

## Please put your Discord username so you can be contacted if a bug or regression is found:

cool_clarky
