### PR TITLE
Add "assign to me" checkbox to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,3 +38,7 @@ If applicable, add screenshots to help explain your problem.
 
 **Additional context**
 Add any other context about the problem here.
+
+**Assignment**
+
+- [ ] I'd like to be assigned to this issue and work on it myself

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,3 +17,7 @@ A clear and concise description of any alternative solutions or features you've 
 
 **Additional context**
 Add any other context or screenshots about the feature request here.
+
+**Assignment**
+
+- [ ] I'd like to be assigned to this issue and work on it myself

--- a/.github/ISSUE_TEMPLATE/new-contribution-template-clean.md
+++ b/.github/ISSUE_TEMPLATE/new-contribution-template-clean.md
@@ -24,4 +24,10 @@ assignees: ""
 
 ---
 
+## Assignment
+
+- [ ] I'd like to be assigned to this issue and work on it myself
+
+---
+
 [Discord Name if Different]

--- a/.github/ISSUE_TEMPLATE/new-contribution-template-examples.md
+++ b/.github/ISSUE_TEMPLATE/new-contribution-template-examples.md
@@ -73,4 +73,10 @@ Examples of what info would be expected:
 
 ---
 
+## Assignment
+
+- [ ] I'd like to be assigned to this issue and work on it myself
+
+---
+
 [Discord Name if Different]


### PR DESCRIPTION
## Summary

Adds an **Assignment** section with a clickable markdown task-list checkbox to the user-facing issue templates, so issue creators can opt in to working on the issue themselves:

```markdown
- [ ] I'd like to be assigned to this issue and work on it myself
```

GitHub renders `- [ ]` as a real clickable checkbox in the issue. Checking it only signals intent — a maintainer still performs the actual assignment.

## Templates changed

- `bug_report.md`
- `feature_request.md`
- `new-contribution-template-clean.md`
- `new-contribution-template-examples.md`

Intentionally **excluded** the API/DB template (`database_request.md`) since that area is maintainer-handled, not contributor work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)