### PR TITLE
fix: stop name censor flagging innocent words like "cons"

### DIFF
--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -90,14 +90,33 @@ export function createMatcher(bannedWords: string[]): RegExpMatcher {
       skipNonAlphabeticTransformer(),
     ],
   });
+  // A collapse-matcher hit is only a genuine elongation bypass when the matched
+  // text actually repeats a letter (e.g. "niiigger", "cooons", "nigg"). The
+  // deduped patterns collapse a banned word's natural double into a shorter,
+  // common substring ("coons" -> "cons", "boong" -> "bong", "nigger" -> "niger"),
+  // so without this guard the collapse matcher censors innocent names like
+  // "console", "Nigeria", or "busy". A canonical slur with no repeated letter is
+  // identical to its deduped pattern and is still caught by substringMatcher, so
+  // requiring a repeat only drops false positives, never real slurs. The span is
+  // widened by one char each side because a collapsed duplicate at the leading or
+  // trailing edge (e.g. "nigg" matching "nig") falls just outside the match.
+  const elongatedCollapseMatches = (input: string, sorted?: boolean) =>
+    collapseMatcher.getAllMatches(input, sorted).filter((m) =>
+      /(.)\1/.test(
+        input
+          .slice(Math.max(0, m.startIndex - 1), m.endIndex + 2)
+          .toLowerCase()
+          .replace(/[^a-z]/g, ""),
+      ),
+    );
   return {
     hasMatch: (input: string) =>
       input.toLowerCase().includes("kkk") ||
       substringMatcher.hasMatch(input) ||
-      collapseMatcher.hasMatch(input),
+      elongatedCollapseMatches(input).length > 0,
     getAllMatches: (input: string, sorted?: boolean) => [
       ...substringMatcher.getAllMatches(input, sorted),
-      ...collapseMatcher.getAllMatches(input, sorted),
+      ...elongatedCollapseMatches(input, sorted),
     ],
   } as unknown as RegExpMatcher;
 }

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -21,6 +21,12 @@ const bannedWords = [
   "faggot",
   "retard",
   "chair", // Test word to verify custom banned words work
+  // Banned words with a natural double letter: the collapse matcher deduped
+  // these to common substrings ("coons" -> "cons", "boong" -> "bong") and used
+  // to censor innocent names. See the elongation regression tests below.
+  "coons",
+  "boong",
+  "bussy",
 ];
 
 const matcher = createMatcher(bannedWords);
@@ -163,6 +169,32 @@ describe("UsernameCensor", () => {
     test("does not false-positive on words containing banned substrings legitimately", () => {
       // "snigger" is whitelisted in englishDataset
       expect(matcher.hasMatch("snigger")).toBe(false);
+    });
+
+    test("does not censor innocent words that collide with a deduped slur", () => {
+      // The collapse matcher deduped "coons" -> "cons", "boong" -> "bong",
+      // "bussy" -> "busy", "nigger" -> "niger". Without the repeated-letter
+      // guard, every word containing those substrings was censored.
+      expect(matcher.hasMatch("cons")).toBe(false);
+      expect(matcher.hasMatch("console")).toBe(false);
+      expect(matcher.hasMatch("icons")).toBe(false);
+      expect(matcher.hasMatch("constitution")).toBe(false);
+      expect(matcher.hasMatch("busy")).toBe(false);
+      expect(matcher.hasMatch("bong")).toBe(false);
+      expect(matcher.hasMatch("Bongo")).toBe(false);
+      expect(matcher.hasMatch("Nigeria")).toBe(false);
+      expect(matcher.hasMatch("Nigerian")).toBe(false);
+    });
+
+    test("still catches elongated slurs (collapse matcher)", () => {
+      // The repeated-letter guard must not weaken elongation detection: these
+      // all have a real repeated letter in the matched span.
+      expect(matcher.hasMatch("niiigger")).toBe(true);
+      expect(matcher.hasMatch("niiigger123")).toBe(true);
+      expect(matcher.hasMatch("cooons")).toBe(true);
+      expect(matcher.hasMatch("coons")).toBe(true);
+      expect(matcher.hasMatch("boooong")).toBe(true);
+      expect(matcher.hasMatch("bussy")).toBe(true);
     });
 
     test("catches kkk as substring", () => {


### PR DESCRIPTION
## Problem

The username censor flags many innocent names — `cons`, `console`, `icons`, `constitution`, `busy`, `bong`, `Bongo`, `Nigeria`, `Nigerian`, `negative`, `renegade`, `boba`, `Koch`, `choker`, `domestic`, … Against the live banned-words list, roughly **half** of ordinary test names were being censored.

## Root cause

`createMatcher` in `src/server/Privilege.ts` runs two matchers:

- **`substringMatcher`** — literal banned-word patterns.
- **`collapseMatcher`** — meant to catch *elongation* bypasses like `niiigger`. It collapses every run of a repeated letter to one, on **both** the input *and* the banned-word patterns (`buildDataset(..., dedup=true)` does `word.replace(/(.)\1+/g, "$1")`).

That pattern-side collapse is the bug. A banned word with a natural double letter collapses into a short, common substring, and since the matcher does **substring** matching, that substring then matches innocent names:

| banned word | collapses to | wrongly censors |
| --- | --- | --- |
| `coons` | `cons` | console, icons, constitution, beacons |
| `boong` | `bong` | bong, Bongo, Bongani |
| `bussy` | `busy` | busy, business |
| `negga` | `nega` | negative, renegade |
| `nigger` | `niger` | Nigeria, Nigerian |
| `booba` / `kooch` / `gooch` | `boba` / `koch` / `goch` | boba, Koch, Gochujang |

## Fix

A collapse hit is only a genuine elongation bypass when the matched text **actually repeats a letter** (`cooons`, `niiigger`, `coons` itself). Innocent collisions like `console` or `Nigeria` match the *collapsed* pattern but have no repeated letter in the matched span. So the collapse matches are filtered to keep only those whose span (widened one char each side, to catch a trailing collapsed duplicate such as `nigg`→`nig`) contains a repeated letter.

```ts
const elongatedCollapseMatches = (input, sorted?) =>
  collapseMatcher.getAllMatches(input, sorted).filter((m) =>
    /(.)\1/.test(
      input.slice(Math.max(0, m.startIndex - 1), m.endIndex + 2)
        .toLowerCase().replace(/[^a-z]/g, ""),
    ),
  );
```

This is **provably safe**: it can only ever *remove* collapse matches, never add. A canonically-spelled slur with no repeated letter is identical to its deduped pattern and is already caught by `substringMatcher`, so no real slur is lost.

## Validation

- All `Privilege.test.ts` tests pass (incl. the `NIGG` slur-abbreviation case), plus the related name/censor suites (92/92).
- Added regression tests covering both the innocent collisions and the elongation cases.
- Against the real banned list + an adversarial probe (~170 innocent, ~150 slur variants): **collapse-bug false positives eliminated, zero new false negatives** — every slur the matcher caught before (`niiigger`, `niiigger123`, `nïgger`, `NIGG`, `n.i.g.g.e.r`, `kkk`, `cooons`, …) is still caught.

## Not addressed (separate, pre-existing)

`debugger` and `Stafford` are still censored, but by the **literal** `substringMatcher` because `bugger` and `staff` are deliberately in the banned list (staff blocks impersonation). That's independent of the collapse bug and left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)