### PR TITLE
feat(crazygames): backend login + surface the signed-in user

### DIFF
--- a/src/client/AccountModal.ts
+++ b/src/client/AccountModal.ts
@@ -25,6 +25,7 @@ import "./components/FriendsList";
 import "./components/SubscriptionPanel";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { fetchCosmetics } from "./Cosmetics";
+import { crazyGamesSDK, type CrazyGamesUser } from "./CrazyGamesSDK";
 import { translateText } from "./Utils";
 
 @customElement("account-modal")
@@ -33,6 +34,9 @@ export class AccountModal extends BaseModal {
 
   @state() private email: string = "";
   @state() private isLoadingUser: boolean = false;
+  // Set on CrazyGames when a CrazyGames user is signed in. Their identity comes
+  // from the SDK, not our backend user object.
+  @state() private crazyGamesUser: CrazyGamesUser | null = null;
 
   private userMeResponse: UserMeResponse | null = null;
   private statsTree: PlayerStatsTree | null = null;
@@ -105,7 +109,7 @@ export class AccountModal extends BaseModal {
 
   private isLinkedAccount(): boolean {
     const me = this.userMeResponse?.user;
-    return !!(me?.discord ?? me?.google ?? me?.email);
+    return !!(me?.discord ?? me?.google ?? me?.email) || !!this.crazyGamesUser;
   }
 
   protected modalConfig() {
@@ -130,7 +134,9 @@ export class AccountModal extends BaseModal {
     }
     if (!this.isLinkedAccount()) {
       return html`<div class="custom-scrollbar mr-1">
-        ${this.renderLoginOptions()}
+        ${crazyGamesSDK.isOnCrazyGames()
+          ? this.renderCrazyGamesSignIn()
+          : this.renderLoginOptions()}
       </div>`;
     }
     return html`
@@ -159,6 +165,9 @@ export class AccountModal extends BaseModal {
   }
 
   private renderAccountTab(): TemplateResult {
+    if (this.crazyGamesUser) {
+      return this.renderCrazyGamesAccount(this.crazyGamesUser);
+    }
     return html`
       <div class="flex flex-col gap-6">
         <div class="bg-white/5 rounded-xl border border-white/10 p-6">
@@ -177,6 +186,59 @@ export class AccountModal extends BaseModal {
           </div>
         </div>
         ${this.renderSubscriptionPanel()}
+      </div>
+    `;
+  }
+
+  // CrazyGames "connected as" view: avatar + username from the SDK, plus
+  // currency/subscription. No Discord/Google/email link or logout (CrazyGames
+  // owns the account and its logout).
+  private renderCrazyGamesAccount(user: CrazyGamesUser): TemplateResult {
+    return html`
+      <div class="flex flex-col gap-6">
+        <div class="bg-white/5 rounded-xl border border-white/10 p-6">
+          <div class="flex flex-col items-center gap-4">
+            <div
+              class="text-xs text-white/40 uppercase tracking-widest font-bold border-b border-white/5 pb-2 px-8"
+            >
+              ${translateText("account_modal.connected_as")}
+            </div>
+            <div class="flex flex-col items-center gap-3">
+              <img
+                src=${user.profilePictureUrl}
+                alt=${user.username}
+                class="w-16 h-16 rounded-full object-cover"
+                referrerpolicy="no-referrer"
+              />
+              <div class="text-white text-lg font-medium">${user.username}</div>
+              ${this.renderCurrency()}
+            </div>
+          </div>
+        </div>
+        ${this.renderSubscriptionPanel()}
+      </div>
+    `;
+  }
+
+  // Shown when a CrazyGames guest opens the modal: hand off to CrazyGames' own
+  // sign-in prompt (no Discord/Google/email on CrazyGames).
+  private renderCrazyGamesSignIn(): TemplateResult {
+    return html`
+      <div class="flex items-center justify-center p-6 min-h-full">
+        <div
+          class="w-full max-w-md bg-white/5 rounded-2xl border border-white/10 p-8 text-center"
+        >
+          <p class="text-white/50 text-sm font-medium mb-6">
+            ${translateText("account_modal.sign_in_desc")}
+          </p>
+          <o-button
+            variant="primary"
+            width="block"
+            size="md"
+            translationKey="main.sign_in"
+            @click=${() => void crazyGamesSDK.showAuthPrompt()}
+          ></o-button>
+        </div>
       </div>
     `;
   }
@@ -555,6 +617,13 @@ export class AccountModal extends BaseModal {
   protected onOpen(args?: Record<string, unknown>): void {
     this.isLoadingUser = true;
     this.handleLinkResult(args);
+
+    if (crazyGamesSDK.isOnCrazyGames()) {
+      void crazyGamesSDK.getUserProfile().then((user) => {
+        this.crazyGamesUser = user;
+        this.requestUpdate();
+      });
+    }
 
     void fetchCosmetics().then((cosmetics) => {
       this.cosmetics = cosmetics;

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { TokenPayload, TokenPayloadSchema } from "../core/ApiSchemas";
 import { base64urlToUuid } from "../core/Base64";
 import { getApiBase, getAudience } from "./Api";
+import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { generateCryptoRandomUUID } from "./Utils";
 
 export type UserAuth = { jwt: string; claims: TokenPayload } | false;
@@ -189,6 +190,15 @@ async function refreshJwt(): Promise<void> {
 }
 
 async function doRefreshJwt(): Promise<void> {
+  if (crazyGamesSDK.isOnCrazyGames()) {
+    const token = await crazyGamesSDK.getUserToken();
+    if (token) {
+      // Signed-in CrazyGames account: exchange their token for our session.
+      // No CrazyGames account / not signed in falls through to the guest flow
+      // below.
+      return doCrazyGamesLogin(token);
+    }
+  }
   try {
     console.log("Refreshing jwt");
     const response = await fetch(getApiBase() + "/auth/refresh", {
@@ -211,6 +221,41 @@ async function doRefreshJwt(): Promise<void> {
     __jwt = null;
     return;
   }
+}
+
+// Exchange a CrazyGames user token for our session. On CrazyGames the refresh
+// cookie isn't usable (SameSite=Lax, cross-site iframe), so we re-exchange on
+// expiry instead of hitting /auth/refresh.
+async function doCrazyGamesLogin(token: string): Promise<void> {
+  try {
+    console.log("Logging in with CrazyGames");
+    const response = await fetch(getApiBase() + "/auth/crazygames", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ token }),
+    });
+    if (response.status !== 200) {
+      console.error("CrazyGames login failed", response);
+      __jwt = null;
+      return;
+    }
+    const json = await response.json();
+    const { jwt, expiresIn } = json;
+    __expiresAt = Date.now() + expiresIn * 1000;
+    console.log("CrazyGames login succeeded");
+    __jwt = jwt;
+  } catch (e) {
+    console.error("CrazyGames login failed", e);
+    __jwt = null;
+  }
+}
+
+// Called when the CrazyGames auth state changes mid-session (e.g. the player
+// signs in): drop the cached session so userAuth() re-exchanges the new token.
+export async function reauthAfterCrazyGamesChange(): Promise<UserAuth> {
+  __jwt = null;
+  __expiresAt = 0;
+  return userAuth();
 }
 
 export async function sendMagicLink(email: string): Promise<boolean> {

--- a/src/client/CrazyGamesSDK.ts
+++ b/src/client/CrazyGamesSDK.ts
@@ -4,9 +4,11 @@ declare global {
       SDK: {
         init: () => Promise<void>;
         user: {
+          isUserAccountAvailable: boolean;
           getUser(): Promise<{
             username: string;
           } | null>;
+          getUserToken(): Promise<string>;
           addAuthListener: (
             listener: (
               user: {
@@ -144,6 +146,24 @@ export class CrazyGamesSDK {
       return (await window.CrazyGames!.SDK.user.getUser())?.username ?? null;
     } catch (e) {
       console.log("error getting CrazyGames username: ", e);
+      return null;
+    }
+  }
+
+  // Returns a fresh CrazyGames-signed user token to exchange with our backend,
+  // or null if accounts aren't available here or no user is signed in.
+  // CrazyGames recommends fetching this fresh each time rather than caching it.
+  async getUserToken(): Promise<string | null> {
+    if (!(await this.ready())) {
+      return null;
+    }
+    try {
+      if (!window.CrazyGames!.SDK.user.isUserAccountAvailable) {
+        return null;
+      }
+      return await window.CrazyGames!.SDK.user.getUserToken();
+    } catch (e) {
+      console.log("error getting CrazyGames user token: ", e);
       return null;
     }
   }

--- a/src/client/CrazyGamesSDK.ts
+++ b/src/client/CrazyGamesSDK.ts
@@ -1,3 +1,8 @@
+export interface CrazyGamesUser {
+  username: string;
+  profilePictureUrl: string;
+}
+
 declare global {
   interface Window {
     CrazyGames?: {
@@ -5,16 +10,11 @@ declare global {
         init: () => Promise<void>;
         user: {
           isUserAccountAvailable: boolean;
-          getUser(): Promise<{
-            username: string;
-          } | null>;
+          getUser(): Promise<CrazyGamesUser | null>;
           getUserToken(): Promise<string>;
+          showAuthPrompt(): Promise<CrazyGamesUser | null>;
           addAuthListener: (
-            listener: (
-              user: {
-                username: string;
-              } | null,
-            ) => void,
+            listener: (user: CrazyGamesUser | null) => void,
           ) => void;
         };
         ad: {
@@ -168,12 +168,36 @@ export class CrazyGamesSDK {
     }
   }
 
+  // Returns the signed-in CrazyGames user (username + avatar), or null if
+  // accounts aren't available here or no user is signed in.
+  async getUserProfile(): Promise<CrazyGamesUser | null> {
+    const isReady = await this.ready();
+    if (!isReady) {
+      return null;
+    }
+    try {
+      return await window.CrazyGames!.SDK.user.getUser();
+    } catch (e) {
+      console.log("error getting CrazyGames user: ", e);
+      return null;
+    }
+  }
+
+  // Opens CrazyGames' own sign-in prompt. On success the auth listener fires,
+  // which drives our re-auth. Resolves regardless of outcome (e.g. cancelled).
+  async showAuthPrompt(): Promise<void> {
+    if (!(await this.ready())) {
+      return;
+    }
+    try {
+      await window.CrazyGames!.SDK.user.showAuthPrompt();
+    } catch (e) {
+      console.log("CrazyGames auth prompt dismissed: ", e);
+    }
+  }
+
   async addAuthListener(
-    listener: (
-      user: {
-        username: string;
-      } | null,
-    ) => void,
+    listener: (user: CrazyGamesUser | null) => void,
   ): Promise<void> {
     if (!(await this.ready())) {
       return;

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -15,7 +15,7 @@ import { GameType } from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import "./AccountModal";
 import { getUserMe, invalidateUserMe } from "./Api";
-import { userAuth } from "./Auth";
+import { reauthAfterCrazyGamesChange, userAuth } from "./Auth";
 import "./ClanModal";
 import { joinLobby, type JoinLobbyResult } from "./ClientGameRunner";
 import { getPlayerCosmeticsRefs } from "./Cosmetics";
@@ -533,6 +533,15 @@ class Client {
       // TODO: Add caching
       getUserMe().then(onUserMe);
     }
+
+    // Re-run auth when the player signs into CrazyGames mid-session. Logout
+    // reloads the page, so only login needs handling here.
+    crazyGamesSDK.addAuthListener(() => {
+      invalidateUserMe();
+      reauthAfterCrazyGamesChange().then((result) =>
+        result === false ? onUserMe(false) : getUserMe().then(onUserMe),
+      );
+    });
 
     const settingsModal = document.querySelector(
       "user-setting",

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -177,6 +177,74 @@ function updateAccountNavButton(userMeResponse: UserMeResponse | false) {
   showSignIn();
 }
 
+// On CrazyGames the player's identity comes from the CrazyGames SDK, not our
+// backend user object. Show their avatar + username when signed in (clicking
+// opens the account modal), or a "Sign in" button that opens CrazyGames' own
+// auth prompt when they're a guest.
+async function updateCrazyGamesNavButton() {
+  const profile = await crazyGamesSDK.getUserProfile();
+
+  const desktopButton = document.getElementById(
+    "nav-account-button",
+  ) as HTMLButtonElement | null;
+  const avatarEl = document.getElementById(
+    "nav-account-avatar",
+  ) as HTMLImageElement | null;
+  const personIconEl = document.getElementById("nav-account-person-icon");
+  const emailBadgeEl = document.getElementById("nav-account-email-badge");
+  const signInTextEl = document.getElementById("nav-account-signin-text");
+  const mobileButton = document.getElementById(
+    "mobile-nav-account-button",
+  ) as HTMLButtonElement | null;
+
+  // CrazyGames accounts have no email, so the email badge is always hidden.
+  emailBadgeEl?.classList.add("hidden");
+
+  if (profile) {
+    // Signed in: avatar + username. Clicking routes to page-account as usual.
+    if (avatarEl) {
+      avatarEl.alt = profile.username;
+      avatarEl.src = profile.profilePictureUrl;
+      avatarEl.classList.remove("hidden");
+    }
+    personIconEl?.classList.add("hidden");
+    if (signInTextEl) {
+      signInTextEl.textContent = profile.username;
+      signInTextEl.classList.remove("hidden");
+    }
+    desktopButton?.classList.remove("border", "border-white/20");
+    if (desktopButton) desktopButton.onclick = null;
+    if (mobileButton) {
+      mobileButton.textContent = profile.username;
+      mobileButton.onclick = null;
+    }
+    return;
+  }
+
+  // Guest: "Sign in" that hands off to CrazyGames' own auth prompt instead of
+  // the account modal.
+  const signInText = translateText("main.sign_in");
+  const promptSignIn = (e: Event) => {
+    // Bypass the data-page router (which would open the account modal).
+    e.stopPropagation();
+    e.preventDefault();
+    void crazyGamesSDK.showAuthPrompt();
+  };
+
+  avatarEl?.classList.add("hidden");
+  personIconEl?.classList.remove("hidden");
+  if (signInTextEl) {
+    signInTextEl.textContent = signInText;
+    signInTextEl.classList.remove("hidden");
+  }
+  desktopButton?.classList.add("border", "border-white/20");
+  if (desktopButton) desktopButton.onclick = promptSignIn;
+  if (mobileButton) {
+    mobileButton.textContent = signInText;
+    mobileButton.onclick = promptSignIn;
+  }
+}
+
 declare global {
   interface Window {
     turnstile: any;
@@ -504,7 +572,11 @@ class Client {
     }
 
     const onUserMe = async (userMeResponse: UserMeResponse | false) => {
-      updateAccountNavButton(userMeResponse);
+      if (crazyGamesSDK.isOnCrazyGames()) {
+        void updateCrazyGamesNavButton();
+      } else {
+        updateAccountNavButton(userMeResponse);
+      }
       const isAdFree =
         userMeResponse !== false && userMeResponse.player?.adfree === true;
       window.adsEnabled = !isAdFree && !crazyGamesSDK.isOnCrazyGames();

--- a/src/client/components/DesktopNavBar.ts
+++ b/src/client/components/DesktopNavBar.ts
@@ -148,14 +148,14 @@ export class DesktopNavBar extends LitElement {
         </div>
         <button
           id="nav-account-button"
-          class="no-crazygames nav-menu-item relative h-10 rounded-full overflow-hidden flex items-center justify-center gap-2 px-3 bg-transparent border border-white/20 text-white/80 hover:text-white cursor-pointer transition-colors [&.active]:text-white"
+          class="nav-menu-item relative h-10 rounded-full overflow-hidden flex items-center justify-center gap-2 px-3 bg-transparent border border-white/20 text-white/80 hover:text-white cursor-pointer transition-colors [&.active]:text-white"
           data-page="page-account"
           data-i18n-aria-label="main.account"
           data-i18n-title="main.account"
         >
           <img
             id="nav-account-avatar"
-            class="no-crazygames hidden w-8 h-8 rounded-full object-cover"
+            class="hidden w-8 h-8 rounded-full object-cover"
             alt=""
             data-i18n-alt="main.discord_avatar_alt"
             referrerpolicy="no-referrer"

--- a/src/client/components/MobileNavBar.ts
+++ b/src/client/components/MobileNavBar.ts
@@ -138,7 +138,8 @@ export class MobileNavBar extends LitElement {
           data-i18n="main.settings"
         ></button>
         <button
-          class="no-crazygames nav-menu-item block w-full text-left font-bold uppercase tracking-[0.05em] text-white/70 transition-all duration-200 cursor-pointer hover:text-blue-600 hover:translate-x-2.5 hover:drop-shadow-[0_0_20px_rgba(37,99,235,0.5)] [&.active]:text-blue-600 [&.active]:translate-x-2.5 [&.active]:drop-shadow-[0_0_20px_rgba(37,99,235,0.5)] text-[clamp(18px,2.8vh,32px)] py-[clamp(0.2rem,0.8vh,0.75rem)]"
+          id="mobile-nav-account-button"
+          class="nav-menu-item block w-full text-left font-bold uppercase tracking-[0.05em] text-white/70 transition-all duration-200 cursor-pointer hover:text-blue-600 hover:translate-x-2.5 hover:drop-shadow-[0_0_20px_rgba(37,99,235,0.5)] [&.active]:text-blue-600 [&.active]:translate-x-2.5 [&.active]:drop-shadow-[0_0_20px_rgba(37,99,235,0.5)] text-[clamp(18px,2.8vh,32px)] py-[clamp(0.2rem,0.8vh,0.75rem)]"
           data-page="page-account"
           data-i18n="main.account"
         ></button>


### PR DESCRIPTION
Client-side CrazyGames login: exchange the SDK user token for our session, then surface that identity in the UI. Implements the client side of the [CrazyGames login handoff guide](https://docs.crazygames.com/sdk/user/).

## Part 1 — Backend login (token exchange)

On CrazyGames we exchange the SDK's user token for our own session via `POST /auth/crazygames`, instead of the cookie-based `/auth/refresh` (the refresh cookie is `SameSite=Lax` and unusable from the CrazyGames iframe).

- **`CrazyGamesSDK.ts`** — `getUserToken()` wrapper (awaits `ready()`, gates on `isUserAccountAvailable`, returns `null` on throw / no signed-in user).
- **`Auth.ts`** — `doRefreshJwt()` routes to `doCrazyGamesLogin()` when on CrazyGames with a signed-in account; a `null` token (guest / no account) falls through to the existing `/auth/refresh` flow. `reauthAfterCrazyGamesChange()` drops the cached session on a mid-session sign-in.
- **`Main.ts`** — `addAuthListener` re-runs auth + `getUserMe()` when the player signs into CrazyGames mid-session.

Everything funnels through the existing `userAuth()` → `refreshJwt()` path, so **startup login and the 15-min re-exchange on expiry come for free** — no new expiry/polling code.

## Part 2 — Surface the signed-in user

- **Top-bar account button** shows the CrazyGames avatar + username (desktop) or username (mobile). Guests get a **"Sign in"** that opens CrazyGames' own `showAuthPrompt()` instead of the account modal. Un-hidden on CrazyGames by dropping `.no-crazygames`.
- **AccountModal** treats the CrazyGames user as logged-in: "Connected as" avatar + username, currency/subscription, and stats/games/friends. **No Discord/Google/email login+link buttons and no logout** (CrazyGames owns the account). A guest who reaches the modal gets a CrazyGames sign-in button, never Discord/Google.
- **`CrazyGamesSDK.ts`** — `getUserProfile()` + `showAuthPrompt()` wrappers; `profilePictureUrl` added to the user type.

Identity comes from the SDK (`getUser()`), not `/users/@me`, which doesn't surface CrazyGames identity yet.

## Behavior

- **Signed-in CrazyGames account** → real backend session; avatar + username in the top bar; CrazyGames-only account modal.
- **CrazyGames guest / not signed in** → silent fallback to guest; "Sign in" button opens `showAuthPrompt()`; auto-logged-in the moment they sign in (via `addAuthListener`).
- **Not on CrazyGames** → completely unchanged.

## Testing

- `npx tsc --noEmit` — clean
- `npx eslint` on changed files — clean
- No new i18n keys (reuses `main.sign_in`, `account_modal.*`).
- No unit tests: this repo tests core sim only, and CrazyGames only initializes inside a crazygames.com iframe, so the CG paths can't run locally (the localhost SDK mock returns unsigned tokens the backend rejects). **Needs a manual pass on the CrazyGames game page (gameId `64178`)** covering: signed-in avatar/username + account modal, guest "Sign in" → prompt, and mid-session sign-in.

## Assumptions to confirm (backend)

1. The `/auth/crazygames` JWT carries the same `iss` (`getApiBase()`) and `aud` (`getAudience()`) as normal openfront.io tokens and satisfies `TokenPayloadSchema` (incl. base64url `sub`) — otherwise `userAuth()` will `logOut()`.
2. CrazyGames iframes our own origin (so `getApiBase()` → `https://api.openfront.io`), consistent with the existing integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
