### PR TITLE
feat: Change factory icons from circles to hexagons

### DIFF
--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -134,7 +134,7 @@
         "iconFill": 0.85
       },
       "Factory": {
-        "scale": 1,
+        "scale": 1.08,
         "iconFill": 0.85
       },
       "Defense Post": {

--- a/src/client/render/gl/shaders/structure/structure.frag.glsl
+++ b/src/client/render/gl/shaders/structure/structure.frag.glsl
@@ -64,10 +64,12 @@ float sdPolygon(vec2 p, float R, float n, float rot) {
 // Per-structure-type shape SDF.
 // Atlas indices: 0=City, 1=Port, 2=Factory, 3=DefensePost, 4=SAM, 5=Silo
 float shapeSDF(vec2 p, float R) {
-  if (vAtlasIdx < 0.5 || (vAtlasIdx > 1.5 && vAtlasIdx < 2.5))
-    return length(p) - R;                     // City / Factory → circle
+  if (vAtlasIdx < 0.5)
+    return length(p) - R;                     // City → circle
   if (vAtlasIdx < 1.5)
     return sdPolygon(p, R, 5.0, PI * 0.5);    // Port → pentagon (vertex up)
+  if (vAtlasIdx < 2.5)
+    return sdPolygon(p, R, 6.0, PI / 6.0);    // Factory → hexagon (flat top)
   if (vAtlasIdx < 3.5)
     return sdPolygon(p, R, 8.0, 0.0);         // Defense Post → octagon (flat top)
   if (vAtlasIdx < 4.5)


### PR DESCRIPTION
Resolves #4413 

## Description:

The factory and city icons are currently undistinguishable when zooming out, this PR changes the factory icon to be hexagon-shaped.

It also increases the icon scale (now equal to port) to put some padding around.

*Before*
<img width="159" height="154" alt="Before" src="https://github.com/user-attachments/assets/2967fbc1-c775-4281-9592-6a52cbadd5a4" />

*After (with `scale = 1.0`)*
<img width="133" height="135" alt="After (with `scale = 1.0`)" src="https://github.com/user-attachments/assets/f2bb9d8a-2f41-434a-b4df-9c1475f51cce" />

*After (with `scale = 1.08`)*
<img width="192" height="191" alt="After (with `scale = 1.08`)" src="https://github.com/user-attachments/assets/c81026d2-f6fe-4115-a00e-e7490d342787" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

lents
