### PR TITLE
Add optional username URL parameter to prefill player name

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -653,6 +653,10 @@ class Client {
       customElements.whenDefined("host-lobby-modal"),
     ]);
 
+    // Apply the optional "?username=" prefill before any join flow reads the
+    // username (and strip it from the URL). Used by iframe/embed integrations.
+    this.consumeUsernameUrl();
+
     // Check if CrazyGames SDK is enabled first (no hash needed in CrazyGames)
     if (crazyGamesSDK.isOnCrazyGames()) {
       const lobbyId = await crazyGamesSDK.getInviteGameId();
@@ -809,6 +813,35 @@ class Client {
       window.location.hash;
     history.replaceState(null, "", newUrl);
     return true;
+  }
+
+  /**
+   * Apply the optional "?username=" query parameter, then remove it from the
+   * URL.
+   *
+   * This lets external integrations (e.g. forums embedding OpenFront in an
+   * iframe) prefill each player's name so it matches their identity on the host
+   * site instead of defaulting to "Anon". Invalid values are ignored by the
+   * username input (which validates + persists). The parameter is always
+   * stripped afterwards so it never lingers in the address bar or gets copied
+   * into a shared lobby link, which would otherwise force one player's name
+   * onto everyone who opens that link.
+   */
+  private consumeUsernameUrl(): void {
+    const searchParams = new URLSearchParams(window.location.search);
+    const username = searchParams.get("username");
+    if (username === null) {
+      return;
+    }
+
+    this.usernameInput?.setUsername(username);
+
+    searchParams.delete("username");
+    const newUrl =
+      window.location.pathname +
+      (searchParams.toString() ? `?${searchParams.toString()}` : "") +
+      window.location.hash;
+    history.replaceState(null, "", newUrl);
   }
 
   private async handleJoinLobby(event: CustomEvent<JoinLobbyEvent>) {

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -7,6 +7,7 @@ import {
   MAX_USERNAME_LENGTH,
   MIN_CLAN_TAG_LENGTH,
   MIN_USERNAME_LENGTH,
+  stripInvalidUsernameChars,
   validateClanTag,
   validateUsername,
 } from "../core/validations/username";
@@ -49,6 +50,30 @@ export class UsernameInput extends LitElement {
 
   public getUsername(): string {
     return this.baseUsername.trim();
+  }
+
+  /**
+   * Programmatically set the username, e.g. from the optional "?username=" URL
+   * parameter that sites embedding OpenFront in an iframe can use to prefill a
+   * player's in-game name so it matches their identity on the host platform
+   * (instead of defaulting to an "Anon" name).
+   *
+   * The value is sanitized (reserved characters stripped) and validated; only a
+   * valid name is applied and persisted, so a malformed parameter silently
+   * leaves the existing (or anon) name untouched rather than blocking play. The
+   * server still censors profanity on join regardless of the source.
+   *
+   * @returns true if the username was applied.
+   */
+  public setUsername(username: string): boolean {
+    const sanitized = stripInvalidUsernameChars(username).trim();
+    if (!validateUsername(sanitized).isValid) {
+      return false;
+    }
+    this.baseUsername = sanitized;
+    // Persists to localStorage and broadcasts validity, exactly as if typed.
+    this.validateAndStore();
+    return true;
   }
 
   public getClanTag(): string | null {
@@ -215,7 +240,7 @@ export class UsernameInput extends LitElement {
   private handleUsernameChange(e: Event) {
     const input = e.target as HTMLInputElement;
     const originalValue = input.value;
-    const val = originalValue.replace(/[[\]]/g, "");
+    const val = stripInvalidUsernameChars(originalValue);
     if (originalValue !== val) {
       input.value = val;
       // Show toast when brackets are removed

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -6,6 +6,21 @@ export const MAX_USERNAME_LENGTH = 27;
 export const MIN_CLAN_TAG_LENGTH = 2;
 export const MAX_CLAN_TAG_LENGTH = 5;
 
+// Characters that are silently removed from usernames rather than rejected.
+// Square brackets are reserved for the clan-tag display format ("[TAG] Name",
+// see formatPlayerDisplayName in core/Util.ts); allowing them inside a username
+// would let a player spoof a clan tag.
+const RESERVED_USERNAME_CHARS = /[[\]]/g;
+
+/**
+ * Strip the reserved characters (square brackets) that are removed from a
+ * username instead of failing validation. Centralized so the manual username
+ * input and the optional "?username=" URL prefill sanitize identically.
+ */
+export function stripInvalidUsernameChars(username: string): string {
+  return username.replace(RESERVED_USERNAME_CHARS, "");
+}
+
 export function validateUsername(username: string): {
   isValid: boolean;
   error?: string;

--- a/tests/Censor.test.ts
+++ b/tests/Censor.test.ts
@@ -7,6 +7,7 @@ vi.mock("../src/client/Utils", () => ({
 import {
   MAX_CLAN_TAG_LENGTH,
   MAX_USERNAME_LENGTH,
+  stripInvalidUsernameChars,
   validateClanTag,
   validateUsername,
 } from "../src/core/validations/username";
@@ -69,6 +70,18 @@ describe("username.ts functions", () => {
     test("accepts valid clan tag", () => {
       const res = validateClanTag("AB12");
       expect(res.isValid).toBe(true);
+    });
+  });
+
+  describe("stripInvalidUsernameChars", () => {
+    test("removes square brackets to prevent clan-tag spoofing", () => {
+      expect(stripInvalidUsernameChars("[ADMIN] Bob")).toBe("ADMIN Bob");
+      expect(stripInvalidUsernameChars("Ae[va]nn")).toBe("Aevann");
+    });
+
+    test("leaves already-valid names untouched", () => {
+      expect(stripInvalidUsernameChars("Good_Name123")).toBe("Good_Name123");
+      expect(stripInvalidUsernameChars("Üser.Name")).toBe("Üser.Name");
     });
   });
 });

--- a/tests/client/UsernameInput.test.ts
+++ b/tests/client/UsernameInput.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// validateUsername() builds its error strings via translateText on the invalid
+// path; mock it to predictable keys so this test doesn't depend on loaded
+// translations. generateCryptoRandomUUID is stubbed because UsernameInput
+// imports it (only used by genAnonUsername, which these tests don't exercise).
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string, vars?: unknown) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+  generateCryptoRandomUUID: () => "00000000-0000-0000-0000-000000000000",
+}));
+
+import { UsernameInput } from "../../src/client/UsernameInput";
+
+describe("UsernameInput.setUsername (?username= prefill)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("applies and persists a valid username", () => {
+    const input = new UsernameInput();
+
+    expect(input.setUsername("Aevann")).toBe(true);
+    expect(input.getUsername()).toBe("Aevann");
+    expect(localStorage.getItem("username")).toBe("Aevann");
+    expect(input.canPlay()).toBe(true);
+  });
+
+  it("trims surrounding whitespace before applying", () => {
+    const input = new UsernameInput();
+
+    expect(input.setUsername("  Bob  ")).toBe(true);
+    expect(input.getUsername()).toBe("Bob");
+    expect(localStorage.getItem("username")).toBe("Bob");
+  });
+
+  it("strips reserved brackets so a clan tag cannot be spoofed", () => {
+    const input = new UsernameInput();
+
+    expect(input.setUsername("[ADMIN] hi")).toBe(true);
+    expect(input.getUsername()).toBe("ADMIN hi");
+  });
+
+  it("ignores a too-short value and keeps the existing name", () => {
+    const input = new UsernameInput();
+    input.setUsername("ValidName");
+
+    expect(input.setUsername("ab")).toBe(false);
+    expect(input.getUsername()).toBe("ValidName");
+    expect(localStorage.getItem("username")).toBe("ValidName");
+  });
+
+  it("ignores a value with disallowed characters", () => {
+    const input = new UsernameInput();
+    input.setUsername("ValidName");
+
+    expect(input.setUsername("Invalid!Name#")).toBe(false);
+    expect(input.getUsername()).toBe("ValidName");
+  });
+
+  it("ignores an empty parameter value", () => {
+    const input = new UsernameInput();
+    input.setUsername("ValidName");
+
+    expect(input.setUsername("")).toBe(false);
+    expect(input.getUsername()).toBe("ValidName");
+  });
+
+  it("ignores a value longer than the max length", () => {
+    const input = new UsernameInput();
+    input.setUsername("ValidName");
+
+    expect(input.setUsername("a".repeat(28))).toBe(false);
+    expect(input.getUsername()).toBe("ValidName");
+  });
+});


### PR DESCRIPTION
Resolves #3561

## Description:

Adds an optional `username` query parameter to game URLs so the player's in-game name can be set from the link, for example:

`https://openfront.io/game/rsBteQx4?username=Aevann`

This helps when OpenFront is embedded in an iframe on another site (in my case rdrama.net): the host page can put the user's existing name in the URL so they don't end up playing as "Anon". If the parameter isn't present, behavior is unchanged.

A few details:
- The value runs through the same validation as the username box (3-27 chars, allowed characters only). Invalid values are ignored so a bad link can't block play.
- Square brackets are stripped first so a username can't be used to fake a clan tag (the `[TAG] Name` format).
- The parameter is removed from the URL right after it's applied, so it isn't copied into shared lobby links.
- Names are still censored server-side on join, same as before.

No new user-facing strings were added (existing validation messages are reused).

### Screenshots

Username prefilled from a `?username=Aevann` link (the parameter is cleaned from the URL automatically afterwards):

<img width="1280" height="800" alt="username_prefilled_from_url" src="https://github.com/user-attachments/assets/ac5d32ba-43a6-4651-abf4-c21ce0c263f2" />

The name carried into an actual game (shown in the leaderboard and as the on-map label):

<img width="1280" height="800" alt="username_used_ingame" src="https://github.com/user-attachments/assets/6ad7462f-42b5-4741-a517-6cff0cf8cc2f" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

Aevann2
