### PR TITLE
fix: kick_player can target a disconnected account by publicId

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -276,14 +276,19 @@ export class GameServer {
             error: "only the lobby creator or an admin can kick players",
           };
         }
-        // Resolve the target to a live clientID: an explicit clientID, or an
-        // account publicId matched against the connected clients (for callers
-        // that know the account but not the per-session clientID).
+        // Resolve the target to a clientID: an explicit clientID, or an account
+        // publicId matched against clients. Check connected clients first, then
+        // fall back to allClients so a disconnected account can still be kicked
+        // (its persistentID is banned, which blocks rejoin/reconnect).
         let target = stamped.targetClientID;
         if (target === undefined && stamped.targetPublicID !== undefined) {
-          target = this.activeClients.find(
-            (c) => c.publicId === stamped.targetPublicID,
-          )?.clientID;
+          target =
+            this.activeClients.find(
+              (c) => c.publicId === stamped.targetPublicID,
+            )?.clientID ??
+            [...this.allClients.values()].find(
+              (c) => c.publicId === stamped.targetPublicID,
+            )?.clientID;
         }
         if (target === undefined) {
           return { status: 404, error: "no matching player to kick" };

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -277,18 +277,14 @@ export class GameServer {
           };
         }
         // Resolve the target to a clientID: an explicit clientID, or an account
-        // publicId matched against clients. Check connected clients first, then
-        // fall back to allClients so a disconnected account can still be kicked
-        // (its persistentID is banned, which blocks rejoin/reconnect).
+        // publicId matched against allClients (a superset of activeClients that
+        // retains disconnected players), so a disconnected account can still be
+        // kicked — its persistentID is banned, blocking rejoin/reconnect.
         let target = stamped.targetClientID;
         if (target === undefined && stamped.targetPublicID !== undefined) {
-          target =
-            this.activeClients.find(
-              (c) => c.publicId === stamped.targetPublicID,
-            )?.clientID ??
-            [...this.allClients.values()].find(
-              (c) => c.publicId === stamped.targetPublicID,
-            )?.clientID;
+          target = [...this.allClients.values()].find(
+            (c) => c.publicId === stamped.targetPublicID,
+          )?.clientID;
         }
         if (target === undefined) {
           return { status: 404, error: "no matching player to kick" };

--- a/tests/server/AdminBotIntent.test.ts
+++ b/tests/server/AdminBotIntent.test.ts
@@ -131,13 +131,13 @@ describe("GameServer.handleIntent (admin bot)", () => {
       ).toBe(403);
     });
 
-    it("resolves a publicID target to the connected client's clientID", () => {
+    it("resolves a publicID target to a connected client's clientID", () => {
       const game = makeGame();
-      (game as any).activeClients.push({
-        clientID: "liveCID1",
-        publicId: "pubABCD1",
-      });
-      const spy = vi.spyOn(game, "kickClient");
+      // A connected client is in both lists; allClients is the superset we match on.
+      const connected = { clientID: "liveCID1", publicId: "pubABCD1" };
+      (game as any).activeClients.push(connected);
+      (game as any).allClients.set("liveCID1", connected);
+      const spy = vi.spyOn(game, "kickClient").mockImplementation(() => {});
       const result = apply(game, {
         type: "kick_player",
         targetPublicID: "pubABCD1",
@@ -166,27 +166,7 @@ describe("GameServer.handleIntent (admin bot)", () => {
       );
     });
 
-    it("prefers a connected client over allClients when both match", () => {
-      const game = makeGame();
-      (game as any).activeClients.push({
-        clientID: "liveCID1",
-        publicId: "dupPUBID",
-      });
-      (game as any).allClients.set("staleCID1", {
-        clientID: "staleCID1",
-        publicId: "dupPUBID",
-        persistentID: "persist-stale-1",
-      });
-      const spy = vi.spyOn(game, "kickClient");
-      const result = apply(game, {
-        type: "kick_player",
-        targetPublicID: "dupPUBID",
-      } as any);
-      expect(result.status).toBe(200);
-      expect(spy).toHaveBeenCalledWith("liveCID1", expect.any(String));
-    });
-
-    it("404s when no client matches the publicID (active or all)", () => {
+    it("404s when no client matches the publicID", () => {
       const game = makeGame();
       expect(
         apply(game, {

--- a/tests/server/AdminBotIntent.test.ts
+++ b/tests/server/AdminBotIntent.test.ts
@@ -146,7 +146,47 @@ describe("GameServer.handleIntent (admin bot)", () => {
       expect(spy).toHaveBeenCalledWith("liveCID1", expect.any(String));
     });
 
-    it("404s when no connected client matches the publicID", () => {
+    it("kicks a disconnected account by publicID via allClients (bans its persistentID)", () => {
+      const game = makeGame();
+      // Disconnected: still known to the game (allClients) but already dropped
+      // from activeClients on socket close. Must stay kickable so the
+      // persistentID ban fires and blocks a rejoin/reconnect.
+      (game as any).allClients.set("goneCID1", {
+        clientID: "goneCID1",
+        publicId: "pubGONE1",
+        persistentID: "persist-gone-1",
+      });
+      const result = apply(game, {
+        type: "kick_player",
+        targetPublicID: "pubGONE1",
+      } as any);
+      expect(result.status).toBe(200);
+      expect((game as any).kickedPersistentIds.has("persist-gone-1")).toBe(
+        true,
+      );
+    });
+
+    it("prefers a connected client over allClients when both match", () => {
+      const game = makeGame();
+      (game as any).activeClients.push({
+        clientID: "liveCID1",
+        publicId: "dupPUBID",
+      });
+      (game as any).allClients.set("staleCID1", {
+        clientID: "staleCID1",
+        publicId: "dupPUBID",
+        persistentID: "persist-stale-1",
+      });
+      const spy = vi.spyOn(game, "kickClient");
+      const result = apply(game, {
+        type: "kick_player",
+        targetPublicID: "dupPUBID",
+      } as any);
+      expect(result.status).toBe(200);
+      expect(spy).toHaveBeenCalledWith("liveCID1", expect.any(String));
+    });
+
+    it("404s when no client matches the publicID (active or all)", () => {
       const game = makeGame();
       expect(
         apply(game, {


### PR DESCRIPTION
## Description:

kick_player resolved a targetPublicID only against activeClients, but a client is dropped from activeClients on socket close (so players technically can disconnect right before getting kicked, then reconnect at a later point and continue playing), aka a disconnected account cannot not be kicked. Fall back to allClients (which persists) so the kick lands and bans the persistentID, blocking rejoin and reconnect.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

zixer._