### PR TITLE
Hide FFA collusion warning in 1v1 ranked games 🎮

### DIFF
--- a/src/client/hud/layers/HeadsUpMessage.ts
+++ b/src/client/hud/layers/HeadsUpMessage.ts
@@ -1,6 +1,6 @@
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import { GameMode, GameType } from "../../../core/game/Game";
+import { GameMode, GameType, RankedType } from "../../../core/game/Game";
 import { GameUpdateType } from "../../../core/game/GameUpdates";
 import { Controller } from "../../Controller";
 import { translateText } from "../../Utils";
@@ -197,6 +197,7 @@ export class HeadsUpMessage extends LitElement implements Controller {
         ${this.game?.inSpawnPhase() &&
         this.game.config().gameConfig().gameMode === GameMode.FFA &&
         this.game.config().gameConfig().gameType === GameType.Public &&
+        this.game.config().gameConfig().rankedType !== RankedType.OneVOne &&
         !this.hasClosedCollusionWarning
           ? html`
               <div


### PR DESCRIPTION
## Description:

The FFA collusion reminder ("teaming up before the game is not allowed in FFA") was incorrectly showing in 1v1 ranked games, where it is irrelevant since there are only two players. Added a check for `rankedType !== RankedType.OneVOne` to the warning condition so it only appears in actual FFA public games.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin