### PR TITLE
feat(store): confirm plutonium and caps purchases before charging

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1295,6 +1295,8 @@
     "change_tier_success": "Switched to {tier}.",
     "checkout_failed": "Failed to create checkout session.",
     "confirm_downgrade": "Downgrade to {tier}? You'll get account credit for the unused portion of your current plan.",
+    "confirm_purchase_body": "Buy {item} for {amount, number} {currency}?",
+    "confirm_purchase_title": "Confirm Purchase",
     "confirm_upgrade": "Upgrade to {tier}? You'll be charged the prorated difference now.",
     "currency_pack_purchase_success": "Currency pack purchase successful!",
     "effects": "Effects",

--- a/src/client/components/CosmeticContainer.ts
+++ b/src/client/components/CosmeticContainer.ts
@@ -344,6 +344,14 @@ export class CosmeticContainer extends LitElement {
       this.onPurchaseSoft,
     ].filter(Boolean);
     if (handlers.length === 1 && !this._loading) {
+      // Plutonium purchases go through the confirmation dialog instead of
+      // firing immediately.
+      if (handlers[0] === this.onPurchaseHard) {
+        (
+          this.querySelector("purchase-button") as PurchaseButton | null
+        )?.requestHardPurchase();
+        return;
+      }
       this._loading = true;
       this._showLoadingOverlay();
       Promise.resolve(handlers[0]!())
@@ -468,6 +476,7 @@ export class CosmeticContainer extends LitElement {
             .rarity=${this.rarity}
             .dollarLabelKey=${this.dollarLabelKey}
             .priceSuffix=${this.priceSuffix}
+            .itemName=${this.name}
             .onPurchaseDollar=${this.onPurchaseDollar}
             .onPurchaseHard=${this.onPurchaseHard}
             .onPurchaseSoft=${this.onPurchaseSoft}

--- a/src/client/components/CosmeticContainer.ts
+++ b/src/client/components/CosmeticContainer.ts
@@ -344,12 +344,17 @@ export class CosmeticContainer extends LitElement {
       this.onPurchaseSoft,
     ].filter(Boolean);
     if (handlers.length === 1 && !this._loading) {
-      // Plutonium purchases go through the confirmation dialog instead of
+      // Currency purchases go through the confirmation dialog instead of
       // firing immediately.
-      if (handlers[0] === this.onPurchaseHard) {
+      if (
+        handlers[0] === this.onPurchaseHard ||
+        handlers[0] === this.onPurchaseSoft
+      ) {
         (
           this.querySelector("purchase-button") as PurchaseButton | null
-        )?.requestHardPurchase();
+        )?.requestCurrencyPurchase(
+          handlers[0] === this.onPurchaseHard ? "hard" : "soft",
+        );
         return;
       }
       this._loading = true;

--- a/src/client/components/PurchaseButton.ts
+++ b/src/client/components/PurchaseButton.ts
@@ -202,7 +202,7 @@ export class PurchaseButton extends LitElement {
   @property({ type: String })
   priceSuffix: string = "";
 
-  /** Display name of the item, used in the plutonium confirmation dialog. */
+  /** Display name of the item, used in the currency confirmation dialog. */
   @property({ type: String })
   itemName: string = "";
 
@@ -217,8 +217,8 @@ export class PurchaseButton extends LitElement {
 
   /** Set when a purchase fails for lack of funds; drives the dialog. */
   @state() private insufficient: InsufficientCurrency | null = null;
-  /** True while the plutonium confirmation dialog is open. */
-  @state() private confirmingHard = false;
+  /** Which currency purchase is awaiting confirmation, if any. */
+  @state() private confirmingCurrency: "hard" | "soft" | null = null;
   private busy = false;
 
   createRenderRoot() {
@@ -230,10 +230,12 @@ export class PurchaseButton extends LitElement {
     this.executePurchase(handler);
   }
 
-  /** Opens the plutonium confirmation dialog; the purchase runs on confirm. */
-  requestHardPurchase() {
-    if (!this.onPurchaseHard || this.busy) return;
-    this.confirmingHard = true;
+  /** Opens the currency confirmation dialog; the purchase runs on confirm. */
+  requestCurrencyPurchase(method: "hard" | "soft") {
+    const handler =
+      method === "hard" ? this.onPurchaseHard : this.onPurchaseSoft;
+    if (!handler || this.busy) return;
+    this.confirmingCurrency = method;
   }
 
   private executePurchase(handler?: () => Promise<PurchaseResult>) {
@@ -282,7 +284,7 @@ export class PurchaseButton extends LitElement {
          hover:bg-green-500 hover:border-green-400 hover:text-white hover:shadow-[0_0_20px_rgba(74,222,128,0.6)]"
         @click=${(e: Event) => {
           e.stopPropagation();
-          this.requestHardPurchase();
+          this.requestCurrencyPurchase("hard");
         }}
       >
         <plutonium-icon .size=${20} style="margin-top:3px"></plutonium-icon>
@@ -296,7 +298,10 @@ export class PurchaseButton extends LitElement {
       <button
         class="purchase-sparkle-btn-soft relative overflow-hidden w-full px-2 py-1.5 bg-amber-700/20 text-amber-600 border border-amber-700/30 rounded-lg text-base font-bold cursor-pointer transition-all duration-200 flex items-center justify-center gap-2
          hover:bg-amber-700 hover:border-amber-600 hover:text-white hover:shadow-[0_0_20px_rgba(217,119,6,0.6)]"
-        @click=${(e: Event) => this.handleClick(e, this.onPurchaseSoft)}
+        @click=${(e: Event) => {
+          e.stopPropagation();
+          this.requestCurrencyPurchase("soft");
+        }}
       >
         <cap-icon .size=${22} style="margin-top:3px"></cap-icon>
         ${this.priceSoft!.toLocaleString()}
@@ -332,20 +337,31 @@ export class PurchaseButton extends LitElement {
           ${hasSoft ? this.renderSoftButton() : null}
         </div>
       </div>
-      ${this.confirmingHard
+      ${this.confirmingCurrency
         ? html`<confirm-dialog
             .heading=${translateText("store.confirm_purchase_title")}
             .message=${translateText("store.confirm_purchase_body", {
               item: this.itemName,
-              amount: this.priceHard ?? 0,
-              currency: translateText("cosmetics.hard"),
+              amount:
+                (this.confirmingCurrency === "hard"
+                  ? this.priceHard
+                  : this.priceSoft) ?? 0,
+              currency: translateText(
+                this.confirmingCurrency === "hard"
+                  ? "cosmetics.hard"
+                  : "cosmetics.soft",
+              ),
             })}
             variant="warning"
             @confirm=${() => {
-              this.confirmingHard = false;
-              this.executePurchase(this.onPurchaseHard);
+              const handler =
+                this.confirmingCurrency === "hard"
+                  ? this.onPurchaseHard
+                  : this.onPurchaseSoft;
+              this.confirmingCurrency = null;
+              this.executePurchase(handler);
             }}
-            @cancel=${() => (this.confirmingHard = false)}
+            @cancel=${() => (this.confirmingCurrency = null)}
           ></confirm-dialog>`
         : nothing}
       <insufficient-currency-dialog

--- a/src/client/components/PurchaseButton.ts
+++ b/src/client/components/PurchaseButton.ts
@@ -4,6 +4,7 @@ import { Product } from "../../core/CosmeticSchemas";
 import type { InsufficientCurrency, PurchaseResult } from "../Cosmetics";
 import { translateText } from "../Utils";
 import "./CapIcon";
+import "./ConfirmDialog";
 import "./InsufficientCurrencyDialog";
 import "./PlutoniumIcon";
 
@@ -201,6 +202,10 @@ export class PurchaseButton extends LitElement {
   @property({ type: String })
   priceSuffix: string = "";
 
+  /** Display name of the item, used in the plutonium confirmation dialog. */
+  @property({ type: String })
+  itemName: string = "";
+
   @property({ type: Function })
   onPurchaseDollar?: () => Promise<PurchaseResult>;
 
@@ -212,6 +217,8 @@ export class PurchaseButton extends LitElement {
 
   /** Set when a purchase fails for lack of funds; drives the dialog. */
   @state() private insufficient: InsufficientCurrency | null = null;
+  /** True while the plutonium confirmation dialog is open. */
+  @state() private confirmingHard = false;
   private busy = false;
 
   createRenderRoot() {
@@ -220,6 +227,16 @@ export class PurchaseButton extends LitElement {
 
   private handleClick(e: Event, handler?: () => Promise<PurchaseResult>) {
     e.stopPropagation();
+    this.executePurchase(handler);
+  }
+
+  /** Opens the plutonium confirmation dialog; the purchase runs on confirm. */
+  requestHardPurchase() {
+    if (!this.onPurchaseHard || this.busy) return;
+    this.confirmingHard = true;
+  }
+
+  private executePurchase(handler?: () => Promise<PurchaseResult>) {
     if (!handler || this.busy) return;
     this.busy = true;
     const container = this.closest("cosmetic-container") as HTMLElement | null;
@@ -263,7 +280,10 @@ export class PurchaseButton extends LitElement {
       <button
         class="purchase-sparkle-btn-hard relative overflow-hidden w-full px-2 py-1.5 bg-green-500/20 text-green-400 border border-green-500/30 rounded-lg text-base font-bold cursor-pointer transition-all duration-200 flex items-center justify-center gap-2
          hover:bg-green-500 hover:border-green-400 hover:text-white hover:shadow-[0_0_20px_rgba(74,222,128,0.6)]"
-        @click=${(e: Event) => this.handleClick(e, this.onPurchaseHard)}
+        @click=${(e: Event) => {
+          e.stopPropagation();
+          this.requestHardPurchase();
+        }}
       >
         <plutonium-icon .size=${20} style="margin-top:3px"></plutonium-icon>
         ${this.priceHard!.toLocaleString()}
@@ -312,6 +332,22 @@ export class PurchaseButton extends LitElement {
           ${hasSoft ? this.renderSoftButton() : null}
         </div>
       </div>
+      ${this.confirmingHard
+        ? html`<confirm-dialog
+            .heading=${translateText("store.confirm_purchase_title")}
+            .message=${translateText("store.confirm_purchase_body", {
+              item: this.itemName,
+              amount: this.priceHard ?? 0,
+              currency: translateText("cosmetics.hard"),
+            })}
+            variant="warning"
+            @confirm=${() => {
+              this.confirmingHard = false;
+              this.executePurchase(this.onPurchaseHard);
+            }}
+            @cancel=${() => (this.confirmingHard = false)}
+          ></confirm-dialog>`
+        : nothing}
       <insufficient-currency-dialog
         .info=${this.insufficient}
         @close=${() => (this.insufficient = null)}


### PR DESCRIPTION
## Summary

Fixes #4218

Currency purchases (Plutonium and Caps) fired immediately on click with no confirmation. This adds a confirmation modal — reusing the existing `confirm-dialog` Lit component — that gates every currency purchase behind an explicit "Confirm".

There were two paths that could trigger a currency purchase, and both are now gated:

- **The Plutonium / Caps price buttons** — `PurchaseButton` no longer calls `onPurchaseHard`/`onPurchaseSoft` directly; it opens a `confirm-dialog` ("Buy {item} for {amount} {currency}?", warning variant) and only runs the purchase on confirm. Cancel / backdrop click dismisses.
- **Whole-card click** — `CosmeticContainer` auto-fires the purchase when there's exactly one payment option, which bypassed the button entirely for currency-only items. That path now delegates to the purchase button's new `requestCurrencyPurchase()` so it goes through the same dialog.

The existing purchase flow (busy guard, loading overlay, insufficient-currency dialog) is unchanged and runs after confirmation. Dollar purchases are untouched (they go through Stripe checkout, which is its own confirmation step).

New i18n keys: `store.confirm_purchase_title`, `store.confirm_purchase_body` (en.json only, per Crowdin convention).

## Test plan

- [x] ESLint, `tsc --noEmit`, Prettier pass
- [ ] Manual check in staging: click a Plutonium or Caps price button → dialog appears with the right currency name and amount; confirm purchases, cancel doesn't
- [ ] Manual check: click the card body of a currency-only item → same dialog (not an instant purchase)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
