### PR TITLE
docs: remove Wicked Sick service-provider paragraph from privacy policy

### DIFF
--- a/resources/privacy-policy.html
+++ b/resources/privacy-policy.html
@@ -72,7 +72,7 @@
   </head>
   <body>
     <h1>Privacy Policy</h1>
-    <p class="updated-date"><strong>Last Updated: 5/13/2026</strong></p>
+    <p class="updated-date"><strong>Last Updated: 7/1/2026</strong></p>
 
     <p>
       This Privacy Policy explains how OpenFront Inc., a Delaware corporation
@@ -95,12 +95,6 @@
       2140 South Dupont Hwy<br />
       Camden, Kent County, DE 19934, United States<br />
       Email: <a href="mailto:legal@openfront.io">legal@openfront.io</a>
-    </p>
-    <p>
-      Day-to-day operational support and certain processing activities are
-      carried out on our behalf by Wicked Sick Limited (a company registered in
-      England and Wales, company number 11117702), acting as our service
-      provider.
     </p>
     <p>
       If you are a resident of the European Economic Area or the United Kingdom,


### PR DESCRIPTION
Remove the paragraph naming Wicked Sick Limited (company number 11117702) as a service provider from Section 1 ("Who We Are") and bump the "Last Updated" date.

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

Remove WS details from this

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

iiamlewis