### PR TITLE
Hide clan tag input on CrazyGames

### DIFF
--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -27,6 +27,9 @@ export class UsernameInput extends LitElement {
   @state() private baseUsername: string = "";
   @state() private clanTag: string = "";
 
+  // Clans aren't supported on CrazyGames — hide the tag input and never submit one.
+  private readonly onCrazyGames = crazyGamesSDK.isOnCrazyGames();
+
   @property({ type: String }) validationError: string = "";
   // Ownership-check feedback (i18n key) shown inline beneath the tag input. Only
   // "not a member" gates the buttons (see emitValidity); the rest is advisory.
@@ -124,7 +127,9 @@ export class UsernameInput extends LitElement {
   private loadStoredUsername() {
     const storedUsername = localStorage.getItem(usernameKey);
     if (storedUsername) {
-      this.clanTag = localStorage.getItem(clanTagKey) ?? "";
+      if (!this.onCrazyGames) {
+        this.clanTag = localStorage.getItem(clanTagKey) ?? "";
+      }
       this.baseUsername = storedUsername;
       this.validateAndStore();
       this.startClanCheck();
@@ -137,7 +142,7 @@ export class UsernameInput extends LitElement {
   render() {
     return html`
       <div class="flex items-center w-full h-full gap-2">
-        <div class="relative flex items-center shrink-0">
+        <div class="no-crazygames relative flex items-center shrink-0">
           <input
             type="text"
             .value=${this.clanTag}
@@ -276,7 +281,9 @@ export class UsernameInput extends LitElement {
     this._isValid = result.isValid;
     if (result.isValid) {
       localStorage.setItem(usernameKey, trimmedBase);
-      localStorage.setItem(clanTagKey, this.getClanTag() ?? "");
+      if (!this.onCrazyGames) {
+        localStorage.setItem(clanTagKey, this.getClanTag() ?? "");
+      }
       this.validationError = "";
     } else {
       this.validationError = result.error ?? "";


### PR DESCRIPTION
## Summary
Clans aren't supported on CrazyGames, so don't let players set a clan tag there.

- Tag the clan tag input wrapper with the existing `no-crazygames` class so Main.ts's hiding logic removes it on CrazyGames, matching how other CrazyGames-hidden elements work.
- Guard loading the stored clan tag (`loadStoredUsername`) so a tag saved on the main site isn't silently submitted in the handshake while on CrazyGames — CSS hiding alone wouldn't prevent that.
- Guard storing the tag (`validateAndStore`) so a returning user's saved tag isn't clobbered with an empty value during a CrazyGames session.

## Testing
- `npx tsc --noEmit` — clean (no UsernameInput errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)