### PR TITLE
Restore subscriptions in store and account modal

### DIFF
--- a/src/client/AccountModal.ts
+++ b/src/client/AccountModal.ts
@@ -27,7 +27,7 @@ import "./components/Difficulties";
 import "./components/FriendsList";
 import "./components/SubscriptionPanel";
 import { modalHeader } from "./components/ui/ModalHeader";
-import { fetchCosmetics, SUBSCRIPTIONS_ENABLED } from "./Cosmetics";
+import { fetchCosmetics } from "./Cosmetics";
 import { translateText } from "./Utils";
 
 @customElement("account-modal")
@@ -38,9 +38,9 @@ export class AccountModal extends BaseModal {
   @state() private isLoadingUser: boolean = false;
 
   private userMeResponse: UserMeResponse | null = null;
-  private cosmetics: Cosmetics | null = null;
   private statsTree: PlayerStatsTree | null = null;
   private recentGames: PlayerGame[] = [];
+  private cosmetics: Cosmetics | null = null;
 
   constructor() {
     super();
@@ -231,7 +231,6 @@ export class AccountModal extends BaseModal {
   }
 
   private renderSubscriptionPanel(): TemplateResult | "" {
-    if (!SUBSCRIPTIONS_ENABLED) return "";
     const sub = this.userMeResponse?.player?.subscription;
     if (!sub) return "";
     const cosmetic = this.cosmetics?.subscriptions?.[sub.tier] ?? null;
@@ -552,12 +551,10 @@ export class AccountModal extends BaseModal {
     this.isLoadingUser = true;
     this.handleLinkResult(args);
 
-    if (SUBSCRIPTIONS_ENABLED) {
-      void fetchCosmetics().then((cosmetics) => {
-        this.cosmetics = cosmetics;
-        this.requestUpdate();
-      });
-    }
+    void fetchCosmetics().then((cosmetics) => {
+      this.cosmetics = cosmetics;
+      this.requestUpdate();
+    });
 
     void getUserMe()
       .then((userMe) => {

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -33,10 +33,6 @@ import { translateText } from "./Utils";
 
 export const TEMP_FLARE_OFFSET = 1 * 60 * 1000; // 1 minute
 
-// Subscriptions are not ready yet — flip to true to show them in the store
-// and on the account/profile modal.
-export const SUBSCRIPTIONS_ENABLED = false;
-
 let __cosmetics: Promise<Cosmetics | null> | null = null;
 let __cosmeticsHash: string | null = null;
 let __cosmeticsCache: Cosmetics | null = null;

--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -14,7 +14,6 @@ import {
   groupCosmeticVariants,
   purchaseCosmetic,
   resolveCosmetics,
-  SUBSCRIPTIONS_ENABLED,
 } from "./Cosmetics";
 import { translateText } from "./Utils";
 
@@ -35,14 +34,7 @@ export class StoreModal extends BaseModal {
     return {
       tabs: [
         { key: "packs", label: translateText("store.packs") },
-        ...(SUBSCRIPTIONS_ENABLED
-          ? [
-              {
-                key: "subscriptions",
-                label: translateText("store.subscriptions"),
-              },
-            ]
-          : []),
+        { key: "subscriptions", label: translateText("store.subscriptions") },
         { key: "patterns", label: translateText("store.patterns") },
         { key: "flags", label: translateText("store.flags") },
         { key: "effects", label: translateText("store.effects") },


### PR DESCRIPTION
Reverts cdcc7747 ("Hide subscriptions in store and account modal behind a feature flag").

This re-adds the Subscriptions tab to the store, restores the subscription panel on the account modal, and re-enables the cosmetics fetch — removing the `SUBSCRIPTIONS_ENABLED` feature flag that gated them all behind `false`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)