### PR TITLE
Reduce compact map chance in 1v1 from 50% to 20% 🗺️

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -402,7 +402,7 @@ export class MapPlaylist {
       GameMapType.Asia, // 20%
       GameMapType.EuropeClassic, // 20%
     ];
-    const isCompact = Math.random() < 0.5;
+    const isCompact = Math.random() < 0.2;
     return {
       donateGold: false,
       donateTroops: false,


### PR DESCRIPTION
## Description:

Changes the probability of getting a compact map in 1v1 games from 50% (Math.random() < 0.5) to 20% (Math.random() < 0.2) in `MapPlaylist.ts`. 

Reasoning is feedback on discord.

This suggestion thread: https://discord.com/channels/1284581928254701718/1514204284173025301

And this, for example:

<img width="634" height="225" alt="image" src="https://github.com/user-attachments/assets/0b4d53de-582c-4e6a-8d18-0007433c12ee" />

Pro players seemingly want to get rid of compact maps completely, but in the thread you can also see people liking them. So lets do 20% for now?

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin