### PR TITLE
Take off the v32 maps from the "New" category to make room for v33 maps

### DIFF
--- a/map-generator/assets/maps/balkans/info.json
+++ b/map-generator/assets/maps/balkans/info.json
@@ -2,7 +2,7 @@
   "id": "Balkans",
   "name": "Balkans",
   "translation_key": "map.balkans",
-  "categories": ["new", "europe"],
+  "categories": ["europe"],
   "multiplayer_frequency": 6,
   "nations": [
     {

--- a/map-generator/assets/maps/caribbean/info.json
+++ b/map-generator/assets/maps/caribbean/info.json
@@ -2,7 +2,7 @@
   "id": "Caribbean",
   "name": "Caribbean",
   "translation_key": "map.caribbean",
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/map-generator/assets/maps/choppingblock/info.json
+++ b/map-generator/assets/maps/choppingblock/info.json
@@ -2,7 +2,7 @@
   "id": "ChoppingBlock",
   "name": "Chopping Block",
   "translation_key": "map.choppingblock",
-  "categories": ["new", "arcade"],
+  "categories": ["arcade"],
   "multiplayer_frequency": 5,
   "special_team_count": 4,
   "nations": [

--- a/map-generator/assets/maps/danishstraits/info.json
+++ b/map-generator/assets/maps/danishstraits/info.json
@@ -2,7 +2,7 @@
   "id": "DanishStraits",
   "name": "Danish Straits",
   "translation_key": "map.danishstraits",
-  "categories": ["new", "europe"],
+  "categories": ["europe"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/map-generator/assets/maps/hongkong/info.json
+++ b/map-generator/assets/maps/hongkong/info.json
@@ -2,7 +2,7 @@
   "id": "HongKong",
   "name": "Hong Kong",
   "translation_key": "map.hongkong",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 6,
   "nations": [
     {

--- a/map-generator/assets/maps/indiansubcontinent/info.json
+++ b/map-generator/assets/maps/indiansubcontinent/info.json
@@ -2,7 +2,7 @@
   "id": "IndianSubcontinent",
   "name": "Indian Subcontinent",
   "translation_key": "map.indiansubcontinent",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 8,
   "nations": [
     {

--- a/map-generator/assets/maps/juandefucastrait/info.json
+++ b/map-generator/assets/maps/juandefucastrait/info.json
@@ -2,7 +2,7 @@
   "id": "JuanDeFucaStrait",
   "name": "Juan De Fuca Strait",
   "translation_key": "map.juandefucastrait",
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "multiplayer_frequency": 4,
   "special_team_count": 3,
   "nations": [

--- a/map-generator/assets/maps/korea/info.json
+++ b/map-generator/assets/maps/korea/info.json
@@ -2,7 +2,7 @@
   "id": "Korea",
   "name": "Korea",
   "translation_key": "map.korea",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/map-generator/assets/maps/labyrinth/info.json
+++ b/map-generator/assets/maps/labyrinth/info.json
@@ -2,7 +2,7 @@
   "id": "Labyrinth",
   "name": "Labyrinth",
   "translation_key": "map.labyrinth",
-  "categories": ["new", "arcade"],
+  "categories": ["arcade"],
   "multiplayer_frequency": 6,
   "nations": [
     {

--- a/map-generator/assets/maps/middleeast/info.json
+++ b/map-generator/assets/maps/middleeast/info.json
@@ -2,7 +2,7 @@
   "id": "MiddleEast",
   "name": "Middle East",
   "translation_key": "map.middleeast",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 8,
   "nations": [
     {

--- a/map-generator/assets/maps/mississippiriver/info.json
+++ b/map-generator/assets/maps/mississippiriver/info.json
@@ -2,7 +2,7 @@
   "id": "MississippiRiver",
   "name": "Mississippi River",
   "translation_key": "map.mississippiriver",
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "multiplayer_frequency": 3,
   "nations": [
     {

--- a/map-generator/assets/maps/northwestpassage/info.json
+++ b/map-generator/assets/maps/northwestpassage/info.json
@@ -2,7 +2,7 @@
   "id": "NorthwestPassage",
   "name": "Northwest Passage",
   "translation_key": "map.northwestpassage",
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/map-generator/assets/maps/onion/info.json
+++ b/map-generator/assets/maps/onion/info.json
@@ -2,7 +2,7 @@
   "id": "Onion",
   "name": "Onion",
   "translation_key": "map.onion",
-  "categories": ["new", "arcade"],
+  "categories": ["arcade"],
   "multiplayer_frequency": 2,
   "nations": [
     {

--- a/map-generator/assets/maps/southeastasia/info.json
+++ b/map-generator/assets/maps/southeastasia/info.json
@@ -3,7 +3,7 @@
   "name": "SoutheastAsia",
   "display_name": "Southeast Asia",
   "translation_key": "map.southeastasia",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/map-generator/assets/maps/taiwanstrait/info.json
+++ b/map-generator/assets/maps/taiwanstrait/info.json
@@ -2,7 +2,7 @@
   "id": "TaiwanStrait",
   "name": "Taiwan Strait",
   "translation_key": "map.taiwanstrait",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/map-generator/assets/maps/titan/info.json
+++ b/map-generator/assets/maps/titan/info.json
@@ -2,7 +2,7 @@
   "id": "Titan",
   "name": "Titan",
   "translation_key": "map.titan",
-  "categories": ["new", "cosmic"],
+  "categories": ["cosmic"],
   "multiplayer_frequency": 3,
   "nations": [
     {

--- a/map-generator/assets/maps/venice/info.json
+++ b/map-generator/assets/maps/venice/info.json
@@ -2,7 +2,7 @@
   "id": "Venice",
   "name": "Venice",
   "translation_key": "map.venice",
-  "categories": ["new", "europe"],
+  "categories": ["europe"],
   "multiplayer_frequency": 6,
   "nations": [
     {

--- a/map-generator/assets/maps/warshipwarship/info.json
+++ b/map-generator/assets/maps/warshipwarship/info.json
@@ -3,7 +3,7 @@
   "id": "WarshipWarship",
   "translation_key": "map.warshipwarship",
   "multiplayer_frequency": 3,
-  "categories": ["arcade", "new"],
+  "categories": ["arcade"],
   "nations": [
     {
       "coordinates": [750, 680],

--- a/map-generator/assets/maps/worldinverted/info.json
+++ b/map-generator/assets/maps/worldinverted/info.json
@@ -2,7 +2,7 @@
   "id": "WorldInverted",
   "name": "World Inverted",
   "translation_key": "map.worldinverted",
-  "categories": ["new", "world", "fictional"],
+  "categories": ["world", "fictional"],
   "multiplayer_frequency": 8,
   "nations": [
     {

--- a/map-generator/assets/maps/yellowsea/info.json
+++ b/map-generator/assets/maps/yellowsea/info.json
@@ -2,7 +2,7 @@
   "id": "YellowSea",
   "name": "Yellow Sea",
   "translation_key": "map.yellowsea",
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "multiplayer_frequency": 5,
   "nations": [
     {

--- a/resources/maps/balkans/manifest.json
+++ b/resources/maps/balkans/manifest.json
@@ -196,7 +196,7 @@
       "name": "Western Macedonia"
     }
   ],
-  "categories": ["new", "europe"],
+  "categories": ["europe"],
   "id": "Balkans",
   "map": {
     "height": 2048,

--- a/resources/maps/caribbean/manifest.json
+++ b/resources/maps/caribbean/manifest.json
@@ -141,7 +141,7 @@
       "name": "Tobago"
     }
   ],
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "id": "Caribbean",
   "map": {
     "height": 1808,

--- a/resources/maps/choppingblock/manifest.json
+++ b/resources/maps/choppingblock/manifest.json
@@ -142,7 +142,7 @@
       "name": "Honeycomb"
     }
   ],
-  "categories": ["new", "arcade"],
+  "categories": ["arcade"],
   "id": "ChoppingBlock",
   "map": {
     "height": 1616,

--- a/resources/maps/danishstraits/manifest.json
+++ b/resources/maps/danishstraits/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "europe"],
+  "categories": ["europe"],
   "id": "DanishStraits",
   "map": {
     "height": 1224,

--- a/resources/maps/hongkong/manifest.json
+++ b/resources/maps/hongkong/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "id": "HongKong",
   "map": {
     "height": 1996,

--- a/resources/maps/indiansubcontinent/manifest.json
+++ b/resources/maps/indiansubcontinent/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "id": "IndianSubcontinent",
   "map": {
     "height": 2220,

--- a/resources/maps/juandefucastrait/manifest.json
+++ b/resources/maps/juandefucastrait/manifest.json
@@ -221,7 +221,7 @@
       "name": "Sudden Valley"
     }
   ],
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "id": "JuanDeFucaStrait",
   "map": {
     "height": 1100,

--- a/resources/maps/korea/manifest.json
+++ b/resources/maps/korea/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "id": "Korea",
   "map": {
     "height": 2148,

--- a/resources/maps/labyrinth/manifest.json
+++ b/resources/maps/labyrinth/manifest.json
@@ -226,7 +226,7 @@
       "name": "Zapopan"
     }
   ],
-  "categories": ["new", "arcade"],
+  "categories": ["arcade"],
   "id": "Labyrinth",
   "map": {
     "height": 1360,

--- a/resources/maps/middleeast/manifest.json
+++ b/resources/maps/middleeast/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "id": "MiddleEast",
   "map": {
     "height": 2060,

--- a/resources/maps/mississippiriver/manifest.json
+++ b/resources/maps/mississippiriver/manifest.json
@@ -256,7 +256,7 @@
       "name": "Round Lake"
     }
   ],
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "id": "MississippiRiver",
   "map": {
     "height": 4200,

--- a/resources/maps/northwestpassage/manifest.json
+++ b/resources/maps/northwestpassage/manifest.json
@@ -196,7 +196,7 @@
       "name": "Zackenberg"
     }
   ],
-  "categories": ["new", "north_america"],
+  "categories": ["north_america"],
   "id": "NorthwestPassage",
   "map": {
     "height": 1664,

--- a/resources/maps/onion/manifest.json
+++ b/resources/maps/onion/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "arcade"],
+  "categories": ["arcade"],
   "id": "Onion",
   "map": {
     "height": 512,

--- a/resources/maps/southeastasia/manifest.json
+++ b/resources/maps/southeastasia/manifest.json
@@ -156,7 +156,7 @@
       "name": "Paracel Islands"
     }
   ],
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "display_name": "Southeast Asia",
   "id": "SoutheastAsia",
   "map": {

--- a/resources/maps/taiwanstrait/manifest.json
+++ b/resources/maps/taiwanstrait/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "id": "TaiwanStrait",
   "map": {
     "height": 1600,

--- a/resources/maps/titan/manifest.json
+++ b/resources/maps/titan/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "cosmic"],
+  "categories": ["cosmic"],
   "id": "Titan",
   "map": {
     "height": 2160,

--- a/resources/maps/venice/manifest.json
+++ b/resources/maps/venice/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "europe"],
+  "categories": ["europe"],
   "id": "Venice",
   "map": {
     "height": 1500,

--- a/resources/maps/warshipwarship/manifest.json
+++ b/resources/maps/warshipwarship/manifest.json
@@ -91,7 +91,7 @@
       "name": "Redoubt Ridge"
     }
   ],
-  "categories": ["arcade", "new"],
+  "categories": ["arcade"],
   "id": "WarshipWarship",
   "map": {
     "height": 1396,

--- a/resources/maps/worldinverted/manifest.json
+++ b/resources/maps/worldinverted/manifest.json
@@ -951,7 +951,7 @@
       "name": "Reykjanes Delta"
     }
   ],
-  "categories": ["new", "world", "fictional"],
+  "categories": ["world", "fictional"],
   "id": "WorldInverted",
   "map": {
     "height": 1248,

--- a/resources/maps/yellowsea/manifest.json
+++ b/resources/maps/yellowsea/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["new", "asia"],
+  "categories": ["asia"],
   "id": "YellowSea",
   "map": {
     "height": 1152,

--- a/src/core/game/Maps.gen.ts
+++ b/src/core/game/Maps.gen.ts
@@ -255,7 +255,7 @@ export const maps: readonly MapInfo[] = [
     id: "Balkans",
     type: GameMapType.Balkans,
     translationKey: "map.balkans",
-    categories: ["new", "europe"],
+    categories: ["europe"],
     multiplayerFrequency: 6,
   },
   {
@@ -314,7 +314,7 @@ export const maps: readonly MapInfo[] = [
     id: "Caribbean",
     type: GameMapType.Caribbean,
     translationKey: "map.caribbean",
-    categories: ["new", "north_america"],
+    categories: ["north_america"],
     multiplayerFrequency: 5,
   },
   {
@@ -328,7 +328,7 @@ export const maps: readonly MapInfo[] = [
     id: "ChoppingBlock",
     type: GameMapType.ChoppingBlock,
     translationKey: "map.choppingblock",
-    categories: ["new", "arcade"],
+    categories: ["arcade"],
     multiplayerFrequency: 5,
     specialTeamCount: 4,
   },
@@ -344,7 +344,7 @@ export const maps: readonly MapInfo[] = [
     id: "DanishStraits",
     type: GameMapType.DanishStraits,
     translationKey: "map.danishstraits",
-    categories: ["new", "europe"],
+    categories: ["europe"],
     multiplayerFrequency: 5,
   },
   {
@@ -467,7 +467,7 @@ export const maps: readonly MapInfo[] = [
     id: "HongKong",
     type: GameMapType.HongKong,
     translationKey: "map.hongkong",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 6,
   },
   {
@@ -481,7 +481,7 @@ export const maps: readonly MapInfo[] = [
     id: "IndianSubcontinent",
     type: GameMapType.IndianSubcontinent,
     translationKey: "map.indiansubcontinent",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 8,
   },
   {
@@ -503,7 +503,7 @@ export const maps: readonly MapInfo[] = [
     id: "JuanDeFucaStrait",
     type: GameMapType.JuanDeFucaStrait,
     translationKey: "map.juandefucastrait",
-    categories: ["new", "north_america"],
+    categories: ["north_america"],
     multiplayerFrequency: 4,
     specialTeamCount: 3,
   },
@@ -511,14 +511,14 @@ export const maps: readonly MapInfo[] = [
     id: "Korea",
     type: GameMapType.Korea,
     translationKey: "map.korea",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 5,
   },
   {
     id: "Labyrinth",
     type: GameMapType.Labyrinth,
     translationKey: "map.labyrinth",
-    categories: ["new", "arcade"],
+    categories: ["arcade"],
     multiplayerFrequency: 6,
   },
   {
@@ -582,7 +582,7 @@ export const maps: readonly MapInfo[] = [
     id: "MiddleEast",
     type: GameMapType.MiddleEast,
     translationKey: "map.middleeast",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 8,
   },
   {
@@ -596,7 +596,7 @@ export const maps: readonly MapInfo[] = [
     id: "MississippiRiver",
     type: GameMapType.MississippiRiver,
     translationKey: "map.mississippiriver",
-    categories: ["new", "north_america"],
+    categories: ["north_america"],
     multiplayerFrequency: 3,
   },
   {
@@ -632,7 +632,7 @@ export const maps: readonly MapInfo[] = [
     id: "NorthwestPassage",
     type: GameMapType.NorthwestPassage,
     translationKey: "map.northwestpassage",
-    categories: ["new", "north_america"],
+    categories: ["north_america"],
     multiplayerFrequency: 5,
   },
   {
@@ -646,7 +646,7 @@ export const maps: readonly MapInfo[] = [
     id: "Onion",
     type: GameMapType.Onion,
     translationKey: "map.onion",
-    categories: ["new", "arcade"],
+    categories: ["arcade"],
     multiplayerFrequency: 2,
   },
   {
@@ -697,7 +697,7 @@ export const maps: readonly MapInfo[] = [
     id: "SoutheastAsia",
     type: GameMapType.SoutheastAsia,
     translationKey: "map.southeastasia",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 5,
   },
   {
@@ -742,7 +742,7 @@ export const maps: readonly MapInfo[] = [
     id: "TaiwanStrait",
     type: GameMapType.TaiwanStrait,
     translationKey: "map.taiwanstrait",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 5,
   },
   {
@@ -756,7 +756,7 @@ export const maps: readonly MapInfo[] = [
     id: "Titan",
     type: GameMapType.Titan,
     translationKey: "map.titan",
-    categories: ["new", "cosmic"],
+    categories: ["cosmic"],
     multiplayerFrequency: 3,
   },
   {
@@ -806,14 +806,14 @@ export const maps: readonly MapInfo[] = [
     id: "Venice",
     type: GameMapType.Venice,
     translationKey: "map.venice",
-    categories: ["new", "europe"],
+    categories: ["europe"],
     multiplayerFrequency: 6,
   },
   {
     id: "WarshipWarship",
     type: GameMapType.WarshipWarship,
     translationKey: "map.warshipwarship",
-    categories: ["arcade", "new"],
+    categories: ["arcade"],
     multiplayerFrequency: 3,
   },
   {
@@ -828,14 +828,14 @@ export const maps: readonly MapInfo[] = [
     id: "WorldInverted",
     type: GameMapType.WorldInverted,
     translationKey: "map.worldinverted",
-    categories: ["new", "world", "fictional"],
+    categories: ["world", "fictional"],
     multiplayerFrequency: 8,
   },
   {
     id: "YellowSea",
     type: GameMapType.YellowSea,
     translationKey: "map.yellowsea",
-    categories: ["new", "asia"],
+    categories: ["asia"],
     multiplayerFrequency: 5,
   },
   {


### PR DESCRIPTION
Resolves #4375

## Description:

Remove V32 maps from "new" to make way for v33 maps. This will allow map makers to add their new maps for v33 into "new", with the v32 maps only remaining in the continental and other categories like the rest of the maps. This is a process we will make every update

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tri.star1011