### PR TITLE
If player is localplayer, set structure border to territory color

### DIFF
--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -930,6 +930,7 @@ export class GPURenderer {
     if (id === this.localPlayerID) return;
     this.localPlayerID = id;
     this.samRadiusPass.setLocalPlayer(id);
+    this.structurePass.setLocalPlayer(id);
     this.affiliationPalette.setLocalPlayer(id);
     this.unitPass.setLocalPlayer(id);
     this.railroadPass.setLocalPlayer(id);

--- a/src/client/render/gl/passes/StructurePass.ts
+++ b/src/client/render/gl/passes/StructurePass.ts
@@ -69,7 +69,7 @@ export class StructurePass {
   private gl: WebGL2RenderingContext;
   private settings: RenderSettings;
   private program: WebGLProgram;
-  private localPlayerID: number;
+  private localPlayerID = 0;
 
   private uLocalPlayerID: WebGLUniformLocation;
   private uCamera: WebGLUniformLocation;

--- a/src/client/render/gl/passes/StructurePass.ts
+++ b/src/client/render/gl/passes/StructurePass.ts
@@ -69,7 +69,9 @@ export class StructurePass {
   private gl: WebGL2RenderingContext;
   private settings: RenderSettings;
   private program: WebGLProgram;
+  private localPlayerID: number;
 
+  private uLocalPlayerID: WebGLUniformLocation;
   private uCamera: WebGLUniformLocation;
   private uZoom: WebGLUniformLocation;
   private uIconSize: WebGLUniformLocation;
@@ -144,6 +146,10 @@ export class StructurePass {
         ATLAS_COLS,
       }),
     );
+    this.uLocalPlayerID = gl.getUniformLocation(
+      this.program,
+      "uLocalPlayerID",
+    )!;
     this.uCamera = gl.getUniformLocation(this.program, "uCamera")!;
     this.uZoom = gl.getUniformLocation(this.program, "uZoom")!;
     this.uIconSize = gl.getUniformLocation(this.program, "uIconSize")!;
@@ -270,6 +276,10 @@ export class StructurePass {
     );
   }
 
+  setLocalPlayer(smallID: number): void {
+    this.localPlayerID = smallID;
+  }
+
   updateStructures(units: Map<number, UnitState>): void {
     let count = 0;
 
@@ -343,6 +353,7 @@ export class StructurePass {
 
     const ss = this.settings.structure;
     gl.uniformMatrix3fv(this.uCamera, false, cameraMatrix);
+    gl.uniform1f(this.uLocalPlayerID, this.localPlayerID);
     gl.uniform1f(this.uZoom, zoom);
     gl.uniform1f(this.uIconSize, ss.iconSize);
     gl.uniform1f(this.uDotsThreshold, ss.dotsZoomThreshold);

--- a/src/client/render/gl/shaders/structure/structure.frag.glsl
+++ b/src/client/render/gl/shaders/structure/structure.frag.glsl
@@ -107,6 +107,7 @@ void main() {
     int local = int(uLocalPlayerID);
     float u = (vOwnerID + 0.5) / float(PALETTE_SIZE);
     fillColor = texture(uPalette, vec2(u, 0.25));
+    // if local player, use territory color because the border color is grey
     borderColor = texture(uPalette, vec2(u, owner == local ? 0.25 : 0.75));
     // Darken via HSV value so hue/saturation stay intact
     // vScale < 1.0 = darker, > 1.0 = brighter

--- a/src/client/render/gl/shaders/structure/structure.frag.glsl
+++ b/src/client/render/gl/shaders/structure/structure.frag.glsl
@@ -16,6 +16,7 @@ uniform float uBorderDarken;    // HSV value multiplier on icon border
 uniform float uIconAlpha;       // global multiplier on final icon alpha
 uniform vec3  uIconColor;       // color of the inner icon glyph (was white)
 uniform float uIconDarken;      // >0: glyph = darkened player color instead of uIconColor
+uniform float uLocalPlayerID;
 
 in vec2  vLocalPos;
 in vec2  vAtlasUV;
@@ -102,9 +103,11 @@ void main() {
     fillColor = vec4(198.0/255.0, 198.0/255.0, 198.0/255.0, 1.0);
     borderColor = vec4(127.0/255.0, 127.0/255.0, 127.0/255.0, 1.0);
   } else {
+    int owner = int(vOwnerID + 0.5);
+    int local = int(uLocalPlayerID);
     float u = (vOwnerID + 0.5) / float(PALETTE_SIZE);
     fillColor = texture(uPalette, vec2(u, 0.25));
-    borderColor = texture(uPalette, vec2(u, 0.75));
+    borderColor = texture(uPalette, vec2(u, owner == local ? 0.25 : 0.75));
     // Darken via HSV value so hue/saturation stay intact
     // vScale < 1.0 = darker, > 1.0 = brighter
     fillColor.rgb = darken(fillColor.rgb, uFillDarken);


### PR DESCRIPTION


Resolves #4365

## Description:

Currently the border of icons are using borderColor which is grey for local player

<img width="227" height="281" alt="image" src="https://github.com/user-attachments/assets/9e334e19-c5b2-49ca-a85d-4576a5bbc1a9" />

This set it to territory color 
<img width="187" height="102" alt="image" src="https://github.com/user-attachments/assets/9b9f27f9-69e2-4ae7-9f35-a789b56b45de" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

Mr. Box
