### PR TITLE
fix(client): prevent Google CCPA button from shifting layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,6 +33,18 @@
         z-index: 150 !important;
       }
 
+      /* Google Funding Choices CCPA link override */
+      .fc-dns-link,
+      .fc-ccpa-root,
+      .fc-consent-root {
+        position: fixed !important;
+        z-index: 999999 !important;
+      }
+      .fc-dns-link {
+        bottom: 15px !important;
+        left: 15px !important;
+      }
+
       /* Ensure full viewport height on iOS */
       html,
       body {


### PR DESCRIPTION
## Description:

When Google Funding Choices CMP dynamically injects the CCPA "Do Not Sell or Share My Personal Information" button (`.fc-dns-link`) directly into the document `<body>`, it becomes a flex child because the body uses a `flex flex-row` layout. This pushes the main page container to the left.
The PR fixes that.

## Please complete the following:

- [x] I have added screenshots for all UI updates *(Tick this if you took a screenshot of the injected button)*
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory 

## Please put your Discord username so you can be contacted if a bug or regression is found:

blontd6
<img width="1470" height="839" alt="Screenshot 2026-07-06 at 7 58 47 PM" src="https://github.com/user-attachments/assets/b8aa20e4-c3af-4cf5-a382-3c4c732bff49" />
