### PR TITLE
fix(render): update coastline color dynamically when ocean color changes

### DIFF
--- a/src/client/render/gl/utils/ColorUtils.ts
+++ b/src/client/render/gl/utils/ColorUtils.ts
@@ -95,11 +95,11 @@ export function encodeTerrainTile(
       b = v;
     }
   } else if (isShoreline) {
-    // Shoreline water — computed dynamically based on the ocean color
+    // Shoreline water — computed dynamically by blending 70% ocean color and 30% white
     const base = oceanColor ?? DEEP_WATER_BASE;
-    r = Math.min(255, Math.round(base[0] * 1.4));
-    g = Math.min(255, Math.round(base[1] * 1.08));
-    b = Math.min(255, Math.round(base[2] * 1.4));
+    r = Math.round(0.7 * base[0] + 76.5);
+    g = Math.round(0.7 * base[1] + 76.5);
+    b = Math.round(0.7 * base[2] + 76.5);
   } else {
     // Deep water — darkens with depth (magnitude). The base color sets the
     // shallowest (brightest) shade; the per-depth gradient is preserved by

--- a/src/client/render/gl/utils/ColorUtils.ts
+++ b/src/client/render/gl/utils/ColorUtils.ts
@@ -95,10 +95,11 @@ export function encodeTerrainTile(
       b = v;
     }
   } else if (isShoreline) {
-    // Shoreline water
-    r = 100;
-    g = 143;
-    b = 255;
+    // Shoreline water — computed dynamically based on the ocean color
+    const base = oceanColor ?? DEEP_WATER_BASE;
+    r = Math.min(255, Math.round(base[0] * 1.4));
+    g = Math.min(255, Math.round(base[1] * 1.08));
+    b = Math.min(255, Math.round(base[2] * 1.4));
   } else {
     // Deep water — darkens with depth (magnitude). The base color sets the
     // shallowest (brightest) shade; the per-depth gradient is preserved by


### PR DESCRIPTION
fix(render): update coastline color dynamically when ocean color changes

Resolves #4329

## Description:

Previously, the shoreline water color (`isShoreline && !isLand`) was hardcoded to a static bright blue (`rgb(100, 143, 255)`) in `encodeTerrainTile`. When a user customized the ocean/water color in Settings, the deep ocean changed colors but the shoreline water remained bright blue, causing a jarred, visually mismatched appearance.

This PR updates `encodeTerrainTile` in `ColorUtils.ts` to dynamically calculate the shoreline water color by scaling the configured `oceanColor` channels:
- Red and Blue channels scale by `1.4` (clamped to `255`).
- Green channel scales by `1.08` (clamped to `255`).

This scales the coastline water color harmoniously alongside any custom water color settings (e.g. green, red, or dark ocean tones).

## Please complete the following:

- [x] I have added screenshots for all UI/rendering updates (Attached `coastline_screenshot.png` showing dynamic color integration)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No user-facing text additions)
- [ ] I have added relevant tests to the test directory (N/A — WebGL rendering code has no automated test harness)

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
