### PR TITLE
update location of color mapping in map generator readme

### DIFF
--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -86,11 +86,10 @@ If you are doing work in image editing software or using automated tools, `./map
 - `Pixel` -> `Terrain Type & Magnitude` mapping in `GenerateMap`
 - `Terrain Type` -> `Thumbnail Color` mapping in `getThumbnailColor`
 
-In-Game, terrain is rendered using themes. The color of a tile is determined dynamically based on
-its **Terrain Type** and **Magnitude**. Theme Files:
+In-Game, the color of a tile is determined dynamically based on its **Terrain Type** and **Magnitude**.
 
-- `../src/core/configuration/PastelTheme.ts` (Light)
-- `../src/core/configuration/PastelThemeDark.ts` (Dark).
+- Ocean default color definition: `../src/client/render/gl/render-settings.json` (user changeable via settings)
+- Terrain color calculations: `../src/client/render/gl/utils/ColorUtils.ts#L50`
 
 ## Create info.json
 


### PR DESCRIPTION
Resolves #4326

## Description:

Updates map-generator readme for terrain color info locations modified in v32.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tidwell
