### PR TITLE
Add configurable leaderboard income columns

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -774,7 +774,10 @@
   },
   "leaderboard": {
     "cities": "Cities",
+    "columns": "Columns",
+    "configure_columns": "Configure columns",
     "gold": "Gold",
+    "gold_per_min": "Gold/min",
     "launchers": "Launchers",
     "maxtroops": "Max troops",
     "owned": "Owned",

--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -2,18 +2,62 @@ import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { renderTroops, translateText } from "../../../client/Utils";
+import { assetUrl } from "../../../core/AssetUrls";
 import { EventBus } from "../../../core/EventBus";
+import { UnitType } from "../../../core/game/Game";
+import {
+  LeaderboardColumnKey,
+  UserSettings,
+} from "../../../core/game/UserSettings";
 import { Controller } from "../../Controller";
 import { GoToPlayerEvent } from "../../TransformHandler";
 import { formatPercentage, renderNumber } from "../../Utils";
 import { GameView, PlayerView } from "../../view";
+
+const settingsIcon = assetUrl("images/SettingIconWhite.svg");
+
+interface ColumnDefinition {
+  key: LeaderboardColumnKey;
+  labelKey: string;
+  width: string;
+}
+
+const COLUMN_DEFINITIONS: ColumnDefinition[] = [
+  {
+    key: "tiles",
+    labelKey: "leaderboard.owned",
+    width: "minmax(45px, 70px)",
+  },
+  {
+    key: "gold",
+    labelKey: "leaderboard.gold",
+    width: "minmax(40px, 55px)",
+  },
+  {
+    key: "goldPerMinute",
+    labelKey: "leaderboard.gold_per_min",
+    width: "minmax(56px, 82px)",
+  },
+  {
+    key: "maxtroops",
+    labelKey: "leaderboard.maxtroops",
+    width: "minmax(55px, 105px)",
+  },
+  {
+    key: "cities",
+    labelKey: "leaderboard.cities",
+    width: "minmax(42px, 62px)",
+  },
+];
 
 interface Entry {
   name: string;
   position: number;
   score: string;
   gold: string;
+  goldPerMinute: string;
   maxTroops: string;
+  cities: string;
   isMyPlayer: boolean;
   isOnSameTeam: boolean;
   player: PlayerView;
@@ -24,16 +68,24 @@ export class Leaderboard extends LitElement implements Controller {
   public game: GameView | null = null;
   public eventBus: EventBus | null = null;
 
+  private readonly userSettings = new UserSettings();
+
   players: Entry[] = [];
 
   @property({ type: Boolean }) visible = false;
   private showTopFive = true;
 
   @state()
-  private _sortKey: "tiles" | "gold" | "maxtroops" = "tiles";
+  private _sortKey: LeaderboardColumnKey = "tiles";
 
   @state()
   private _sortOrder: "asc" | "desc" = "desc";
+
+  @state()
+  private showColumnSettings = false;
+
+  @state()
+  private visibleColumnKeys = this.userSettings.leaderboardColumns();
 
   createRenderRoot() {
     return this; // use light DOM for Tailwind support
@@ -57,7 +109,7 @@ export class Leaderboard extends LitElement implements Controller {
     this.updateLeaderboard();
   }
 
-  private setSort(key: "tiles" | "gold" | "maxtroops") {
+  private setSort(key: LeaderboardColumnKey) {
     if (this._sortKey === key) {
       this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
     } else {
@@ -67,31 +119,87 @@ export class Leaderboard extends LitElement implements Controller {
     this.updateLeaderboard();
   }
 
+  private visibleColumns(): ColumnDefinition[] {
+    const visible = new Set(this.visibleColumnKeys);
+    const columns = COLUMN_DEFINITIONS.filter((column) =>
+      visible.has(column.key),
+    );
+    return columns.length > 0 ? columns : [COLUMN_DEFINITIONS[0]];
+  }
+
+  private ensureVisibleSortKey(columns: readonly ColumnDefinition[]): void {
+    if (!columns.some((column) => column.key === this._sortKey)) {
+      this._sortKey = columns[0].key;
+      this._sortOrder = "desc";
+    }
+  }
+
+  private toggleColumn(key: LeaderboardColumnKey) {
+    this.visibleColumnKeys = this.userSettings.toggleLeaderboardColumn(key);
+    this.ensureVisibleSortKey(this.visibleColumns());
+    this.updateLeaderboard();
+  }
+
+  private sortValue(player: PlayerView, key: LeaderboardColumnKey): number {
+    switch (key) {
+      case "gold":
+        return Number(player.gold());
+      case "goldPerMinute":
+        return player.goldPerMinute();
+      case "maxtroops":
+        return this.game!.config().maxTroops(player);
+      case "cities":
+        return player.totalUnitLevels(UnitType.City);
+      case "tiles":
+        return player.numTilesOwned();
+    }
+  }
+
+  private entryValue(entry: Entry, key: LeaderboardColumnKey): string {
+    switch (key) {
+      case "gold":
+        return entry.gold;
+      case "goldPerMinute":
+        return entry.goldPerMinute;
+      case "maxtroops":
+        return entry.maxTroops;
+      case "cities":
+        return entry.cities;
+      case "tiles":
+        return entry.score;
+    }
+  }
+
+  private sortIndicator(key: LeaderboardColumnKey) {
+    if (this._sortKey !== key) return "";
+    return this._sortOrder === "asc" ? "⬆️" : "⬇️";
+  }
+
+  private gridTemplateColumns(columns: readonly ColumnDefinition[]): string {
+    return [
+      "minmax(24px, 30px)",
+      "minmax(60px, 100px)",
+      ...columns.map((column) => column.width),
+    ].join(" ");
+  }
+
   private updateLeaderboard() {
     if (this.game === null) throw new Error("Not initialized");
     const myPlayer = this.game.myPlayer();
+    const columns = this.visibleColumns();
+    this.ensureVisibleSortKey(columns);
 
     let sorted = this.game.playerViews();
 
     const compare = (a: number, b: number) =>
       this._sortOrder === "asc" ? a - b : b - a;
 
-    const maxTroops = (p: PlayerView) => this.game!.config().maxTroops(p);
-
-    switch (this._sortKey) {
-      case "gold":
-        sorted = sorted.sort((a, b) =>
-          compare(Number(a.gold()), Number(b.gold())),
-        );
-        break;
-      case "maxtroops":
-        sorted = sorted.sort((a, b) => compare(maxTroops(a), maxTroops(b)));
-        break;
-      default:
-        sorted = sorted.sort((a, b) =>
-          compare(a.numTilesOwned(), b.numTilesOwned()),
-        );
-    }
+    sorted = sorted.sort((a, b) =>
+      compare(
+        this.sortValue(a, this._sortKey),
+        this.sortValue(b, this._sortKey),
+      ),
+    );
 
     const numTilesWithoutFallout =
       this.game.numLandTiles() - this.game.numTilesWithFallout();
@@ -110,7 +218,9 @@ export class Leaderboard extends LitElement implements Controller {
           player.numTilesOwned() / numTilesWithoutFallout,
         ),
         gold: renderNumber(player.gold()),
+        goldPerMinute: renderNumber(player.goldPerMinute()),
         maxTroops: renderTroops(maxTroops),
+        cities: renderNumber(player.totalUnitLevels(UnitType.City)),
         isMyPlayer: player === myPlayer,
         isOnSameTeam:
           myPlayer !== null &&
@@ -141,7 +251,9 @@ export class Leaderboard extends LitElement implements Controller {
             myPlayer.numTilesOwned() / this.game.numLandTiles(),
           ),
           gold: renderNumber(myPlayer.gold()),
+          goldPerMinute: renderNumber(myPlayer.goldPerMinute()),
           maxTroops: renderTroops(myPlayerMaxTroops),
+          cities: renderNumber(myPlayer.totalUnitLevels(UnitType.City)),
           isMyPlayer: true,
           isOnSameTeam: true,
           player: myPlayer,
@@ -157,10 +269,43 @@ export class Leaderboard extends LitElement implements Controller {
     this.eventBus.emit(new GoToPlayerEvent(player));
   }
 
+  private renderColumnSettings() {
+    if (!this.showColumnSettings) return html``;
+    const selected = new Set(this.visibleColumnKeys);
+    return html`
+      <div
+        class="mt-2 rounded-md border border-slate-500 bg-gray-800/90 p-2 text-white text-xs md:text-xs lg:text-sm shadow-lg"
+      >
+        <div class="font-bold mb-1">
+          ${translateText("leaderboard.columns")}
+        </div>
+        <div class="grid grid-cols-2 gap-1">
+          ${COLUMN_DEFINITIONS.map(
+            (column) => html`
+              <label
+                class="flex items-center gap-2 rounded-sm px-2 py-1 hover:bg-white/10"
+              >
+                <input
+                  type="checkbox"
+                  class="accent-slate-300"
+                  .checked=${selected.has(column.key)}
+                  .disabled=${selected.size === 1 && selected.has(column.key)}
+                  @change=${() => this.toggleColumn(column.key)}
+                />
+                <span class="truncate">${translateText(column.labelKey)}</span>
+              </label>
+            `,
+          )}
+        </div>
+      </div>
+    `;
+  }
+
   render() {
     if (!this.visible) {
       return html``;
     }
+    const columns = this.visibleColumns();
     return html`
       <div
         class="max-h-[35vh] overflow-y-auto text-white text-xs md:text-xs lg:text-sm md:max-h-[50vh] mt-2 ${this
@@ -171,7 +316,7 @@ export class Leaderboard extends LitElement implements Controller {
       >
         <div
           class="grid bg-gray-800/85 w-full text-xs md:text-xs lg:text-sm rounded-lg overflow-hidden"
-          style="grid-template-columns: minmax(24px, 30px) minmax(60px, 100px) minmax(45px, 70px) minmax(40px, 55px) minmax(55px, 105px);"
+          style=${`grid-template-columns: ${this.gridTemplateColumns(columns)};`}
         >
           <div class="contents font-bold bg-gray-700/60">
             <div class="py-1 md:py-2 text-center border-b border-slate-500">
@@ -182,39 +327,17 @@ export class Leaderboard extends LitElement implements Controller {
             >
               ${translateText("leaderboard.player")}
             </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("tiles")}
-            >
-              ${translateText("leaderboard.owned")}
-              ${this._sortKey === "tiles"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("gold")}
-            >
-              ${translateText("leaderboard.gold")}
-              ${this._sortKey === "gold"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("maxtroops")}
-            >
-              ${translateText("leaderboard.maxtroops")}
-              ${this._sortKey === "maxtroops"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
+            ${columns.map(
+              (column) => html`
+                <div
+                  class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+                  @click=${() => this.setSort(column.key)}
+                >
+                  ${translateText(column.labelKey)}
+                  ${this.sortIndicator(column.key)}
+                </div>
+              `,
+            )}
           </div>
 
           ${repeat(
@@ -243,47 +366,48 @@ export class Leaderboard extends LitElement implements Controller {
                 >
                   ${player.name}
                 </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.score}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.gold}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.maxTroops}
-                </div>
+                ${columns.map(
+                  (column) => html`
+                    <div
+                      class="py-1 md:py-2 text-center ${index <
+                      this.players.length - 1
+                        ? "border-b border-slate-500"
+                        : ""}"
+                    >
+                      ${this.entryValue(player, column.key)}
+                    </div>
+                  `,
+                )}
               </div>
             `,
           )}
         </div>
       </div>
 
-      <button
-        class="mt-2 p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm 
-        border rounded-md border-slate-500 transition-colors
-        text-white mx-auto block hover:bg-white/10 bg-gray-700/50"
-        @click=${() => {
-          this.showTopFive = !this.showTopFive;
-          this.updateLeaderboard();
-        }}
-      >
-        ${this.showTopFive ? "+" : "-"}
-      </button>
+      <div class="mt-2 flex items-center justify-center gap-2">
+        <button
+          class="p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm
+          border rounded-md border-slate-500 transition-colors
+          text-white hover:bg-white/10 bg-gray-700/50"
+          @click=${() => {
+            this.showTopFive = !this.showTopFive;
+            this.updateLeaderboard();
+          }}
+        >
+          ${this.showTopFive ? "+" : "-"}
+        </button>
+        <button
+          class="h-7 w-7 flex items-center justify-center border rounded-md border-slate-500 transition-colors text-white hover:bg-white/10 bg-gray-700/50"
+          title=${translateText("leaderboard.configure_columns")}
+          aria-label=${translateText("leaderboard.configure_columns")}
+          @click=${() => {
+            this.showColumnSettings = !this.showColumnSettings;
+          }}
+        >
+          <img src=${settingsIcon} alt="" width="14" height="14" />
+        </button>
+      </div>
+      ${this.renderColumnSettings()}
     `;
   }
 }

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -59,6 +59,7 @@ export interface PlayerState {
   isDisconnected: boolean;
   tilesOwned: number;
   gold: number;
+  goldPerMinute: number;
   troops: number;
   isTraitor: boolean;
   traitorRemainingTicks: number;

--- a/src/client/view/PlayerView.ts
+++ b/src/client/view/PlayerView.ts
@@ -78,6 +78,7 @@ function stateFromUpdate(pu: PlayerUpdate): PlayerState {
     isDisconnected: pu.isDisconnected!,
     tilesOwned: pu.tilesOwned!,
     gold: Number(pu.gold!),
+    goldPerMinute: pu.goldPerMinute!,
     troops: pu.troops!,
     isTraitor: pu.isTraitor!,
     traitorRemainingTicks: Math.max(0, pu.traitorRemainingTicks ?? 0),
@@ -470,6 +471,10 @@ export class PlayerView {
     // Engine Gold is bigint; renderer state stores number. Convert back at the
     // accessor for game-code that still expects bigint semantics.
     return BigInt(this.state.gold);
+  }
+
+  goldPerMinute(): number {
+    return this.state.goldPerMinute;
   }
 
   troops(): number {

--- a/src/core/game/GameUpdateUtils.ts
+++ b/src/core/game/GameUpdateUtils.ts
@@ -53,6 +53,7 @@ export function diffPlayerUpdate(
   setIfDifferent("isAlive", prev.isAlive === next.isAlive);
   setIfDifferent("isDisconnected", prev.isDisconnected === next.isDisconnected);
   // tilesOwned / gold / troops intentionally absent — see EXCEPTION above.
+  setIfDifferent("goldPerMinute", prev.goldPerMinute === next.goldPerMinute);
   setIfDifferent("isTraitor", prev.isTraitor === next.isTraitor);
   setIfDifferent(
     "traitorRemainingTicks",
@@ -114,6 +115,7 @@ export function applyStateUpdate(target: PlayerState, pu: PlayerUpdate): void {
     target.isDisconnected = pu.isDisconnected;
   if (pu.tilesOwned !== undefined) target.tilesOwned = pu.tilesOwned;
   if (pu.gold !== undefined) target.gold = Number(pu.gold);
+  if (pu.goldPerMinute !== undefined) target.goldPerMinute = pu.goldPerMinute;
   if (pu.troops !== undefined) target.troops = pu.troops;
   if (pu.isTraitor !== undefined) target.isTraitor = pu.isTraitor;
   if (pu.traitorRemainingTicks !== undefined) {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -228,6 +228,7 @@ export interface PlayerUpdate {
   isDisconnected?: boolean;
   tilesOwned?: number;
   gold?: Gold;
+  goldPerMinute?: number;
   troops?: number;
   allies?: number[];
   embargoes?: Set<PlayerID>;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -90,12 +90,24 @@ Object.freeze(EMPTY_ATTACK_UPDATES);
 Object.freeze(EMPTY_ALLIANCE_VIEWS);
 Object.freeze(EMPTY_EMOJIS);
 
+const GOLD_INCOME_BUCKET_TICKS = 10;
+const GOLD_INCOME_BUCKET_COUNT = 60;
+const GOLD_INCOME_SAMPLE_TICKS = 100;
+
 export class PlayerImpl implements Player {
   public _lastTileChange: number = 0;
   public _pseudo_random: PseudoRandom;
 
   private _gold: bigint;
   private _troops: bigint;
+  private _goldPerMinute = 0;
+  private lastGoldIncomeSample = -1;
+  private readonly goldIncomeBuckets = Array<bigint>(
+    GOLD_INCOME_BUCKET_COUNT,
+  ).fill(0n);
+  private readonly goldIncomeBucketIds = Array<number>(
+    GOLD_INCOME_BUCKET_COUNT,
+  ).fill(-1);
 
   markedTraitorTick = -1;
   private _betrayalCount: number = 0;
@@ -310,6 +322,7 @@ export class PlayerImpl implements Player {
       isDisconnected: this.isDisconnected(),
       tilesOwned: this.numTilesOwned(),
       gold: this._gold,
+      goldPerMinute: this.goldPerMinute(),
       troops: this.troops(),
       allies: allies,
       embargoes: embargoes,
@@ -1114,6 +1127,7 @@ export class PlayerImpl implements Player {
 
   addGold(toAdd: Gold, tile?: TileRef): void {
     this._gold += toAdd;
+    this.recordGoldIncome(toAdd);
     if (tile) {
       this.mg.addUpdate({
         type: GameUpdateType.BonusEvent,
@@ -1123,6 +1137,40 @@ export class PlayerImpl implements Player {
         troops: 0,
       });
     }
+  }
+
+  private recordGoldIncome(toAdd: Gold): void {
+    if (toAdd <= 0n) return;
+    const bucketId = this.currentGoldIncomeBucket();
+    const index = bucketId % GOLD_INCOME_BUCKET_COUNT;
+    if (this.goldIncomeBucketIds[index] !== bucketId) {
+      this.goldIncomeBucketIds[index] = bucketId;
+      this.goldIncomeBuckets[index] = 0n;
+    }
+    this.goldIncomeBuckets[index] += toAdd;
+  }
+
+  private goldPerMinute(): number {
+    const bucketId = this.currentGoldIncomeBucket();
+    const sampleId = Math.floor(this.mg.ticks() / GOLD_INCOME_SAMPLE_TICKS);
+    if (sampleId === this.lastGoldIncomeSample) {
+      return this._goldPerMinute;
+    }
+    this.lastGoldIncomeSample = sampleId;
+    const oldestBucketId = bucketId - GOLD_INCOME_BUCKET_COUNT + 1;
+    let total = 0n;
+    for (let i = 0; i < GOLD_INCOME_BUCKET_COUNT; i++) {
+      const id = this.goldIncomeBucketIds[i];
+      if (id >= oldestBucketId && id <= bucketId) {
+        total += this.goldIncomeBuckets[i];
+      }
+    }
+    this._goldPerMinute = Number(total);
+    return this._goldPerMinute;
+  }
+
+  private currentGoldIncomeBucket(): number {
+    return Math.floor(this.mg.ticks() / GOLD_INCOME_BUCKET_TICKS);
   }
 
   removeGold(toRemove: Gold): Gold {

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -57,6 +57,36 @@ export const COLOR_KEY = "settings.territoryColor";
 export const PERFORMANCE_OVERLAY_KEY = "settings.performanceOverlay";
 export const KEYBINDS_KEY = "settings.keybinds";
 export const GRAPHICS_KEY = "settings.graphics";
+export const LEADERBOARD_COLUMNS_KEY = "settings.leaderboardColumns";
+
+export type LeaderboardColumnKey =
+  | "tiles"
+  | "gold"
+  | "goldPerMinute"
+  | "maxtroops"
+  | "cities";
+
+const LEADERBOARD_COLUMN_KEYS: LeaderboardColumnKey[] = [
+  "tiles",
+  "gold",
+  "goldPerMinute",
+  "maxtroops",
+  "cities",
+];
+
+const DEFAULT_LEADERBOARD_COLUMNS: LeaderboardColumnKey[] = [
+  "tiles",
+  "gold",
+  "goldPerMinute",
+  "maxtroops",
+];
+
+function isLeaderboardColumnKey(value: unknown): value is LeaderboardColumnKey {
+  return (
+    typeof value === "string" &&
+    LEADERBOARD_COLUMN_KEYS.includes(value as LeaderboardColumnKey)
+  );
+}
 
 export class UserSettings {
   private static cache = new Map<string, string | null>();
@@ -118,6 +148,47 @@ export class UserSettings {
 
   private setString(key: string, value: string) {
     this.setCached(key, value);
+  }
+
+  leaderboardColumns(): LeaderboardColumnKey[] {
+    const raw = this.getString(LEADERBOARD_COLUMNS_KEY, "");
+    if (!raw) return DEFAULT_LEADERBOARD_COLUMNS.slice();
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        const columns = LEADERBOARD_COLUMN_KEYS.filter((key) =>
+          parsed.includes(key),
+        );
+        if (columns.length > 0) return columns;
+      }
+    } catch {
+      // Fall back to defaults below.
+    }
+    return DEFAULT_LEADERBOARD_COLUMNS.slice();
+  }
+
+  setLeaderboardColumns(columns: readonly LeaderboardColumnKey[]): void {
+    const normalized = LEADERBOARD_COLUMN_KEYS.filter((key) =>
+      columns.includes(key),
+    );
+    this.setString(
+      LEADERBOARD_COLUMNS_KEY,
+      JSON.stringify(
+        normalized.length > 0 ? normalized : DEFAULT_LEADERBOARD_COLUMNS,
+      ),
+    );
+  }
+
+  toggleLeaderboardColumn(key: LeaderboardColumnKey): LeaderboardColumnKey[] {
+    if (!isLeaderboardColumnKey(key)) return this.leaderboardColumns();
+    const columns = this.leaderboardColumns();
+    const next = columns.includes(key)
+      ? columns.length === 1
+        ? columns
+        : columns.filter((column) => column !== key)
+      : [...columns, key];
+    this.setLeaderboardColumns(next);
+    return this.leaderboardColumns();
   }
 
   private getFloat(key: string, defaultValue: number): number {

--- a/tests/GameUpdateUtils.test.ts
+++ b/tests/GameUpdateUtils.test.ts
@@ -20,6 +20,7 @@ function makePlayerState(overrides: Partial<PlayerState> = {}): PlayerState {
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0,
+    goldPerMinute: 0,
     troops: 100,
     isTraitor: false,
     traitorRemainingTicks: 0,
@@ -70,6 +71,17 @@ describe("diffPlayerUpdate", () => {
     const prev = makePlayerUpdate({ gold: 100n, troops: 50, tilesOwned: 5 });
     const next = makePlayerUpdate({ gold: 200n, troops: 75, tilesOwned: 9 });
     expect(diffPlayerUpdate(prev, next)).toBeNull();
+  });
+
+  it("detects goldPerMinute changes", () => {
+    const prev = makePlayerUpdate({ goldPerMinute: 100 });
+    const next = makePlayerUpdate({ goldPerMinute: 250 });
+    const diff = diffPlayerUpdate(prev, next)!;
+    expect(diff).toEqual({
+      type: GameUpdateType.Player,
+      id: "player-a",
+      goldPerMinute: 250,
+    });
   });
 
   it("detects allies array additions", () => {
@@ -353,10 +365,16 @@ describe("applyStateUpdate", () => {
     applyStateUpdate(target, {
       type: GameUpdateType.Player,
       id: "p",
+      goldPerMinute: 500,
+    });
+    applyStateUpdate(target, {
+      type: GameUpdateType.Player,
+      id: "p",
       isAlive: false,
     });
     expect(target.gold).toBe(100);
     expect(target.troops).toBe(250);
+    expect(target.goldPerMinute).toBe(500);
     expect(target.isAlive).toBe(false);
   });
 });

--- a/tests/PlayerUpdateDiff.test.ts
+++ b/tests/PlayerUpdateDiff.test.ts
@@ -124,9 +124,45 @@ describe("Player update diffing (toUpdate)", () => {
     const full = dora.toUpdate(statsOut);
     expect(full).not.toBeNull();
     expect(full!.gold).toBe(dora.gold());
+    expect(full!.goldPerMinute).toBe(0);
     expect(full!.troops).toBe(dora.troops());
     expect(full!.tilesOwned).toBe(dora.numTilesOwned());
     expect(statsOut).toEqual([]);
+  });
+
+  test("goldPerMinute is positive gold credited during the last 60 seconds", () => {
+    const info = new PlayerInfo(
+      "income",
+      PlayerType.Human,
+      "income_client",
+      "income_id",
+    );
+    game.addPlayer(info);
+    const income = game.player("income_id");
+    income.toUpdate();
+
+    income.addGold(600n);
+    let diff: PlayerUpdate | undefined;
+    for (let i = 0; i < 100; i++) {
+      const updates = game.executeNextTick();
+      diff = (updates[GameUpdateType.Player] as PlayerUpdate[]).find(
+        (u) => u.id === "income_id" && u.goldPerMinute !== undefined,
+      );
+      if (diff !== undefined) break;
+    }
+
+    expect(diff?.goldPerMinute).toBe(600);
+
+    let expired: PlayerUpdate | undefined;
+    for (let i = 0; i < 600; i++) {
+      const updates = game.executeNextTick();
+      expired = (updates[GameUpdateType.Player] as PlayerUpdate[]).find(
+        (u) => u.id === "income_id" && u.goldPerMinute !== undefined,
+      );
+      if (expired?.goldPerMinute === 0) break;
+    }
+
+    expect(expired?.goldPerMinute).toBe(0);
   });
 
   test("adding and removing an embargo shows up in consecutive diffs", () => {

--- a/tests/client/render/frame/derive/nuke-telegraphs.test.ts
+++ b/tests/client/render/frame/derive/nuke-telegraphs.test.ts
@@ -33,6 +33,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0,
+    goldPerMinute: 0,
     troops: 0,
     isTraitor: false,
     traitorRemainingTicks: 0,

--- a/tests/client/render/frame/derive/player-status.test.ts
+++ b/tests/client/render/frame/derive/player-status.test.ts
@@ -29,6 +29,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0,
+    goldPerMinute: 0,
     troops: 0,
     isTraitor: false,
     traitorRemainingTicks: 0,

--- a/tests/client/view/GameView.test.ts
+++ b/tests/client/view/GameView.test.ts
@@ -162,6 +162,21 @@ describe("GameView.update — packed channels", () => {
     expect(alice.troops()).toBe(250);
   });
 
+  it("player diffs update goldPerMinute", () => {
+    const game = makeGameView();
+    game.update(
+      withPlayers(1, [makePlayerUpdate({ id: "alice", smallID: 1 })]),
+    );
+
+    const gu = makeEmptyGu(2);
+    gu.updates[GameUpdateType.Player] = [
+      { type: GameUpdateType.Player, id: "alice", goldPerMinute: 750 },
+    ];
+    game.update(gu);
+
+    expect(game.player("alice").goldPerMinute()).toBe(750);
+  });
+
   it("packedAttackUpdates patches troop counts by direction and index", () => {
     const game = makeGameView();
     game.update(

--- a/tests/util/viewStubs.ts
+++ b/tests/util/viewStubs.ts
@@ -124,6 +124,7 @@ export function makePlayerUpdate(
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0n,
+    goldPerMinute: 0,
     troops: 100,
     allies: [],
     embargoes: new Set(),


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4074

## Description:

Adds gold/min and configurable scoreboard columns. Adds optional cities column.

![Leaderboard](https://raw.githubusercontent.com/jsshap/OpenFrontIO/pr-4452-screenshots/pr-assets/4452/leaderboard.png)

![Leaderboard column chooser](https://raw.githubusercontent.com/jsshap/OpenFrontIO/pr-4452-screenshots/pr-assets/4452/leaderboard-columns.png)

Testing: `npm test`

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jsshap