### PR TITLE
Fix anonymize-names desync: seed cluster-recalc offset from id() not name()

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -40,10 +40,6 @@ export class PlayerExecution implements Execution {
     this.mg = mg;
     this.map = mg.map();
     this.config = mg.config();
-    // Seed the per-player phase offset from id() (identical on every client),
-    // never name(): with the anonymize-names option the username differs per
-    // client, which would stagger removeClusters() onto different ticks and
-    // desync tile ownership.
     this.lastCalc =
       ticks + (simpleHash(this.player.id()) % this.ticksPerClusterCalc);
   }

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -40,8 +40,12 @@ export class PlayerExecution implements Execution {
     this.mg = mg;
     this.map = mg.map();
     this.config = mg.config();
+    // Seed the per-player phase offset from id() (identical on every client),
+    // never name(): with the anonymize-names option the username differs per
+    // client, which would stagger removeClusters() onto different ticks and
+    // desync tile ownership.
     this.lastCalc =
-      ticks + (simpleHash(this.player.name()) % this.ticksPerClusterCalc);
+      ticks + (simpleHash(this.player.id()) % this.ticksPerClusterCalc);
   }
 
   tick(ticks: number) {

--- a/tests/core/executions/PlayerExecution.test.ts
+++ b/tests/core/executions/PlayerExecution.test.ts
@@ -6,7 +6,6 @@ import {
   PlayerType,
   UnitType,
 } from "../../../src/core/game/Game";
-import { simpleHash } from "../../../src/core/Util";
 import { setup } from "../../util/Setup";
 import { executeTicks } from "../../util/utils";
 
@@ -82,35 +81,5 @@ describe("PlayerExecution", () => {
     expect(city.level()).toBe(1);
     expect(city.owner()).toBe(otherPlayer);
     expect(city.isActive()).toBe(true);
-  });
-});
-
-// Regression guard for the anonymize-names desync: the cluster-removal schedule
-// must be seeded from a value that is identical on every client. The
-// anonymize-names option sends each client a different username for the same
-// player, so seeding from name() staggered removeClusters() onto different
-// ticks per client and desynced tile ownership. id() is client-identical.
-describe("PlayerExecution cluster-recalc determinism", () => {
-  test("phase offset is seeded from id(), not the (per-client) username", async () => {
-    const STABLE_ID = "stable-player-id";
-
-    // Two clients that disagree on the username but agree on id() — exactly what
-    // anonymize-names produces for the same logical player.
-    const gameA = await setup("big_plains", {}, [
-      new PlayerInfo("Alice", PlayerType.Human, "client_a", STABLE_ID),
-    ]);
-    const execA = new PlayerExecution(gameA.player(STABLE_ID));
-    execA.init(gameA, 0);
-
-    const gameB = await setup("big_plains", {}, [
-      new PlayerInfo("Crimson Tiger", PlayerType.Human, "client_a", STABLE_ID),
-    ]);
-    const execB = new PlayerExecution(gameB.player(STABLE_ID));
-    execB.init(gameB, 0);
-
-    // Same id => same schedule, regardless of the differing usernames.
-    expect((execA as any).lastCalc).toBe((execB as any).lastCalc);
-    // And it is the id-derived offset (ticksPerClusterCalc = 20).
-    expect((execA as any).lastCalc).toBe(simpleHash(STABLE_ID) % 20);
   });
 });

--- a/tests/core/executions/PlayerExecution.test.ts
+++ b/tests/core/executions/PlayerExecution.test.ts
@@ -6,6 +6,7 @@ import {
   PlayerType,
   UnitType,
 } from "../../../src/core/game/Game";
+import { simpleHash } from "../../../src/core/Util";
 import { setup } from "../../util/Setup";
 import { executeTicks } from "../../util/utils";
 
