### PR TITLE
fix(core): add safe integer constraints to client intent schemas

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -331,6 +331,8 @@ const TokenSchema = z
 
 const EmojiSchema = z
   .number()
+  .safe()
+  .int()
   .nonnegative()
   .max(flattenedEmojiTable.length - 1);
 
@@ -361,18 +363,18 @@ export const AllianceExtensionIntentSchema = z.object({
 export const AttackIntentSchema = z.object({
   type: z.literal("attack"),
   targetID: ID.nullable(),
-  troops: z.number().nonnegative().nullable(),
+  troops: z.number().safe().int().nonnegative().nullable(),
 });
 
 export const SpawnIntentSchema = z.object({
   type: z.literal("spawn"),
-  tile: z.number(),
+  tile: z.number().safe().int().nonnegative(),
 });
 
 export const BoatAttackIntentSchema = z.object({
   type: z.literal("boat"),
-  troops: z.number().nonnegative(),
-  dst: z.number(),
+  troops: z.number().safe().int().nonnegative(),
+  dst: z.number().safe().int().nonnegative(),
 });
 
 export const AllianceRequestIntentSchema = z.object({
@@ -415,26 +417,26 @@ export const EmbargoAllIntentSchema = z.object({
 export const DonateGoldIntentSchema = z.object({
   type: z.literal("donate_gold"),
   recipient: ID,
-  gold: z.number().nonnegative().nullable(),
+  gold: z.number().safe().int().nonnegative().nullable(),
 });
 
 export const DonateTroopIntentSchema = z.object({
   type: z.literal("donate_troops"),
   recipient: ID,
-  troops: z.number().nonnegative().nullable(),
+  troops: z.number().safe().int().nonnegative().nullable(),
 });
 
 export const BuildUnitIntentSchema = z.object({
   type: z.literal("build_unit"),
   unit: z.enum(UnitType),
-  tile: z.number(),
+  tile: z.number().safe().int().nonnegative(),
   rocketDirectionUp: z.boolean().optional(),
 });
 
 export const UpgradeStructureIntentSchema = z.object({
   type: z.literal("upgrade_structure"),
   unit: z.enum(UnitType),
-  unitId: z.number(),
+  unitId: z.number().safe().int().nonnegative(),
 });
 
 export const CancelAttackIntentSchema = z.object({
@@ -444,18 +446,18 @@ export const CancelAttackIntentSchema = z.object({
 
 export const CancelBoatIntentSchema = z.object({
   type: z.literal("cancel_boat"),
-  unitID: z.number(),
+  unitID: z.number().safe().int().nonnegative(),
 });
 
 export const MoveWarshipIntentSchema = z.object({
   type: z.literal("move_warship"),
-  unitIds: z.array(z.number().int()).nonempty(),
-  tile: z.number(),
+  unitIds: z.array(z.number().safe().int().nonnegative()).nonempty(),
+  tile: z.number().safe().int().nonnegative(),
 });
 
 export const DeleteUnitIntentSchema = z.object({
   type: z.literal("delete_unit"),
-  unitId: z.number(),
+  unitId: z.number().safe().int().nonnegative(),
 });
 
 export const QuickChatIntentSchema = z.object({
@@ -681,8 +683,8 @@ export const ClientSendWinnerSchema = z.object({
 
 export const ClientHashSchema = z.object({
   type: z.literal("hash"),
-  hash: z.number(),
-  turnNumber: z.number(),
+  hash: z.number().safe().int(),
+  turnNumber: z.number().safe().int().nonnegative(),
 });
 
 export const ClientLogMessageSchema = z.object({
@@ -717,7 +719,7 @@ export const ClientRejoinMessageSchema = z.object({
   type: z.literal("rejoin"),
   gameID: ID,
   // Note: clientID is NOT sent - server looks it up from persistentID in token
-  lastTurn: z.number(),
+  lastTurn: z.number().safe().int().nonnegative(),
   token: TokenSchema,
 });
 

--- a/tests/core/IntentSchemaHardening.test.ts
+++ b/tests/core/IntentSchemaHardening.test.ts
@@ -1,0 +1,426 @@
+import {
+  AttackIntentSchema,
+  BoatAttackIntentSchema,
+  BuildUnitIntentSchema,
+  CancelBoatIntentSchema,
+  ClientHashSchema,
+  ClientRejoinMessageSchema,
+  DeleteUnitIntentSchema,
+  DonateGoldIntentSchema,
+  DonateTroopIntentSchema,
+  MoveWarshipIntentSchema,
+  SpawnIntentSchema,
+  UpgradeStructureIntentSchema,
+} from "../../src/core/Schemas";
+
+describe("IntentSchemaHardening", () => {
+  describe("SpawnIntentSchema", () => {
+    it("accepts a valid tile integer", () => {
+      expect(
+        SpawnIntentSchema.safeParse({ type: "spawn", tile: 42 }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional tile numbers", () => {
+      expect(
+        SpawnIntentSchema.safeParse({ type: "spawn", tile: 42.5 }).success,
+      ).toBe(false);
+    });
+
+    it("rejects negative tile numbers", () => {
+      expect(
+        SpawnIntentSchema.safeParse({ type: "spawn", tile: -1 }).success,
+      ).toBe(false);
+    });
+
+    it("rejects unsafe floats/infinity", () => {
+      expect(
+        SpawnIntentSchema.safeParse({ type: "spawn", tile: 1e308 }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("AttackIntentSchema", () => {
+    it("accepts a valid positive troops count", () => {
+      expect(
+        AttackIntentSchema.safeParse({
+          type: "attack",
+          targetID: "abc12345",
+          troops: 100,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("accepts null troops", () => {
+      expect(
+        AttackIntentSchema.safeParse({
+          type: "attack",
+          targetID: "abc12345",
+          troops: null,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional troops", () => {
+      expect(
+        AttackIntentSchema.safeParse({
+          type: "attack",
+          targetID: "abc12345",
+          troops: 10.5,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects negative troops", () => {
+      expect(
+        AttackIntentSchema.safeParse({
+          type: "attack",
+          targetID: "abc12345",
+          troops: -5,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects unsafe float troops", () => {
+      expect(
+        AttackIntentSchema.safeParse({
+          type: "attack",
+          targetID: "abc12345",
+          troops: 1e308,
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("BoatAttackIntentSchema", () => {
+    it("accepts valid integer troops and dst", () => {
+      expect(
+        BoatAttackIntentSchema.safeParse({ type: "boat", troops: 50, dst: 100 })
+          .success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional troops or dst", () => {
+      expect(
+        BoatAttackIntentSchema.safeParse({
+          type: "boat",
+          troops: 50.1,
+          dst: 100,
+        }).success,
+      ).toBe(false);
+      expect(
+        BoatAttackIntentSchema.safeParse({
+          type: "boat",
+          troops: 50,
+          dst: 100.5,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects negative troops or dst", () => {
+      expect(
+        BoatAttackIntentSchema.safeParse({
+          type: "boat",
+          troops: -10,
+          dst: 100,
+        }).success,
+      ).toBe(false);
+      expect(
+        BoatAttackIntentSchema.safeParse({ type: "boat", troops: 50, dst: -1 })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  describe("DonateGoldIntentSchema", () => {
+    it("accepts valid gold amount", () => {
+      expect(
+        DonateGoldIntentSchema.safeParse({
+          type: "donate_gold",
+          recipient: "abc12345",
+          gold: 1000,
+        }).success,
+      ).toBe(true);
+      expect(
+        DonateGoldIntentSchema.safeParse({
+          type: "donate_gold",
+          recipient: "abc12345",
+          gold: null,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative gold", () => {
+      expect(
+        DonateGoldIntentSchema.safeParse({
+          type: "donate_gold",
+          recipient: "abc12345",
+          gold: 100.5,
+        }).success,
+      ).toBe(false);
+      expect(
+        DonateGoldIntentSchema.safeParse({
+          type: "donate_gold",
+          recipient: "abc12345",
+          gold: -100,
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("DonateTroopIntentSchema", () => {
+    it("accepts valid troops amount", () => {
+      expect(
+        DonateTroopIntentSchema.safeParse({
+          type: "donate_troops",
+          recipient: "abc12345",
+          troops: 100,
+        }).success,
+      ).toBe(true);
+      expect(
+        DonateTroopIntentSchema.safeParse({
+          type: "donate_troops",
+          recipient: "abc12345",
+          troops: null,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative troops", () => {
+      expect(
+        DonateTroopIntentSchema.safeParse({
+          type: "donate_troops",
+          recipient: "abc12345",
+          troops: 10.2,
+        }).success,
+      ).toBe(false);
+      expect(
+        DonateTroopIntentSchema.safeParse({
+          type: "donate_troops",
+          recipient: "abc12345",
+          troops: -1,
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("BuildUnitIntentSchema", () => {
+    it("accepts valid build unit intent", () => {
+      expect(
+        BuildUnitIntentSchema.safeParse({
+          type: "build_unit",
+          unit: "City",
+          tile: 200,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative tile", () => {
+      expect(
+        BuildUnitIntentSchema.safeParse({
+          type: "build_unit",
+          unit: "City",
+          tile: 200.7,
+        }).success,
+      ).toBe(false);
+      expect(
+        BuildUnitIntentSchema.safeParse({
+          type: "build_unit",
+          unit: "City",
+          tile: -200,
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("UpgradeStructureIntentSchema", () => {
+    it("accepts valid unitId", () => {
+      expect(
+        UpgradeStructureIntentSchema.safeParse({
+          type: "upgrade_structure",
+          unit: "City",
+          unitId: 5,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative unitId", () => {
+      expect(
+        UpgradeStructureIntentSchema.safeParse({
+          type: "upgrade_structure",
+          unit: "City",
+          unitId: 5.5,
+        }).success,
+      ).toBe(false);
+      expect(
+        UpgradeStructureIntentSchema.safeParse({
+          type: "upgrade_structure",
+          unit: "City",
+          unitId: -5,
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("CancelBoatIntentSchema", () => {
+    it("accepts valid unitID", () => {
+      expect(
+        CancelBoatIntentSchema.safeParse({ type: "cancel_boat", unitID: 15 })
+          .success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative unitID", () => {
+      expect(
+        CancelBoatIntentSchema.safeParse({ type: "cancel_boat", unitID: 15.2 })
+          .success,
+      ).toBe(false);
+      expect(
+        CancelBoatIntentSchema.safeParse({ type: "cancel_boat", unitID: -1 })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  describe("MoveWarshipIntentSchema", () => {
+    it("accepts valid unitIds array and tile", () => {
+      expect(
+        MoveWarshipIntentSchema.safeParse({
+          type: "move_warship",
+          unitIds: [1, 2, 3],
+          tile: 450,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative elements in unitIds or tile", () => {
+      expect(
+        MoveWarshipIntentSchema.safeParse({
+          type: "move_warship",
+          unitIds: [1, 2.5, 3],
+          tile: 450,
+        }).success,
+      ).toBe(false);
+      expect(
+        MoveWarshipIntentSchema.safeParse({
+          type: "move_warship",
+          unitIds: [1, -2, 3],
+          tile: 450,
+        }).success,
+      ).toBe(false);
+      expect(
+        MoveWarshipIntentSchema.safeParse({
+          type: "move_warship",
+          unitIds: [1, 2, 3],
+          tile: 450.1,
+        }).success,
+      ).toBe(false);
+      expect(
+        MoveWarshipIntentSchema.safeParse({
+          type: "move_warship",
+          unitIds: [1, 2, 3],
+          tile: -450,
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("DeleteUnitIntentSchema", () => {
+    it("accepts valid unitId", () => {
+      expect(
+        DeleteUnitIntentSchema.safeParse({ type: "delete_unit", unitId: 99 })
+          .success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative unitId", () => {
+      expect(
+        DeleteUnitIntentSchema.safeParse({ type: "delete_unit", unitId: 99.9 })
+          .success,
+      ).toBe(false);
+      expect(
+        DeleteUnitIntentSchema.safeParse({ type: "delete_unit", unitId: -99 })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  describe("ClientRejoinMessageSchema", () => {
+    it("accepts valid rejoin params", () => {
+      expect(
+        ClientRejoinMessageSchema.safeParse({
+          type: "rejoin",
+          gameID: "abc12345",
+          lastTurn: 150,
+          token: "00000000-0000-0000-0000-000000000000",
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative lastTurn", () => {
+      expect(
+        ClientRejoinMessageSchema.safeParse({
+          type: "rejoin",
+          gameID: "abc12345",
+          lastTurn: 150.5,
+          token: "00000000-0000-0000-0000-000000000000",
+        }).success,
+      ).toBe(false);
+
+      expect(
+        ClientRejoinMessageSchema.safeParse({
+          type: "rejoin",
+          gameID: "abc12345",
+          lastTurn: -1,
+          token: "00000000-0000-0000-0000-000000000000",
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("ClientHashSchema", () => {
+    it("accepts valid hash and turnNumber", () => {
+      expect(
+        ClientHashSchema.safeParse({
+          type: "hash",
+          hash: 123456789,
+          turnNumber: 50,
+        }).success,
+      ).toBe(true);
+      expect(
+        ClientHashSchema.safeParse({
+          type: "hash",
+          hash: -123456789,
+          turnNumber: 50,
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects fractional or negative turnNumber", () => {
+      expect(
+        ClientHashSchema.safeParse({
+          type: "hash",
+          hash: 123456789,
+          turnNumber: 50.5,
+        }).success,
+      ).toBe(false);
+      expect(
+        ClientHashSchema.safeParse({
+          type: "hash",
+          hash: 123456789,
+          turnNumber: -1,
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects fractional hash", () => {
+      expect(
+        ClientHashSchema.safeParse({
+          type: "hash",
+          hash: 123456.789,
+          turnNumber: 50,
+        }).success,
+      ).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
fix(core): add safe integer constraints to client intent schemas

Resolves #4330

## Description:

This PR hardens client-controlled numeric validation constraints on all incoming WebSocket intents to prevent server crashes, data truncation, or logic corruption from fractional, negative, or unsafe floating-point inputs.

### Details of Changes:
1. **Integer & Boundary Checks**: Modified schemas in `src/core/Schemas.ts` using Zod's `.safe().int().nonnegative()` constraints for the following fields:
   - `SpawnIntentSchema` (`tile` index)
   - `AttackIntentSchema` (`troops` count)
   - `BoatAttackIntentSchema` (`troops` count and `dst` tile index)
   - `DonateGoldIntentSchema` (`gold` amount)
   - `DonateTroopIntentSchema` (`troops` count)
   - `BuildUnitIntentSchema` (`tile` index)
   - `UpgradeStructureIntentSchema` (`unitId`)
   - `CancelBoatIntentSchema` (`unitID`)
   - `MoveWarshipIntentSchema` (each element of `unitIds` and the destination `tile` index)
   - `DeleteUnitIntentSchema` (`unitId`)
   - `ClientRejoinMessageSchema` (`lastTurn` index)
   - `ClientHashSchema` (`hash` value and `turnNumber`)
2. **Regression Tests**: Added a complete suite in `tests/core/IntentSchemaHardening.test.ts` to ensure that integers are validated correctly, while fractional numbers, negative values, and massive floats/infinities are strictly rejected.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — No UI elements added/updated)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No user-facing text additions)
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
