### PR TITLE
Restore default terrain colors changed by #4391

### DIFF
--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -18,9 +18,9 @@
   },
   "terrain": {
     "oceanColor": "#4785b5",
-    "sandColor": "#CC9E9E",
-    "plainsColor": "#BECD8A",
-    "highlandColor": "#C8B78A",
+    "sandColor": "#CCCB9E",
+    "plainsColor": "#BEDC8A",
+    "highlandColor": "#DCCB9E",
     "mountainColor": "#e6e6e6"
   },
   "falloutBloom": {


### PR DESCRIPTION
## Description

The terrain colors settings refactor (#4391) inadvertently changed the **default** land terrain colors. The PR moved the hardcoded terrain colors into configurable settings, but the new default hex values in `render-settings.json` — combined with the new shading math — no longer reproduced the original sand/plains/highland appearance.

In particular the new shading formulas use each JSON color as a *base* and apply offsets differently (e.g. highland now adds `2*(magnitude-10)` instead of `2*magnitude`), so the default hex values needed to compensate.

## Fix

Surgical, JSON-only change to the defaults so the new formulas produce **pixel-identical** output to the pre-#4391 code:

| Terrain | Was (#4391) | Restored |
| --- | --- | --- |
| sand | `#CC9E9E` | `#CCCB9E` |
| plains | `#BECD8A` | `#BEDC8A` |
| highland | `#C8B78A` | `#DCCB9E` |
| mountain | `#e6e6e6` | `#e6e6e6` (unchanged) |
| ocean | `#4785b5` | `#4785b5` (unchanged) |

The settings/UI machinery from #4391 stays intact and users can still override colors — only the defaults are corrected. Verified across all magnitude/shoreline combinations that the rendered land colors match the original output exactly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)