### PR TITLE
fix(server): add stop mechanism to startPolling (#2921)

### DIFF
--- a/src/server/PollingLoop.ts
+++ b/src/server/PollingLoop.ts
@@ -3,22 +3,54 @@ import { logger } from "./Logger";
 const log = logger.child({ comp: "polling" });
 
 /**
+ * Handle returned by {@link startPolling}. Calling {@link PollingHandle.stop}
+ * cancels any pending scheduled execution and prevents an in-flight task from
+ * scheduling the next one, letting the loop halt cleanly (e.g. on component
+ * teardown or server shutdown).
+ */
+export interface PollingHandle {
+  /** Stops the polling loop. Idempotent; safe to call multiple times. */
+  stop: () => void;
+}
+
+/**
  * Starts a polling loop that executes the given async task effectively recursively using setTimeout.
  * This guarantees that the next execution only starts after the previous one has completed (or failed),
  * preventing request pile-ups.
  *
  * @param task The async function to execute.
  * @param intervalMs The delay in milliseconds before the next execution.
+ * @returns A {@link PollingHandle} whose `stop` method cancels the loop.
  */
-export function startPolling(task: () => Promise<void>, intervalMs: number) {
+export function startPolling(
+  task: () => Promise<void>,
+  intervalMs: number,
+): PollingHandle {
+  let stopped = false;
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+
   const runLoop = () => {
     task()
       .catch((error) => {
         log.error("Error in polling loop:", error);
       })
       .finally(() => {
-        setTimeout(runLoop, intervalMs);
+        // Don't schedule another run if stop() was called, including while
+        // this task was in flight.
+        if (stopped) return;
+        timeout = setTimeout(runLoop, intervalMs);
       });
   };
+
   runLoop();
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timeout !== undefined) {
+        clearTimeout(timeout);
+        timeout = undefined;
+      }
+    },
+  };
 }

--- a/tests/server/PollingLoop.test.ts
+++ b/tests/server/PollingLoop.test.ts
@@ -74,4 +74,58 @@ describe("PollingLoop", () => {
     // Second call
     expect(taskCallCount).toBe(2);
   });
+
+  it("should stop scheduling further tasks after stop() is called", async () => {
+    const task = vi.fn().mockResolvedValue(undefined);
+
+    const handle = startPolling(task, 100);
+
+    // Initial call runs immediately.
+    expect(task).toHaveBeenCalledTimes(1);
+
+    // Let the first task settle so the next run gets scheduled.
+    await new Promise(process.nextTick);
+
+    handle.stop();
+
+    // Advancing well past several intervals must not trigger any more runs.
+    await vi.advanceTimersByTimeAsync(500);
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("should not schedule the next task if stopped while a task is in flight", async () => {
+    let resolveTask: ((value?: void) => void) | undefined;
+    const task = vi.fn().mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveTask = resolve;
+        }),
+    );
+
+    const handle = startPolling(task, 100);
+    expect(task).toHaveBeenCalledTimes(1);
+
+    // Stop while the first task is still pending.
+    handle.stop();
+
+    // Completing the in-flight task must not reschedule via the finally block.
+    if (resolveTask) resolveTask();
+    await new Promise(process.nextTick);
+    await vi.advanceTimersByTimeAsync(500);
+
+    expect(task).toHaveBeenCalledTimes(1);
+  });
+
+  it("should treat stop() as idempotent", async () => {
+    const task = vi.fn().mockResolvedValue(undefined);
+
+    const handle = startPolling(task, 100);
+    await new Promise(process.nextTick);
+
+    handle.stop();
+    expect(() => handle.stop()).not.toThrow();
+
+    await vi.advanceTimersByTimeAsync(500);
+    expect(task).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
Resolves #2921

## Description:

`startPolling` in `src/server/PollingLoop.ts` starts a recursive `setTimeout` loop with no way to cancel it, so tasks like `PrivilegeRefresher`, `MasterLobbyService`, and matchmaking (`Worker.ts`) keep polling forever even after the owning component is logically destroyed or the server is shutting down.

This PR makes `startPolling` return a `PollingHandle` with a `stop()` method that:

- clears any pending scheduled run (`clearTimeout`), and
- sets a flag so a task that is *in flight* when `stop()` is called won't reschedule itself in its `finally` block.

`stop()` is idempotent, and the change is fully backward compatible — every existing caller simply ignores the new return value.

Follow-up (kept out of scope to stay small): wiring `PrivilegeRefresher` / `MasterLobbyService` / matchmaking to store the handle and call `.stop()` on shutdown, once a shutdown lifecycle hook is decided.

## Please complete the following:

- [x] I have added screenshots for all UI updates _(N/A — no UI changes)_
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file _(N/A — no user-facing text)_
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

_(add your Discord username here)_
