### PR TITLE
Harden client intent numeric validation

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -341,6 +341,13 @@ export const ID = z.string().regex(GAME_ID_REGEX);
 
 export const AllPlayersStatsSchema = z.record(ID, PlayerStatsSchema);
 
+const SafeNonNegativeNumberSchema = z
+  .number()
+  .nonnegative()
+  .max(Number.MAX_SAFE_INTEGER);
+const TileRefSchema = z.number().int().nonnegative().safe();
+const UnitIDSchema = z.number().int().nonnegative().safe();
+
 export const QuickChatKeySchema = z.enum(
   Object.entries(quickChatData).flatMap(([category, entries]) =>
     entries.map((entry) => `${category}.${entry.key}`),
@@ -359,18 +366,18 @@ export const AllianceExtensionIntentSchema = z.object({
 export const AttackIntentSchema = z.object({
   type: z.literal("attack"),
   targetID: ID.nullable(),
-  troops: z.number().nonnegative().nullable(),
+  troops: SafeNonNegativeNumberSchema.nullable(),
 });
 
 export const SpawnIntentSchema = z.object({
   type: z.literal("spawn"),
-  tile: z.number(),
+  tile: TileRefSchema,
 });
 
 export const BoatAttackIntentSchema = z.object({
   type: z.literal("boat"),
-  troops: z.number().nonnegative(),
-  dst: z.number(),
+  troops: SafeNonNegativeNumberSchema,
+  dst: TileRefSchema,
 });
 
 export const AllianceRequestIntentSchema = z.object({
@@ -413,26 +420,26 @@ export const EmbargoAllIntentSchema = z.object({
 export const DonateGoldIntentSchema = z.object({
   type: z.literal("donate_gold"),
   recipient: ID,
-  gold: z.number().nonnegative().nullable(),
+  gold: SafeNonNegativeNumberSchema.nullable(),
 });
 
 export const DonateTroopIntentSchema = z.object({
   type: z.literal("donate_troops"),
   recipient: ID,
-  troops: z.number().nonnegative().nullable(),
+  troops: SafeNonNegativeNumberSchema.nullable(),
 });
 
 export const BuildUnitIntentSchema = z.object({
   type: z.literal("build_unit"),
   unit: z.enum(UnitType),
-  tile: z.number(),
+  tile: TileRefSchema,
   rocketDirectionUp: z.boolean().optional(),
 });
 
 export const UpgradeStructureIntentSchema = z.object({
   type: z.literal("upgrade_structure"),
   unit: z.enum(UnitType),
-  unitId: z.number(),
+  unitId: UnitIDSchema,
 });
 
 export const CancelAttackIntentSchema = z.object({
@@ -442,18 +449,18 @@ export const CancelAttackIntentSchema = z.object({
 
 export const CancelBoatIntentSchema = z.object({
   type: z.literal("cancel_boat"),
-  unitID: z.number(),
+  unitID: UnitIDSchema,
 });
 
 export const MoveWarshipIntentSchema = z.object({
   type: z.literal("move_warship"),
-  unitIds: z.array(z.number().int()).nonempty(),
-  tile: z.number(),
+  unitIds: z.array(UnitIDSchema).nonempty(),
+  tile: TileRefSchema,
 });
 
 export const DeleteUnitIntentSchema = z.object({
   type: z.literal("delete_unit"),
-  unitId: z.number(),
+  unitId: UnitIDSchema,
 });
 
 export const QuickChatIntentSchema = z.object({

--- a/tests/ClientIntentSchema.test.ts
+++ b/tests/ClientIntentSchema.test.ts
@@ -35,8 +35,7 @@ describe("Client intent schema", () => {
 
   test("accepts valid finite resource amounts and integer refs", () => {
     expect(
-      parseIntent({ type: "attack", targetID: VALID_ID, troops: 10.5 })
-        .success,
+      parseIntent({ type: "attack", targetID: VALID_ID, troops: 10.5 }).success,
     ).toBe(true);
     expect(parseIntent({ type: "spawn", tile: 0 }).success).toBe(true);
     expect(

--- a/tests/ClientIntentSchema.test.ts
+++ b/tests/ClientIntentSchema.test.ts
@@ -1,0 +1,50 @@
+import { UnitType } from "../src/core/game/Game";
+import { ClientMessageSchema } from "../src/core/Schemas";
+
+const VALID_ID = "ABCDEFGH";
+
+function parseIntent(intent: unknown) {
+  return ClientMessageSchema.safeParse({
+    type: "intent",
+    intent,
+  });
+}
+
+describe("Client intent schema", () => {
+  test.each([
+    [{ type: "spawn", tile: 0.5 }],
+    [{ type: "build_unit", unit: UnitType.City, tile: 0.5 }],
+    [{ type: "boat", troops: 100, dst: 0.5 }],
+    [{ type: "move_warship", unitIds: [1], tile: 0.5 }],
+    [{ type: "move_warship", unitIds: [1.5], tile: 1 }],
+    [{ type: "upgrade_structure", unit: UnitType.City, unitId: 1.5 }],
+    [{ type: "cancel_boat", unitID: 1.5 }],
+    [{ type: "delete_unit", unitId: 1.5 }],
+  ])("rejects non-integer tile and unit references %#", (intent) => {
+    expect(parseIntent(intent).success).toBe(false);
+  });
+
+  test.each([
+    [{ type: "attack", targetID: VALID_ID, troops: 1e308 }],
+    [{ type: "boat", troops: 1e308, dst: 1 }],
+    [{ type: "donate_gold", recipient: VALID_ID, gold: 1e308 }],
+    [{ type: "donate_troops", recipient: VALID_ID, troops: 1e308 }],
+  ])("rejects unsafe numeric resource amounts %#", (intent) => {
+    expect(parseIntent(intent).success).toBe(false);
+  });
+
+  test("accepts valid finite resource amounts and integer refs", () => {
+    expect(
+      parseIntent({ type: "attack", targetID: VALID_ID, troops: 10.5 })
+        .success,
+    ).toBe(true);
+    expect(parseIntent({ type: "spawn", tile: 0 }).success).toBe(true);
+    expect(
+      parseIntent({
+        type: "build_unit",
+        unit: UnitType.City,
+        tile: 12,
+      }).success,
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Closes #4330

## Description:

Hardens client intent validation for attacker-controlled numeric fields before they enter server turn history and deterministic game simulation. Tile refs and unit ids now must be non-negative safe integers, while resource amount fields reject unsafe finite numbers above `Number.MAX_SAFE_INTEGER`. This prevents crafted WebSocket intent payloads with fractional refs or extreme numeric values from reaching core execution paths that assume valid integer map/unit indexes and bounded resource amounts.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

ahmetcemkaraca

## Test plan

- `npx vitest tests/ClientIntentSchema.test.ts --run`
- `npx vitest tests/server/KickPlayerAuthorization.test.ts --run`
- `npm run lint`
- `npm run build-prod`
- `npm test`