### PR TITLE
Leaderboard update part 2: stat columns

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -804,6 +804,7 @@
   "leaderboard": {
     "cities": "Cities",
     "gold": "Gold",
+    "gold_per_min": "Gold/min",
     "launchers": "Launchers",
     "maxtroops": "Max troops",
     "owned": "Owned",
@@ -812,6 +813,7 @@
     "show_control": "Show Control",
     "show_units": "Show Units",
     "team": "Team",
+    "troops": "Troops",
     "warships": "Warships"
   },
   "leaderboard_modal": {

--- a/src/client/hud/layers/Leaderboard.ts
+++ b/src/client/hud/layers/Leaderboard.ts
@@ -3,17 +3,29 @@ import { customElement, property, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { renderTroops, translateText } from "../../../client/Utils";
 import { EventBus } from "../../../core/EventBus";
+import { UnitType } from "../../../core/game/Game";
 import { Controller } from "../../Controller";
 import { GoToPlayerEvent } from "../../TransformHandler";
 import { formatPercentage, renderNumber } from "../../Utils";
 import { GameView, PlayerView } from "../../view";
+
+type SortKey =
+  | "tiles"
+  | "gold"
+  | "goldPerMinute"
+  | "troops"
+  | "maxtroops"
+  | "cities";
 
 interface Entry {
   name: string;
   position: number;
   score: string;
   gold: string;
+  goldPerMinute: string;
+  troops: string;
   maxTroops: string;
+  cities: string;
   isMyPlayer: boolean;
   isOnSameTeam: boolean;
   player: PlayerView;
@@ -30,7 +42,7 @@ export class Leaderboard extends LitElement implements Controller {
   private showTopFive = true;
 
   @state()
-  private _sortKey: "tiles" | "gold" | "maxtroops" = "tiles";
+  private _sortKey: SortKey = "tiles";
 
   @state()
   private _sortOrder: "asc" | "desc" = "desc";
@@ -57,7 +69,7 @@ export class Leaderboard extends LitElement implements Controller {
     this.updateLeaderboard();
   }
 
-  private setSort(key: "tiles" | "gold" | "maxtroops") {
+  private setSort(key: SortKey) {
     if (this._sortKey === key) {
       this._sortOrder = this._sortOrder === "asc" ? "desc" : "asc";
     } else {
@@ -83,6 +95,7 @@ export class Leaderboard extends LitElement implements Controller {
 
     const sorted: PlayerViewTroopsCache[] = this.game
       .playerViews()
+      .filter((p) => p.isAlive())
       .map((p) => ({ pv: p, maxTroops: maxTroops(p) }));
 
     switch (this._sortKey) {
@@ -91,8 +104,24 @@ export class Leaderboard extends LitElement implements Controller {
           compare(Number(a.pv.gold()), Number(b.pv.gold())),
         );
         break;
+      case "goldPerMinute":
+        sorted.sort((a, b) =>
+          compare(a.pv.goldPerMinute(), b.pv.goldPerMinute()),
+        );
+        break;
+      case "troops":
+        sorted.sort((a, b) => compare(a.pv.troops(), b.pv.troops()));
+        break;
       case "maxtroops":
         sorted.sort((a, b) => compare(a.maxTroops, b.maxTroops));
+        break;
+      case "cities":
+        sorted.sort((a, b) =>
+          compare(
+            a.pv.totalUnitLevels(UnitType.City),
+            b.pv.totalUnitLevels(UnitType.City),
+          ),
+        );
         break;
       default:
         sorted.sort((a, b) =>
@@ -103,10 +132,7 @@ export class Leaderboard extends LitElement implements Controller {
     const numTilesWithoutFallout =
       this.game.numLandTiles() - this.game.numTilesWithFallout();
 
-    const alivePlayers = sorted.filter((player) => player.pv.isAlive());
-    const playersToShow = this.showTopFive
-      ? alivePlayers.slice(0, 5)
-      : alivePlayers;
+    const playersToShow = this.showTopFive ? sorted.slice(0, 5) : sorted;
 
     this.players = playersToShow.map((playerCache, index) => {
       const player = playerCache.pv;
@@ -118,7 +144,10 @@ export class Leaderboard extends LitElement implements Controller {
           player.numTilesOwned() / numTilesWithoutFallout,
         ),
         gold: renderNumber(player.gold()),
+        goldPerMinute: renderNumber(player.goldPerMinute()),
+        troops: renderTroops(player.troops()),
         maxTroops: renderTroops(maxTroops),
+        cities: renderNumber(player.totalUnitLevels(UnitType.City)),
         isMyPlayer: player === myPlayer,
         isOnSameTeam:
           myPlayer !== null &&
@@ -149,7 +178,10 @@ export class Leaderboard extends LitElement implements Controller {
             myPlayer.numTilesOwned() / this.game.numLandTiles(),
           ),
           gold: renderNumber(myPlayer.gold()),
+          goldPerMinute: renderNumber(myPlayer.goldPerMinute()),
+          troops: renderTroops(myPlayer.troops()),
           maxTroops: renderTroops(myPlayerMaxTroops),
+          cities: renderNumber(myPlayer.totalUnitLevels(UnitType.City)),
           isMyPlayer: true,
           isOnSameTeam: true,
           player: myPlayer,
@@ -179,7 +211,7 @@ export class Leaderboard extends LitElement implements Controller {
       >
         <div
           class="grid bg-gray-800/85 w-full text-xs md:text-xs lg:text-sm rounded-lg overflow-hidden"
-          style="grid-template-columns: minmax(24px, 30px) minmax(60px, 100px) minmax(45px, 70px) minmax(40px, 55px) minmax(55px, 105px);"
+          style="grid-template-columns: minmax(24px, 30px) minmax(60px, 100px) minmax(45px, 70px) minmax(40px, 55px) minmax(56px, 82px) minmax(55px, 95px) minmax(55px, 105px) minmax(42px, 62px);"
         >
           <div class="contents font-bold bg-gray-700/60">
             <div class="py-1 md:py-2 text-center border-b border-slate-500">
@@ -214,10 +246,43 @@ export class Leaderboard extends LitElement implements Controller {
             </div>
             <div
               class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+              @click=${() => this.setSort("goldPerMinute")}
+            >
+              ${translateText("leaderboard.gold_per_min")}
+              ${this._sortKey === "goldPerMinute"
+                ? this._sortOrder === "asc"
+                  ? "⬆️"
+                  : "⬇️"
+                : ""}
+            </div>
+            <div
+              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+              @click=${() => this.setSort("troops")}
+            >
+              ${translateText("leaderboard.troops")}
+              ${this._sortKey === "troops"
+                ? this._sortOrder === "asc"
+                  ? "⬆️"
+                  : "⬇️"
+                : ""}
+            </div>
+            <div
+              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
               @click=${() => this.setSort("maxtroops")}
             >
               ${translateText("leaderboard.maxtroops")}
               ${this._sortKey === "maxtroops"
+                ? this._sortOrder === "asc"
+                  ? "⬆️"
+                  : "⬇️"
+                : ""}
+            </div>
+            <div
+              class="py-1 md:py-2 text-center border-b border-slate-500 cursor-pointer whitespace-nowrap truncate"
+              @click=${() => this.setSort("cities")}
+            >
+              ${translateText("leaderboard.cities")}
+              ${this._sortKey === "cities"
                 ? this._sortOrder === "asc"
                   ? "⬆️"
                   : "⬇️"
@@ -273,7 +338,31 @@ export class Leaderboard extends LitElement implements Controller {
                     ? "border-b border-slate-500"
                     : ""}"
                 >
+                  ${player.goldPerMinute}
+                </div>
+                <div
+                  class="py-1 md:py-2 text-center ${index <
+                  this.players.length - 1
+                    ? "border-b border-slate-500"
+                    : ""}"
+                >
+                  ${player.troops}
+                </div>
+                <div
+                  class="py-1 md:py-2 text-center ${index <
+                  this.players.length - 1
+                    ? "border-b border-slate-500"
+                    : ""}"
+                >
                   ${player.maxTroops}
+                </div>
+                <div
+                  class="py-1 md:py-2 text-center ${index <
+                  this.players.length - 1
+                    ? "border-b border-slate-500"
+                    : ""}"
+                >
+                  ${player.cities}
                 </div>
               </div>
             `,

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -59,6 +59,7 @@ export interface PlayerState {
   isDisconnected: boolean;
   tilesOwned: number;
   gold: number;
+  goldPerMinute: number;
   troops: number;
   isTraitor: boolean;
   traitorRemainingTicks: number;

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -394,19 +394,20 @@ export class GameView implements GameMap {
       player.setEmbargoSmallIDs(smallIDs);
     });
 
-    // Packed per-player stats: [smallID, tilesOwned, gold, troops] quads for
+    // Packed per-player stats: [smallID, tilesOwned, gold, goldPerMinute, troops] records for
     // every player whose stats changed this tick (the per-tick churn that no
     // longer travels in PlayerUpdate objects). Applied after pass 1 so
     // first-emission players exist; their quad carries the same values as
     // the full update, so double-applying is harmless.
     const packedStats = gu.packedPlayerUpdates;
     if (packedStats !== undefined) {
-      for (let i = 0; i + 3 < packedStats.length; i += 4) {
+      for (let i = 0; i + 4 < packedStats.length; i += 5) {
         const state = this._playerStates.get(packedStats[i]);
         if (state === undefined) continue;
         state.tilesOwned = packedStats[i + 1];
         state.gold = packedStats[i + 2];
-        state.troops = packedStats[i + 3];
+        state.goldPerMinute = packedStats[i + 3];
+        state.troops = packedStats[i + 4];
       }
     }
 

--- a/src/client/view/PlayerView.ts
+++ b/src/client/view/PlayerView.ts
@@ -78,6 +78,7 @@ function stateFromUpdate(pu: PlayerUpdate): PlayerState {
     isDisconnected: pu.isDisconnected!,
     tilesOwned: pu.tilesOwned!,
     gold: Number(pu.gold!),
+    goldPerMinute: pu.goldPerMinute!,
     troops: pu.troops!,
     isTraitor: pu.isTraitor!,
     traitorRemainingTicks: Math.max(0, pu.traitorRemainingTicks ?? 0),
@@ -470,6 +471,10 @@ export class PlayerView {
     // Engine Gold is bigint; renderer state stores number. Convert back at the
     // accessor for game-code that still expects bigint semantics.
     return BigInt(this.state.gold);
+  }
+
+  goldPerMinute(): number {
+    return this.state.goldPerMinute;
   }
 
   troops(): number {

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -557,7 +557,7 @@ export interface Player {
 
   // Resources & Troops
   gold(): Gold;
-  addGold(toAdd: Gold, tile?: TileRef): void;
+  addGold(toAdd: Gold, tile?: TileRef, countAsIncome?: boolean): void;
   removeGold(toRemove: Gold): Gold;
   troops(): number;
   setTroops(troops: number): void;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -95,7 +95,7 @@ export class GameImpl implements Game {
 
   private updates: GameUpdates = createGameUpdatesMap();
   private tileUpdatePairs: number[] = [];
-  /** [smallID, tilesOwned, gold, troops] quads — see PlayerImpl.toUpdate. */
+  /** [smallID, tilesOwned, gold, goldPerMinute, troops] records — see PlayerImpl.toUpdate. */
   private playerStatsQuads: number[] = [];
   /** [smallID, direction, index, troops] quads — see packAttackTroopDeltas. */
   private attackTroopsQuads: number[] = [];

--- a/src/core/game/GameUpdateUtils.ts
+++ b/src/core/game/GameUpdateUtils.ts
@@ -21,7 +21,7 @@ import {
  * apply line in applyStateUpdate below. A field missing here is never diffed,
  * so its changes silently never reach the main thread after the first update.
  *
- * EXCEPTION: tilesOwned / gold / troops are deliberately NOT diffed here.
+ * EXCEPTION: tilesOwned / gold / goldPerMinute / troops are deliberately NOT diffed here.
  * They change for nearly every alive player every tick, so they travel on
  * the transferable `GameUpdateViewData.packedPlayerUpdates` channel instead
  * (see PlayerImpl.toUpdate) and appear in PlayerUpdate objects only on a
@@ -52,7 +52,7 @@ export function diffPlayerUpdate(
   setIfDifferent("playerType", prev.playerType === next.playerType);
   setIfDifferent("isAlive", prev.isAlive === next.isAlive);
   setIfDifferent("isDisconnected", prev.isDisconnected === next.isDisconnected);
-  // tilesOwned / gold / troops intentionally absent — see EXCEPTION above.
+  // tilesOwned / gold / goldPerMinute / troops intentionally absent — see EXCEPTION above.
   setIfDifferent("isTraitor", prev.isTraitor === next.isTraitor);
   setIfDifferent(
     "traitorRemainingTicks",
@@ -114,6 +114,7 @@ export function applyStateUpdate(target: PlayerState, pu: PlayerUpdate): void {
     target.isDisconnected = pu.isDisconnected;
   if (pu.tilesOwned !== undefined) target.tilesOwned = pu.tilesOwned;
   if (pu.gold !== undefined) target.gold = Number(pu.gold);
+  if (pu.goldPerMinute !== undefined) target.goldPerMinute = pu.goldPerMinute;
   if (pu.troops !== undefined) target.troops = pu.troops;
   if (pu.isTraitor !== undefined) target.isTraitor = pu.isTraitor;
   if (pu.traitorRemainingTicks !== undefined) {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -34,8 +34,9 @@ export interface GameUpdateViewData {
    */
   packedMotionPlans?: Uint32Array;
   /**
-   * Packed per-player numeric stats as `[smallID, tilesOwned, gold, troops]`
-   * float64 quads — the fields that change for nearly every alive player
+   * Packed per-player numeric stats as
+   * `[smallID, tilesOwned, gold, goldPerMinute, troops]` float64 records —
+   * the fields that change for nearly every alive player
    * every tick. They travel here (transferred, not structured-cloned) instead
    * of in `PlayerUpdate` object diffs, which only carry them on a player's
    * first emission. Gold is exact in a float64 (game values stay far below
@@ -228,6 +229,7 @@ export interface PlayerUpdate {
   isDisconnected?: boolean;
   tilesOwned?: number;
   gold?: Gold;
+  goldPerMinute?: number;
   troops?: number;
   allies?: number[];
   embargoes?: Set<PlayerID>;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -90,12 +90,23 @@ Object.freeze(EMPTY_ATTACK_UPDATES);
 Object.freeze(EMPTY_ALLIANCE_VIEWS);
 Object.freeze(EMPTY_EMOJIS);
 
+const GOLD_INCOME_BUCKET_TICKS = 10;
+const GOLD_INCOME_BUCKET_COUNT = 60;
+
 export class PlayerImpl implements Player {
   public _lastTileChange: number = 0;
   public _pseudo_random: PseudoRandom;
 
   private _gold: bigint;
   private _troops: bigint;
+  private goldIncomeTotal = 0n;
+  private lastGoldIncomeBucket = -1;
+  private readonly goldIncomeBuckets = Array<bigint>(
+    GOLD_INCOME_BUCKET_COUNT,
+  ).fill(0n);
+  private readonly goldIncomeBucketIds = Array<number>(
+    GOLD_INCOME_BUCKET_COUNT,
+  ).fill(-1);
 
   markedTraitorTick = -1;
   private _betrayalCount: number = 0;
@@ -159,9 +170,9 @@ export class PlayerImpl implements Player {
    * return only fields that changed since the previous call (a partial
    * `{ type, id, ...changedFields }`), or `null` if nothing changed.
    *
-   * tilesOwned / gold / troops are excluded from partial updates (they churn
+   * tilesOwned / gold / goldPerMinute / troops are excluded from partial updates (they churn
    * for every alive player every tick): when any of them changed, a
-   * `[smallID, tilesOwned, gold, troops]` quad is pushed to `statsOut`
+   * `[smallID, tilesOwned, gold, goldPerMinute, troops]` record is pushed to `statsOut`
    * instead, which GameImpl drains into the transferable
    * `packedPlayerUpdates` buffer. Attack troop counts likewise go to
    * `attackTroopsOut` as `[smallID, direction, index, troops]` quads
@@ -181,12 +192,14 @@ export class PlayerImpl implements Player {
       statsOut !== undefined &&
       (prev.tilesOwned !== full.tilesOwned ||
         prev.gold !== full.gold ||
+        prev.goldPerMinute !== full.goldPerMinute ||
         prev.troops !== full.troops)
     ) {
       statsOut.push(
         full.smallID!,
         full.tilesOwned!,
         Number(full.gold),
+        full.goldPerMinute!,
         full.troops!,
       );
     }
@@ -310,6 +323,7 @@ export class PlayerImpl implements Player {
       isDisconnected: this.isDisconnected(),
       tilesOwned: this.numTilesOwned(),
       gold: this._gold,
+      goldPerMinute: this.goldPerMinute(),
       troops: this.troops(),
       allies: allies,
       embargoes: embargoes,
@@ -986,7 +1000,7 @@ export class PlayerImpl implements Player {
     if (gold <= 0n) return false;
     const removed = this.removeGold(gold);
     if (removed === 0n) return false;
-    recipient.addGold(removed);
+    recipient.addGold(removed, undefined, false);
 
     this.sentDonations.push(new Donation(recipient, this.mg.ticks()));
     this.mg.addUpdate({
@@ -1118,8 +1132,11 @@ export class PlayerImpl implements Player {
     return this._gold;
   }
 
-  addGold(toAdd: Gold, tile?: TileRef): void {
+  addGold(toAdd: Gold, tile?: TileRef, countAsIncome = true): void {
     this._gold += toAdd;
+    if (countAsIncome) {
+      this.recordGoldIncome(toAdd);
+    }
     if (tile) {
       this.mg.addUpdate({
         type: GameUpdateType.BonusEvent,
@@ -1129,6 +1146,53 @@ export class PlayerImpl implements Player {
         troops: 0,
       });
     }
+  }
+
+  private recordGoldIncome(toAdd: Gold): void {
+    if (toAdd <= 0n) return;
+    this.advanceGoldIncomeBuckets();
+    const bucketId = this.currentGoldIncomeBucket();
+    const index = bucketId % GOLD_INCOME_BUCKET_COUNT;
+    if (this.goldIncomeBucketIds[index] !== bucketId) {
+      this.goldIncomeTotal -= this.goldIncomeBuckets[index];
+      this.goldIncomeBucketIds[index] = bucketId;
+      this.goldIncomeBuckets[index] = 0n;
+    }
+    this.goldIncomeBuckets[index] += toAdd;
+    this.goldIncomeTotal += toAdd;
+  }
+
+  private goldPerMinute(): number {
+    this.advanceGoldIncomeBuckets();
+    return Number(this.goldIncomeTotal);
+  }
+
+  private advanceGoldIncomeBuckets(): void {
+    const bucketId = this.currentGoldIncomeBucket();
+    if (this.lastGoldIncomeBucket < 0) {
+      this.lastGoldIncomeBucket = bucketId;
+      return;
+    }
+    if (bucketId <= this.lastGoldIncomeBucket) {
+      return;
+    }
+
+    const bucketsToClear = Math.min(
+      bucketId - this.lastGoldIncomeBucket,
+      GOLD_INCOME_BUCKET_COUNT,
+    );
+    for (let offset = 1; offset <= bucketsToClear; offset++) {
+      const nextBucketId = this.lastGoldIncomeBucket + offset;
+      const index = nextBucketId % GOLD_INCOME_BUCKET_COUNT;
+      this.goldIncomeTotal -= this.goldIncomeBuckets[index];
+      this.goldIncomeBucketIds[index] = nextBucketId;
+      this.goldIncomeBuckets[index] = 0n;
+    }
+    this.lastGoldIncomeBucket = bucketId;
+  }
+
+  private currentGoldIncomeBucket(): number {
+    return Math.floor(this.mg.ticks() / GOLD_INCOME_BUCKET_TICKS);
   }
 
   removeGold(toRemove: Gold): Gold {

--- a/tests/GameUpdateUtils.test.ts
+++ b/tests/GameUpdateUtils.test.ts
@@ -20,6 +20,7 @@ function makePlayerState(overrides: Partial<PlayerState> = {}): PlayerState {
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0,
+    goldPerMinute: 0,
     troops: 100,
     isTraitor: false,
     traitorRemainingTicks: 0,
@@ -66,9 +67,19 @@ describe("diffPlayerUpdate", () => {
     expect(diff.hasSpawned).toBeUndefined();
   });
 
-  it("ignores tilesOwned/gold/troops — they travel via packedPlayerUpdates", () => {
-    const prev = makePlayerUpdate({ gold: 100n, troops: 50, tilesOwned: 5 });
-    const next = makePlayerUpdate({ gold: 200n, troops: 75, tilesOwned: 9 });
+  it("ignores stat churn — it travels via packedPlayerUpdates", () => {
+    const prev = makePlayerUpdate({
+      gold: 100n,
+      goldPerMinute: 25,
+      troops: 50,
+      tilesOwned: 5,
+    });
+    const next = makePlayerUpdate({
+      gold: 200n,
+      goldPerMinute: 50,
+      troops: 75,
+      tilesOwned: 9,
+    });
     expect(diffPlayerUpdate(prev, next)).toBeNull();
   });
 
@@ -353,17 +364,23 @@ describe("applyStateUpdate", () => {
     applyStateUpdate(target, {
       type: GameUpdateType.Player,
       id: "p",
+      goldPerMinute: 500,
+    });
+    applyStateUpdate(target, {
+      type: GameUpdateType.Player,
+      id: "p",
       isAlive: false,
     });
     expect(target.gold).toBe(100);
     expect(target.troops).toBe(250);
+    expect(target.goldPerMinute).toBe(500);
     expect(target.isAlive).toBe(false);
   });
 });
 
 describe("diff + apply round-trip", () => {
   it("emitting full first + diff second reconstructs final state", () => {
-    // tilesOwned/gold/troops round-trip via packedPlayerUpdates instead
+    // tilesOwned/gold/goldPerMinute/troops round-trip via packedPlayerUpdates instead
     // (covered in tests/client/view/GameView.test.ts).
     const v0 = makePlayerUpdate({ betrayals: 0, allies: [] });
     const v1 = makePlayerUpdate({ betrayals: 2, allies: [2] });

--- a/tests/PackedPlayerUpdates.test.ts
+++ b/tests/PackedPlayerUpdates.test.ts
@@ -1,6 +1,6 @@
 /**
  * The worker→main tick payload: per-tick numeric stat churn travels on the
- * transferable `packedPlayerUpdates` quad buffer (drained from GameImpl),
+ * transferable `packedPlayerUpdates` record buffer (drained from GameImpl),
  * and `playerNameViewData` is attached only on ticks where the worker
  * recomputed name placements. See GameUpdateViewData in GameUpdates.ts.
  */
@@ -36,22 +36,24 @@ describe("packedPlayerUpdates (GameImpl drain)", () => {
     game.drainPackedPlayerUpdates(); // discard spawn-time churn
   });
 
-  test("a stat change is drained as a [smallID, tiles, gold, troops] quad", () => {
+  test("a stat change is drained as a [smallID, tiles, gold, goldPerMinute, troops] record", () => {
     alice.addGold(500n);
     game.executeNextTick();
     const packed = game.drainPackedPlayerUpdates();
     expect(packed).not.toBeNull();
-    // Find alice's quad (other players may have churned too).
-    let quad: number[] | undefined;
-    for (let i = 0; i + 3 < packed!.length; i += 4) {
+    const expectedGoldPerMinute = 600;
+    // Find alice's record (other players may have churned too).
+    let record: number[] | undefined;
+    for (let i = 0; i + 4 < packed!.length; i += 5) {
       if (packed![i] === alice.smallID()) {
-        quad = Array.from(packed!.subarray(i, i + 4));
+        record = Array.from(packed!.subarray(i, i + 5));
       }
     }
-    expect(quad).toEqual([
+    expect(record).toEqual([
       alice.smallID(),
       alice.numTilesOwned(),
       Number(alice.gold()),
+      expectedGoldPerMinute,
       alice.troops(),
     ]);
   });
@@ -134,17 +136,19 @@ describe("GameRunner payload cadence", () => {
     const gu = byTick.get(game.ticks())!;
     const packed = gu.packedPlayerUpdates;
     expect(packed).toBeDefined();
-    expect(packed!.length % 4).toBe(0);
-    let quad: number[] | undefined;
-    for (let i = 0; i + 3 < packed!.length; i += 4) {
+    expect(packed!.length % 5).toBe(0);
+    const expectedGoldPerMinute = 700;
+    let record: number[] | undefined;
+    for (let i = 0; i + 4 < packed!.length; i += 5) {
       if (packed![i] === alice.smallID()) {
-        quad = Array.from(packed!.subarray(i, i + 4));
+        record = Array.from(packed!.subarray(i, i + 5));
       }
     }
-    expect(quad).toEqual([
+    expect(record).toEqual([
       alice.smallID(),
       alice.numTilesOwned(),
       Number(alice.gold()),
+      expectedGoldPerMinute,
       alice.troops(),
     ]);
     // And the object channel no longer carries the stat fields: alice must

--- a/tests/PlayerUpdateDiff.test.ts
+++ b/tests/PlayerUpdateDiff.test.ts
@@ -83,7 +83,7 @@ describe("Player update diffing (toUpdate)", () => {
     expect(diff!.alliances).toBeUndefined();
   });
 
-  test("stat churn (gold/troops/tilesOwned) travels via statsOut, not the diff", () => {
+  test("stat churn travels via statsOut, not the diff", () => {
     const statsOut: number[] = [];
     alice.toUpdate(statsOut);
     statsOut.length = 0;
@@ -97,6 +97,7 @@ describe("Player update diffing (toUpdate)", () => {
       alice.smallID(),
       alice.numTilesOwned(),
       Number(alice.gold()),
+      123,
       alice.troops(),
     ]);
 
@@ -124,9 +125,90 @@ describe("Player update diffing (toUpdate)", () => {
     const full = dora.toUpdate(statsOut);
     expect(full).not.toBeNull();
     expect(full!.gold).toBe(dora.gold());
+    expect(full!.goldPerMinute).toBe(0);
     expect(full!.troops).toBe(dora.troops());
     expect(full!.tilesOwned).toBe(dora.numTilesOwned());
     expect(statsOut).toEqual([]);
+  });
+
+  test("goldPerMinute is packed from positive gold credited during the last 60 seconds", async () => {
+    const info = new PlayerInfo(
+      "income",
+      PlayerType.Human,
+      "income_client",
+      "income_id",
+    );
+    const incomeGame = await setup("plains", { infiniteTroops: true }, [info]);
+    const income = incomeGame.player("income_id");
+    income.toUpdate();
+
+    income.addGold(600n);
+    incomeGame.executeNextTick();
+    let packed = incomeGame.drainPackedPlayerUpdates();
+    let record: number[] | undefined;
+    for (let i = 0; i + 4 < packed!.length; i += 5) {
+      if (packed![i] === income.smallID()) {
+        record = Array.from(packed!.subarray(i, i + 5));
+      }
+    }
+
+    expect(record).toEqual([
+      income.smallID(),
+      income.numTilesOwned(),
+      Number(income.gold()),
+      600,
+      income.troops(),
+    ]);
+
+    let expired: number[] | undefined;
+    for (let i = 0; i < 600; i++) {
+      incomeGame.executeNextTick();
+      packed = incomeGame.drainPackedPlayerUpdates();
+      if (packed === null) continue;
+      for (let j = 0; j + 4 < packed.length; j += 5) {
+        if (packed[j] === income.smallID()) {
+          expired = Array.from(packed.subarray(j, j + 5));
+        }
+      }
+      if (expired?.[3] === 0) break;
+    }
+
+    expect(expired?.[3]).toBe(0);
+  });
+
+  test("donated gold does not count as recipient income", async () => {
+    const donorInfo = new PlayerInfo(
+      "donor",
+      PlayerType.Human,
+      "donor_client",
+      "donor_id",
+    );
+    const recipientInfo = new PlayerInfo(
+      "recipient",
+      PlayerType.Human,
+      "recipient_client",
+      "recipient_id",
+    );
+    const donationGame = await setup("plains", { infiniteTroops: true }, [
+      donorInfo,
+      recipientInfo,
+    ]);
+    const donor = donationGame.player("donor_id");
+    const recipient = donationGame.player("recipient_id");
+    donor.addGold(1000n);
+    recipient.toUpdate();
+
+    expect(donor.donateGold(recipient, 250n)).toBe(true);
+
+    const statsOut: number[] = [];
+    expect(recipient.toUpdate(statsOut)).toBeNull();
+    expect(statsOut).toEqual([
+      recipient.smallID(),
+      recipient.numTilesOwned(),
+      Number(recipient.gold()),
+      0,
+      recipient.troops(),
+    ]);
   });
 
   test("adding and removing an embargo shows up in consecutive diffs", () => {

--- a/tests/client/render/frame/derive/nuke-telegraphs.test.ts
+++ b/tests/client/render/frame/derive/nuke-telegraphs.test.ts
@@ -33,6 +33,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0,
+    goldPerMinute: 0,
     troops: 0,
     isTraitor: false,
     traitorRemainingTicks: 0,

--- a/tests/client/render/frame/derive/player-status.test.ts
+++ b/tests/client/render/frame/derive/player-status.test.ts
@@ -29,6 +29,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0,
+    goldPerMinute: 0,
     troops: 0,
     isTraitor: false,
     traitorRemainingTicks: 0,

--- a/tests/client/view/GameView.test.ts
+++ b/tests/client/view/GameView.test.ts
@@ -143,7 +143,7 @@ describe("GameView.update — players", () => {
 });
 
 describe("GameView.update — packed channels", () => {
-  it("packedPlayerUpdates quads update tilesOwned/gold/troops in place", () => {
+  it("packedPlayerUpdates records update tilesOwned/gold/goldPerMinute/troops in place", () => {
     const game = makeGameView();
     game.update(
       withPlayers(1, [
@@ -152,13 +152,14 @@ describe("GameView.update — packed channels", () => {
     );
 
     const gu = makeEmptyGu(2);
-    // [smallID, tilesOwned, gold, troops]
-    gu.packedPlayerUpdates = new Float64Array([1, 42, 999, 250]);
+    // [smallID, tilesOwned, gold, goldPerMinute, troops]
+    gu.packedPlayerUpdates = new Float64Array([1, 42, 999, 750, 250]);
     game.update(gu);
 
     const alice = game.player("alice");
     expect(alice.numTilesOwned()).toBe(42);
     expect(alice.gold()).toBe(999n);
+    expect(alice.goldPerMinute()).toBe(750);
     expect(alice.troops()).toBe(250);
   });
 
@@ -214,7 +215,7 @@ describe("GameView.update — packed channels", () => {
       withPlayers(1, [makePlayerUpdate({ id: "alice", smallID: 1 })]),
     );
     const gu = makeEmptyGu(2);
-    gu.packedPlayerUpdates = new Float64Array([99, 1, 1, 1]);
+    gu.packedPlayerUpdates = new Float64Array([99, 1, 1, 1, 1]);
     gu.packedAttackUpdates = new Float64Array([1, 0, 5, 123, 99, 1, 0, 7]);
     expect(() => game.update(gu)).not.toThrow();
   });
@@ -291,7 +292,7 @@ describe("GameView.update — packed channels", () => {
     );
     const bigGold = 2 ** 52 + 11; // integer, exactly representable in f64
     const gu = makeEmptyGu(2);
-    gu.packedPlayerUpdates = new Float64Array([1, 0, bigGold, 0]);
+    gu.packedPlayerUpdates = new Float64Array([1, 0, bigGold, 0, 0]);
     game.update(gu);
     expect(game.player("alice").gold()).toBe(BigInt(bigGold));
   });

--- a/tests/util/viewStubs.ts
+++ b/tests/util/viewStubs.ts
@@ -124,6 +124,7 @@ export function makePlayerUpdate(
     isDisconnected: false,
     tilesOwned: 0,
     gold: 0n,
+    goldPerMinute: 0,
     troops: 100,
     allies: [],
     embargoes: new Set(),


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue - unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4074

## Description:

Leaderboard update part 2. Adds the new leaderboard stat items on a branch based directly on main.

This adds rolling 60 second Gold/min tracking, sends it through packed player updates, and displays Gold/min, current Troops, and Cities in the in-game leaderboard.

The configurable column chooser is split out into #4453.

![Leaderboard](https://raw.githubusercontent.com/jsshap/OpenFrontIO/pr-4452-screenshots/pr-assets/4452/leaderboard.png)

Testing: `npx vitest tests/PackedPlayerUpdates.test.ts tests/PlayerUpdateDiff.test.ts tests/GameUpdateUtils.test.ts tests/client/view/GameView.test.ts --run`; `npx tsc --noEmit`; targeted ESLint/Prettier

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I have added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jsshap
