### PR TITLE
fix: Ctrl+click on Mac no attack

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -50,6 +50,7 @@ import {
   ToggleRenderDebugGuiEvent,
 } from "./InputHandler";
 import { endGame, startGame, startTime } from "./LocalPersistantStats";
+import { Platform } from "./Platform";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 import { GoToPlayerEvent } from "./TransformHandler";
 import {
@@ -918,8 +919,11 @@ export class ClientGameRunner {
       if (myPlayer === null) return;
       this.myPlayer = myPlayer;
     }
+    // On macOS, Ctrl+left-click is the system "secondary click" gesture, so
+    // don't treat it as an attack on another player.
+    const suppressAttack = Platform.isMac && event.ctrlKey;
     this.myPlayer.actions(tile, [UnitType.TransportShip]).then((actions) => {
-      if (actions.canAttack) {
+      if (actions.canAttack && !suppressAttack) {
         this.eventBus.emit(
           new SendAttackIntentEvent(
             this.gameView.owner(tile).id(),

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -10,6 +10,7 @@ export class MouseUpEvent implements GameEvent {
   constructor(
     public readonly x: number,
     public readonly y: number,
+    public readonly ctrlKey: boolean = false,
   ) {}
 }
 
@@ -722,7 +723,7 @@ export class InputHandler {
         event.shiftKey ||
         this.gameView.inSpawnPhase() // No Radial Menu during spawn phase, only spawn point selection
       ) {
-        this.eventBus.emit(new MouseUpEvent(event.x, event.y));
+        this.eventBus.emit(new MouseUpEvent(event.x, event.y, event.ctrlKey));
       } else {
         this.eventBus.emit(new ContextMenuEvent(event.clientX, event.clientY));
       }

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -21,6 +21,8 @@ class MockPointerEvent {
   pointerId: number;
   type: string;
   pointerType: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
   preventDefault: () => void;
 
   constructor(type: string, init: any) {
@@ -32,6 +34,8 @@ class MockPointerEvent {
     this.y = init.y ?? init.clientY;
     this.pointerId = init.pointerId;
     this.pointerType = init.pointerType ?? "mouse";
+    this.ctrlKey = init.ctrlKey ?? false;
+    this.shiftKey = init.shiftKey ?? false;
     this.preventDefault = vi.fn();
   }
 }
@@ -284,6 +288,46 @@ describe("InputHandler AutoUpgrade", () => {
         (call) => call[0].constructor.name,
       );
       expect(emittedTypes).not.toContain("ContextMenuEvent");
+    });
+  });
+
+  describe("MouseUpEvent modifier passthrough", () => {
+    const emitMouseUp = (ctrlKey: boolean) => {
+      const mockEmit = vi.spyOn(eventBus, "emit");
+      // Left-click that resolves to a MouseUpEvent (not the radial menu).
+      inputHandler["userSettings"].leftClickOpensMenu = () => false;
+
+      const pointerEvent = new PointerEvent("pointerup", {
+        button: 0,
+        clientX: 150,
+        clientY: 250,
+        ctrlKey,
+      });
+      inputHandler["lastPointerDownX"] = 150;
+      inputHandler["lastPointerDownY"] = 250;
+
+      inputHandler["onPointerUp"](pointerEvent);
+
+      const call = mockEmit.mock.calls.find(
+        (c) => c[0].constructor.name === "MouseUpEvent",
+      );
+      return call?.[0] as { x: number; y: number; ctrlKey: boolean } | undefined;
+    };
+
+    test("MouseUpEvent carries ctrlKey=true when Ctrl is held", () => {
+      expect(emitMouseUp(true)).toMatchObject({
+        x: 150,
+        y: 250,
+        ctrlKey: true,
+      });
+    });
+
+    test("MouseUpEvent carries ctrlKey=false when Ctrl is not held", () => {
+      expect(emitMouseUp(false)).toMatchObject({
+        x: 150,
+        y: 250,
+        ctrlKey: false,
+      });
     });
   });
 

--- a/tests/client/ClientGameRunner.test.ts
+++ b/tests/client/ClientGameRunner.test.ts
@@ -1,0 +1,104 @@
+import { ClientGameRunner } from "../../src/client/ClientGameRunner";
+import { MouseUpEvent } from "../../src/client/InputHandler";
+import { Platform } from "../../src/client/Platform";
+import { SendAttackIntentEvent } from "../../src/client/Transport";
+import { EventBus } from "../../src/core/EventBus";
+
+// Builds a ClientGameRunner with just enough wiring for inputEvent() to reach
+// the attack decision. The constructor is bypassed (Object.create) so we don't
+// have to stand up the whole rendering/transport stack.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function makeRunner(eventBus: EventBus, actions: any) {
+  const runner = Object.create(
+    ClientGameRunner.prototype,
+  ) as ClientGameRunner & Record<string, any>;
+
+  runner["isActive"] = true;
+  runner["eventBus"] = eventBus;
+  runner["renderer"] = {
+    uiState: { ghostStructure: null, attackRatio: 0.5 },
+    transformHandler: {
+      screenToWorldCoordinates: () => ({ x: 1, y: 1 }),
+    },
+  };
+  runner["gameView"] = {
+    isValidCoord: () => true,
+    ref: () => 42,
+    isLand: () => true,
+    hasOwner: () => true,
+    inSpawnPhase: () => false,
+    config: () => ({ isRandomSpawn: () => false }),
+    owner: () => ({ id: () => "enemy-id" }),
+  };
+  runner["myPlayer"] = {
+    actions: vi.fn().mockResolvedValue(actions),
+    troops: () => 100,
+  };
+  return runner;
+}
+
+describe("ClientGameRunner left-click attack (Mac Ctrl suppression)", () => {
+  let originalIsMac: boolean;
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    originalIsMac = Platform.isMac;
+    eventBus = new EventBus();
+  });
+
+  afterEach(() => {
+    (Platform as any).isMac = originalIsMac;
+  });
+
+  test("suppresses attack on Mac when Ctrl is held", async () => {
+    (Platform as any).isMac = true;
+    const emit = vi.spyOn(eventBus, "emit");
+    const runner = makeRunner(eventBus, {
+      canAttack: true,
+      buildableUnits: [],
+    });
+
+    runner["inputEvent"](new MouseUpEvent(150, 250, true));
+    await flush();
+
+    const attackEmitted = emit.mock.calls.some(
+      (c) => c[0] instanceof SendAttackIntentEvent,
+    );
+    expect(attackEmitted).toBe(false);
+  });
+
+  test("attacks on Mac when Ctrl is NOT held", async () => {
+    (Platform as any).isMac = true;
+    const emit = vi.spyOn(eventBus, "emit");
+    const runner = makeRunner(eventBus, {
+      canAttack: true,
+      buildableUnits: [],
+    });
+
+    runner["inputEvent"](new MouseUpEvent(150, 250, false));
+    await flush();
+
+    const attackEmitted = emit.mock.calls.some(
+      (c) => c[0] instanceof SendAttackIntentEvent,
+    );
+    expect(attackEmitted).toBe(true);
+  });
+
+  test("attacks on non-Mac even when Ctrl is held", async () => {
+    (Platform as any).isMac = false;
+    const emit = vi.spyOn(eventBus, "emit");
+    const runner = makeRunner(eventBus, {
+      canAttack: true,
+      buildableUnits: [],
+    });
+
+    runner["inputEvent"](new MouseUpEvent(150, 250, true));
+    await flush();
+
+    const attackEmitted = emit.mock.calls.some(
+      (c) => c[0] instanceof SendAttackIntentEvent,
+    );
+    expect(attackEmitted).toBe(true);
+  });
+});


### PR DESCRIPTION
Resolves #2719

## Description:

On Macs, any time you ctrl+click to open the radial menu, it tries to attack whoever your mouse happens to be on.

This doesn't happen on Windows/Linux.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

minitauros
