### PR TITLE
Fix ad layout overlap and HUD conflicts

### DIFF
--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -664,3 +664,35 @@ news-button .active button::after {
 .remove-player-btn:hover {
   background: #ff6666;
 }
+
+/* Hide bottom rail ads in-game to prevent blocking controls and spawn phase selection */
+body.in-game [id^="pw-oop-bottom_rail"],
+body.in-game [id*="bottom_rail"],
+body.in-game [class*="bottom-rail"],
+body.in-game [id^="pw-bottom_rail"] {
+  display: none !important;
+  visibility: hidden !important;
+  pointer-events: none !important;
+}
+
+/* Prevent the in-game bottom-left ad wrapper from blocking map interactions on empty space */
+#in-game-promo-container {
+  pointer-events: none !important;
+}
+#in-game-promo-container > div {
+  pointer-events: auto !important;
+}
+
+/* Ensure out-of-page/anchor ads remain behind the bottom HUD (z-index 200) */
+[id^="pw-oop-"],
+[class*="pw-oop-"],
+[class*="pw-ad-"] {
+  z-index: 50 !important;
+}
+
+/* Prevent Google AdSense from overflowing/distorting parent modal containers */
+google-ad,
+.adsbygoogle {
+  max-height: 250px !important;
+  overflow: hidden !important;
+}


### PR DESCRIPTION
Resolves #4477

Description:
Adds CSS styling fixes to resolve ad layout and UI overlap issues that disrupt gameplay controls and modal interfaces:
1. Hides In-Game Bottom Rail Ads: Playwire/Ramp bottom rail ads ([id^="pw-oop-bottom_rail"]) are now completely hidden (display: none !important) when the player is in-game (body.in-game). This prevents the bottom rail ad from rendering over the main control panel and blocking spawn phase selection or troop controls.
2. Prevents Click Blocking on Empty Space: Changed the in-game bottom-left ad wrapper (#in-game-promo-container) to pointer-events: none so that clicking on empty/padding space inside the container does not block interactions with the game map. Only the child ad blocks themselves (#in-game-promo-container > div) retain pointer-events: auto.
3. Controls Z-Indexing: Ensures out-of-page/anchor ads remain behind the bottom HUD by setting their z-index to 50 (below the HUD's z-index of 200).
4. Constrains Google AdSense in Modals: Restricts Google AdSense element heights (google-ad, .adsbygoogle) to max-height: 250px inside modals to prevent them from distorting layouts or pushing buttons off-screen.

Please complete the following:
[x] I have added screenshots for all UI updates
[x] I process any text displayed to the user through translateText() and I've added it to the en.json file
[ ] I have added relevant tests to the test directory (N/A for CSS/layout changes)

Please put your Discord username so you can be contacted if a bug or regression is found:
blontd6
