### PR TITLE
Leaderboard update part 1: configurable columns

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -803,6 +803,8 @@
   },
   "leaderboard": {
     "cities": "Cities",
+    "columns": "Columns",
+    "configure_columns": "Configure columns",
     "gold": "Gold",
     "launchers": "Launchers",
     "maxtroops": "Max troops",

--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -2,11 +2,42 @@ import { LitElement, html } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { renderTroops, translateText } from "../../../client/Utils";
+import { assetUrl } from "../../../core/AssetUrls";
 import { EventBus } from "../../../core/EventBus";
+import {
+  LeaderboardColumnKey,
+  UserSettings,
+} from "../../../core/game/UserSettings";
 import { Controller } from "../../Controller";
 import { GoToPlayerEvent } from "../../TransformHandler";
 import { formatPercentage, renderNumber } from "../../Utils";
 import { GameView, PlayerView } from "../../view";
+
+const settingsIcon = assetUrl("images/SettingIconWhite.svg");
+
+interface ColumnDefinition {
+  key: LeaderboardColumnKey;
+  labelKey: string;
+  width: string;
+}
+
+const COLUMN_DEFINITIONS: ColumnDefinition[] = [
+  {
+    key: "tiles",
+    labelKey: "leaderboard.owned",
+    width: "minmax(45px, 70px)",
+  },
+  {
+    key: "gold",
+    labelKey: "leaderboard.gold",
+    width: "minmax(40px, 55px)",
+  },
+  {
+    key: "maxtroops",
+    labelKey: "leaderboard.maxtroops",
+    width: "minmax(55px, 105px)",
+  },
+];
 
 interface Entry {
   name: string;
@@ -24,16 +55,24 @@ export class Leaderboard extends LitElement implements Controller {
   public game: GameView | null = null;
   public eventBus: EventBus | null = null;
 
+  private readonly userSettings = new UserSettings();
+
   players: Entry[] = [];
 
   @property({ type: Boolean }) visible = false;
   private showTopFive = true;
 
   @state()
-  private _sortKey: "tiles" | "gold" | "maxtroops" = "tiles";
+  private _sortKey: LeaderboardColumnKey = "tiles";
 
   @state()
   private _sortOrder: "asc" | "desc" = "desc";
+
+  @state()
+  private showColumnSettings = false;
+
+  @state()
+  private visibleColumnKeys = this.userSettings.leaderboardColumns();
 
   createRenderRoot() {
     return this; // use light DOM for Tailwind support
@@ -57,7 +96,7 @@ export class Leaderboard extends LitElement implements Controller {
     this.updateLeaderboard();
   }
 
-  private setSort(key: "tiles" | "gold" | "maxtroops") {
+  private setSort(key: LeaderboardColumnKey) {
     if (this._sortKey === key) {
       this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
     } else {
@@ -67,9 +106,56 @@ export class Leaderboard extends LitElement implements Controller {
     this.updateLeaderboard();
   }
 
+  private visibleColumns(): ColumnDefinition[] {
+    const visible = new Set(this.visibleColumnKeys);
+    const columns = COLUMN_DEFINITIONS.filter((column) =>
+      visible.has(column.key),
+    );
+    return columns.length > 0 ? columns : [COLUMN_DEFINITIONS[0]];
+  }
+
+  private ensureVisibleSortKey(columns: readonly ColumnDefinition[]): void {
+    if (!columns.some((column) => column.key === this._sortKey)) {
+      this._sortKey = columns[0].key;
+      this._sortOrder = "desc";
+    }
+  }
+
+  private toggleColumn(key: LeaderboardColumnKey) {
+    this.visibleColumnKeys = this.userSettings.toggleLeaderboardColumn(key);
+    this.ensureVisibleSortKey(this.visibleColumns());
+    this.updateLeaderboard();
+  }
+
+  private entryValue(entry: Entry, key: LeaderboardColumnKey): string {
+    switch (key) {
+      case "gold":
+        return entry.gold;
+      case "maxtroops":
+        return entry.maxTroops;
+      case "tiles":
+        return entry.score;
+    }
+  }
+
+  private sortIndicator(key: LeaderboardColumnKey) {
+    if (this._sortKey !== key) return "";
+    return this._sortOrder === "asc" ? "⬆️" : "⬇️";
+  }
+
+  private gridTemplateColumns(columns: readonly ColumnDefinition[]): string {
+    return [
+      "minmax(24px, 30px)",
+      "minmax(60px, 100px)",
+      ...columns.map((column) => column.width),
+    ].join(" ");
+  }
+
   private updateLeaderboard() {
     if (this.game === null) throw new Error("Not initialized");
     const myPlayer = this.game.myPlayer();
+    const columns = this.visibleColumns();
+    this.ensureVisibleSortKey(columns);
 
     interface PlayerViewTroopsCache {
       pv: PlayerView;
@@ -83,6 +169,7 @@ export class Leaderboard extends LitElement implements Controller {
 
     const sorted: PlayerViewTroopsCache[] = this.game
       .playerViews()
+      .filter((p) => p.isAlive())
       .map((p) => ({ pv: p, maxTroops: maxTroops(p) }));
 
     switch (this._sortKey) {
@@ -103,10 +190,7 @@ export class Leaderboard extends LitElement implements Controller {
     const numTilesWithoutFallout =
       this.game.numLandTiles() - this.game.numTilesWithFallout();
 
-    const alivePlayers = sorted.filter((player) => player.pv.isAlive());
-    const playersToShow = this.showTopFive
-      ? alivePlayers.slice(0, 5)
-      : alivePlayers;
+    const playersToShow = this.showTopFive ? sorted.slice(0, 5) : sorted;
 
     this.players = playersToShow.map((playerCache, index) => {
       const player = playerCache.pv;
@@ -165,133 +249,160 @@ export class Leaderboard extends LitElement implements Controller {
     this.eventBus.emit(new GoToPlayerEvent(player));
   }
 
-  render() {
-    if (!this.visible) {
-      return html``;
-    }
+  private stopGameInput(event: Event) {
+    event.stopPropagation();
+  }
+
+  private renderColumnSettings() {
+    if (!this.showColumnSettings) return html``;
+    const selected = new Set(this.visibleColumnKeys);
     return html`
       <div
-        class="max-h-[35vh] overflow-y-auto text-white text-xs md:text-xs lg:text-sm md:max-h-[50vh] mt-2 ${this
-          .visible
-          ? ""
-          : "hidden"}"
-        @contextmenu=${(e: Event) => e.preventDefault()}
+        class="mt-2 rounded-md border border-slate-500 bg-gray-800/90 p-2 text-white text-xs md:text-xs lg:text-sm shadow-lg"
       >
-        <div
-          class="grid bg-gray-800/85 w-full text-xs md:text-xs lg:text-sm rounded-lg overflow-hidden"
-          style="grid-template-columns: minmax(24px, 30px) minmax(60px, 100px) minmax(45px, 70px) minmax(40px, 55px) minmax(55px, 105px);"
-        >
-          <div class="contents font-bold bg-gray-700/60">
-            <div class="py-1 md:py-2 text-center border-b border-slate-500">
-              #
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 truncate"
-            >
-              ${translateText("leaderboard.player")}
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("tiles")}
-            >
-              ${translateText("leaderboard.owned")}
-              ${this._sortKey === "tiles"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("gold")}
-            >
-              ${translateText("leaderboard.gold")}
-              ${this._sortKey === "gold"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
-            <div
-              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
-              @click=${() => this.setSort("maxtroops")}
-            >
-              ${translateText("leaderboard.maxtroops")}
-              ${this._sortKey === "maxtroops"
-                ? this._sortOrder === "asc"
-                  ? "⬆️"
-                  : "⬇️"
-                : ""}
-            </div>
-          </div>
-
-          ${repeat(
-            this.players,
-            (p) => p.player.id(),
-            (player, index) => html`
-              <div
-                class="contents hover:bg-slate-600/60 ${player.isOnSameTeam
-                  ? "font-bold"
-                  : ""} cursor-pointer"
-                @click=${() => this.handleRowClickPlayer(player.player)}
+        <div class="font-bold mb-1">
+          ${translateText("leaderboard.columns")}
+        </div>
+        <div class="grid grid-cols-2 gap-1">
+          ${COLUMN_DEFINITIONS.map(
+            (column) => html`
+              <label
+                class="flex items-center gap-2 rounded-sm px-2 py-1 hover:bg-white/10"
               >
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.position}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""} truncate"
-                >
-                  ${player.name}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.score}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.gold}
-                </div>
-                <div
-                  class="py-1 md:py-2 text-center ${index <
-                  this.players.length - 1
-                    ? "border-b border-slate-500"
-                    : ""}"
-                >
-                  ${player.maxTroops}
-                </div>
-              </div>
+                <input
+                  type="checkbox"
+                  class="accent-slate-300"
+                  .checked=${selected.has(column.key)}
+                  .disabled=${selected.size === 1 && selected.has(column.key)}
+                  @change=${() => this.toggleColumn(column.key)}
+                />
+                <span class="truncate">${translateText(column.labelKey)}</span>
+              </label>
             `,
           )}
         </div>
       </div>
+    `;
+  }
 
-      <button
-        class="mt-2 p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm 
-        border rounded-md border-slate-500 transition-colors
-        text-white mx-auto block hover:bg-white/10 bg-gray-700/50"
-        @click=${() => {
-          this.showTopFive = !this.showTopFive;
-          this.updateLeaderboard();
+  render() {
+    if (!this.visible) {
+      return html``;
+    }
+    const columns = this.visibleColumns();
+    return html`
+      <div
+        @click=${this.stopGameInput}
+        @pointerdown=${this.stopGameInput}
+        @pointerup=${this.stopGameInput}
+        @pointercancel=${this.stopGameInput}
+        @contextmenu=${(e: Event) => {
+          e.preventDefault();
+          e.stopPropagation();
         }}
       >
-        ${this.showTopFive ? "+" : "-"}
-      </button>
+        <div
+          class="max-h-[35vh] overflow-y-auto text-white text-xs md:text-xs lg:text-sm md:max-h-[50vh] mt-2 ${this
+            .visible
+            ? ""
+            : "hidden"}"
+          @contextmenu=${(e: Event) => e.preventDefault()}
+        >
+          <div
+            class="grid bg-gray-800/85 w-full text-xs md:text-xs lg:text-sm rounded-lg overflow-hidden"
+            style=${`grid-template-columns: ${this.gridTemplateColumns(columns)};`}
+          >
+            <div class="contents font-bold bg-gray-700/60">
+              <div class="py-1 md:py-2 text-center border-b border-slate-500">
+                #
+              </div>
+              <div
+                class="py-1 md:py-2 text-center border-b border-slate-500 truncate"
+              >
+                ${translateText("leaderboard.player")}
+              </div>
+              ${columns.map(
+                (column) => html`
+                  <div
+                    class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+                    @click=${() => this.setSort(column.key)}
+                  >
+                    ${translateText(column.labelKey)}
+                    ${this.sortIndicator(column.key)}
+                  </div>
+                `,
+              )}
+            </div>
+
+            ${repeat(
+              this.players,
+              (p) => p.player.id(),
+              (player, index) => html`
+                <div
+                  class="contents hover:bg-slate-600/60 ${player.isOnSameTeam
+                    ? "font-bold"
+                    : ""} cursor-pointer"
+                  @click=${() => this.handleRowClickPlayer(player.player)}
+                >
+                  <div
+                    class="py-1 md:py-2 text-center ${index <
+                    this.players.length - 1
+                      ? "border-b border-slate-500"
+                      : ""}"
+                  >
+                    ${player.position}
+                  </div>
+                  <div
+                    class="py-1 md:py-2 text-center ${index <
+                    this.players.length - 1
+                      ? "border-b border-slate-500"
+                      : ""} truncate"
+                  >
+                    ${player.name}
+                  </div>
+                  ${columns.map(
+                    (column) => html`
+                      <div
+                        class="py-1 md:py-2 text-center ${index <
+                        this.players.length - 1
+                          ? "border-b border-slate-500"
+                          : ""}"
+                      >
+                        ${this.entryValue(player, column.key)}
+                      </div>
+                    `,
+                  )}
+                </div>
+              `,
+            )}
+          </div>
+        </div>
+
+        <div class="mt-2 flex items-center justify-center gap-2">
+          <button
+            class="p-0.5 px-1.5 md:px-2 text-xs md:text-xs lg:text-sm
+          border rounded-md border-slate-500 transition-colors
+          text-white hover:bg-white/10 bg-gray-700/50"
+            @click=${() => {
+              this.showTopFive = !this.showTopFive;
+              this.updateLeaderboard();
+            }}
+          >
+            ${this.showTopFive ? "+" : "-"}
+          </button>
+          <button
+            class="h-7 w-7 flex items-center justify-center border rounded-md border-slate-500 transition-colors text-white hover:bg-white/10 bg-gray-700/50"
+            title=${translateText("leaderboard.configure_columns")}
+            aria-label=${translateText("leaderboard.configure_columns")}
+            @click=${() => {
+              this.showColumnSettings = !this.showColumnSettings;
+            }}
+          >
+            <img src=${settingsIcon} alt="" width="14" height="14" />
+          </button>
+        </div>
+        ${this.renderColumnSettings()}
+      </div>
     `;
   }
 }

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -58,7 +58,29 @@ export const COLOR_KEY = "settings.territoryColor";
 export const PERFORMANCE_OVERLAY_KEY = "settings.performanceOverlay";
 export const KEYBINDS_KEY = "settings.keybinds";
 export const GRAPHICS_KEY = "settings.graphics";
+export const LEADERBOARD_COLUMNS_KEY = "settings.leaderboardColumns";
 export const EFFECTS_KEY = "settings.effects";
+
+export type LeaderboardColumnKey = "tiles" | "gold" | "maxtroops";
+
+const LEADERBOARD_COLUMN_KEYS: LeaderboardColumnKey[] = [
+  "tiles",
+  "gold",
+  "maxtroops",
+];
+
+const DEFAULT_LEADERBOARD_COLUMNS: LeaderboardColumnKey[] = [
+  "tiles",
+  "gold",
+  "maxtroops",
+];
+
+function isLeaderboardColumnKey(value: unknown): value is LeaderboardColumnKey {
+  return (
+    typeof value === "string" &&
+    LEADERBOARD_COLUMN_KEYS.includes(value as LeaderboardColumnKey)
+  );
+}
 
 export class UserSettings {
   private static cache = new Map<string, string | null>();
@@ -120,6 +142,47 @@ export class UserSettings {
 
   private setString(key: string, value: string) {
     this.setCached(key, value);
+  }
+
+  leaderboardColumns(): LeaderboardColumnKey[] {
+    const raw = this.getString(LEADERBOARD_COLUMNS_KEY, "");
+    if (!raw) return DEFAULT_LEADERBOARD_COLUMNS.slice();
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        const columns = LEADERBOARD_COLUMN_KEYS.filter((key) =>
+          parsed.includes(key),
+        );
+        if (columns.length > 0) return columns;
+      }
+    } catch {
+      // Fall back to defaults below.
+    }
+    return DEFAULT_LEADERBOARD_COLUMNS.slice();
+  }
+
+  setLeaderboardColumns(columns: readonly LeaderboardColumnKey[]): void {
+    const normalized = LEADERBOARD_COLUMN_KEYS.filter((key) =>
+      columns.includes(key),
+    );
+    this.setString(
+      LEADERBOARD_COLUMNS_KEY,
+      JSON.stringify(
+        normalized.length > 0 ? normalized : DEFAULT_LEADERBOARD_COLUMNS,
+      ),
+    );
+  }
+
+  toggleLeaderboardColumn(key: LeaderboardColumnKey): LeaderboardColumnKey[] {
+    if (!isLeaderboardColumnKey(key)) return this.leaderboardColumns();
+    const columns = this.leaderboardColumns();
+    const next = columns.includes(key)
+      ? columns.length === 1
+        ? columns
+        : columns.filter((column) => column !== key)
+      : [...columns, key];
+    this.setLeaderboardColumns(next);
+    return this.leaderboardColumns();
   }
 
   private getFloat(key: string, defaultValue: number): number {

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -1,13 +1,21 @@
-import { EFFECTS_KEY, UserSettings } from "../src/core/game/UserSettings";
+import {
+  EFFECTS_KEY,
+  LEADERBOARD_COLUMNS_KEY,
+  UserSettings,
+} from "../src/core/game/UserSettings";
+
+const DEFAULT_LEADERBOARD_COLUMNS = ["tiles", "gold", "maxtroops"];
+
+function clearUserSettingsCache(): void {
+  (
+    UserSettings as unknown as { cache: Map<string, string | null> }
+  ).cache.clear();
+}
 
 describe("UserSettings effect selection", () => {
   beforeEach(() => {
     localStorage.clear();
-    // UserSettings keeps a static in-memory cache; reset it too so each test
-    // reads fresh from the (cleared) localStorage.
-    (
-      UserSettings as unknown as { cache: Map<string, string | null> }
-    ).cache.clear();
+    clearUserSettingsCache();
   });
 
   it("sets and reads a per-effectType selection", () => {
@@ -44,5 +52,52 @@ describe("UserSettings effect selection", () => {
   it("returns an empty map for a corrupt blob", () => {
     localStorage.setItem(EFFECTS_KEY, "not json");
     expect(new UserSettings().getSelectedEffects()).toEqual({});
+  });
+});
+
+describe("UserSettings leaderboard columns", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    clearUserSettingsCache();
+  });
+
+  it("falls back to defaults for invalid JSON", () => {
+    localStorage.setItem(LEADERBOARD_COLUMNS_KEY, "not-json");
+
+    expect(new UserSettings().leaderboardColumns()).toEqual(
+      DEFAULT_LEADERBOARD_COLUMNS,
+    );
+  });
+
+  it("filters unknown keys", () => {
+    localStorage.setItem(
+      LEADERBOARD_COLUMNS_KEY,
+      JSON.stringify(["gold", "unknown", "maxtroops"]),
+    );
+
+    expect(new UserSettings().leaderboardColumns()).toEqual([
+      "gold",
+      "maxtroops",
+    ]);
+  });
+
+  it("falls back to defaults for empty or fully invalid selections", () => {
+    const settings = new UserSettings();
+
+    settings.setLeaderboardColumns([]);
+    expect(settings.leaderboardColumns()).toEqual(DEFAULT_LEADERBOARD_COLUMNS);
+
+    clearUserSettingsCache();
+    localStorage.setItem(LEADERBOARD_COLUMNS_KEY, JSON.stringify(["unknown"]));
+    expect(new UserSettings().leaderboardColumns()).toEqual(
+      DEFAULT_LEADERBOARD_COLUMNS,
+    );
+  });
+
+  it("keeps the last selected column enabled", () => {
+    const settings = new UserSettings();
+
+    settings.setLeaderboardColumns(["gold"]);
+    expect(settings.toggleLeaderboardColumn("gold")).toEqual(["gold"]);
   });
 });


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue - unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Refs #4074

## Description:

Adds a settings cog to the in-game leaderboard so players can choose which existing columns to show.

This first PR only makes the existing Owned, Gold, and Max troops columns configurable. The new leaderboard items are split into a follow-up PR.

![Leaderboard](https://raw.githubusercontent.com/jsshap/OpenFrontIO/pr-4452-screenshots/pr-assets/4452/leaderboard.png)

![Leaderboard column chooser](https://raw.githubusercontent.com/jsshap/OpenFrontIO/pr-4452-screenshots/pr-assets/4452/leaderboard-columns.png)

Testing: `npx vitest tests/UserSettings.test.ts --run`; `npx tsc --noEmit`; targeted ESLint/Prettier

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I have added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jsshap
