### PR TITLE
Fixes malformed flag svg url in playerRow

### DIFF
--- a/src/client/components/baseComponents/ranking/PlayerRow.ts
+++ b/src/client/components/baseComponents/ranking/PlayerRow.ts
@@ -256,7 +256,7 @@ export class PlayerRow extends LitElement {
       </div>`;
     } else if (this.player.flag) {
       return html`<img
-        src=${assetUrl(`flags/${this.player.flag}.svg`)}
+        src=${assetUrl(`${this.player.flag}`)}
         class="min-w-7.5 h-7.5 sm:min-w-10 sm:h-10 shrink-0"
       />`;
     }


### PR DESCRIPTION
Resolves #4194 

## Description:

Fixes the malformed flag svg link when viewing the player row component. 

This has been tested by temporarily registering a route to the game-info modal locally and confirming the flag svg now loads.

Local before

<img width="698" height="500" alt="image" src="https://github.com/user-attachments/assets/a5bd0958-e4f2-4ab6-9203-b49e42a34ca7" />

---
Local after

<img width="770" height="573" alt="Screenshot 2026-06-09 at 6 56 17 PM" src="https://github.com/user-attachments/assets/ffc64c50-f0d9-4c22-9325-34924b68c985" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

Caidora