@@ -81,5 +82,35 @@ describe("PlayerExecution", () => {
     expect(city.level()).toBe(1);
     expect(city.owner()).toBe(otherPlayer);
     expect(city.isActive()).toBe(true);
+  });
+});
+
+// Regression guard for the anonymize-names desync: the cluster-removal schedule
+// must be seeded from a value that is identical on every client. The
+// anonymize-names option sends each client a different username for the same
+// player, so seeding from name() staggered removeClusters() onto different
+// ticks per client and desynced tile ownership. id() is client-identical.
+describe("PlayerExecution cluster-recalc determinism", () => {
+  test("phase offset is seeded from id(), not the (per-client) username", async () => {
+    const STABLE_ID = "stable-player-id";
+
+    // Two clients that disagree on the username but agree on id() — exactly what
+    // anonymize-names produces for the same logical player.
+    const gameA = await setup("big_plains", {}, [
+      new PlayerInfo("Alice", PlayerType.Human, "client_a", STABLE_ID),
+    ]);
+    const execA = new PlayerExecution(gameA.player(STABLE_ID));
+    execA.init(gameA, 0);
+
+    const gameB = await setup("big_plains", {}, [
+      new PlayerInfo("Crimson Tiger", PlayerType.Human, "client_a", STABLE_ID),
+    ]);
+    const execB = new PlayerExecution(gameB.player(STABLE_ID));
+    execB.init(gameB, 0);
+
+    // Same id => same schedule, regardless of the differing usernames.
+    expect((execA as any).lastCalc).toBe((execB as any).lastCalc);
+    // And it is the id-derived offset (ticksPerClusterCalc = 20).
+    expect((execA as any).lastCalc).toBe(simpleHash(STABLE_ID) % 20);
   });
 });


### PR DESCRIPTION
## Description

Fixes a hard desync that hit anonymous-names lobbies (e.g. the OFM tournament): in an anonymized FFA, roughly half the clients desynced.

### Root cause

`PlayerExecution.init()` seeded the per-player phase offset that schedules `removeClusters()` from the player's **username**:

```ts
this.lastCalc = ticks + (simpleHash(this.player.name()) % this.ticksPerClusterCalc);
```

`removeClusters()` is not display-only — it both sets `largestClusterBoundingBox` (read by `AiAttackBehavior` for targeting) **and removes disconnected/surrounded territory, mutating tile ownership**.

The anonymize-names option (#4318) sends each client a *different* username for the same player (`anonName(target + viewer)`). So `simpleHash(name()) % 20` differs per client → `removeClusters()` runs on different ticks per client → `numTilesOwned()` diverges → the every-10-tick state hash (`simpleHash(id) * (troops + numTilesOwned) + units`) diverges → **desync**.

**Why only half the lobby:** clients granted real-name reveal (host / admins / casters via `nameReveals` / `nameRevealPublicIds`) all see real names, compute identical offsets, and stay in sync with each other and the server record. Every non-granted (anonymized) client sees a unique random name per player and diverges. Hence the clean split.

This line has been latent and harmless since 2024 (`f01949f0`) because `name()` used to be identical on every client; #4318 was the first feature to feed a per-client value into the core. The PR comment in `GameServer.ts` even states the assumption — *"username … neither of which the simulation reads"* — which turned out to be false.

### Fix

Seed the offset from `id()` instead of `name()`. Player `id()` is assigned from a `gameID`-seeded PRNG by spawn order, so it is identical on every client while still spreading cluster recalculation across players (the line's original load-balancing intent). One-line sim change; no schema/wire change.

### Verification / scope

- Audited every `name()`/`username` read in `src/core/`: this was the **only** state-affecting one (all others are `console.log` / error strings / display-only update fields). So this closes the whole desync class.
- Confirmed player order, ids, config, `clanTag`/`friends` and cosmetics are all client-identical under anonymize-names — `username` was the sole per-client field reaching the sim.
- Swept the other recent core commits (impassable terrain, rail network, nations AI, inline sfc32 PRNG, troop/economy changes) for independent determinism regressions — none found.

### Follow-up

`name()` should be removed from the core `Player` surface entirely so a per-client username can never re-enter the sim again (the remaining reads are logging + the display payload the renderer needs). Tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
