### PR TITLE
docs: remove Wicked Sick service-provider paragraph from privacy policy

### DIFF
--- a/resources/privacy-policy.html
+++ b/resources/privacy-policy.html
@@ -72,7 +72,7 @@
   </head>
   <body>
     <h1>Privacy Policy</h1>
-    <p class="updated-date"><strong>Last Updated: 5/13/2026</strong></p>
+    <p class="updated-date"><strong>Last Updated: 7/1/2026</strong></p>
 
     <p>
       This Privacy Policy explains how OpenFront Inc., a Delaware corporation
@@ -95,12 +95,6 @@
       2140 South Dupont Hwy<br />
       Camden, Kent County, DE 19934, United States<br />
       Email: <a href="mailto:legal@openfront.io">legal@openfront.io</a>
-    </p>
-    <p>
-      Day-to-day operational support and certain processing activities are
-      carried out on our behalf by Wicked Sick Limited (a company registered in
-      England and Wales, company number 11117702), acting as our service
-      provider.
     </p>
     <p>
       If you are a resident of the European Economic Area or the United Kingdom,


### PR DESCRIPTION
Removes the paragraph in Section 1 ("Who We Are") of the privacy policy that named Wicked Sick Limited (company number 11117702) as a service provider, and bumps the "Last Updated" date to 7/1/2026.

- Repo-wide search confirmed no other references to "Wicked Sick" / "11117702" anywhere in the codebase.
- Section 1 reads correctly after removal (data-controller block flows into the EEA/UK representative paragraph).

Replaces closed PR #4471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)