### PR TITLE
"stats" not "ranking"

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -557,7 +557,7 @@
     "war": "War"
   },
   "game_list": {
-    "ranking": "Ranking"
+    "stats": "Stats"
   },
   "game_mode": {
     "ffa": "Free for All",

--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -455,7 +455,7 @@ export class PlayerGameHistoryView extends LitElement {
               @click=${() => this.showRanking(game.gameId)}
               class="px-3 py-1.5 text-xs font-bold text-white/80 uppercase tracking-wider bg-white/10 hover:bg-white/20 border border-white/10 rounded-lg transition-colors"
             >
-              ${translateText("game_list.ranking")}
+              ${translateText("game_list.stats")}
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Description:

people confused what "ranking" means on the games stats modal
<img width="606" height="255" alt="image" src="https://github.com/user-attachments/assets/ac695d74-c5b2-4940-b3af-abe3196d2f00" />


also sorta helps with the overflow

before:
<img width="350" height="334" alt="image" src="https://github.com/user-attachments/assets/8a788b79-2d76-4914-b14f-48838494fae5" />

after:
<img width="357" height="332" alt="image" src="https://github.com/user-attachments/assets/164515c7-8b22-45c9-bd11-b5b47d4f17ed" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
