### PR TITLE
Fix/expiration window staying after expiration

### DIFF
--- a/src/client/hud/layers/ActionableEvents.ts
+++ b/src/client/hud/layers/ActionableEvents.ts
@@ -81,7 +81,6 @@ export class ActionableEvents extends LitElement implements Controller {
           event.allianceID === allianceID
         ),
     );
-    this.requestUpdate();
   }
 
   tick() {
@@ -186,6 +185,7 @@ export class ActionableEvents extends LitElement implements Controller {
       if (!currentAllianceIds.has(allianceId)) {
         this.removeAllianceRenewalEvents(allianceId);
         this.alliancesCheckedAt.delete(allianceId);
+        this.requestUpdate();
       }
     }
   }

--- a/src/client/hud/layers/ActionableEvents.ts
+++ b/src/client/hud/layers/ActionableEvents.ts
@@ -34,6 +34,7 @@ interface ActionableEvent {
   priority?: number;
   allianceID?: number;
   duration?: Tick;
+  requestorID: number;
 }
 
 @customElement("actionable-events")
@@ -111,8 +112,13 @@ export class ActionableEvents extends LitElement implements Controller {
 
     const remainingEvents = this.events.filter(
       (event) =>
-        event.duration === undefined ||
-        this.game.ticks() - event.createdAt < event.duration,
+        (event.duration === undefined ||
+          this.game.ticks() - event.createdAt < event.duration) &&
+        (event.type !== MessageType.ALLIANCE_REQUEST ||
+          // We remove Alliance Requests if the requestor is no longer requesting an alliance with us.
+          (
+            this.game.playerBySmallID(event.requestorID) as PlayerView
+          ).isRequestingAllianceWith(this.game.myPlayer() as PlayerView)),
     );
 
     if (this.events.length !== remainingEvents.length) {
@@ -178,6 +184,7 @@ export class ActionableEvents extends LitElement implements Controller {
         createdAt: this.game.ticks(),
         focusID: other.smallID(),
         allianceID: alliance.id,
+        requestorID: other.smallID(),
       });
     }
 
@@ -237,6 +244,7 @@ export class ActionableEvents extends LitElement implements Controller {
       priority: 0,
       duration: this.game.config().allianceRequestDuration(),
       focusID: update.requestorID,
+      requestorID: update.requestorID,
     });
   }
 

--- a/src/client/hud/layers/ActionableEvents.ts
+++ b/src/client/hud/layers/ActionableEvents.ts
@@ -81,6 +81,7 @@ export class ActionableEvents extends LitElement implements Controller {
           event.allianceID === allianceID
         ),
     );
+    this.requestUpdate();
   }
 
   tick() {


### PR DESCRIPTION
Resolves #4209

## Description:

While filtering events in the src/client/hud/layers/ActionableEvents.ts tick function, we remove from the event list any event where the requestor is not requesting an alliance anymore. This excludes alliance requests where the requestor attacked (or bombed) AND alliance requests where the recipient accepted through the radial menu.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:
Katokoda
