### PR TITLE
Reapply graphics overrides on debug render GUI reset

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -514,10 +514,9 @@ async function createClientGame(
     const regenerateRenderSettings = (): void => {
       deepAssign(view.getSettings(), resolveRenderSettings());
     };
-    // Re-apply render settings, then re-theme and recolor players, on a
-    // graphics-override change (covers a theme switch such as colorblind mode).
-    const onGraphicsChanged = (): void => {
-      regenerateRenderSettings();
+    // Rebuild the GPU-derived graphics state that the per-frame passes don't
+    // pick up from the live settings object on their own.
+    const refreshDerivedGraphics = (): void => {
       // Terrain is baked into a GPU texture rather than read per-frame, so a
       // terrain-color override (e.g. ocean) needs an explicit texture rebuild.
       view.rebuildTerrain();
@@ -526,6 +525,12 @@ async function createClientGame(
       // territory fills/borders live.
       gameView.refreshPlayerColors();
       webglBuilder.refreshPalette(gameView);
+    };
+    // Re-apply render settings, then re-theme and recolor players, on a
+    // graphics-override change (covers a theme switch such as colorblind mode).
+    const onGraphicsChanged = (): void => {
+      regenerateRenderSettings();
+      refreshDerivedGraphics();
     };
     // No initial regenerate or terrain rebuild needed — the renderer was
     // constructed with the resolved settings above, so the terrain texture
@@ -545,7 +550,11 @@ async function createClientGame(
         debugGuiLoading = true;
         import("./render/gl/debug/index")
           .then(({ createDebugGui }) => {
-            debugGui = createDebugGui(view.getSettings());
+            debugGui = createDebugGui(
+              view.getSettings(),
+              resolveRenderSettings,
+              refreshDerivedGraphics,
+            );
             debugGui.open();
           })
           .finally(() => {

--- a/src/client/render/gl/debug/Wiring.ts
+++ b/src/client/render/gl/debug/Wiring.ts
@@ -1,6 +1,6 @@
 import GUI, { FunctionController } from "lil-gui";
 import type { RenderSettings } from "../RenderSettings";
-import { createRenderSettings, dumpSettings } from "../RenderSettings";
+import { dumpSettings } from "../RenderSettings";
 import { deepAssign } from "../SettingsUtils";
 import type { ConfigProp } from "./ConfigProp";
 
@@ -66,6 +66,7 @@ export function wireActions(
   gui: GUI,
   settings: RenderSettings,
   props: ConfigProp[],
+  resolveDefaults: () => RenderSettings,
   onSettingsChanged?: () => void,
 ): void {
   gui.add({ dump: () => dumpSettings(settings) }, "dump").name("Download JSON");
@@ -99,7 +100,7 @@ export function wireActions(
     .add(
       {
         reset: () => {
-          deepAssign(settings, createRenderSettings());
+          deepAssign(settings, resolveDefaults());
           props.forEach((p) => p.resetToDefault());
           onSettingsChanged?.();
         },

--- a/src/client/render/gl/debug/index.ts
+++ b/src/client/render/gl/debug/index.ts
@@ -7,6 +7,7 @@ import { makeDraggable, wireActions, wireModifiedIndicators } from "./Wiring";
 
 export function createDebugGui(
   settings: RenderSettings,
+  resolveDefaults: () => RenderSettings = createRenderSettings,
   onSettingsChanged?: () => void,
 ): GUI {
   const gui = new GUI({ title: "Render Settings", width: 320 });
@@ -17,10 +18,13 @@ export function createDebugGui(
 
   makeDraggable(gui);
 
-  const defaults = createRenderSettings();
+  // Defaults include the user's graphics overrides so "Reset to Defaults"
+  // (and the per-prop reset / modified indicators) restore the same settings
+  // the renderer was built with — not bare defaults that drop the overrides.
+  const defaults = resolveDefaults();
   const props = walkTree(buildTree(settings, defaults), gui);
 
-  wireActions(gui, settings, props, onSettingsChanged);
+  wireActions(gui, settings, props, resolveDefaults, onSettingsChanged);
   wireModifiedIndicators(gui, props, onSettingsChanged);
 
   gui.close();


### PR DESCRIPTION
## Problem

The debug render GUI's **"Reset to Defaults"** restored bare `createRenderSettings()` defaults, wiping the user's graphics overrides (colorblind theme, ocean color, lighting, name scaling, etc.) from the live render settings. The per-prop right-click "reset to default" and the modified-indicators had the same flaw — their captured defaults were raw, ignoring overrides.

## Fix

Thread the existing `resolveRenderSettings` (`createRenderSettings()` + `applyGraphicsOverrides()`) into the debug GUI as the defaults provider, so reset restores the same settings the renderer was actually built with.

- **`debug/index.ts`** — added a `resolveDefaults` param (defaults to `createRenderSettings` to keep the module decoupled). The captured `defaults` now include overrides, fixing the per-prop reset and modified indicators too.
- **`debug/Wiring.ts`** — `wireActions` takes `resolveDefaults`; the reset handler `deepAssign`s `resolveDefaults()` instead of `createRenderSettings()`.
- **`ClientGameRunner.ts`** — passes `resolveRenderSettings` into `createDebugGui`, and extracts a `refreshDerivedGraphics` helper (terrain rebuild + re-theme/palette) from `onGraphicsChanged`, wired as the GUI's `onSettingsChanged` so the reapplied terrain/colorblind overrides become *visible* after reset (they're baked into GPU textures and aren't picked up per-frame).

Side benefit: editing terrain/theme settings in the debug GUI now refreshes those textures live too (that callback was previously never wired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)