### PR TITLE
fix: pass prevValue in resetToDefault so conflict rejection correctly reverts keybind UI

### DIFF
--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -82,8 +82,11 @@ export class UserSettingModal extends BaseModal {
   ) {
     const { action, value, key, prevValue } = e.detail;
 
+    // Build the effective keybind map, excluding the action being changed so
+    // its old user override doesn't interfere with the conflict check.
     const activeKeybinds = { ...this.defaultKeybinds };
     for (const [k, v] of Object.entries(this.userKeybinds)) {
+      if (k === action) continue; // exclude current action – we're replacing it
       const normalizedValue = v.value;
       if (normalizedValue === "Null") {
         delete activeKeybinds[k];
@@ -146,10 +149,19 @@ export class UserSettingModal extends BaseModal {
       return;
     }
 
-    this.userKeybinds = {
-      ...this.userKeybinds,
-      [action]: { value: value, key: key },
-    };
+    // Save the new keybind. If the new value matches the default, remove the
+    // override entirely so that localStorage stays clean (no redundant entries).
+    const isDefault = value === this.defaultKeybinds[action];
+    if (isDefault) {
+      const rest = { ...this.userKeybinds };
+      delete rest[action];
+      this.userKeybinds = rest;
+    } else {
+      this.userKeybinds = {
+        ...this.userKeybinds,
+        [action]: { value: value, key: key },
+      };
+    }
     this.userSettings.setKeybinds(this.userKeybinds);
   }
 

--- a/src/client/components/baseComponents/setting/SettingKeybind.ts
+++ b/src/client/components/baseComponents/setting/SettingKeybind.ts
@@ -143,12 +143,15 @@ export class SettingKeybind extends LitElement {
   }
 
   private resetToDefault() {
+    const prevValue = this.value;
     this.value = this.defaultKey;
     this.dispatchEvent(
       new CustomEvent("change", {
         detail: {
           action: this.action,
           value: this.defaultKey,
+          key: this.defaultKey,
+          prevValue,
         },
         bubbles: true,
         composed: true,


### PR DESCRIPTION
Fixes #4285

## What changed and why

`resetToDefault()` in `SettingKeybind.ts` dispatched a `change` event without
`prevValue` or `key`. The parent handler in `UserSettingModal.ts` uses:

```ts
element.value = prevValue ?? this.defaultKeybinds[action] ?? "";

With prevValue missing, the fallback was always defaultKey  exact key the reset was trying to assign. So even when the conflict check correctly rejected the reset and returned early, the UI element was set to defaultKey anyway, making it appear as if the reset succeeded. The actual binding in localStorage was untouched, silently diverging from what the UI showed.

A second consequence: once the element shows defaultKey, canReset becomes false (this.value !== this.defaultKey → false), permanently disabling the Reset button. The user has no way to recover without manually reassigning the key.

Changes
src/client/components/baseComponents/setting/SettingKeybind.ts
resetToDefault() now saves prevValue before updating this.value and forwards both prevValue and key in the dispatched event/matching the contract that handleKeydown already follows. If the parent rejects the reset, element.value is correctly restored to the action's actual previous binding.

src/client/UserSettingModal.ts
Two supporting improvements in handleKeybindChange:
1.Conflict check: skip the action's own current user override when building activeKeybinds. The values filter already excludes the action from the conflict check, but excluding it from the override loop too makes the intent explicit and avoids any future confusion.
2.Clean save: if the accepted value equals the action's default, remove the override entry from userKeybinds entirely instead of writing a redundant { value: "Digit8", key: "Digit8" }. The keybinds() merge in UserSettings already applies defaults; storing an identical override just adds noise to localStorage.
Testing
All 1517 existing tests pass (npx vitest run).
No unit tests exist for UserSettingModal or SettingKeybind. The fix was verified manually by reproducing the exact steps from #4285.