### PR TITLE
Fix nuclear fallout covering UI overlays

### DIFF
--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1144,6 +1144,7 @@ export class GPURenderer {
     if (pe.borderStamp) this.borderStampPass.draw(cam);
     if (pe.railroad) this.railroadPass.draw(cam, zoom);
     if (pe.unit) this.unitPass.drawGround(cam);
+    if (pe.falloutBloom) this.bloomPass.draw(cam, this.frameTick);
     this.samRadiusPass.draw(cam);
     this.rangeCirclePass.draw(cam);
     this.nukeTrajectoryPass.draw(cam);
@@ -1155,7 +1156,6 @@ export class GPURenderer {
     this.selectionBoxPass.draw(cam, this.frameTick);
     this.moveIndicatorPass.draw(cam, zoom);
     this.nukeTelegraphPass.draw(cam);
-    if (pe.falloutBloom) this.bloomPass.draw(cam, this.frameTick);
     if (pe.trail) this.trailPass.draw(cam);
     if (pe.unit) this.unitPass.drawMissiles(cam);
 


### PR DESCRIPTION
## Problem

Nuclear fallout was rendering on top of UI overlays (most visibly the SAM launcher range circles), hiding them.

## Cause

In `renderOverlays()` (`src/client/render/gl/Renderer.ts`), the fallout bloom pass was drawn near the end of the overlay sequence — after the SAM radius, range circles, structures, bars, etc. — so it painted over all of them.

## Fix

Moved `bloomPass.draw(...)` (fallout bloom) to draw right after the ground units and before all UI overlays. Fallout is a ground-contamination effect, so it now sits above the terrain/units but below every UI overlay, which all render on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)