### PR TITLE
fix(crazygames): guest username on logout, hide fullscreen, in-game pop-ups

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -35,6 +35,7 @@ import {
 } from "../core/game/UserSettings";
 import { WorkerClient } from "../core/worker/WorkerClient";
 import { getPersistentID } from "./Auth";
+import { showInGameAlert } from "./InGameModal";
 import {
   AutoUpgradeEvent,
   DoBoatAttackEvent,
@@ -218,14 +219,15 @@ export function joinLobby(
           }),
         );
       } else if (message.error === "kick_reason.host_left") {
-        alert(translateText("kick_reason.host_left"));
-        document.dispatchEvent(
-          new CustomEvent("leave-lobby", {
-            detail: { lobby: lobbyConfig.gameID, cause: "host-left" },
-            bubbles: true,
-            composed: true,
-          }),
-        );
+        showInGameAlert(translateText("kick_reason.host_left")).then(() => {
+          document.dispatchEvent(
+            new CustomEvent("leave-lobby", {
+              detail: { lobby: lobbyConfig.gameID, cause: "host-left" },
+              bubbles: true,
+              composed: true,
+            }),
+          );
+        });
       } else {
         showErrorModal(
           message.error,

--- a/src/client/InGameModal.ts
+++ b/src/client/InGameModal.ts
@@ -1,0 +1,133 @@
+import { html, LitElement } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { crazyGamesSDK } from "./CrazyGamesSDK";
+import { translateText } from "./Utils";
+
+type Resolver = (confirmed: boolean) => void;
+
+/**
+ * A lightweight in-game replacement for the native `confirm()` / `alert()`
+ * browser dialogs. CrazyGames does not allow native browser prompts inside the
+ * game frame, so these must be rendered in-game. While a pop-up is displayed we
+ * report gameplay as stopped to CrazyGames (and resume it when dismissed).
+ */
+@customElement("in-game-modal")
+export class InGameModal extends LitElement {
+  @state() private isVisible = false;
+  @state() private message = "";
+  @state() private showCancel = true;
+  private resolver: Resolver | null = null;
+
+  createRenderRoot() {
+    // Light DOM so Tailwind classes apply.
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    window.addEventListener("keydown", this.onKeyDown);
+  }
+
+  disconnectedCallback() {
+    window.removeEventListener("keydown", this.onKeyDown);
+    super.disconnectedCallback();
+  }
+
+  open(message: string, showCancel: boolean): Promise<boolean> {
+    // Dismiss any dialog already on screen before showing the new one.
+    this.resolver?.(false);
+
+    this.message = message;
+    this.showCancel = showCancel;
+    this.isVisible = true;
+    this.requestUpdate();
+
+    crazyGamesSDK.gameplayStop();
+
+    return new Promise<boolean>((resolve) => {
+      this.resolver = resolve;
+    });
+  }
+
+  private close(confirmed: boolean) {
+    if (!this.isVisible) return;
+    this.isVisible = false;
+    this.requestUpdate();
+
+    crazyGamesSDK.gameplayStart();
+
+    const resolve = this.resolver;
+    this.resolver = null;
+    resolve?.(confirmed);
+  }
+
+  private onKeyDown = (e: KeyboardEvent) => {
+    if (!this.isVisible) return;
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this.close(false);
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      this.close(true);
+    }
+  };
+
+  render() {
+    if (!this.isVisible) return null;
+    return html`
+      <div
+        class="fixed inset-0 z-[10000] flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs"
+        @click=${(e: MouseEvent) => {
+          if (e.target === e.currentTarget) this.close(false);
+        }}
+        @contextmenu=${(e: Event) => e.preventDefault()}
+      >
+        <div
+          class="bg-slate-800 border border-slate-600 rounded-lg max-w-sm w-full p-6 shadow-xl"
+        >
+          <div class="text-white text-base whitespace-pre-line mb-6">
+            ${this.message}
+          </div>
+          <div class="flex justify-end gap-3">
+            ${this.showCancel
+              ? html`<button
+                  class="px-4 py-2 rounded-md text-sm font-medium text-white bg-slate-600 hover:bg-slate-500 transition-colors"
+                  @click=${() => this.close(false)}
+                >
+                  ${translateText("common.cancel")}
+                </button>`
+              : null}
+            <button
+              class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 transition-colors"
+              @click=${() => this.close(true)}
+            >
+              ${this.showCancel
+                ? translateText("common.confirm")
+                : translateText("common.close")}
+            </button>
+          </div>
+        </div>
+      </div>
+    `;
+  }
+}
+
+let instance: InGameModal | null = null;
+
+function getInstance(): InGameModal {
+  if (instance === null) {
+    instance = document.createElement("in-game-modal") as InGameModal;
+    document.body.appendChild(instance);
+  }
+  return instance;
+}
+
+/** In-game replacement for `confirm()`. Resolves true when confirmed. */
+export function showInGameConfirm(message: string): Promise<boolean> {
+  return getInstance().open(message, true);
+}
+
+/** In-game replacement for `alert()`. Resolves once dismissed. */
+export function showInGameAlert(message: string): Promise<boolean> {
+  return getInstance().open(message, false);
+}

--- a/src/client/InGameModal.ts
+++ b/src/client/InGameModal.ts
@@ -1,133 +1,47 @@
-import { html, LitElement } from "lit";
-import { customElement, state } from "lit/decorators.js";
+import "./components/ConfirmDialog";
+import { ConfirmDialog } from "./components/ConfirmDialog";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { translateText } from "./Utils";
 
-type Resolver = (confirmed: boolean) => void;
-
 /**
- * A lightweight in-game replacement for the native `confirm()` / `alert()`
- * browser dialogs. CrazyGames does not allow native browser prompts inside the
- * game frame, so these must be rendered in-game. While a pop-up is displayed we
- * report gameplay as stopped to CrazyGames (and resume it when dismissed).
+ * Promise-based, imperative replacements for the native `confirm()` / `alert()`
+ * browser dialogs, for use during gameplay (CrazyGames disallows native prompts
+ * inside the game frame). These wrap the shared <confirm-dialog> component so
+ * the styling stays consistent with the rest of the app, and are callable from
+ * non-Lit contexts (WebSocket handlers, popstate, etc.).
+ *
+ * While a pop-up is displayed we report gameplay as stopped to CrazyGames, and
+ * resume it once dismissed.
  */
-@customElement("in-game-modal")
-export class InGameModal extends LitElement {
-  @state() private isVisible = false;
-  @state() private message = "";
-  @state() private showCancel = true;
-  private resolver: Resolver | null = null;
+function showDialog(props: Partial<ConfirmDialog>): Promise<boolean> {
+  const dialog = document.createElement("confirm-dialog") as ConfirmDialog;
+  Object.assign(dialog, props);
 
-  createRenderRoot() {
-    // Light DOM so Tailwind classes apply.
-    return this;
-  }
+  crazyGamesSDK.gameplayStop();
+  document.body.appendChild(dialog);
 
-  connectedCallback() {
-    super.connectedCallback();
-    window.addEventListener("keydown", this.onKeyDown);
-  }
-
-  disconnectedCallback() {
-    window.removeEventListener("keydown", this.onKeyDown);
-    super.disconnectedCallback();
-  }
-
-  open(message: string, showCancel: boolean): Promise<boolean> {
-    // Dismiss any dialog already on screen before showing the new one.
-    this.resolver?.(false);
-
-    this.message = message;
-    this.showCancel = showCancel;
-    this.isVisible = true;
-    this.requestUpdate();
-
-    crazyGamesSDK.gameplayStop();
-
-    return new Promise<boolean>((resolve) => {
-      this.resolver = resolve;
-    });
-  }
-
-  private close(confirmed: boolean) {
-    if (!this.isVisible) return;
-    this.isVisible = false;
-    this.requestUpdate();
-
-    crazyGamesSDK.gameplayStart();
-
-    const resolve = this.resolver;
-    this.resolver = null;
-    resolve?.(confirmed);
-  }
-
-  private onKeyDown = (e: KeyboardEvent) => {
-    if (!this.isVisible) return;
-    if (e.key === "Escape") {
-      e.preventDefault();
-      this.close(false);
-    } else if (e.key === "Enter") {
-      e.preventDefault();
-      this.close(true);
-    }
-  };
-
-  render() {
-    if (!this.isVisible) return null;
-    return html`
-      <div
-        class="fixed inset-0 z-[10000] flex items-center justify-center p-4 bg-black/60 backdrop-blur-xs"
-        @click=${(e: MouseEvent) => {
-          if (e.target === e.currentTarget) this.close(false);
-        }}
-        @contextmenu=${(e: Event) => e.preventDefault()}
-      >
-        <div
-          class="bg-slate-800 border border-slate-600 rounded-lg max-w-sm w-full p-6 shadow-xl"
-        >
-          <div class="text-white text-base whitespace-pre-line mb-6">
-            ${this.message}
-          </div>
-          <div class="flex justify-end gap-3">
-            ${this.showCancel
-              ? html`<button
-                  class="px-4 py-2 rounded-md text-sm font-medium text-white bg-slate-600 hover:bg-slate-500 transition-colors"
-                  @click=${() => this.close(false)}
-                >
-                  ${translateText("common.cancel")}
-                </button>`
-              : null}
-            <button
-              class="px-4 py-2 rounded-md text-sm font-medium text-white bg-blue-600 hover:bg-blue-500 transition-colors"
-              @click=${() => this.close(true)}
-            >
-              ${this.showCancel
-                ? translateText("common.confirm")
-                : translateText("common.close")}
-            </button>
-          </div>
-        </div>
-      </div>
-    `;
-  }
-}
-
-let instance: InGameModal | null = null;
-
-function getInstance(): InGameModal {
-  if (instance === null) {
-    instance = document.createElement("in-game-modal") as InGameModal;
-    document.body.appendChild(instance);
-  }
-  return instance;
+  return new Promise<boolean>((resolve) => {
+    const done = (result: boolean) => {
+      dialog.remove();
+      crazyGamesSDK.gameplayStart();
+      resolve(result);
+    };
+    dialog.addEventListener("confirm", () => done(true));
+    dialog.addEventListener("cancel", () => done(false));
+  });
 }
 
 /** In-game replacement for `confirm()`. Resolves true when confirmed. */
 export function showInGameConfirm(message: string): Promise<boolean> {
-  return getInstance().open(message, true);
+  return showDialog({ message, variant: "danger", buttons: "confirmCancel" });
 }
 
 /** In-game replacement for `alert()`. Resolves once dismissed. */
 export function showInGameAlert(message: string): Promise<boolean> {
-  return getInstance().open(message, false);
+  return showDialog({
+    message,
+    variant: "warning",
+    buttons: "confirmOnly",
+    confirmText: translateText("common.close"),
+  });
 }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -35,6 +35,7 @@ import "./GoogleAdElement";
 import { HelpModal } from "./HelpModal";
 import "./HomepagePromos";
 import { HostLobbyModal as HostPrivateLobbyModal } from "./HostLobbyModal";
+import { showInGameConfirm } from "./InGameModal";
 import { JoinLobbyModal } from "./JoinLobbyModal";
 import "./LangSelector";
 import { LangSelector } from "./LangSelector";
@@ -586,6 +587,13 @@ class Client {
       onJoinChanged();
     };
 
+    const leaveGame = () => {
+      crazyGamesSDK.gameplayStop().then(() => {
+        // redirect to the home page
+        window.location.href = "/";
+      });
+    };
+
     const onPopState = () => {
       if (this.currentUrl !== null && this.lobbyHandle !== null) {
         console.info("Game is active");
@@ -593,23 +601,20 @@ class Client {
         if (!this.lobbyHandle.stop()) {
           console.info("Player is active, ask before leaving game");
 
-          const isConfirmed = confirm(
-            translateText("help_modal.exit_confirmation"),
+          // We can't block navigation on an async confirmation, so restore the
+          // history entry immediately and only leave once the player confirms.
+          history.pushState(null, "", this.currentUrl);
+          showInGameConfirm(translateText("help_modal.exit_confirmation")).then(
+            (isConfirmed) => {
+              if (isConfirmed) leaveGame();
+            },
           );
-
-          if (!isConfirmed) {
-            // Rollback navigator history
-            history.pushState(null, "", this.currentUrl);
-            return;
-          }
+          return;
         }
 
         console.info("Player is not active, leave the game immediately");
 
-        crazyGamesSDK.gameplayStop().then(() => {
-          // redirect to the home page
-          window.location.href = "/";
-        });
+        leaveGame();
       } else {
         console.info("Game not active, handle hash update");
 

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -30,6 +30,7 @@ import {
 import { replacer } from "../core/Util";
 import { getPlayToken } from "./Auth";
 import { LobbyConfig } from "./ClientGameRunner";
+import { showInGameAlert } from "./InGameModal";
 import { LocalServer } from "./LocalServer";
 import { PlayerView } from "./view";
 
@@ -387,8 +388,7 @@ export class Transport {
         `WebSocket closed. Code: ${event.code}, Reason: ${event.reason}`,
       );
       if (event.code === 1002) {
-        // TODO: make this a modal
-        alert(`connection refused: ${event.reason}`);
+        showInGameAlert(`connection refused: ${event.reason}`);
       } else if (event.code !== 1000) {
         console.log(`received error code ${event.code}, reconnecting`);
         this.reconnect();

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -90,18 +90,30 @@ export class UsernameInput extends LitElement {
     });
   }
 
+  // True once a CrazyGames account has been signed in, so that a later logout
+  // (auth listener firing with `null`) reverts to a guest username instead of
+  // keeping the CrazyGames name.
+  private crazyGamesLoggedIn = false;
+
   connectedCallback() {
     super.connectedCallback();
     this.loadStoredUsername();
     crazyGamesSDK.getUsername().then((username) => {
       if (username) {
+        this.crazyGamesLoggedIn = true;
         this.baseUsername = username;
         this.validateAndStore();
       }
     });
     crazyGamesSDK.addAuthListener((user) => {
       if (user) {
+        this.crazyGamesLoggedIn = true;
         this.baseUsername = user.username;
+        this.validateAndStore();
+      } else if (this.crazyGamesLoggedIn) {
+        // Logged out of CrazyGames — revert to a fresh guest username.
+        this.crazyGamesLoggedIn = false;
+        this.baseUsername = genAnonUsername();
         this.validateAndStore();
       }
     });

--- a/src/client/hud/layers/GameRightSidebar.ts
+++ b/src/client/hud/layers/GameRightSidebar.ts
@@ -6,6 +6,7 @@ import { GameType } from "../../../core/game/Game";
 import "../../components/DoomsdayClockPanel";
 import { Controller } from "../../Controller";
 import { crazyGamesSDK } from "../../CrazyGamesSDK";
+import { showInGameConfirm } from "../../InGameModal";
 import { TogglePauseIntentEvent } from "../../InputHandler";
 import { PauseGameIntentEvent, SendWinnerEvent } from "../../Transport";
 import { translateText } from "../../Utils";
@@ -45,6 +46,8 @@ export class GameRightSidebar extends LitElement implements Controller {
   @state()
   private timer: number = 0;
 
+  // CrazyGames provides its own fullscreen control in the game frame, so hide ours.
+  private readonly onCrazyGames = crazyGamesSDK.isOnCrazyGames();
   private hasWinner = false;
   private isLobbyCreator = false;
   private spawnBarVisible = false;
@@ -194,7 +197,7 @@ export class GameRightSidebar extends LitElement implements Controller {
   private async onExitButtonClick() {
     const isAlive = this.game.myPlayer()?.isAlive();
     if (isAlive) {
-      const isConfirmed = confirm(
+      const isConfirmed = await showInGameConfirm(
         translateText("help_modal.exit_confirmation"),
       );
       if (!isConfirmed) return;
@@ -250,7 +253,7 @@ export class GameRightSidebar extends LitElement implements Controller {
           <img src=${settingsIcon} alt="settings" width="20" height="20" />
         </div>
 
-        ${document.fullscreenEnabled
+        ${document.fullscreenEnabled && !this.onCrazyGames
           ? html`<div
               class="cursor-pointer"
               @click=${this.onFullscreenButtonClick}

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -167,12 +167,17 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
   }
 
   private pauseGame(pause: boolean) {
+    // CrazyGames: report gameplay as stopped whenever this settings menu is open,
+    // and resumed when it closes — unless the game was already paused when opened.
+    if (pause) {
+      crazyGamesSDK.gameplayStop();
+    } else if (!this.wasPausedWhenOpened) {
+      crazyGamesSDK.gameplayStart();
+    }
+
+    // Only pause the simulation itself when we own the pause (singleplayer or
+    // lobby creator).
     if (this.shouldPause && !this.wasPausedWhenOpened) {
-      if (pause) {
-        crazyGamesSDK.gameplayStop();
-      } else {
-        crazyGamesSDK.gameplayStart();
-      }
       this.eventBus.emit(new PauseGameIntentEvent(pause));
     }
   }

--- a/src/client/hud/layers/PlayerModerationModal.ts
+++ b/src/client/hud/layers/PlayerModerationModal.ts
@@ -4,6 +4,7 @@ import { assetUrl } from "../../../core/AssetUrls";
 import { EventBus } from "../../../core/EventBus";
 import { PlayerType } from "../../../core/game/Game";
 import { actionButton } from "../../components/ui/ActionButton";
+import { showInGameConfirm } from "../../InGameModal";
 import { SendKickPlayerIntentEvent } from "../../Transport";
 import { translateText } from "../../Utils";
 import { PlayerView } from "../../view";
@@ -52,7 +53,7 @@ export class PlayerModerationModal extends LitElement {
     );
   }
 
-  private handleKickClick = (e: MouseEvent) => {
+  private handleKickClick = async (e: MouseEvent) => {
     e.stopPropagation();
 
     const my = this.myPlayer;
@@ -66,7 +67,7 @@ export class PlayerModerationModal extends LitElement {
     const targetClientID = other.clientID();
     if (!targetClientID || targetClientID.length === 0) return;
 
-    const confirmed = confirm(
+    const confirmed = await showInGameConfirm(
       translateText("player_panel.kick_confirm", { name: other.displayName() }),
     );
     if (!confirmed) return;

--- a/src/client/hud/layers/SettingsModal.ts
+++ b/src/client/hud/layers/SettingsModal.ts
@@ -108,12 +108,17 @@ export class SettingsModal extends LitElement implements Controller {
   }
 
   private pauseGame(pause: boolean) {
+    // CrazyGames: report gameplay as stopped whenever the settings menu is open,
+    // and resumed when it closes — unless the game was already paused when opened.
+    if (pause) {
+      crazyGamesSDK.gameplayStop();
+    } else if (!this.wasPausedWhenOpened) {
+      crazyGamesSDK.gameplayStart();
+    }
+
+    // Only pause the simulation itself when we own the pause (singleplayer or
+    // lobby creator).
     if (this.shouldPause && !this.wasPausedWhenOpened) {
-      if (pause) {
-        crazyGamesSDK.gameplayStop();
-      } else {
-        crazyGamesSDK.gameplayStart();
-      }
       this.eventBus.emit(new PauseGameIntentEvent(pause));
     }
   }


### PR DESCRIPTION
Addresses four requests from the CrazyGames platform team.

## 1. Username reverts to guest on CrazyGames logout
When a player logged into their CrazyGames account and then logged out, the username stayed the CrazyGames name. It now reverts to a fresh guest (`AnonXXX`) name. A `crazyGamesLoggedIn` flag guards this so it only fires on a real login→logout transition (not on the initial "not logged in" state, which would otherwise wipe a stored name).

## 2. Fullscreen button hidden on CrazyGames
CrazyGames provides its own fullscreen control in the game frame, so our in-game fullscreen button is now hidden when running on CrazyGames (and unchanged everywhere else).

## 3. Native browser prompts → in-game pop-ups
New `InGameModal` provides promise-based `showInGameConfirm()` / `showInGameAlert()` rendered as a real in-game modal (styled to match the Settings modal). Every native `confirm()`/`alert()` shown **during gameplay** now uses it:
- Exit-game confirmation (right sidebar + browser-back path)
- Kick-player confirmation
- Host-left notice (dispatches leave-lobby only after dismiss, preserving the old blocking UX)
- Connection-refused notice (also removes a stale `// TODO: make this a modal`)

## 4. `gameplayStop` when Settings menu / pop-up is open
- The pop-up itself reports `gameplayStop()` while shown and `gameplayStart()` on dismiss.
- Settings + Graphics Settings modals now report `gameplayStop` whenever the menu is open — previously it only fired when the modal *also* paused the sim (singleplayer / lobby-creator), so regular multiplayer players never triggered it. Also fixes graphics-settings so gameplay resumes correctly on close for those players.

## Scope
Per request, this covers **in-game dialogs only**. The main-menu native alerts (store/checkout, account, subscriptions, friends, login) were intentionally left as-is.

## Testing
- `tsc --noEmit`, `eslint`, and `prettier --check` all pass.
- Verified the confirm and alert pop-ups render correctly in the running app, and Cancel resolves the promise to `false` and dismisses the overlay.
- CrazyGames-iframe-only behaviors (username revert, `gameplayStop`, fullscreen hiding) are verified by code inspection — they require running inside the actual CrazyGames frame.

🤖 Generated with [Claude Code](https://claude.com/claude-code)