### PR TITLE
Add Fallout effects toggle to graphics settings ☢️

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -523,6 +523,8 @@
     "colored_names_label": "Name color",
     "coordinate_grid_opacity_desc": "How opaque the coordinate grid is (lower lets more things show through)",
     "coordinate_grid_opacity_label": "Coordinate grid opacity",
+    "fallout_desc": "Show the green nuclear fallout glow on irradiated territory. Disable to improve performance",
+    "fallout_label": "Fallout effects",
     "highlight_brighten_desc": "How strongly the border brightens on hover (0 to disable)",
     "highlight_brighten_label": "Border highlight amount",
     "highlight_fill_desc": "How strongly territory brightens on hover (0 to disable)",

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -487,6 +487,17 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     this.patchPassEnabled({ fx: !this.currentSpecialEffects() });
   }
 
+  private currentFallout(): boolean {
+    return (
+      this.userSettings.graphicsOverrides().passEnabled?.fallout ??
+      renderDefaults.passEnabled.falloutBloom
+    );
+  }
+
+  private onToggleFallout() {
+    this.patchPassEnabled({ fallout: !this.currentFallout() });
+  }
+
   /** Whether colorblind mode is currently enabled. */
   private currentColorblind(): boolean {
     return (
@@ -1132,6 +1143,25 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
               </div>
               <div class="text-sm text-slate-400">
                 ${this.currentSpecialEffects()
+                  ? translateText("user_setting.on")
+                  : translateText("user_setting.off")}
+              </div>
+            </button>
+
+            <button
+              class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
+              @click=${this.onToggleFallout}
+            >
+              <div class="flex-1">
+                <div class="font-medium">
+                  ${translateText("graphics_setting.fallout_label")}
+                </div>
+                <div class="text-sm text-slate-400">
+                  ${translateText("graphics_setting.fallout_desc")}
+                </div>
+              </div>
+              <div class="text-sm text-slate-400">
+                ${this.currentFallout()
                   ? translateText("user_setting.on")
                   : translateText("user_setting.off")}
               </div>

--- a/src/client/render/gl/GraphicsOverrides.ts
+++ b/src/client/render/gl/GraphicsOverrides.ts
@@ -38,6 +38,9 @@ export const GraphicsOverridesSchema = z
     passEnabled: z
       .object({
         fx: z.boolean(),
+        // Nuclear fallout effects: the broiling green territory bloom and its
+        // light emission in day/night mode. Disable to improve performance.
+        fallout: z.boolean(),
       })
       .partial(),
     accessibility: z

--- a/src/client/render/gl/RenderOverrides.ts
+++ b/src/client/render/gl/RenderOverrides.ts
@@ -73,6 +73,12 @@ export function applyGraphicsOverrides(
   if (overrides.passEnabled?.fx !== undefined) {
     settings.passEnabled.fx = overrides.passEnabled.fx;
   }
+  if (overrides.passEnabled?.fallout !== undefined) {
+    // One user-facing toggle drives both fallout passes: the territory bloom
+    // and its additive light contribution in the day/night composite.
+    settings.passEnabled.falloutBloom = overrides.passEnabled.fallout;
+    settings.passEnabled.falloutLight = overrides.passEnabled.fallout;
+  }
   if (overrides.terrain?.oceanColor !== undefined) {
     settings.terrain.oceanColor = overrides.terrain.oceanColor;
   }

--- a/src/client/render/gl/RenderSettings.ts
+++ b/src/client/render/gl/RenderSettings.ts
@@ -52,6 +52,7 @@ export interface RenderSettings {
     unit: boolean;
     name: boolean;
     falloutBloom: boolean;
+    falloutLight: boolean;
     railroad: boolean;
     fx: boolean;
     bar: boolean;

--- a/src/client/render/gl/passes/LightmapPass.ts
+++ b/src/client/render/gl/passes/LightmapPass.ts
@@ -160,7 +160,9 @@ export class LightmapPass {
     this.pointLightPass.draw(cameraMatrix);
 
     // --- 2. Fallout light → extract at tile res, composite into FBO A (additive) ---
-    this.falloutLightPass.draw(cameraMatrix, this.lightFboA, lw, lh, tick);
+    if (this.settings.passEnabled.falloutLight) {
+      this.falloutLightPass.draw(cameraMatrix, this.lightFboA, lw, lh, tick);
+    }
 
     // --- 3. Blur: 2 iterations separable H+V Gaussian ---
     const zoom = Math.abs(cameraMatrix[0]);

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -10,6 +10,7 @@
     "unit": true,
     "name": true,
     "falloutBloom": true,
+    "falloutLight": true,
     "railroad": true,
     "fx": true,
     "bar": true,


### PR DESCRIPTION
## Summary

Adds a **"Fallout effects"** toggle to the *Effects* section of the graphics settings modal, letting players disable the nuclear fallout visuals (useful for performance).

Fallout is rendered by two passes — the broiling green **bloom** on irradiated territory and its additive **light** contribution in day/night mode. The bloom pass was already gated by `passEnabled.falloutBloom`, but the light pass had no gate. This adds a `passEnabled.falloutLight` flag and a single user-facing `passEnabled.fallout` graphics override that drives both together.

## Changes

- **`RenderSettings.ts` / `render-settings.json`** — new `passEnabled.falloutLight` flag (default `true`).
- **`LightmapPass.ts`** — gate the fallout light pass behind `passEnabled.falloutLight`.
- **`GraphicsOverrides.ts`** — add `fallout: z.boolean()` to the `passEnabled` override group.
- **`RenderOverrides.ts`** — apply `passEnabled.fallout` to both `falloutBloom` and `falloutLight`.
- **`GraphicsSettingsModal.ts`** — `currentFallout()` / `onToggleFallout()` + a toggle button (mirrors the existing Special Effects toggle).
- **`en.json`** — `graphics_setting.fallout_label` / `fallout_desc`.

## Testing

- `tsc --noEmit` passes; JSON files validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)