### PR TITLE
Restore gray in-game background to match v31

### DIFF
--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1124,7 +1124,7 @@ export class GPURenderer {
   private drawBaseLayer(cam: Float32Array): void {
     const gl = this.gl;
     const pe = this.settings.passEnabled;
-    gl.clearColor(0.04, 0.04, 0.06, 1.0);
+    gl.clearColor(60 / 255, 60 / 255, 60 / 255, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.disable(gl.BLEND);
     if (pe.terrain) this.terrainPass.draw(cam);


### PR DESCRIPTION
## Summary

The in-game map background changed from gray (v31) to near-black after the WebGL renderer rewrite. This restores the gray.

The renderer rewrite hardcoded the base-layer clear color to `(0.04, 0.04, 0.06)` in `drawBaseLayer` (`src/client/render/gl/Renderer.ts`). v31 set the background via `PastelTheme.backgroundColor()`, which returned `rgb(60,60,60)`. This change sets the clear color back to that gray.

## Notes

- The old theme-based `backgroundColor()` system was removed in the rewrite, so this hardcoded clear color is now the single source for the map background.

🤖 Generated with [Claude Code](https://claude.com/claude-code)