### PR TITLE
feat: effects cosmetic category (transport-ship trail) + UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -272,6 +272,11 @@
           inline
           class="hidden w-full h-full page-content relative z-50"
         ></territory-patterns-modal>
+        <effects-modal
+          id="effects-modal"
+          inline
+          class="hidden w-full h-full page-content relative z-50"
+        ></effects-modal>
         <ranked-modal
           id="page-ranked"
           inline

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -396,7 +396,7 @@
     "button_title": "Pick an effect!",
     "title": "Effects",
     "type": {
-      "transportShipTrail": "Boat Trail"
+      "transport_ship_trail": "Boat Trail"
     }
   },
   "error_modal": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -396,7 +396,7 @@
     "button_title": "Pick an effect!",
     "title": "Effects",
     "type": {
-      "transport_ship_trail": "Boat Trail"
+      "transportShipTrail": "Boat Trail"
     }
   },
   "error_modal": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -392,6 +392,13 @@
   "discord_user_header": {
     "avatar_alt": "Avatar"
   },
+  "effects": {
+    "button_title": "Pick an effect!",
+    "title": "Effects",
+    "type": {
+      "transportShipTrail": "Boat Trail"
+    }
+  },
   "error_modal": {
     "connection_error": "Connection error!",
     "copied": "Copied!",
@@ -1255,8 +1262,10 @@
     "confirm_downgrade": "Downgrade to {tier}? You'll get account credit for the unused portion of your current plan.",
     "confirm_upgrade": "Upgrade to {tier}? You'll be charged the prorated difference now.",
     "currency_pack_purchase_success": "Currency pack purchase successful!",
+    "effects": "Effects",
     "flags": "Flags",
     "login_required": "You must be logged in to purchase with currency.",
+    "no_effects": "No effects available. Check back later for new items.",
     "no_flags": "No flags available. Check back later for new items.",
     "no_packs": "No packs available. Check back later for new items.",
     "no_skins": "No skins available. Check back later for new items.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -457,7 +457,7 @@
   "flag_input": {
     "button_title": "Pick a flag!",
     "search_flag": "Search...",
-    "title": "Select Flag"
+    "title": "Flag"
   },
   "friends": {
     "accept": "Accept",
@@ -1299,7 +1299,7 @@
       "default": "Default"
     },
     "search": "Search...",
-    "select_skin": "Select Skin",
+    "select_skin": "Skin",
     "selected": "selected",
     "title": "Skins"
   },

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -95,7 +95,7 @@ export function invalidateUserMe() {
 }
 
 export async function purchaseWithCurrency(
-  cosmeticType: "pattern" | "skin" | "flag",
+  cosmeticType: "pattern" | "skin" | "flag" | "effect",
   cosmeticName: string,
   currencyType: "hard" | "soft",
   colorPaletteName?: string,

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -461,15 +461,18 @@ export function resolveCosmetics(
   }
 
   // Effects (boat-trail wakes, etc.) — a cosmetic category like skins/flags.
-  for (const [effectKey, effect] of Object.entries(cosmetics.effects ?? {})) {
-    const rel = effectRelationship(effect, userMeResponse, affiliateCode);
-    result.push({
-      type: "effect",
-      cosmetic: effect,
-      colorPalette: null,
-      relationship: rel,
-      key: `effect:${effectKey}`,
-    });
+  // Catalog is nested: effects[effectType][effectName].
+  for (const byName of Object.values(cosmetics.effects ?? {})) {
+    for (const [effectKey, effect] of Object.entries(byName)) {
+      const rel = effectRelationship(effect, userMeResponse, affiliateCode);
+      result.push({
+        type: "effect",
+        cosmetic: effect,
+        colorPalette: null,
+        relationship: rel,
+        key: `effect:${effectKey}`,
+      });
+    }
   }
 
   // Packs
@@ -626,7 +629,7 @@ export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
   const selectedEffects = userSettings.getSelectedEffects();
   const effects: Record<string, string> = {};
   for (const [effectType, name] of Object.entries(selectedEffects)) {
-    const effect = cosmetics?.effects?.[name];
+    const effect = cosmetics?.effects?.[effectType]?.[name];
     if (cosmetics && (!effect || effect.effectType !== effectType)) {
       userSettings.setSelectedEffectName(effectType as EffectType, undefined);
       continue;
@@ -699,7 +702,7 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
   if (refs.effects && cosmetics) {
     const effects: Record<string, PlayerEffect> = {};
     for (const [effectType, name] of Object.entries(refs.effects)) {
-      const effect = cosmetics.effects?.[name];
+      const effect = cosmetics.effects?.[effectType]?.[name];
       if (effect && effect.effectType === effectType) {
         effects[effectType] = {
           name: effect.name,

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -4,6 +4,8 @@ import {
   ColorPalette,
   Cosmetics,
   CosmeticsSchema,
+  Effect,
+  EffectType,
   Flag,
   Pack,
   Pattern,
@@ -14,6 +16,7 @@ import {
 import {
   PlayerCosmeticRefs,
   PlayerCosmetics,
+  PlayerEffect,
   PlayerPattern,
 } from "../core/Schemas";
 import { UserSettings } from "../core/game/UserSettings";
@@ -156,7 +159,7 @@ export async function purchaseCosmetic(
     return;
   }
 
-  const cosmeticType = resolved.type as "pattern" | "skin" | "flag";
+  const cosmeticType = resolved.type as "pattern" | "skin" | "flag" | "effect";
   const success = await purchaseWithCurrency(
     cosmeticType,
     c.name,
@@ -357,9 +360,28 @@ export function skinRelationship(
   );
 }
 
+export function effectRelationship(
+  effect: Effect,
+  userMeResponse: UserMeResponse | false,
+  affiliateCode: string | null,
+): "owned" | "purchasable" | "blocked" {
+  return cosmeticRelationship(
+    {
+      wildcardFlare: "effect:*",
+      requiredFlare: `effect:${effect.name}`,
+      product: effect.product,
+      priceSoft: effect.priceSoft,
+      priceHard: effect.priceHard,
+      affiliateCode,
+      itemAffiliateCode: effect.affiliateCode ?? null,
+    },
+    userMeResponse,
+  );
+}
+
 export type ResolvedCosmetic = {
-  type: "pattern" | "skin" | "flag" | "pack" | "subscription";
-  cosmetic: Pattern | Skin | Flag | Pack | Subscription | null;
+  type: "pattern" | "skin" | "flag" | "effect" | "pack" | "subscription";
+  cosmetic: Pattern | Skin | Flag | Effect | Pack | Subscription | null;
   colorPalette: ColorPalette | null;
   relationship: "owned" | "purchasable" | "blocked";
   /** Unique key for selection/identity, e.g. "pattern:hearts:red" or "skin:mountain" */
@@ -435,6 +457,18 @@ export function resolveCosmetics(
       colorPalette: null,
       relationship: rel,
       key: `skin:${skinKey}`,
+    });
+  }
+
+  // Effects (boat-trail wakes, etc.) — a cosmetic category like skins/flags.
+  for (const [effectKey, effect] of Object.entries(cosmetics.effects ?? {})) {
+    const rel = effectRelationship(effect, userMeResponse, affiliateCode);
+    result.push({
+      type: "effect",
+      cosmetic: effect,
+      colorPalette: null,
+      relationship: rel,
+      key: `effect:${effectKey}`,
     });
   }
 
@@ -585,11 +619,41 @@ export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
     }
   }
 
+  // Effects: a per-effectType map (effectType -> effect name). Drop any entry
+  // whose effect no longer exists, has the wrong type, or the user can't access.
+  // Like skins/flags/patterns above, a selection is kept (and left to the
+  // server to validate) when cosmetics or userMe fail to load.
+  const selectedEffects = userSettings.getSelectedEffects();
+  const effects: Record<string, string> = {};
+  for (const [effectType, name] of Object.entries(selectedEffects)) {
+    const effect = cosmetics?.effects?.[name];
+    if (cosmetics && (!effect || effect.effectType !== effectType)) {
+      userSettings.setSelectedEffectName(effectType as EffectType, undefined);
+      continue;
+    }
+    if (effect) {
+      const userMe = await getUserMe();
+      if (userMe) {
+        const flares = userMe.player.flares ?? [];
+        const hasWildcard = flares.includes("effect:*");
+        if (!hasWildcard && !flares.includes(`effect:${effect.name}`)) {
+          userSettings.setSelectedEffectName(
+            effectType as EffectType,
+            undefined,
+          );
+          continue;
+        }
+      }
+    }
+    effects[effectType] = name;
+  }
+
   return {
     flag: flag ?? undefined,
     patternName: pattern?.name ?? undefined,
     patternColorPaletteName: pattern?.colorPalette?.name ?? undefined,
     skinName,
+    effects: Object.keys(effects).length > 0 ? effects : undefined,
   };
 }
 
@@ -630,6 +694,21 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
     if (skin) {
       result.skin = { name: refs.skinName, url: skin.url };
     }
+  }
+
+  if (refs.effects && cosmetics) {
+    const effects: Record<string, PlayerEffect> = {};
+    for (const [effectType, name] of Object.entries(refs.effects)) {
+      const effect = cosmetics.effects?.[name];
+      if (effect && effect.effectType === effectType) {
+        effects[effectType] = {
+          name: effect.name,
+          effectType: effect.effectType,
+          attributes: effect.attributes,
+        };
+      }
+    }
+    if (Object.keys(effects).length > 0) result.effects = effects;
   }
 
   return result;

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -386,6 +386,8 @@ export type ResolvedCosmetic = {
   relationship: "owned" | "purchasable" | "blocked";
   /** Unique key for selection/identity, e.g. "pattern:hearts:red" or "skin:mountain" */
   key: string;
+  /** For effects only: the effectType (the catalog's outer key, not a field). */
+  effectType?: string;
 };
 
 /**
@@ -461,8 +463,9 @@ export function resolveCosmetics(
   }
 
   // Effects (boat-trail wakes, etc.) — a cosmetic category like skins/flags.
-  // Catalog is nested: effects[effectType][effectName].
-  for (const byName of Object.values(cosmetics.effects ?? {})) {
+  // Catalog is nested: effects[effectType][effectName]. effectType is the outer
+  // key (carried on the resolved item, since it's not a field on the effect).
+  for (const [effectType, byName] of Object.entries(cosmetics.effects ?? {})) {
     for (const [effectKey, effect] of Object.entries(byName)) {
       const rel = effectRelationship(effect, userMeResponse, affiliateCode);
       result.push({
@@ -470,7 +473,8 @@ export function resolveCosmetics(
         cosmetic: effect,
         colorPalette: null,
         relationship: rel,
-        key: `effect:${effectKey}`,
+        key: `effect:${effectType}:${effectKey}`,
+        effectType,
       });
     }
   }
@@ -623,14 +627,14 @@ export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
   }
 
   // Effects: a per-effectType map (effectType -> effect name). Drop any entry
-  // whose effect no longer exists, has the wrong type, or the user can't access.
-  // Like skins/flags/patterns above, a selection is kept (and left to the
-  // server to validate) when cosmetics or userMe fail to load.
+  // whose effect no longer exists or the user can't access. Like
+  // skins/flags/patterns above, a selection is kept (and left to the server to
+  // validate) when cosmetics or userMe fail to load.
   const selectedEffects = userSettings.getSelectedEffects();
   const effects: Record<string, string> = {};
   for (const [effectType, name] of Object.entries(selectedEffects)) {
     const effect = cosmetics?.effects?.[effectType]?.[name];
-    if (cosmetics && (!effect || effect.effectType !== effectType)) {
+    if (cosmetics && !effect) {
       userSettings.setSelectedEffectName(effectType as EffectType, undefined);
       continue;
     }
@@ -703,10 +707,10 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
     const effects: Record<string, PlayerEffect> = {};
     for (const [effectType, name] of Object.entries(refs.effects)) {
       const effect = cosmetics.effects?.[effectType]?.[name];
-      if (effect && effect.effectType === effectType) {
+      if (effect) {
         effects[effectType] = {
           name: effect.name,
-          effectType: effect.effectType,
+          effectType: effectType as EffectType,
           attributes: effect.attributes,
         };
       }

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -712,7 +712,6 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
         effects[effectType] = {
           name: effect.name,
           effectType: effect.effectType,
-          attributes: effect.attributes,
         };
       }
     }

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -387,7 +387,7 @@ export type ResolvedCosmetic = {
   relationship: "owned" | "purchasable" | "blocked";
   /** Unique key for selection/identity, e.g. "pattern:hearts:red" or "skin:mountain" */
   key: string;
-  /** For effects only: the effectType (the catalog's outer key, not a field). */
+  /** For effects only: the effectType (also the catalog's outer key). */
   effectType?: string;
 };
 
@@ -464,10 +464,10 @@ export function resolveCosmetics(
   }
 
   // Effects (boat-trail wakes, etc.) — a cosmetic category like skins/flags.
-  // Catalog is nested: effects[effectType][effectName]. effectType is the outer
-  // key (carried on the resolved item, since it's not a field on the effect).
+  // Catalog is nested: effects[effectType][effectName]. We carry effectType (the
+  // outer key, which each effect also stores) on the resolved item.
   for (const [effectType, byName] of Object.entries(cosmetics.effects ?? {})) {
-    for (const [effectKey, effect] of Object.entries(byName)) {
+    for (const [effectKey, effect] of Object.entries(byName ?? {})) {
       const rel = effectRelationship(effect, userMeResponse, affiliateCode);
       result.push({
         type: "effect",
@@ -711,7 +711,7 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
       if (effect) {
         effects[effectType] = {
           name: effect.name,
-          effectType: effectType as EffectType,
+          effectType: effect.effectType,
           attributes: effect.attributes,
         };
       }

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -6,6 +6,7 @@ import {
   CosmeticsSchema,
   Effect,
   EffectType,
+  findEffect,
   Flag,
   Pack,
   Pattern,
@@ -633,7 +634,7 @@ export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
   const selectedEffects = userSettings.getSelectedEffects();
   const effects: Record<string, string> = {};
   for (const [effectType, name] of Object.entries(selectedEffects)) {
-    const effect = cosmetics?.effects?.[effectType]?.[name];
+    const effect = findEffect(cosmetics, effectType, name);
     if (cosmetics && !effect) {
       userSettings.setSelectedEffectName(effectType as EffectType, undefined);
       continue;
@@ -706,7 +707,7 @@ export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
   if (refs.effects && cosmetics) {
     const effects: Record<string, PlayerEffect> = {};
     for (const [effectType, name] of Object.entries(refs.effects)) {
-      const effect = cosmetics.effects?.[effectType]?.[name];
+      const effect = findEffect(cosmetics, effectType, name);
       if (effect) {
         effects[effectType] = {
           name: effect.name,

--- a/src/client/EffectsInput.ts
+++ b/src/client/EffectsInput.ts
@@ -1,0 +1,90 @@
+import { LitElement, html } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { TransportShipTrailAttributes } from "../core/CosmeticSchemas";
+import {
+  EFFECTS_KEY,
+  USER_SETTINGS_CHANGED_EVENT,
+} from "../core/game/UserSettings";
+import { renderTransportShipTrailSwatch } from "./components/EffectPreview";
+import { getPlayerCosmetics } from "./Cosmetics";
+import { crazyGamesSDK } from "./CrazyGamesSDK";
+import { translateText } from "./Utils";
+
+@customElement("effects-input")
+export class EffectsInput extends LitElement {
+  // The selected transport-ship-trail attributes, if any (one effectType today).
+  // Not named `attributes` — that collides with HTMLElement.attributes.
+  @state() private trailAttributes: TransportShipTrailAttributes | null = null;
+
+  private _abortController: AbortController | null = null;
+
+  private _onCosmeticSelected = async () => {
+    const cosmetics = await getPlayerCosmetics();
+    this.trailAttributes =
+      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
+  };
+
+  private onInputClick(e: Event) {
+    e.preventDefault();
+    e.stopPropagation();
+    this.dispatchEvent(
+      new CustomEvent("effects-input-click", {
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  async connectedCallback() {
+    super.connectedCallback();
+    this._abortController = new AbortController();
+    const cosmetics = await getPlayerCosmetics();
+    this.trailAttributes =
+      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
+    window.addEventListener(
+      `${USER_SETTINGS_CHANGED_EVENT}:${EFFECTS_KEY}`,
+      this._onCosmeticSelected,
+      { signal: this._abortController.signal },
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._abortController) {
+      this._abortController.abort();
+      this._abortController = null;
+    }
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  render() {
+    if (crazyGamesSDK.isOnCrazyGames()) {
+      return html``;
+    }
+
+    const preview =
+      this.trailAttributes === null
+        ? html`<span
+            class="text-[7px] lg:text-[10px] font-black tracking-wider text-white uppercase leading-tight lg:leading-none w-full text-center px-0.5 lg:px-1"
+          >
+            ${translateText("effects.title")}
+          </span>`
+        : html`<span class="w-full h-full p-1.5"
+            >${renderTransportShipTrailSwatch(this.trailAttributes)}</span
+          >`;
+
+    return html`
+      <button
+        id="effects-input"
+        class="p-0 m-0 border-0 w-full h-full flex cursor-pointer justify-center items-center focus:outline-none focus:ring-0 transition-all duration-200 hover:scale-105 bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:shadow-[var(--shadow-action-card-hover)] rounded-lg overflow-hidden"
+        title=${translateText("effects.button_title")}
+        @click=${this.onInputClick}
+      >
+        ${preview}
+      </button>
+    `;
+  }
+}

--- a/src/client/EffectsInput.ts
+++ b/src/client/EffectsInput.ts
@@ -1,12 +1,15 @@
-import { LitElement, html } from "lit";
+import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { TransportShipTrailAttributes } from "../core/CosmeticSchemas";
+import {
+  findEffect,
+  TransportShipTrailAttributes,
+} from "../core/CosmeticSchemas";
 import {
   EFFECTS_KEY,
   USER_SETTINGS_CHANGED_EVENT,
 } from "../core/game/UserSettings";
 import { renderTransportShipTrailSwatch } from "./components/EffectPreview";
-import { getPlayerCosmetics } from "./Cosmetics";
+import { fetchCosmetics, getPlayerCosmetics } from "./Cosmetics";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { translateText } from "./Utils";
 
@@ -18,10 +21,24 @@ export class EffectsInput extends LitElement {
 
   private _abortController: AbortController | null = null;
 
-  private _onCosmeticSelected = async () => {
+  // PlayerEffect is just { name, effectType }; resolve the visual style from the
+  // cosmetics catalog by (effectType, name).
+  private async resolveTrailAttributes(): Promise<TransportShipTrailAttributes | null> {
     const cosmetics = await getPlayerCosmetics();
-    this.trailAttributes =
-      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
+    const name = cosmetics.effects?.["transportShipTrail"]?.name;
+    if (!name) return null;
+    const effect = findEffect(
+      await fetchCosmetics(),
+      "transportShipTrail",
+      name,
+    );
+    return effect?.effectType === "transportShipTrail"
+      ? effect.attributes
+      : null;
+  }
+
+  private _onCosmeticSelected = async () => {
+    this.trailAttributes = await this.resolveTrailAttributes();
   };
 
   private onInputClick(e: Event) {
@@ -38,9 +55,7 @@ export class EffectsInput extends LitElement {
   async connectedCallback() {
     super.connectedCallback();
     this._abortController = new AbortController();
-    const cosmetics = await getPlayerCosmetics();
-    this.trailAttributes =
-      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
+    this.trailAttributes = await this.resolveTrailAttributes();
     window.addEventListener(
       `${USER_SETTINGS_CHANGED_EVENT}:${EFFECTS_KEY}`,
       this._onCosmeticSelected,

--- a/src/client/EffectsInput.ts
+++ b/src/client/EffectsInput.ts
@@ -21,7 +21,7 @@ export class EffectsInput extends LitElement {
   private _onCosmeticSelected = async () => {
     const cosmetics = await getPlayerCosmetics();
     this.trailAttributes =
-      cosmetics.effects?.["transport_ship_trail"]?.attributes ?? null;
+      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
   };
 
   private onInputClick(e: Event) {
@@ -40,7 +40,7 @@ export class EffectsInput extends LitElement {
     this._abortController = new AbortController();
     const cosmetics = await getPlayerCosmetics();
     this.trailAttributes =
-      cosmetics.effects?.["transport_ship_trail"]?.attributes ?? null;
+      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
     window.addEventListener(
       `${USER_SETTINGS_CHANGED_EVENT}:${EFFECTS_KEY}`,
       this._onCosmeticSelected,

--- a/src/client/EffectsInput.ts
+++ b/src/client/EffectsInput.ts
@@ -21,7 +21,7 @@ export class EffectsInput extends LitElement {
   private _onCosmeticSelected = async () => {
     const cosmetics = await getPlayerCosmetics();
     this.trailAttributes =
-      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
+      cosmetics.effects?.["transport_ship_trail"]?.attributes ?? null;
   };
 
   private onInputClick(e: Event) {
@@ -40,7 +40,7 @@ export class EffectsInput extends LitElement {
     this._abortController = new AbortController();
     const cosmetics = await getPlayerCosmetics();
     this.trailAttributes =
-      cosmetics.effects?.["transportShipTrail"]?.attributes ?? null;
+      cosmetics.effects?.["transport_ship_trail"]?.attributes ?? null;
     window.addEventListener(
       `${USER_SETTINGS_CHANGED_EVENT}:${EFFECTS_KEY}`,
       this._onCosmeticSelected,

--- a/src/client/EffectsModal.ts
+++ b/src/client/EffectsModal.ts
@@ -1,0 +1,73 @@
+import { html } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { UserMeResponse } from "../core/ApiSchemas";
+import { Cosmetics } from "../core/CosmeticSchemas";
+import { BaseModal } from "./components/BaseModal";
+import "./components/EffectsGrid";
+import "./components/NotLoggedInWarning";
+import { modalHeader } from "./components/ui/ModalHeader";
+import { fetchCosmetics } from "./Cosmetics";
+import { translateText } from "./Utils";
+
+@customElement("effects-modal")
+export class EffectsModal extends BaseModal {
+  protected routerName = "effects";
+
+  @state() private cosmetics: Cosmetics | null = null;
+  @state() private userMeResponse: UserMeResponse | false = false;
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener(
+      "userMeResponse",
+      (event: CustomEvent<UserMeResponse | false>) => {
+        this.onUserMe(event.detail);
+      },
+    );
+  }
+
+  async onUserMe(userMeResponse: UserMeResponse | false) {
+    this.userMeResponse = userMeResponse;
+    this.cosmetics = await fetchCosmetics();
+    this.requestUpdate();
+  }
+
+  protected renderHeaderSlot() {
+    return html`
+      <div
+        class="relative flex flex-col border-b border-white/10 pb-4 shrink-0"
+      >
+        ${modalHeader({
+          title: translateText("effects.title"),
+          onBack: () => this.close(),
+          ariaLabel: translateText("common.back"),
+          rightContent: html`<not-logged-in-warning></not-logged-in-warning>`,
+        })}
+      </div>
+    `;
+  }
+
+  protected renderBody() {
+    return html`
+      <div class="flex flex-col">
+        <div class="flex justify-center py-3 shrink-0">
+          <o-button
+            class="no-crazygames"
+            variant="primary"
+            size="sm"
+            translationKey="main.store"
+            @click=${() => {
+              this.close();
+              window.showPage?.("page-item-store");
+            }}
+          ></o-button>
+        </div>
+        <effects-grid
+          mode="select"
+          .cosmetics=${this.cosmetics}
+          .userMeResponse=${this.userMeResponse}
+        ></effects-grid>
+      </div>
+    `;
+  }
+}

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -235,6 +235,9 @@ export class LangSelector extends LitElement {
       "leaderboard-modal",
       "flag-input-modal",
       "flag-input",
+      "effects-modal",
+      "effects-input",
+      "effects-grid",
       "matchmaking-button",
       "token-login",
     ];

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -20,6 +20,9 @@ import "./ClanModal";
 import { joinLobby, type JoinLobbyResult } from "./ClientGameRunner";
 import { getPlayerCosmeticsRefs } from "./Cosmetics";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
+import "./EffectsInput";
+import "./EffectsModal";
+import { EffectsModal } from "./EffectsModal";
 import "./FlagInput";
 import { FlagInput } from "./FlagInput";
 import "./FlagInputModal";
@@ -311,6 +314,7 @@ class Client {
       tag: "territory-patterns-modal",
     });
     modalRouter.register("flag-input", { tag: "flag-input-modal" });
+    modalRouter.register("effects", { tag: "effects-modal" });
 
     // Prefetch turnstile token so it is available when
     // the user joins a lobby.
@@ -417,6 +421,20 @@ class Client {
       flagInput.addEventListener("flag-input-click", () => {
         if (flagInputModal && flagInputModal instanceof FlagInputModal) {
           flagInputModal.open();
+        }
+      });
+    });
+
+    const effectsModal = document.querySelector(
+      "effects-modal",
+    ) as EffectsModal;
+    if (!effectsModal || !(effectsModal instanceof EffectsModal)) {
+      console.warn("Effects modal element not found");
+    }
+    document.querySelectorAll("effects-input").forEach((effectsInput) => {
+      effectsInput.addEventListener("effects-input-click", () => {
+        if (effectsModal && effectsModal instanceof EffectsModal) {
+          effectsModal.open();
         }
       });
     });
@@ -864,6 +882,7 @@ class Client {
         "language-modal",
         "news-modal",
         "flag-input-modal",
+        "effects-modal",
         "account-button",
         "leaderboard-button",
         "token-login",

--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -6,6 +6,7 @@ import { Cosmetics } from "../core/CosmeticSchemas";
 import { UserSettings } from "../core/game/UserSettings";
 import { BaseModal } from "./components/BaseModal";
 import "./components/CosmeticButton";
+import "./components/EffectsGrid";
 import "./components/NotLoggedInWarning";
 import { modalHeader } from "./components/ui/ModalHeader";
 import {
@@ -17,7 +18,7 @@ import {
 } from "./Cosmetics";
 import { translateText } from "./Utils";
 
-type StoreTab = "patterns" | "flags" | "packs" | "subscriptions";
+type StoreTab = "patterns" | "flags" | "effects" | "packs" | "subscriptions";
 
 @customElement("store-modal")
 export class StoreModal extends BaseModal {
@@ -44,6 +45,7 @@ export class StoreModal extends BaseModal {
           : []),
         { key: "patterns", label: translateText("store.patterns") },
         { key: "flags", label: translateText("store.flags") },
+        { key: "effects", label: translateText("store.effects") },
       ],
     };
   }
@@ -150,6 +152,17 @@ export class StoreModal extends BaseModal {
     `;
   }
 
+  private renderEffectGrid(): TemplateResult {
+    // Grouped by effectType with a sub-header per type (see <effects-grid>),
+    // matching the home selection modal.
+    return html`<effects-grid
+      mode="purchase"
+      .cosmetics=${this.cosmetics}
+      .userMeResponse=${this.userMeResponse}
+      .affiliateCode=${this.affiliateCode}
+    ></effects-grid>`;
+  }
+
   private renderPackGrid(): TemplateResult {
     const items = resolveCosmetics(
       this.cosmetics,
@@ -234,6 +247,8 @@ export class StoreModal extends BaseModal {
         return this.renderPatternGrid();
       case "flags":
         return this.renderFlagGrid();
+      case "effects":
+        return this.renderEffectGrid();
       case "subscriptions":
         return this.renderSubscriptionGrid();
       case "packs":
@@ -252,6 +267,7 @@ export class StoreModal extends BaseModal {
         (r.type === "pattern" ||
           r.type === "skin" ||
           r.type === "flag" ||
+          r.type === "effect" ||
           r.type === "pack") &&
         r.relationship === "purchasable",
     );

--- a/src/client/components/CosmeticButton.ts
+++ b/src/client/components/CosmeticButton.ts
@@ -182,7 +182,7 @@ export class CosmeticButton extends LitElement {
           ${translateText("territory_patterns.pattern.default")}
         </div>`;
       }
-      // Only effectType today is transportShipTrail; c.attributes is its style.
+      // Only effectType today is transport_ship_trail; c.attributes is its style.
       return renderTransportShipTrailSwatch(c.attributes);
     }
 

--- a/src/client/components/CosmeticButton.ts
+++ b/src/client/components/CosmeticButton.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import {
+  Effect,
   Flag,
   Pack,
   Pattern,
@@ -17,6 +18,7 @@ import { translateText } from "../Utils";
 import "./CapIcon";
 import "./CosmeticContainer";
 import "./CosmeticInfo";
+import { renderTransportShipTrailSwatch } from "./EffectPreview";
 import { renderPatternPreview } from "./PatternPreview";
 import "./PlutoniumIcon";
 
@@ -80,6 +82,9 @@ export class CosmeticButton extends LitElement {
     }
     if (this.activeResolved.type === "subscription") {
       return translateCosmetic("subscriptions", c.name);
+    }
+    if (this.activeResolved.type === "effect") {
+      return translateCosmetic("effects", c.name);
     }
     return translateCosmetic("flags", c.name);
   }
@@ -165,6 +170,20 @@ export class CosmeticButton extends LitElement {
         draggable="false"
         loading="lazy"
       />`;
+    }
+
+    if (this.activeResolved.type === "effect") {
+      const c = this.activeResolved.cosmetic as Effect | null;
+      if (c === null) {
+        // "Default" tile — selecting it clears the effect for that type.
+        return html`<div
+          class="w-full h-full flex items-center justify-center text-white/40 text-xs uppercase"
+        >
+          ${translateText("territory_patterns.pattern.default")}
+        </div>`;
+      }
+      // Only effectType today is transportShipTrail; c.attributes is its style.
+      return renderTransportShipTrailSwatch(c.attributes);
     }
 
     if (this.activeResolved.type === "pack") {
@@ -254,7 +273,7 @@ export class CosmeticButton extends LitElement {
   render() {
     const active = this.activeResolved;
     const c = active.cosmetic;
-    const priced = c as Pattern | Skin | Flag | Pack | null;
+    const priced = c as Pattern | Skin | Flag | Effect | Pack | null;
     const priceHard = priced?.priceHard;
     const priceSoft = priced?.priceSoft;
     const artist = priced?.artist;

--- a/src/client/components/CosmeticButton.ts
+++ b/src/client/components/CosmeticButton.ts
@@ -182,7 +182,7 @@ export class CosmeticButton extends LitElement {
           ${translateText("territory_patterns.pattern.default")}
         </div>`;
       }
-      // Only effectType today is transport_ship_trail; c.attributes is its style.
+      // Only effectType today is transportShipTrail; c.attributes is its style.
       return renderTransportShipTrailSwatch(c.attributes);
     }
 

--- a/src/client/components/EffectPreview.ts
+++ b/src/client/components/EffectPreview.ts
@@ -17,7 +17,6 @@ const UNKNOWN_BG = "#444";
 export function renderTransportShipTrailSwatch(
   attributes: TransportShipTrailAttributes,
 ): TemplateResult {
-  const color = attributes.color ?? UNKNOWN_BG;
   switch (attributes.type) {
     case "rainbow":
       return html`<div
@@ -27,21 +26,20 @@ export function renderTransportShipTrailSwatch(
     case "gradient":
       return html`<div
         class="w-full h-full rounded-md"
-        style="background:linear-gradient(90deg,${color},${attributes.color2 ??
-        color});"
+        style="background:linear-gradient(90deg,${attributes.color},${attributes.color2});"
       ></div>`;
     case "pulse":
       return html`<div
         class="w-full h-full rounded-md animate-pulse"
-        style="background:${color};"
+        style="background:${attributes.color};"
       ></div>`;
     case "solid":
       return html`<div
         class="w-full h-full rounded-md"
-        style="background:${color};"
+        style="background:${attributes.color};"
       ></div>`;
     default:
-      // Unknown attribute type — neutral swatch.
+      // Unknown / unrecognized style — neutral swatch.
       return html`<div
         class="w-full h-full rounded-md"
         style="background:${UNKNOWN_BG};"

--- a/src/client/components/EffectPreview.ts
+++ b/src/client/components/EffectPreview.ts
@@ -5,29 +5,46 @@ import { TransportShipTrailAttributes } from "../../core/CosmeticSchemas";
 const RAINBOW_GRADIENT =
   "linear-gradient(90deg,#ff0000,#ff8a00,#ffe600,#28c76f,#00a8ff,#7d5fff,#ff0000)";
 
+// Neutral fallback for attribute types we don't recognize.
+const UNKNOWN_BG = "#444";
+
 /**
  * Render a swatch preview of a transport-ship-trail's attributes, filling its
  * container: solid = flat color, pulse = same color pulsing, rainbow = full
- * spectrum, gradient = two-color blend.
+ * spectrum, gradient = two-color blend. Unknown attribute types render a neutral
+ * swatch (we ignore types we don't know about).
  */
 export function renderTransportShipTrailSwatch(
   attributes: TransportShipTrailAttributes,
 ): TemplateResult {
-  if (attributes.type === "rainbow") {
-    return html`<div
-      class="w-full h-full rounded-md"
-      style="background:${RAINBOW_GRADIENT};"
-    ></div>`;
+  const color = attributes.color ?? UNKNOWN_BG;
+  switch (attributes.type) {
+    case "rainbow":
+      return html`<div
+        class="w-full h-full rounded-md"
+        style="background:${RAINBOW_GRADIENT};"
+      ></div>`;
+    case "gradient":
+      return html`<div
+        class="w-full h-full rounded-md"
+        style="background:linear-gradient(90deg,${color},${attributes.color2 ??
+        color});"
+      ></div>`;
+    case "pulse":
+      return html`<div
+        class="w-full h-full rounded-md animate-pulse"
+        style="background:${color};"
+      ></div>`;
+    case "solid":
+      return html`<div
+        class="w-full h-full rounded-md"
+        style="background:${color};"
+      ></div>`;
+    default:
+      // Unknown attribute type — neutral swatch.
+      return html`<div
+        class="w-full h-full rounded-md"
+        style="background:${UNKNOWN_BG};"
+      ></div>`;
   }
-  if (attributes.type === "gradient") {
-    return html`<div
-      class="w-full h-full rounded-md"
-      style="background:linear-gradient(90deg,${attributes.color},${attributes.color2});"
-    ></div>`;
-  }
-  const pulseClass = attributes.type === "pulse" ? "animate-pulse" : "";
-  return html`<div
-    class="w-full h-full rounded-md ${pulseClass}"
-    style="background:${attributes.color};"
-  ></div>`;
 }

--- a/src/client/components/EffectPreview.ts
+++ b/src/client/components/EffectPreview.ts
@@ -1,0 +1,33 @@
+import { html, TemplateResult } from "lit";
+import { TransportShipTrailAttributes } from "../../core/CosmeticSchemas";
+
+// A flowing spectrum used for the "rainbow" transport-ship-trail preview.
+const RAINBOW_GRADIENT =
+  "linear-gradient(90deg,#ff0000,#ff8a00,#ffe600,#28c76f,#00a8ff,#7d5fff,#ff0000)";
+
+/**
+ * Render a swatch preview of a transport-ship-trail's attributes, filling its
+ * container: solid = flat color, pulse = same color pulsing, rainbow = full
+ * spectrum, gradient = two-color blend.
+ */
+export function renderTransportShipTrailSwatch(
+  attributes: TransportShipTrailAttributes,
+): TemplateResult {
+  if (attributes.type === "rainbow") {
+    return html`<div
+      class="w-full h-full rounded-md"
+      style="background:${RAINBOW_GRADIENT};"
+    ></div>`;
+  }
+  if (attributes.type === "gradient") {
+    return html`<div
+      class="w-full h-full rounded-md"
+      style="background:linear-gradient(90deg,${attributes.color},${attributes.color2});"
+    ></div>`;
+  }
+  const pulseClass = attributes.type === "pulse" ? "animate-pulse" : "";
+  return html`<div
+    class="w-full h-full rounded-md ${pulseClass}"
+    style="background:${attributes.color};"
+  ></div>`;
+}

--- a/src/client/components/EffectsGrid.ts
+++ b/src/client/components/EffectsGrid.ts
@@ -1,0 +1,160 @@
+import { html, LitElement, TemplateResult } from "lit";
+import { customElement, property } from "lit/decorators.js";
+import { UserMeResponse } from "../../core/ApiSchemas";
+import {
+  Cosmetics,
+  Effect,
+  EFFECT_TYPES,
+  EffectType,
+} from "../../core/CosmeticSchemas";
+import {
+  EFFECTS_KEY,
+  USER_SETTINGS_CHANGED_EVENT,
+  UserSettings,
+} from "../../core/game/UserSettings";
+import {
+  purchaseCosmetic,
+  resolveCosmetics,
+  ResolvedCosmetic,
+} from "../Cosmetics";
+import { translateText } from "../Utils";
+import "./CosmeticButton";
+
+// "Default" (none) tile — selecting it clears the effect for that effectType.
+function noneTile(effectType: EffectType): ResolvedCosmetic {
+  return {
+    type: "effect",
+    cosmetic: null,
+    colorPalette: null,
+    relationship: "owned",
+    key: `effect:none:${effectType}`,
+  };
+}
+
+/**
+ * Renders effect cosmetics grouped by effectType, one sub-header per type.
+ * Shared by the home selection modal and the Store's Effects tab.
+ *
+ * - mode="select": owned effects + a Default tile per type; clicking persists
+ *   the selection to UserSettings and re-renders.
+ * - mode="purchase": purchasable effects per type with the buy flow.
+ */
+@customElement("effects-grid")
+export class EffectsGrid extends LitElement {
+  @property({ attribute: false }) cosmetics: Cosmetics | null = null;
+  @property({ attribute: false }) userMeResponse: UserMeResponse | false =
+    false;
+  @property({ type: String }) mode: "select" | "purchase" = "select";
+  @property({ attribute: false }) affiliateCode: string | null = null;
+
+  private userSettings = new UserSettings();
+  private _onChange = () => this.requestUpdate();
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener(
+      `${USER_SETTINGS_CHANGED_EVENT}:${EFFECTS_KEY}`,
+      this._onChange,
+    );
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    window.removeEventListener(
+      `${USER_SETTINGS_CHANGED_EVENT}:${EFFECTS_KEY}`,
+      this._onChange,
+    );
+  }
+
+  createRenderRoot() {
+    return this;
+  }
+
+  private select(effectType: EffectType, name: string | null) {
+    this.userSettings.setSelectedEffectName(effectType, name ?? undefined);
+    // Stay rendered; the change event re-renders this grid and the home button.
+    this.requestUpdate();
+  }
+
+  private itemsForType(
+    all: ResolvedCosmetic[],
+    effectType: EffectType,
+  ): ResolvedCosmetic[] {
+    const ofType = all.filter(
+      (r) =>
+        r.type === "effect" &&
+        r.cosmetic !== null &&
+        (r.cosmetic as Effect).effectType === effectType,
+    );
+    if (this.mode === "purchase") {
+      return ofType.filter((r) => r.relationship === "purchasable");
+    }
+    return [
+      noneTile(effectType),
+      ...ofType.filter((r) => r.relationship === "owned"),
+    ];
+  }
+
+  private renderTile(
+    effectType: EffectType,
+    r: ResolvedCosmetic,
+  ): TemplateResult {
+    if (this.mode === "purchase") {
+      return html`<cosmetic-button
+        .resolved=${r}
+        .onPurchase=${purchaseCosmetic}
+      ></cosmetic-button>`;
+    }
+    const name = (r.cosmetic as Effect | null)?.name ?? null;
+    const selected = this.userSettings.getSelectedEffectName(effectType);
+    const isSelected =
+      (name === null && selected === null) ||
+      (name !== null && selected === name);
+    return html`<cosmetic-button
+      .resolved=${r}
+      .selected=${isSelected}
+      .onSelect=${() => this.select(effectType, name)}
+    ></cosmetic-button>`;
+  }
+
+  render() {
+    const all = resolveCosmetics(
+      this.cosmetics,
+      this.userMeResponse,
+      this.affiliateCode,
+    );
+    const sections = EFFECT_TYPES.map((type) => ({
+      type,
+      items: this.itemsForType(all, type),
+    })).filter((s) => s.items.length > 0);
+
+    if (sections.length === 0) {
+      return html`<div
+        class="text-white/40 text-sm font-bold uppercase tracking-wider text-center py-8"
+      >
+        ${translateText("store.no_effects")}
+      </div>`;
+    }
+
+    return html`
+      <div class="flex flex-col gap-4 p-4">
+        ${sections.map(
+          (s) => html`
+            <div class="flex flex-col">
+              <h3
+                class="text-white/70 text-sm font-black uppercase tracking-wider px-2 pb-2 mb-2 border-b border-white/10"
+              >
+                ${translateText(`effects.type.${s.type}`)}
+              </h3>
+              <div
+                class="flex flex-wrap gap-4 justify-center items-stretch content-start"
+              >
+                ${s.items.map((r) => this.renderTile(s.type, r))}
+              </div>
+            </div>
+          `,
+        )}
+      </div>
+    `;
+  }
+}

--- a/src/client/components/EffectsGrid.ts
+++ b/src/client/components/EffectsGrid.ts
@@ -28,6 +28,7 @@ function noneTile(effectType: EffectType): ResolvedCosmetic {
     colorPalette: null,
     relationship: "owned",
     key: `effect:none:${effectType}`,
+    effectType,
   };
 }
 
@@ -84,7 +85,7 @@ export class EffectsGrid extends LitElement {
       (r) =>
         r.type === "effect" &&
         r.cosmetic !== null &&
-        (r.cosmetic as Effect).effectType === effectType,
+        r.effectType === effectType,
     );
     if (this.mode === "purchase") {
       return ofType.filter((r) => r.relationship === "purchasable");

--- a/src/client/components/PlayPage.ts
+++ b/src/client/components/PlayPage.ts
@@ -96,6 +96,10 @@ export class PlayPage extends LitElement {
                 show-select-label
                 class="shrink-0 lg:hidden h-10 w-10"
               ></flag-input>
+              <effects-input
+                id="effects-input-mobile"
+                class="shrink-0 lg:hidden h-10 w-10"
+              ></effects-input>
             </div>
           </div>
 
@@ -111,6 +115,10 @@ export class PlayPage extends LitElement {
               show-select-label
               class="flex-1 h-full"
             ></flag-input>
+            <effects-input
+              id="effects-input-desktop"
+              class="flex-1 h-full"
+            ></effects-input>
           </div>
         </div>
 

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -9,6 +9,8 @@ export type Flag = z.infer<typeof FlagSchema>;
 export type Skin = z.infer<typeof SkinSchema>;
 export type Pack = z.infer<typeof PackSchema>;
 export type Subscription = z.infer<typeof SubscriptionSchema>;
+// An effect cosmetic of any type — discriminated on effectType (today only
+// transportShipTrail; gains a member per effectType).
 export type Effect = z.infer<typeof EffectSchema>;
 export type EffectType = z.infer<typeof EffectTypeSchema>;
 export type TransportShipTrailAttributes = z.infer<
@@ -91,11 +93,12 @@ export const SkinSchema = CosmeticSchema.extend({
 });
 
 // "effects" is a cosmetic category alongside skins/flags. The catalog is nested
-// effects[effectType][effectName]; the effectType is the OUTER key, NOT a field
-// on each effect. Both the effectType and the attribute `type` are kept lenient
-// so effectTypes / attribute types we don't recognize don't fail the whole
-// cosmetics parse — the UI simply ignores anything outside EFFECT_TYPES and the
-// known attribute types.
+// effects[effectType][effectName], and each effect also carries an effectType
+// field matching its outer key (so an Effect can stand alone / discriminate).
+// effectTypes are listed explicitly in CosmeticsSchema so each type's attributes
+// stay precisely typed; an effectType the client doesn't list is dropped at parse
+// (the UI only handles EFFECT_TYPES), so a new server-side effectType never fails
+// the whole cosmetics parse.
 export const EFFECT_TYPES = ["transportShipTrail"] as const;
 export const EffectTypeSchema = z.enum(EFFECT_TYPES);
 
@@ -121,10 +124,16 @@ export const TransportShipTrailAttributesSchema = z.union([
     .transform(() => ({ type: "unknown" as const })),
 ]);
 
-export const EffectSchema = CosmeticSchema.extend({
+const TransportShipTrailEffectSchema = CosmeticSchema.extend({
+  effectType: z.literal("transportShipTrail"),
   attributes: TransportShipTrailAttributesSchema,
   url: z.string().optional(),
 });
+
+// Any catalog effect, discriminated on effectType. Add a member per effectType.
+export const EffectSchema = z.discriminatedUnion("effectType", [
+  TransportShipTrailEffectSchema,
+]);
 
 export const PackSchema = CosmeticSchema.extend({
   displayName: z.string(),
@@ -146,8 +155,16 @@ export const CosmeticsSchema = z.object({
   patterns: z.record(z.string(), PatternSchema),
   flags: z.record(z.string(), FlagSchema),
   skins: z.record(z.string(), SkinSchema).optional(),
-  // Two-level: effects[effectType][effectName] -> Effect.
-  effects: z.record(z.string(), z.record(z.string(), EffectSchema)).optional(),
+  // Grouped by effectType. Each effect also carries its own effectType (matching
+  // this outer key) so an Effect stands alone and EffectSchema can discriminate
+  // on it. Add a key per new effectType.
+  effects: z
+    .object({
+      transportShipTrail: z
+        .record(z.string(), TransportShipTrailEffectSchema)
+        .optional(),
+    })
+    .optional(),
   currencyPacks: z.record(z.string(), PackSchema).optional(),
   subscriptions: z.record(z.string(), SubscriptionSchema).optional(),
 });
@@ -164,7 +181,12 @@ export function findEffect(
   effectType: string,
   name: string,
 ): Effect | undefined {
-  const byName = cosmetics?.effects?.[effectType];
+  // effects is keyed by the known effectTypes; index it by an arbitrary runtime
+  // string (a selection/ref may name a type this client doesn't list).
+  const byType = cosmetics?.effects as
+    | Record<string, Record<string, Effect>>
+    | undefined;
+  const byName = byType?.[effectType];
   if (!byName) return undefined;
   return byName[name] ?? Object.values(byName).find((e) => e.name === name);
 }

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -9,6 +9,11 @@ export type Flag = z.infer<typeof FlagSchema>;
 export type Skin = z.infer<typeof SkinSchema>;
 export type Pack = z.infer<typeof PackSchema>;
 export type Subscription = z.infer<typeof SubscriptionSchema>;
+export type Effect = z.infer<typeof EffectSchema>;
+export type EffectType = z.infer<typeof EffectTypeSchema>;
+export type TransportShipTrailAttributes = z.infer<
+  typeof TransportShipTrailAttributesSchema
+>;
 export type PatternName = z.infer<typeof CosmeticNameSchema>;
 export type Product = z.infer<typeof ProductSchema>;
 export type ColorPalette = z.infer<typeof ColorPaletteSchema>;
@@ -85,6 +90,34 @@ export const SkinSchema = CosmeticSchema.extend({
   url: z.string(),
 });
 
+// "effects" is a cosmetic category alongside skins/flags. Each effect declares
+// an `effectType` (the kind of thing it changes); the only type today is
+// "transportShipTrail", whose visual config lives in `attributes`. New effect
+// types are added by extending the EffectSchema union with another member.
+export const EFFECT_TYPES = ["transportShipTrail"] as const;
+export const EffectTypeSchema = z.enum(EFFECT_TYPES);
+
+export const TransportShipTrailAttributesSchema = z.discriminatedUnion("type", [
+  z.object({ type: z.literal("solid"), color: z.string() }),
+  z.object({ type: z.literal("rainbow") }),
+  z.object({ type: z.literal("pulse"), color: z.string() }),
+  z.object({
+    type: z.literal("gradient"),
+    color: z.string(),
+    color2: z.string(),
+  }),
+]);
+
+export const TransportShipTrailEffectSchema = CosmeticSchema.extend({
+  effectType: z.literal("transportShipTrail"),
+  attributes: TransportShipTrailAttributesSchema,
+  url: z.string().optional(),
+});
+
+export const EffectSchema = z.discriminatedUnion("effectType", [
+  TransportShipTrailEffectSchema,
+]);
+
 export const PackSchema = CosmeticSchema.extend({
   displayName: z.string(),
   currency: z.enum(["hard", "soft"]),
@@ -105,6 +138,7 @@ export const CosmeticsSchema = z.object({
   patterns: z.record(z.string(), PatternSchema),
   flags: z.record(z.string(), FlagSchema),
   skins: z.record(z.string(), SkinSchema).optional(),
+  effects: z.record(z.string(), EffectSchema).optional(),
   currencyPacks: z.record(z.string(), PackSchema).optional(),
   subscriptions: z.record(z.string(), SubscriptionSchema).optional(),
 });

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -138,6 +138,23 @@ export const CosmeticsSchema = z.object({
   subscriptions: z.record(z.string(), SubscriptionSchema).optional(),
 });
 
+/**
+ * Resolve an effect in the nested catalog (effects[effectType][effectKey]). The
+ * catalog object key is normally identical to the effect's `name`, but selection
+ * and ownership flares are both name-based, so fall back to a `name`-field search
+ * when the object key differs. Without this fallback a catalog whose key !== name
+ * would make the effect silently unselectable (the selected name never resolves).
+ */
+export function findEffect(
+  cosmetics: Cosmetics | null | undefined,
+  effectType: string,
+  name: string,
+): Effect | undefined {
+  const byName = cosmetics?.effects?.[effectType];
+  if (!byName) return undefined;
+  return byName[name] ?? Object.values(byName).find((e) => e.name === name);
+}
+
 export const DefaultPattern = {
   name: "default",
   patternData: "AAAAAA",

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -90,33 +90,27 @@ export const SkinSchema = CosmeticSchema.extend({
   url: z.string(),
 });
 
-// "effects" is a cosmetic category alongside skins/flags. Each effect declares
-// an `effectType` (the kind of thing it changes); the only type today is
-// "transport_ship_trail", whose visual config lives in `attributes`. New effect
-// types are added by extending the EffectSchema union with another member.
-export const EFFECT_TYPES = ["transport_ship_trail"] as const;
+// "effects" is a cosmetic category alongside skins/flags. The catalog is nested
+// effects[effectType][effectName]; the effectType is the OUTER key, NOT a field
+// on each effect. Both the effectType and the attribute `type` are kept lenient
+// so effectTypes / attribute types we don't recognize don't fail the whole
+// cosmetics parse — the UI simply ignores anything outside EFFECT_TYPES and the
+// known attribute types.
+export const EFFECT_TYPES = ["transportShipTrail"] as const;
 export const EffectTypeSchema = z.enum(EFFECT_TYPES);
 
-export const TransportShipTrailAttributesSchema = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("solid"), color: z.string() }),
-  z.object({ type: z.literal("rainbow") }),
-  z.object({ type: z.literal("pulse"), color: z.string() }),
-  z.object({
-    type: z.literal("gradient"),
-    color: z.string(),
-    color2: z.string(),
-  }),
-]);
+// `type` is any string (unknown attribute types tolerated); color/color2 are
+// kept for the known solid / pulse / gradient styles.
+export const TransportShipTrailAttributesSchema = z.object({
+  type: z.string(),
+  color: z.string().optional(),
+  color2: z.string().optional(),
+});
 
-export const TransportShipTrailEffectSchema = CosmeticSchema.extend({
-  effectType: z.literal("transport_ship_trail"),
+export const EffectSchema = CosmeticSchema.extend({
   attributes: TransportShipTrailAttributesSchema,
   url: z.string().optional(),
 });
-
-export const EffectSchema = z.discriminatedUnion("effectType", [
-  TransportShipTrailEffectSchema,
-]);
 
 export const PackSchema = CosmeticSchema.extend({
   displayName: z.string(),

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -92,9 +92,9 @@ export const SkinSchema = CosmeticSchema.extend({
 
 // "effects" is a cosmetic category alongside skins/flags. Each effect declares
 // an `effectType` (the kind of thing it changes); the only type today is
-// "transportShipTrail", whose visual config lives in `attributes`. New effect
+// "transport_ship_trail", whose visual config lives in `attributes`. New effect
 // types are added by extending the EffectSchema union with another member.
-export const EFFECT_TYPES = ["transportShipTrail"] as const;
+export const EFFECT_TYPES = ["transport_ship_trail"] as const;
 export const EffectTypeSchema = z.enum(EFFECT_TYPES);
 
 export const TransportShipTrailAttributesSchema = z.discriminatedUnion("type", [
@@ -109,7 +109,7 @@ export const TransportShipTrailAttributesSchema = z.discriminatedUnion("type", [
 ]);
 
 export const TransportShipTrailEffectSchema = CosmeticSchema.extend({
-  effectType: z.literal("transportShipTrail"),
+  effectType: z.literal("transport_ship_trail"),
   attributes: TransportShipTrailAttributesSchema,
   url: z.string().optional(),
 });
@@ -138,7 +138,8 @@ export const CosmeticsSchema = z.object({
   patterns: z.record(z.string(), PatternSchema),
   flags: z.record(z.string(), FlagSchema),
   skins: z.record(z.string(), SkinSchema).optional(),
-  effects: z.record(z.string(), EffectSchema).optional(),
+  // Two-level: effects[effectType][effectName] -> Effect.
+  effects: z.record(z.string(), z.record(z.string(), EffectSchema)).optional(),
   currencyPacks: z.record(z.string(), PackSchema).optional(),
   subscriptions: z.record(z.string(), SubscriptionSchema).optional(),
 });

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -99,13 +99,27 @@ export const SkinSchema = CosmeticSchema.extend({
 export const EFFECT_TYPES = ["transportShipTrail"] as const;
 export const EffectTypeSchema = z.enum(EFFECT_TYPES);
 
-// `type` is any string (unknown attribute types tolerated); color/color2 are
-// kept for the known solid / pulse / gradient styles.
-export const TransportShipTrailAttributesSchema = z.object({
-  type: z.string(),
-  color: z.string().optional(),
-  color2: z.string().optional(),
-});
+// Boat-trail styles, discriminated on `type`: each known style carries exactly
+// the fields it uses (rainbow has none; solid/pulse need a color; gradient needs
+// both). A `type` we don't recognize — a style shipped to cosmetics.json before
+// this client updated — normalizes to { type: "unknown" } instead of failing the
+// catalog parse, so one new style never wipes the whole catalog; the renderer
+// shows a neutral swatch. `type` itself stays required.
+export const TransportShipTrailAttributesSchema = z.union([
+  z.discriminatedUnion("type", [
+    z.object({ type: z.literal("solid"), color: z.string() }),
+    z.object({ type: z.literal("rainbow") }),
+    z.object({ type: z.literal("pulse"), color: z.string() }),
+    z.object({
+      type: z.literal("gradient"),
+      color: z.string(),
+      color2: z.string(),
+    }),
+  ]),
+  z
+    .object({ type: z.string() })
+    .transform(() => ({ type: "unknown" as const })),
+]);
 
 export const EffectSchema = CosmeticSchema.extend({
   attributes: TransportShipTrailAttributesSchema,

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -3,7 +3,9 @@ import { z } from "zod";
 import {
   ColorPaletteSchema,
   CosmeticNameSchema,
+  EffectTypeSchema,
   PatternDataSchema,
+  TransportShipTrailAttributesSchema,
 } from "./CosmeticSchemas";
 import type { GameEvent } from "./EventBus";
 import {
@@ -142,6 +144,7 @@ export type PlayerCosmeticRefs = z.infer<typeof PlayerCosmeticRefsSchema>;
 export type PlayerPattern = z.infer<typeof PlayerPatternSchema>;
 export type PlayerColor = z.infer<typeof PlayerColorSchema>;
 export type PlayerSkin = z.infer<typeof PlayerSkinSchema>;
+export type PlayerEffect = z.infer<typeof PlayerEffectSchema>;
 export type GameStartInfo = z.infer<typeof GameStartInfoSchema>;
 export type GameInfo = z.infer<typeof GameInfoSchema>;
 export type PublicGames = z.infer<typeof PublicGamesSchema>;
@@ -593,11 +596,20 @@ export const PlayerCosmeticRefsSchema = z.object({
   patternName: CosmeticNameSchema.optional(),
   patternColorPaletteName: z.string().optional(),
   skinName: CosmeticNameSchema.optional(),
+  // At most one selected effect per effectType: key = effectType, value = effect name.
+  effects: z.record(z.string(), CosmeticNameSchema).optional(),
 });
 
 export const PlayerSkinSchema = z.object({
   name: CosmeticNameSchema,
   url: z.string(),
+});
+
+export const PlayerEffectSchema = z.object({
+  name: CosmeticNameSchema,
+  effectType: EffectTypeSchema,
+  // Widen to an attributes union once a second effectType ships.
+  attributes: TransportShipTrailAttributesSchema,
 });
 
 // Server converts refs to the actual cosmetics here
@@ -606,6 +618,8 @@ export const PlayerCosmeticsSchema = z.object({
   pattern: PlayerPatternSchema.optional(),
   color: PlayerColorSchema.optional(),
   skin: PlayerSkinSchema.optional(),
+  // Resolved effects keyed by effectType.
+  effects: z.record(z.string(), PlayerEffectSchema).optional(),
 });
 
 export const PlayerSchema = z.object({

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 import {
   ColorPaletteSchema,
   CosmeticNameSchema,
+  EffectTypeSchema,
   PatternDataSchema,
-  TransportShipTrailAttributesSchema,
 } from "./CosmeticSchemas";
 import type { GameEvent } from "./EventBus";
 import {
@@ -604,16 +604,14 @@ export const PlayerSkinSchema = z.object({
   url: z.string(),
 });
 
-// Discriminated on effectType: one variant per effectType, each pairing the
-// effectType literal with its attributes shape. Add a variant when a new
-// effectType ships, e.g. z.object({ effectType: z.literal("glow"), ... }).
-export const PlayerEffectSchema = z.discriminatedUnion("effectType", [
-  z.object({
-    name: CosmeticNameSchema,
-    effectType: z.literal("transportShipTrail"),
-    attributes: TransportShipTrailAttributesSchema,
-  }),
-]);
+// A resolved effect is just an identity: which effect, of which type. Its
+// attributes (the visual style) are resolved from the cosmetics catalog by
+// (effectType, name), so this needs no per-type variants — a new effectType
+// just becomes a new EFFECT_TYPES entry, no change here.
+export const PlayerEffectSchema = z.object({
+  name: CosmeticNameSchema,
+  effectType: EffectTypeSchema,
+});
 
 // Server converts refs to the actual cosmetics here
 export const PlayerCosmeticsSchema = z.object({

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 import {
   ColorPaletteSchema,
   CosmeticNameSchema,
-  EffectTypeSchema,
   PatternDataSchema,
   TransportShipTrailAttributesSchema,
 } from "./CosmeticSchemas";
@@ -605,12 +604,16 @@ export const PlayerSkinSchema = z.object({
   url: z.string(),
 });
 
-export const PlayerEffectSchema = z.object({
-  name: CosmeticNameSchema,
-  effectType: EffectTypeSchema,
-  // Widen to an attributes union once a second effectType ships.
-  attributes: TransportShipTrailAttributesSchema,
-});
+// Discriminated on effectType: one variant per effectType, each pairing the
+// effectType literal with its attributes shape. Add a variant when a new
+// effectType ships, e.g. z.object({ effectType: z.literal("glow"), ... }).
+export const PlayerEffectSchema = z.discriminatedUnion("effectType", [
+  z.object({
+    name: CosmeticNameSchema,
+    effectType: z.literal("transportShipTrail"),
+    attributes: TransportShipTrailAttributesSchema,
+  }),
+]);
 
 // Server converts refs to the actual cosmetics here
 export const PlayerCosmeticsSchema = z.object({

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -2,7 +2,7 @@ import {
   GraphicsOverrides,
   GraphicsOverridesSchema,
 } from "../../client/render/gl/GraphicsOverrides";
-import { Cosmetics } from "../CosmeticSchemas";
+import { Cosmetics, EffectType } from "../CosmeticSchemas";
 import { PlayerPattern } from "../Schemas";
 
 export function getDefaultKeybinds(isMac: boolean): Record<string, string> {
@@ -57,6 +57,7 @@ export const COLOR_KEY = "settings.territoryColor";
 export const PERFORMANCE_OVERLAY_KEY = "settings.performanceOverlay";
 export const KEYBINDS_KEY = "settings.keybinds";
 export const GRAPHICS_KEY = "settings.graphics";
+export const EFFECTS_KEY = "settings.effects";
 
 export class UserSettings {
   private static cache = new Map<string, string | null>();
@@ -310,6 +311,38 @@ export class UserSettings {
 
   clearFlag(emitChange: boolean = false): void {
     this.removeCached(FLAG_KEY, emitChange);
+  }
+
+  /**
+   * Selected effect cosmetics, keyed by effectType (at most one per type).
+   * Persisted as a single JSON blob under EFFECTS_KEY.
+   */
+  getSelectedEffects(): Record<string, string> {
+    const raw = this.getString(EFFECTS_KEY, "");
+    if (!raw) return {};
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+        ? parsed
+        : {};
+    } catch {
+      return {};
+    }
+  }
+
+  getSelectedEffectName(effectType: EffectType): string | null {
+    return this.getSelectedEffects()[effectType] ?? null;
+  }
+
+  setSelectedEffectName(
+    effectType: EffectType,
+    name: string | undefined,
+  ): void {
+    const map = this.getSelectedEffects();
+    if (name === undefined) delete map[effectType];
+    else map[effectType] = name;
+    if (Object.keys(map).length === 0) this.removeCached(EFFECTS_KEY);
+    else this.setString(EFFECTS_KEY, JSON.stringify(map));
   }
 
   backgroundMusicVolume(): number {

--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -11,12 +11,13 @@ import {
 } from "obscenity";
 import countries from "resources/countries.json";
 
-import { Cosmetics } from "../core/CosmeticSchemas";
+import { Cosmetics, EffectType } from "../core/CosmeticSchemas";
 import { decodePatternData } from "../core/PatternDecoder";
 import {
   PlayerColor,
   PlayerCosmeticRefs,
   PlayerCosmetics,
+  PlayerEffect,
   PlayerPattern,
   PlayerSkin,
 } from "../core/Schemas";
@@ -257,8 +258,46 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
         return { type: "forbidden", reason: "invalid skin: " + message };
       }
     }
+    if (refs.effects) {
+      for (const [type, name] of Object.entries(refs.effects)) {
+        try {
+          cosmetics.effects ??= {};
+          cosmetics.effects[type] = this.isEffectAllowed(
+            flares,
+            type as EffectType,
+            name,
+          );
+        } catch (e) {
+          const message = e instanceof Error ? e.message : String(e);
+          return { type: "forbidden", reason: "invalid effect: " + message };
+        }
+      }
+    }
 
     return { type: "allowed", cosmetics };
+  }
+
+  isEffectAllowed(
+    flares: string[],
+    effectType: EffectType,
+    name: string,
+  ): PlayerEffect {
+    const found = this.cosmetics.effects?.[name];
+    if (!found) throw new Error(`Effect ${name} not found`);
+    if (found.effectType !== effectType) {
+      throw new Error(`Effect ${name} type mismatch`);
+    }
+    if (
+      flares.includes("effect:*") ||
+      flares.includes(`effect:${found.name}`)
+    ) {
+      return {
+        name: found.name,
+        effectType: found.effectType,
+        attributes: found.attributes,
+      };
+    }
+    throw new Error(`No flares for effect ${name}`);
   }
 
   isSkinAllowed(flares: string[], name: string): PlayerSkin {

--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -291,7 +291,6 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
       return {
         name: found.name,
         effectType: found.effectType,
-        attributes: found.attributes,
       };
     }
     throw new Error(`No flares for effect ${name}`);

--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -11,7 +11,7 @@ import {
 } from "obscenity";
 import countries from "resources/countries.json";
 
-import { Cosmetics, EffectType } from "../core/CosmeticSchemas";
+import { Cosmetics, EffectType, findEffect } from "../core/CosmeticSchemas";
 import { decodePatternData } from "../core/PatternDecoder";
 import {
   PlayerColor,
@@ -282,7 +282,7 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
     effectType: EffectType,
     name: string,
   ): PlayerEffect {
-    const found = this.cosmetics.effects?.[effectType]?.[name];
+    const found = findEffect(this.cosmetics, effectType, name);
     if (!found) throw new Error(`Effect ${name} not found`);
     if (
       flares.includes("effect:*") ||

--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -288,10 +288,9 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
       flares.includes("effect:*") ||
       flares.includes(`effect:${found.name}`)
     ) {
-      // effectType is the catalog's outer key, not a field on the effect.
       return {
         name: found.name,
-        effectType,
+        effectType: found.effectType,
         attributes: found.attributes,
       };
     }

--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -282,11 +282,8 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
     effectType: EffectType,
     name: string,
   ): PlayerEffect {
-    const found = this.cosmetics.effects?.[name];
+    const found = this.cosmetics.effects?.[effectType]?.[name];
     if (!found) throw new Error(`Effect ${name} not found`);
-    if (found.effectType !== effectType) {
-      throw new Error(`Effect ${name} type mismatch`);
-    }
     if (
       flares.includes("effect:*") ||
       flares.includes(`effect:${found.name}`)

--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -288,9 +288,10 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
       flares.includes("effect:*") ||
       flares.includes(`effect:${found.name}`)
     ) {
+      // effectType is the catalog's outer key, not a field on the effect.
       return {
         name: found.name,
-        effectType: found.effectType,
+        effectType,
         attributes: found.attributes,
       };
     }

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -59,7 +59,7 @@ describe("Effect cosmetic schemas", () => {
       expect(
         EffectSchema.safeParse({
           ...base,
-          effectType: "transportShipTrail",
+          effectType: "transport_ship_trail",
           attributes: { type: "rainbow" },
         }).success,
       ).toBe(true);
@@ -75,9 +75,9 @@ describe("Effect cosmetic schemas", () => {
       ).toBe(false);
     });
 
-    it("rejects a transportShipTrail effect with no attributes", () => {
+    it("rejects a transport_ship_trail effect with no attributes", () => {
       expect(
-        EffectSchema.safeParse({ ...base, effectType: "transportShipTrail" })
+        EffectSchema.safeParse({ ...base, effectType: "transport_ship_trail" })
           .success,
       ).toBe(false);
     });
@@ -88,7 +88,7 @@ describe("Effect cosmetic schemas", () => {
   it("parses the real cosmetics.json effect entry", () => {
     const realEffect = {
       name: "read_transport_trail",
-      effectType: "transportShipTrail",
+      effectType: "transport_ship_trail",
       attributes: { type: "solid", color: "#f91515" },
       url: "",
       affiliateCode: null,
@@ -100,13 +100,15 @@ describe("Effect cosmetic schemas", () => {
     const result = CosmeticsSchema.safeParse({
       patterns: {},
       flags: {},
-      effects: { read_transport_trail: realEffect },
+      // Catalog is nested: effects[effectType][effectName].
+      effects: { transport_ship_trail: { read_transport_trail: realEffect } },
     });
     expect(result.success).toBe(true);
     if (result.success) {
-      expect(result.data.effects?.read_transport_trail.effectType).toBe(
-        "transportShipTrail",
-      );
+      expect(
+        result.data.effects?.transport_ship_trail.read_transport_trail
+          .effectType,
+      ).toBe("transport_ship_trail");
     }
   });
 });

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -5,10 +5,10 @@ import {
 } from "../src/core/CosmeticSchemas";
 
 describe("Effect cosmetic schemas", () => {
-  const base = { name: "spectrum", product: null, rarity: "legendary" };
+  const base = { name: "spectrum", product: null, rarity: "common" };
 
-  describe("TransportShipTrailAttributesSchema", () => {
-    it("parses each attribute variant", () => {
+  describe("TransportShipTrailAttributesSchema (lenient)", () => {
+    it("parses the known attribute variants", () => {
       expect(
         TransportShipTrailAttributesSchema.safeParse({
           type: "solid",
@@ -34,81 +34,107 @@ describe("Effect cosmetic schemas", () => {
       ).toBe(true);
     });
 
-    it("rejects an unknown attribute type", () => {
+    it("tolerates an unknown attribute type (ignored at render time)", () => {
       expect(
         TransportShipTrailAttributesSchema.safeParse({ type: "sparkle" })
           .success,
-      ).toBe(false);
+      ).toBe(true);
     });
 
-    it("requires color for solid/pulse and both colors for gradient", () => {
-      expect(
-        TransportShipTrailAttributesSchema.safeParse({ type: "solid" }).success,
-      ).toBe(false);
-      expect(
-        TransportShipTrailAttributesSchema.safeParse({
-          type: "gradient",
-          color: "#f00",
-        }).success,
-      ).toBe(false);
+    it("requires a `type`", () => {
+      expect(TransportShipTrailAttributesSchema.safeParse({}).success).toBe(
+        false,
+      );
     });
   });
 
   describe("EffectSchema", () => {
-    it("discriminates an effect on effectType", () => {
+    it("parses an effect (effectType is the catalog key, not a field)", () => {
       expect(
-        EffectSchema.safeParse({
-          ...base,
-          effectType: "transport_ship_trail",
-          attributes: { type: "rainbow" },
-        }).success,
+        EffectSchema.safeParse({ ...base, attributes: { type: "rainbow" } })
+          .success,
       ).toBe(true);
     });
 
-    it("rejects an unknown effectType", () => {
-      expect(
-        EffectSchema.safeParse({
-          ...base,
-          effectType: "explosion",
-          attributes: { type: "rainbow" },
-        }).success,
-      ).toBe(false);
+    it("rejects an effect with no attributes", () => {
+      expect(EffectSchema.safeParse({ ...base }).success).toBe(false);
     });
 
-    it("rejects a transport_ship_trail effect with no attributes", () => {
+    it("tolerates an effect with an unknown attribute type", () => {
       expect(
-        EffectSchema.safeParse({ ...base, effectType: "transport_ship_trail" })
+        EffectSchema.safeParse({ ...base, attributes: { type: "sparkle" } })
           .success,
-      ).toBe(false);
+      ).toBe(true);
     });
   });
 
-  // Exact shape served by the production cosmetics.json (incl. the `url` field
-  // and stripped extras like `description`) — guards against schema drift.
-  it("parses the real cosmetics.json effect entry", () => {
-    const realEffect = {
-      name: "read_transport_trail",
-      effectType: "transport_ship_trail",
-      attributes: { type: "solid", color: "#f91515" },
-      url: "",
-      affiliateCode: null,
-      product: null,
-      rarity: "common",
-    };
-    expect(EffectSchema.safeParse(realEffect).success).toBe(true);
-
+  // Exact shape served by the production cosmetics.json: nested
+  // effects[effectType][effectName], no `effectType` field on the effect, and
+  // extras (e.g. product.priceInCents) stripped.
+  it("parses the real nested cosmetics.json effects", () => {
     const result = CosmeticsSchema.safeParse({
       patterns: {},
       flags: {},
-      // Catalog is nested: effects[effectType][effectName].
-      effects: { transport_ship_trail: { read_transport_trail: realEffect } },
+      effects: {
+        transportShipTrail: {
+          rainbow_ship: {
+            name: "rainbow_ship",
+            attributes: { type: "rainbow" },
+            affiliateCode: null,
+            product: null,
+            priceHard: 123,
+            rarity: "common",
+          },
+          gradient: {
+            name: "gradient",
+            attributes: {
+              type: "gradient",
+              color: "#aea2a2",
+              color2: "#a80000",
+            },
+            affiliateCode: null,
+            product: {
+              price: "$0.99",
+              priceInCents: 99,
+              productId: "prod_x",
+              priceId: "price_x",
+            },
+            rarity: "common",
+          },
+        },
+      },
     });
     expect(result.success).toBe(true);
     if (result.success) {
       expect(
-        result.data.effects?.transport_ship_trail.read_transport_trail
-          .effectType,
-      ).toBe("transport_ship_trail");
+        result.data.effects?.transportShipTrail?.rainbow_ship?.attributes?.type,
+      ).toBe("rainbow");
     }
+  });
+
+  it("tolerates an unknown effectType (outer key) without failing the parse", () => {
+    const result = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: {
+        transportShipTrail: {
+          ship: {
+            name: "ship",
+            attributes: { type: "solid", color: "#fff" },
+            product: null,
+            rarity: "common",
+          },
+        },
+        someFutureEffect: {
+          thing: {
+            name: "thing",
+            attributes: { type: "whatever" },
+            product: null,
+            rarity: "common",
+          },
+        },
+      },
+    });
+    expect(result.success).toBe(true);
   });
 });

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -254,33 +254,28 @@ describe("findEffect", () => {
   });
 });
 
-describe("PlayerEffectSchema (discriminated on effectType)", () => {
-  it("parses the transportShipTrail variant", () => {
+describe("PlayerEffectSchema (identity: name + effectType)", () => {
+  it("parses a name + effectType (attributes live in the catalog)", () => {
     expect(
       PlayerEffectSchema.safeParse({
         name: "spectrum",
         effectType: "transportShipTrail",
-        attributes: { type: "rainbow" },
       }).success,
     ).toBe(true);
   });
 
-  it("rejects an unknown effectType (no matching union variant)", () => {
+  it("rejects an unknown effectType (not in EFFECT_TYPES)", () => {
     expect(
       PlayerEffectSchema.safeParse({
         name: "spectrum",
         effectType: "glow",
-        attributes: { type: "rainbow" },
       }).success,
     ).toBe(false);
   });
 
-  it("rejects a variant missing its attributes", () => {
-    expect(
-      PlayerEffectSchema.safeParse({
-        name: "spectrum",
-        effectType: "transportShipTrail",
-      }).success,
-    ).toBe(false);
+  it("requires an effectType", () => {
+    expect(PlayerEffectSchema.safeParse({ name: "spectrum" }).success).toBe(
+      false,
+    );
   });
 });

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -1,0 +1,112 @@
+import {
+  CosmeticsSchema,
+  EffectSchema,
+  TransportShipTrailAttributesSchema,
+} from "../src/core/CosmeticSchemas";
+
+describe("Effect cosmetic schemas", () => {
+  const base = { name: "spectrum", product: null, rarity: "legendary" };
+
+  describe("TransportShipTrailAttributesSchema", () => {
+    it("parses each attribute variant", () => {
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({
+          type: "solid",
+          color: "#f00",
+        }).success,
+      ).toBe(true);
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({ type: "rainbow" })
+          .success,
+      ).toBe(true);
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({
+          type: "pulse",
+          color: "#0f0",
+        }).success,
+      ).toBe(true);
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({
+          type: "gradient",
+          color: "#f00",
+          color2: "#00f",
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects an unknown attribute type", () => {
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({ type: "sparkle" })
+          .success,
+      ).toBe(false);
+    });
+
+    it("requires color for solid/pulse and both colors for gradient", () => {
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({ type: "solid" }).success,
+      ).toBe(false);
+      expect(
+        TransportShipTrailAttributesSchema.safeParse({
+          type: "gradient",
+          color: "#f00",
+        }).success,
+      ).toBe(false);
+    });
+  });
+
+  describe("EffectSchema", () => {
+    it("discriminates an effect on effectType", () => {
+      expect(
+        EffectSchema.safeParse({
+          ...base,
+          effectType: "transportShipTrail",
+          attributes: { type: "rainbow" },
+        }).success,
+      ).toBe(true);
+    });
+
+    it("rejects an unknown effectType", () => {
+      expect(
+        EffectSchema.safeParse({
+          ...base,
+          effectType: "explosion",
+          attributes: { type: "rainbow" },
+        }).success,
+      ).toBe(false);
+    });
+
+    it("rejects a transportShipTrail effect with no attributes", () => {
+      expect(
+        EffectSchema.safeParse({ ...base, effectType: "transportShipTrail" })
+          .success,
+      ).toBe(false);
+    });
+  });
+
+  // Exact shape served by the production cosmetics.json (incl. the `url` field
+  // and stripped extras like `description`) — guards against schema drift.
+  it("parses the real cosmetics.json effect entry", () => {
+    const realEffect = {
+      name: "read_transport_trail",
+      effectType: "transportShipTrail",
+      attributes: { type: "solid", color: "#f91515" },
+      url: "",
+      affiliateCode: null,
+      product: null,
+      rarity: "common",
+    };
+    expect(EffectSchema.safeParse(realEffect).success).toBe(true);
+
+    const result = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: { read_transport_trail: realEffect },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.effects?.read_transport_trail.effectType).toBe(
+        "transportShipTrail",
+      );
+    }
+  });
+});

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -1,6 +1,8 @@
 import {
+  Cosmetics,
   CosmeticsSchema,
   EffectSchema,
+  findEffect,
   TransportShipTrailAttributesSchema,
 } from "../src/core/CosmeticSchemas";
 
@@ -136,5 +138,54 @@ describe("Effect cosmetic schemas", () => {
       },
     });
     expect(result.success).toBe(true);
+  });
+});
+
+describe("findEffect", () => {
+  const effect = (name: string) => ({
+    name,
+    attributes: { type: "solid", color: "#fff" } as const,
+    product: null,
+    rarity: "common" as const,
+  });
+
+  it("resolves by the catalog object key (the common key === name case)", () => {
+    const cosmetics = {
+      effects: { transportShipTrail: { spectrum: effect("spectrum") } },
+    } as unknown as Cosmetics;
+    expect(findEffect(cosmetics, "transportShipTrail", "spectrum")?.name).toBe(
+      "spectrum",
+    );
+  });
+
+  it("falls back to the name field when the object key differs", () => {
+    // Catalog key "trail_01" but the effect's name is "spectrum"; selection and
+    // flares are name-based, so the name must still resolve the effect.
+    const cosmetics = {
+      effects: { transportShipTrail: { trail_01: effect("spectrum") } },
+    } as unknown as Cosmetics;
+    expect(findEffect(cosmetics, "transportShipTrail", "spectrum")?.name).toBe(
+      "spectrum",
+    );
+  });
+
+  it("returns undefined for an unknown effect name", () => {
+    const cosmetics = {
+      effects: { transportShipTrail: { spectrum: effect("spectrum") } },
+    } as unknown as Cosmetics;
+    expect(
+      findEffect(cosmetics, "transportShipTrail", "ghost"),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for an unknown effectType or missing catalog", () => {
+    const cosmetics = {
+      effects: { transportShipTrail: { spectrum: effect("spectrum") } },
+    } as unknown as Cosmetics;
+    expect(findEffect(cosmetics, "wrongType", "spectrum")).toBeUndefined();
+    expect(findEffect(null, "transportShipTrail", "spectrum")).toBeUndefined();
+    expect(
+      findEffect({} as Cosmetics, "transportShipTrail", "x"),
+    ).toBeUndefined();
   });
 });

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -8,7 +8,12 @@ import {
 import { PlayerEffectSchema } from "../src/core/Schemas";
 
 describe("Effect cosmetic schemas", () => {
-  const base = { name: "spectrum", product: null, rarity: "common" };
+  const base = {
+    name: "spectrum",
+    effectType: "transportShipTrail",
+    product: null,
+    rarity: "common",
+  };
 
   describe("TransportShipTrailAttributesSchema (lenient)", () => {
     it("parses the known attribute variants", () => {
@@ -93,10 +98,12 @@ describe("Effect cosmetic schemas", () => {
   });
 
   describe("EffectSchema", () => {
-    it("parses an effect (effectType is the catalog key, not a field)", () => {
+    it("parses an effect (discriminated on effectType)", () => {
       expect(
-        EffectSchema.safeParse({ ...base, attributes: { type: "rainbow" } })
-          .success,
+        EffectSchema.safeParse({
+          ...base,
+          attributes: { type: "rainbow" },
+        }).success,
       ).toBe(true);
     });
 
@@ -104,16 +111,28 @@ describe("Effect cosmetic schemas", () => {
       expect(EffectSchema.safeParse({ ...base }).success).toBe(false);
     });
 
+    it("rejects an effect with an unknown effectType (no union member)", () => {
+      expect(
+        EffectSchema.safeParse({
+          ...base,
+          effectType: "glow",
+          attributes: { type: "rainbow" },
+        }).success,
+      ).toBe(false);
+    });
+
     it("tolerates an effect with an unknown attribute type", () => {
       expect(
-        EffectSchema.safeParse({ ...base, attributes: { type: "sparkle" } })
-          .success,
+        EffectSchema.safeParse({
+          ...base,
+          attributes: { type: "sparkle" },
+        }).success,
       ).toBe(true);
     });
   });
 
   // Exact shape served by the production cosmetics.json: nested
-  // effects[effectType][effectName], no `effectType` field on the effect, and
+  // effects[effectType][effectName], each effect carrying its effectType, and
   // extras (e.g. product.priceInCents) stripped.
   it("parses the real nested cosmetics.json effects", () => {
     const result = CosmeticsSchema.safeParse({
@@ -123,6 +142,7 @@ describe("Effect cosmetic schemas", () => {
         transportShipTrail: {
           rainbow_ship: {
             name: "rainbow_ship",
+            effectType: "transportShipTrail",
             attributes: { type: "rainbow" },
             affiliateCode: null,
             product: null,
@@ -131,6 +151,7 @@ describe("Effect cosmetic schemas", () => {
           },
           gradient: {
             name: "gradient",
+            effectType: "transportShipTrail",
             attributes: {
               type: "gradient",
               color: "#aea2a2",
@@ -164,6 +185,7 @@ describe("Effect cosmetic schemas", () => {
         transportShipTrail: {
           ship: {
             name: "ship",
+            effectType: "transportShipTrail",
             attributes: { type: "solid", color: "#fff" },
             product: null,
             rarity: "common",

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -5,6 +5,7 @@ import {
   findEffect,
   TransportShipTrailAttributesSchema,
 } from "../src/core/CosmeticSchemas";
+import { PlayerEffectSchema } from "../src/core/Schemas";
 
 describe("Effect cosmetic schemas", () => {
   const base = { name: "spectrum", product: null, rarity: "common" };
@@ -47,6 +48,47 @@ describe("Effect cosmetic schemas", () => {
       expect(TransportShipTrailAttributesSchema.safeParse({}).success).toBe(
         false,
       );
+    });
+  });
+
+  describe("TransportShipTrailAttributesSchema (discriminated styles)", () => {
+    it("keeps the fields of a known style", () => {
+      const solid = TransportShipTrailAttributesSchema.parse({
+        type: "solid",
+        color: "#f00",
+      });
+      expect(solid).toEqual({ type: "solid", color: "#f00" });
+      const gradient = TransportShipTrailAttributesSchema.parse({
+        type: "gradient",
+        color: "#f00",
+        color2: "#00f",
+      });
+      expect(gradient).toEqual({
+        type: "gradient",
+        color: "#f00",
+        color2: "#00f",
+      });
+    });
+
+    it('normalizes an unrecognized style to { type: "unknown" }', () => {
+      expect(
+        TransportShipTrailAttributesSchema.parse({ type: "sparkle" }),
+      ).toEqual({ type: "unknown" });
+    });
+
+    it("normalizes a known style missing required fields to unknown", () => {
+      // solid without color / gradient without color2 don't match their strict
+      // variant, so they degrade to the neutral unknown swatch rather than
+      // failing the parse.
+      expect(
+        TransportShipTrailAttributesSchema.parse({ type: "solid" }),
+      ).toEqual({ type: "unknown" });
+      expect(
+        TransportShipTrailAttributesSchema.parse({
+          type: "gradient",
+          color: "#f00",
+        }),
+      ).toEqual({ type: "unknown" });
     });
   });
 
@@ -187,5 +229,36 @@ describe("findEffect", () => {
     expect(
       findEffect({} as Cosmetics, "transportShipTrail", "x"),
     ).toBeUndefined();
+  });
+});
+
+describe("PlayerEffectSchema (discriminated on effectType)", () => {
+  it("parses the transportShipTrail variant", () => {
+    expect(
+      PlayerEffectSchema.safeParse({
+        name: "spectrum",
+        effectType: "transportShipTrail",
+        attributes: { type: "rainbow" },
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects an unknown effectType (no matching union variant)", () => {
+    expect(
+      PlayerEffectSchema.safeParse({
+        name: "spectrum",
+        effectType: "glow",
+        attributes: { type: "rainbow" },
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects a variant missing its attributes", () => {
+    expect(
+      PlayerEffectSchema.safeParse({
+        name: "spectrum",
+        effectType: "transportShipTrail",
+      }).success,
+    ).toBe(false);
   });
 });

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -93,11 +93,11 @@ const effectCosmetics = {
   colorPalettes: {},
   flags: {},
   effects: {
-    transport_ship_trail: {
+    // effectType is the OUTER key; effects carry no effectType field.
+    transportShipTrail: {
       spectrum: {
         name: "spectrum",
-        effectType: "transport_ship_trail" as const,
-        attributes: { type: "rainbow" as const },
+        attributes: { type: "rainbow" },
         url: "",
         affiliateCode: null,
         product: null,
@@ -107,8 +107,7 @@ const effectCosmetics = {
       },
       crimson: {
         name: "crimson",
-        effectType: "transport_ship_trail" as const,
-        attributes: { type: "solid" as const, color: "#e01b24" },
+        attributes: { type: "solid", color: "#e01b24" },
         url: "",
         affiliateCode: null,
         product: { productId: "prod_1", priceId: "price_1", price: "$4.99" },
@@ -561,13 +560,13 @@ describe("Skin validation", () => {
 describe("Effect validation in isAllowed", () => {
   test("allows valid effect with wildcard flare", () => {
     const result = effectChecker.isAllowed(["effect:*"], {
-      effects: { transport_ship_trail: "spectrum" },
+      effects: { transportShipTrail: "spectrum" },
     });
     expect(result.type).toBe("allowed");
     if (result.type === "allowed") {
-      expect(result.cosmetics.effects?.transport_ship_trail).toEqual({
+      expect(result.cosmetics.effects?.transportShipTrail).toEqual({
         name: "spectrum",
-        effectType: "transport_ship_trail",
+        effectType: "transportShipTrail",
         attributes: { type: "rainbow" },
       });
     }
@@ -575,13 +574,11 @@ describe("Effect validation in isAllowed", () => {
 
   test("allows valid effect with exact-match flare", () => {
     const result = effectChecker.isAllowed(["effect:crimson"], {
-      effects: { transport_ship_trail: "crimson" },
+      effects: { transportShipTrail: "crimson" },
     });
     expect(result.type).toBe("allowed");
     if (result.type === "allowed") {
-      expect(
-        result.cosmetics.effects?.transport_ship_trail?.attributes,
-      ).toEqual({
+      expect(result.cosmetics.effects?.transportShipTrail?.attributes).toEqual({
         type: "solid",
         color: "#e01b24",
       });
@@ -590,7 +587,7 @@ describe("Effect validation in isAllowed", () => {
 
   test("rejects effect when user lacks flare", () => {
     const result = effectChecker.isAllowed([], {
-      effects: { transport_ship_trail: "spectrum" },
+      effects: { transportShipTrail: "spectrum" },
     });
     expect(result.type).toBe("forbidden");
     if (result.type === "forbidden") {
@@ -610,7 +607,7 @@ describe("Effect validation in isAllowed", () => {
 
   test("rejects nonexistent effect", () => {
     const result = effectChecker.isAllowed(["effect:*"], {
-      effects: { transport_ship_trail: "ghost" },
+      effects: { transportShipTrail: "ghost" },
     });
     expect(result.type).toBe("forbidden");
     if (result.type === "forbidden") {

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -570,7 +570,6 @@ describe("Effect validation in isAllowed", () => {
       expect(result.cosmetics.effects?.transportShipTrail).toEqual({
         name: "spectrum",
         effectType: "transportShipTrail",
-        attributes: { type: "rainbow" },
       });
     }
   });
@@ -581,9 +580,9 @@ describe("Effect validation in isAllowed", () => {
     });
     expect(result.type).toBe("allowed");
     if (result.type === "allowed") {
-      expect(result.cosmetics.effects?.transportShipTrail?.attributes).toEqual({
-        type: "solid",
-        color: "#e01b24",
+      expect(result.cosmetics.effects?.transportShipTrail).toEqual({
+        name: "crimson",
+        effectType: "transportShipTrail",
       });
     }
   });
@@ -659,7 +658,6 @@ describe("Effect validation in isAllowed", () => {
       expect(result.cosmetics.effects?.transportShipTrail).toEqual({
         name: "spectrum",
         effectType: "transportShipTrail",
-        attributes: { type: "rainbow" },
       });
     }
   });

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -622,6 +622,43 @@ describe("Effect validation in isAllowed", () => {
       expect(result.cosmetics.effects).toBeUndefined();
     }
   });
+
+  test("resolves an effect whose catalog key differs from its name", () => {
+    // Catalog key "trail_01" but name "spectrum"; selection/flares are
+    // name-based, so the name must still resolve and validate.
+    const checker = new PrivilegeCheckerImpl(
+      {
+        patterns: {},
+        colorPalettes: {},
+        flags: {},
+        effects: {
+          transportShipTrail: {
+            trail_01: {
+              name: "spectrum",
+              attributes: { type: "rainbow" },
+              url: "",
+              affiliateCode: null,
+              product: null,
+              rarity: "legendary",
+            },
+          },
+        },
+      },
+      mockDecoder,
+      bannedWords,
+    );
+    const result = checker.isAllowed(["effect:spectrum"], {
+      effects: { transportShipTrail: "spectrum" },
+    });
+    expect(result.type).toBe("allowed");
+    if (result.type === "allowed") {
+      expect(result.cosmetics.effects?.transportShipTrail).toEqual({
+        name: "spectrum",
+        effectType: "transportShipTrail",
+        attributes: { type: "rainbow" },
+      });
+    }
+  });
 });
 
 describe("PrivilegeCheckerImpl#resolveClanTag", () => {

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -88,6 +88,41 @@ const skinChecker = new PrivilegeCheckerImpl(
   bannedWords,
 );
 
+const effectCosmetics = {
+  patterns: {},
+  colorPalettes: {},
+  flags: {},
+  effects: {
+    spectrum: {
+      name: "spectrum",
+      effectType: "transportShipTrail" as const,
+      attributes: { type: "rainbow" as const },
+      url: "",
+      affiliateCode: null,
+      product: null,
+      priceSoft: undefined,
+      priceHard: undefined,
+      rarity: "legendary",
+    },
+    crimson: {
+      name: "crimson",
+      effectType: "transportShipTrail" as const,
+      attributes: { type: "solid" as const, color: "#e01b24" },
+      url: "",
+      affiliateCode: null,
+      product: { productId: "prod_1", priceId: "price_1", price: "$4.99" },
+      priceSoft: undefined,
+      priceHard: undefined,
+      rarity: "common",
+    },
+  },
+};
+const effectChecker = new PrivilegeCheckerImpl(
+  effectCosmetics,
+  mockDecoder,
+  bannedWords,
+);
+
 describe("UsernameCensor", () => {
   describe("isProfane (via matcher.hasMatch)", () => {
     test("detects exact banned words", () => {
@@ -518,6 +553,73 @@ describe("Skin validation", () => {
       });
       expect(result.type).toBe("forbidden");
     });
+  });
+});
+
+describe("Effect validation in isAllowed", () => {
+  test("allows valid effect with wildcard flare", () => {
+    const result = effectChecker.isAllowed(["effect:*"], {
+      effects: { transportShipTrail: "spectrum" },
+    });
+    expect(result.type).toBe("allowed");
+    if (result.type === "allowed") {
+      expect(result.cosmetics.effects?.transportShipTrail).toEqual({
+        name: "spectrum",
+        effectType: "transportShipTrail",
+        attributes: { type: "rainbow" },
+      });
+    }
+  });
+
+  test("allows valid effect with exact-match flare", () => {
+    const result = effectChecker.isAllowed(["effect:crimson"], {
+      effects: { transportShipTrail: "crimson" },
+    });
+    expect(result.type).toBe("allowed");
+    if (result.type === "allowed") {
+      expect(result.cosmetics.effects?.transportShipTrail?.attributes).toEqual({
+        type: "solid",
+        color: "#e01b24",
+      });
+    }
+  });
+
+  test("rejects effect when user lacks flare", () => {
+    const result = effectChecker.isAllowed([], {
+      effects: { transportShipTrail: "spectrum" },
+    });
+    expect(result.type).toBe("forbidden");
+    if (result.type === "forbidden") {
+      expect(result.reason).toMatch(/invalid effect/);
+    }
+  });
+
+  test("rejects effect when effectType key mismatches", () => {
+    const result = effectChecker.isAllowed(["effect:*"], {
+      effects: { wrongType: "spectrum" },
+    });
+    expect(result.type).toBe("forbidden");
+    if (result.type === "forbidden") {
+      expect(result.reason).toMatch(/type mismatch/);
+    }
+  });
+
+  test("rejects nonexistent effect", () => {
+    const result = effectChecker.isAllowed(["effect:*"], {
+      effects: { transportShipTrail: "ghost" },
+    });
+    expect(result.type).toBe("forbidden");
+    if (result.type === "forbidden") {
+      expect(result.reason).toMatch(/Effect ghost not found/);
+    }
+  });
+
+  test("no effects in refs leaves cosmetics.effects undefined", () => {
+    const result = effectChecker.isAllowed(["effect:*"], {});
+    expect(result.type).toBe("allowed");
+    if (result.type === "allowed") {
+      expect(result.cosmetics.effects).toBeUndefined();
+    }
   });
 });
 

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -97,7 +97,7 @@ const effectCosmetics = {
     transportShipTrail: {
       spectrum: {
         name: "spectrum",
-        attributes: { type: "rainbow" },
+        attributes: { type: "rainbow" } as const,
         url: "",
         affiliateCode: null,
         product: null,
@@ -107,7 +107,7 @@ const effectCosmetics = {
       },
       crimson: {
         name: "crimson",
-        attributes: { type: "solid", color: "#e01b24" },
+        attributes: { type: "solid", color: "#e01b24" } as const,
         url: "",
         affiliateCode: null,
         product: { productId: "prod_1", priceId: "price_1", price: "$4.99" },
@@ -635,7 +635,7 @@ describe("Effect validation in isAllowed", () => {
           transportShipTrail: {
             trail_01: {
               name: "spectrum",
-              attributes: { type: "rainbow" },
+              attributes: { type: "rainbow" } as const,
               url: "",
               affiliateCode: null,
               product: null,

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -93,27 +93,29 @@ const effectCosmetics = {
   colorPalettes: {},
   flags: {},
   effects: {
-    spectrum: {
-      name: "spectrum",
-      effectType: "transportShipTrail" as const,
-      attributes: { type: "rainbow" as const },
-      url: "",
-      affiliateCode: null,
-      product: null,
-      priceSoft: undefined,
-      priceHard: undefined,
-      rarity: "legendary",
-    },
-    crimson: {
-      name: "crimson",
-      effectType: "transportShipTrail" as const,
-      attributes: { type: "solid" as const, color: "#e01b24" },
-      url: "",
-      affiliateCode: null,
-      product: { productId: "prod_1", priceId: "price_1", price: "$4.99" },
-      priceSoft: undefined,
-      priceHard: undefined,
-      rarity: "common",
+    transport_ship_trail: {
+      spectrum: {
+        name: "spectrum",
+        effectType: "transport_ship_trail" as const,
+        attributes: { type: "rainbow" as const },
+        url: "",
+        affiliateCode: null,
+        product: null,
+        priceSoft: undefined,
+        priceHard: undefined,
+        rarity: "legendary",
+      },
+      crimson: {
+        name: "crimson",
+        effectType: "transport_ship_trail" as const,
+        attributes: { type: "solid" as const, color: "#e01b24" },
+        url: "",
+        affiliateCode: null,
+        product: { productId: "prod_1", priceId: "price_1", price: "$4.99" },
+        priceSoft: undefined,
+        priceHard: undefined,
+        rarity: "common",
+      },
     },
   },
 };
@@ -559,13 +561,13 @@ describe("Skin validation", () => {
 describe("Effect validation in isAllowed", () => {
   test("allows valid effect with wildcard flare", () => {
     const result = effectChecker.isAllowed(["effect:*"], {
-      effects: { transportShipTrail: "spectrum" },
+      effects: { transport_ship_trail: "spectrum" },
     });
     expect(result.type).toBe("allowed");
     if (result.type === "allowed") {
-      expect(result.cosmetics.effects?.transportShipTrail).toEqual({
+      expect(result.cosmetics.effects?.transport_ship_trail).toEqual({
         name: "spectrum",
-        effectType: "transportShipTrail",
+        effectType: "transport_ship_trail",
         attributes: { type: "rainbow" },
       });
     }
@@ -573,11 +575,13 @@ describe("Effect validation in isAllowed", () => {
 
   test("allows valid effect with exact-match flare", () => {
     const result = effectChecker.isAllowed(["effect:crimson"], {
-      effects: { transportShipTrail: "crimson" },
+      effects: { transport_ship_trail: "crimson" },
     });
     expect(result.type).toBe("allowed");
     if (result.type === "allowed") {
-      expect(result.cosmetics.effects?.transportShipTrail?.attributes).toEqual({
+      expect(
+        result.cosmetics.effects?.transport_ship_trail?.attributes,
+      ).toEqual({
         type: "solid",
         color: "#e01b24",
       });
@@ -586,7 +590,7 @@ describe("Effect validation in isAllowed", () => {
 
   test("rejects effect when user lacks flare", () => {
     const result = effectChecker.isAllowed([], {
-      effects: { transportShipTrail: "spectrum" },
+      effects: { transport_ship_trail: "spectrum" },
     });
     expect(result.type).toBe("forbidden");
     if (result.type === "forbidden") {
@@ -594,19 +598,19 @@ describe("Effect validation in isAllowed", () => {
     }
   });
 
-  test("rejects effect when effectType key mismatches", () => {
+  test("rejects effect under an unknown effectType key", () => {
     const result = effectChecker.isAllowed(["effect:*"], {
       effects: { wrongType: "spectrum" },
     });
     expect(result.type).toBe("forbidden");
     if (result.type === "forbidden") {
-      expect(result.reason).toMatch(/type mismatch/);
+      expect(result.reason).toMatch(/Effect spectrum not found/);
     }
   });
 
   test("rejects nonexistent effect", () => {
     const result = effectChecker.isAllowed(["effect:*"], {
-      effects: { transportShipTrail: "ghost" },
+      effects: { transport_ship_trail: "ghost" },
     });
     expect(result.type).toBe("forbidden");
     if (result.type === "forbidden") {

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -93,10 +93,12 @@ const effectCosmetics = {
   colorPalettes: {},
   flags: {},
   effects: {
-    // effectType is the OUTER key; effects carry no effectType field.
+    // Each effect carries its effectType field (matching the outer key), as the
+    // schema requires.
     transportShipTrail: {
       spectrum: {
         name: "spectrum",
+        effectType: "transportShipTrail" as const,
         attributes: { type: "rainbow" } as const,
         url: "",
         affiliateCode: null,
@@ -107,6 +109,7 @@ const effectCosmetics = {
       },
       crimson: {
         name: "crimson",
+        effectType: "transportShipTrail" as const,
         attributes: { type: "solid", color: "#e01b24" } as const,
         url: "",
         affiliateCode: null,
@@ -635,6 +638,7 @@ describe("Effect validation in isAllowed", () => {
           transportShipTrail: {
             trail_01: {
               name: "spectrum",
+              effectType: "transportShipTrail" as const,
               attributes: { type: "rainbow" } as const,
               url: "",
               affiliateCode: null,

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -12,21 +12,21 @@ describe("UserSettings effect selection", () => {
 
   it("sets and reads a per-effectType selection", () => {
     const s = new UserSettings();
-    s.setSelectedEffectName("transportShipTrail", "spectrum");
-    expect(s.getSelectedEffectName("transportShipTrail")).toBe("spectrum");
+    s.setSelectedEffectName("transport_ship_trail", "spectrum");
+    expect(s.getSelectedEffectName("transport_ship_trail")).toBe("spectrum");
   });
 
   it("returns null when nothing is selected", () => {
     expect(
-      new UserSettings().getSelectedEffectName("transportShipTrail"),
+      new UserSettings().getSelectedEffectName("transport_ship_trail"),
     ).toBeNull();
   });
 
   it("clearing the last selection removes the storage key", () => {
     const s = new UserSettings();
-    s.setSelectedEffectName("transportShipTrail", "spectrum");
-    s.setSelectedEffectName("transportShipTrail", undefined);
-    expect(s.getSelectedEffectName("transportShipTrail")).toBeNull();
+    s.setSelectedEffectName("transport_ship_trail", "spectrum");
+    s.setSelectedEffectName("transport_ship_trail", undefined);
+    expect(s.getSelectedEffectName("transport_ship_trail")).toBeNull();
     expect(localStorage.getItem(EFFECTS_KEY)).toBeNull();
   });
 
@@ -35,9 +35,9 @@ describe("UserSettings effect selection", () => {
     // Seed two types directly (only one real effectType exists today).
     localStorage.setItem(
       EFFECTS_KEY,
-      JSON.stringify({ transportShipTrail: "spectrum", future: "x" }),
+      JSON.stringify({ transport_ship_trail: "spectrum", future: "x" }),
     );
-    s.setSelectedEffectName("transportShipTrail", undefined);
+    s.setSelectedEffectName("transport_ship_trail", undefined);
     expect(s.getSelectedEffects()).toEqual({ future: "x" });
   });
 

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -1,0 +1,48 @@
+import { EFFECTS_KEY, UserSettings } from "../src/core/game/UserSettings";
+
+describe("UserSettings effect selection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // UserSettings keeps a static in-memory cache; reset it too so each test
+    // reads fresh from the (cleared) localStorage.
+    (
+      UserSettings as unknown as { cache: Map<string, string | null> }
+    ).cache.clear();
+  });
+
+  it("sets and reads a per-effectType selection", () => {
+    const s = new UserSettings();
+    s.setSelectedEffectName("transportShipTrail", "spectrum");
+    expect(s.getSelectedEffectName("transportShipTrail")).toBe("spectrum");
+  });
+
+  it("returns null when nothing is selected", () => {
+    expect(
+      new UserSettings().getSelectedEffectName("transportShipTrail"),
+    ).toBeNull();
+  });
+
+  it("clearing the last selection removes the storage key", () => {
+    const s = new UserSettings();
+    s.setSelectedEffectName("transportShipTrail", "spectrum");
+    s.setSelectedEffectName("transportShipTrail", undefined);
+    expect(s.getSelectedEffectName("transportShipTrail")).toBeNull();
+    expect(localStorage.getItem(EFFECTS_KEY)).toBeNull();
+  });
+
+  it("clearing one effectType leaves other types intact", () => {
+    const s = new UserSettings();
+    // Seed two types directly (only one real effectType exists today).
+    localStorage.setItem(
+      EFFECTS_KEY,
+      JSON.stringify({ transportShipTrail: "spectrum", future: "x" }),
+    );
+    s.setSelectedEffectName("transportShipTrail", undefined);
+    expect(s.getSelectedEffects()).toEqual({ future: "x" });
+  });
+
+  it("returns an empty map for a corrupt blob", () => {
+    localStorage.setItem(EFFECTS_KEY, "not json");
+    expect(new UserSettings().getSelectedEffects()).toEqual({});
+  });
+});

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -12,21 +12,21 @@ describe("UserSettings effect selection", () => {
 
   it("sets and reads a per-effectType selection", () => {
     const s = new UserSettings();
-    s.setSelectedEffectName("transport_ship_trail", "spectrum");
-    expect(s.getSelectedEffectName("transport_ship_trail")).toBe("spectrum");
+    s.setSelectedEffectName("transportShipTrail", "spectrum");
+    expect(s.getSelectedEffectName("transportShipTrail")).toBe("spectrum");
   });
 
   it("returns null when nothing is selected", () => {
     expect(
-      new UserSettings().getSelectedEffectName("transport_ship_trail"),
+      new UserSettings().getSelectedEffectName("transportShipTrail"),
     ).toBeNull();
   });
 
   it("clearing the last selection removes the storage key", () => {
     const s = new UserSettings();
-    s.setSelectedEffectName("transport_ship_trail", "spectrum");
-    s.setSelectedEffectName("transport_ship_trail", undefined);
-    expect(s.getSelectedEffectName("transport_ship_trail")).toBeNull();
+    s.setSelectedEffectName("transportShipTrail", "spectrum");
+    s.setSelectedEffectName("transportShipTrail", undefined);
+    expect(s.getSelectedEffectName("transportShipTrail")).toBeNull();
     expect(localStorage.getItem(EFFECTS_KEY)).toBeNull();
   });
 
@@ -35,9 +35,9 @@ describe("UserSettings effect selection", () => {
     // Seed two types directly (only one real effectType exists today).
     localStorage.setItem(
       EFFECTS_KEY,
-      JSON.stringify({ transport_ship_trail: "spectrum", future: "x" }),
+      JSON.stringify({ transportShipTrail: "spectrum", future: "x" }),
     );
-    s.setSelectedEffectName("transport_ship_trail", undefined);
+    s.setSelectedEffectName("transportShipTrail", undefined);
     expect(s.getSelectedEffects()).toEqual({ future: "x" });
   });
 


### PR DESCRIPTION
## What

Adds a new **`effects`** cosmetic category alongside `skins`/`flags`. Each effect is discriminated by **`effectType`** (only `transportShipTrail` today), whose visual config lives in **`attributes`** (`solid` / `rainbow` / `pulse` / `gradient`). Schema matches the production cosmetics.json shape exactly (incl. the `url` field).

**This PR is UI + taxonomy only — the in-game WebGL trail rendering is intentionally deferred.**

## UI

- **Store** gains an **"Effects"** tab.
- **Home page** gains an **"Effects"** button opening a picker modal.
- Both render effects **grouped by `effectType` with a sub-header per type**, via a shared `<effects-grid>` Lit element (`mode="select"` for the picker, `mode="purchase"` for the store). The picker shows owned effects + a Default tile and persists per-type; the store shows purchasable effects.

## Data flow

- Ownership via `effect:*` / `effect:<name>` flares (reuses `cosmeticRelationship`).
- Selection is a per-`effectType` map persisted in UserSettings (`settings.effects`).
- Server validates in `isEffectAllowed`, wired into `isAllowed`.
- `getPlayerCosmeticsRefs` / `getPlayerCosmetics` resolve effects the same way as skins/flags (kept-on-fetch-failure, server is authority).

## Tests

- `tsc --noEmit`, ESLint, Prettier clean; full suite green.
- New: `CosmeticSchemas` parse tests (incl. parsing the **real** `read_transport_trail` entry), `UserSettings` per-type selection, and `Privilege` effect validation.

## Notes / follow-ups

- The effect's display label shows **"Boat Trail"** for the `transportShipTrail` type (friendlier than the id).
- Closed-source API gap: `/shop/purchase` (`purchaseWithCurrency`) needs to learn `"effect"` for **currency** purchase of effects; the **dollar/product** purchase path already works. Client types were widened accordingly.
- In-game wake rendering can be ported from #4416.

🤖 Generated with [Claude Code](https://claude.com/claude-code)