### PR TITLE
Remove committed map-generator binary from the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ src/assets/
 *debug*.txt
 eslint_out.txt
 tests/perf/output/
+
+# Locally built Go binary (gen-maps uses `go run .`)
+map-generator/map-generator


### PR DESCRIPTION
**Add approved & assigned issue number here:**

N/A — maintainer housekeeping.

## Description:

Removes the committed `map-generator/map-generator` Go binary from the repo and adds it to `.gitignore`.

The binary is a local build artifact: `npm run gen-maps` runs the generator with `go run .`, and nothing in the repo (scripts, CI workflows, docs) references the committed file. Tracking it just causes opaque binary churn in every PR that touches the generator (e.g. #4227, #4231). The `.gitignore` entry keeps locally built binaries from being accidentally re-committed.

## Please complete the following:

- [x] I have added screenshots for all UI updates (no UI changes)
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file (no user-visible text)
- [x] I have added relevant tests to the test directory (no behavior to test — removes an unused build artifact)

## Please put your Discord username so you can be contacted if a bug or regression is found:

evanpelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
