### PR TITLE
Bugfix/leaderboard try again

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -391,6 +391,17 @@ export async function fetchPlayerLeaderboard(
     });
 
     if (!res.ok) {
+      if (res.status === 400) {
+        try {
+          const json = await res.json();
+          const message = json?.message ?? json?.error;
+          if (typeof message === "string" && message.toLowerCase().includes("page")) {
+            return "reached_limit";
+          }
+        } catch (_) {
+          // ignore
+        }
+      }
       console.warn(
         "fetchPlayerLeaderboard: unexpected status",
         res.status,


### PR DESCRIPTION
Resolves #4500

## Description:

Fixes a pagination bug on the 1v1 Ranked leaderboard modal where scrolling near the bottom of the first page triggers an infinite fetch loop/error and permanently displays a "Try Again" button in the footer.

**What was changed:**
- Modified `fetchPlayerLeaderboard` in `src/client/Api.ts` to check if a failed response (`!res.ok`) is a `400 Bad Request` containing a validation error about the page bounds.
- If so, it returns `"reached_limit"`, signaling the infinite-scroll component that it has successfully hit the end of the leaderboard pages, which stops further fetching and hides the error footer.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

blontd6

BEFORE:
<img width="738" height="461" alt="Screenshot 2026-07-03 at 9 41 58 PM" src="https://github.com/user-attachments/assets/e3bcec67-6262-4b55-abe8-dfd73057fdc2" />
AFTER:
<img width="768" height="571" alt="Screenshot 2026-07-03 at 9 41 40 PM" src="https://github.com/user-attachments/assets/489ef70e-56d8-489f-9e09-9f42afd71cbd" />
