### PR TITLE
Fix lobby status bar scrolling out of view when many players join 🎯

### DIFF
--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -165,7 +165,9 @@ export class JoinLobbyModal extends BaseModal {
         </div>
 
         ${html`
-          <div class="p-6 lg:p-6 border-t border-white/10 bg-black/20 shrink-0">
+          <div
+            class="p-6 lg:p-6 border-t border-white/10 bg-black/60 backdrop-blur-md shrink-0 sticky bottom-0 z-10"
+          >
             <div
               class="w-full px-4 py-3 rounded-xl border border-white/10 bg-white/5 flex items-center justify-between gap-3"
             >


### PR DESCRIPTION
## Description:

Make the lobby status bar (status label + player count) sticky at the bottom of the player list scroll area in JoinLobbyModal. Previously, when many players joined a lobby the status bar would scroll out of view. The bar is now pinned with `sticky bottom-0` and has a semi-opaque blurred background (`bg-black/60 backdrop-blur-md`) to cleanly occlude content scrolling behind it.

**Before:**

<img width="951" height="789" alt="image" src="https://github.com/user-attachments/assets/8a2a2f1d-1530-4f13-82be-837eaaa00256" />

**With this PR:**

<img width="938" height="688" alt="image" src="https://github.com/user-attachments/assets/6c5259fb-a969-4a5f-b951-a4310f6c68c0" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin