### PR TITLE
Remove in-game CrazyGames banner ad

### DIFF
--- a/src/client/CrazyGamesSDK.ts
+++ b/src/client/CrazyGamesSDK.ts
@@ -27,16 +27,6 @@ declare global {
             },
           ) => void;
         };
-        banner: {
-          requestBanner: (options: {
-            id: string;
-            width: number;
-            height: number;
-          }) => Promise<void>;
-          requestResponsiveBanner: (containerId: string) => Promise<void>;
-          clearBanner: (containerId: string) => void;
-          clearAllBanners: () => void;
-        };
         game: {
           gameplayStart: () => Promise<void>;
           gameplayStop: () => Promise<void>;
@@ -385,70 +375,6 @@ export class CrazyGamesSDK {
       console.error(`Failed to get invite gameId:`, error);
       return null;
     }
-  }
-
-  private bottomLeftContainerId = "cg-bottom-left-ad";
-  private bottomLeftAdVisible = false;
-
-  createBottomLeftAd(): void {
-    console.log(
-      `[CrazyGames] createBottomLeftAd called, isReady=${this.isReady()}`,
-    );
-    if (!this.isReady()) {
-      console.log("[CrazyGames] SDK not ready, skipping bottom-left ad");
-      return;
-    }
-
-    if (this.bottomLeftAdVisible) {
-      console.log("[CrazyGames] Bottom-left ad already visible");
-      return;
-    }
-
-    // Remove existing container if any
-    document.getElementById(this.bottomLeftContainerId)?.remove();
-
-    const container = document.createElement("div");
-    container.id = this.bottomLeftContainerId;
-    container.style.cssText = `
-      position: fixed;
-      bottom: 0;
-      left: 0;
-      width: 300px;
-      height: 250px;
-      z-index: 9999;
-      pointer-events: auto;
-    `;
-    document.body.appendChild(container);
-    console.log("[CrazyGames] Created bottom-left ad container");
-
-    (async () => {
-      try {
-        await window.CrazyGames!.SDK.banner.requestBanner({
-          id: this.bottomLeftContainerId,
-          width: 300,
-          height: 250,
-        });
-        console.log("[CrazyGames] Bottom-left banner loaded");
-      } catch (e) {
-        console.log("[CrazyGames] Bottom-left banner error:", e);
-      }
-    })();
-
-    this.bottomLeftAdVisible = true;
-  }
-
-  clearBottomLeftAd(): void {
-    if (!this.bottomLeftAdVisible) return;
-
-    try {
-      window.CrazyGames!.SDK.banner.clearBanner(this.bottomLeftContainerId);
-    } catch (e) {
-      console.error("[CrazyGames] Error clearing bottom-left banner:", e);
-    }
-
-    document.getElementById(this.bottomLeftContainerId)?.remove();
-    this.bottomLeftAdVisible = false;
-    console.log("[CrazyGames] Bottom-left ad cleared");
   }
 
   requestMidgameAd(): Promise<void> {

--- a/src/client/hud/layers/InGamePromo.ts
+++ b/src/client/hud/layers/InGamePromo.ts
@@ -1,7 +1,6 @@
 import { LitElement, html } from "lit";
 import { customElement } from "lit/decorators.js";
 import { Controller } from "../../Controller";
-import { crazyGamesSDK } from "../../CrazyGamesSDK";
 import { GameView } from "../../view";
 
 const AD_TYPES = [
@@ -52,16 +51,8 @@ export class InGamePromo extends LitElement implements Controller {
   }
 
   private showAd(): void {
-    console.log(
-      `[InGamePromo] showAd called, isOnCrazyGames=${crazyGamesSDK.isOnCrazyGames()}`,
-    );
     if (window.innerWidth < 1100) return;
     if (window.innerHeight < 750) return;
-
-    if (crazyGamesSDK.isOnCrazyGames()) {
-      this.showCrazyGamesAd();
-      return;
-    }
 
     if (!window.adsEnabled) return;
 
@@ -71,25 +62,6 @@ export class InGamePromo extends LitElement implements Controller {
     this.updateComplete.then(() => {
       this.loadAd();
       this.checkForAds();
-    });
-  }
-
-  private showCrazyGamesAd(): void {
-    console.log(
-      `[InGamePromo] showCrazyGamesAd called, isReady=${crazyGamesSDK.isReady()}, width=${window.innerWidth}, height=${window.innerHeight}`,
-    );
-    if (!crazyGamesSDK.isReady()) {
-      console.log(
-        "[InGamePromo] CrazyGames SDK not ready, skipping in-game ad",
-      );
-      return;
-    }
-
-    this.requestUpdate();
-
-    this.updateComplete.then(() => {
-      console.log("[InGamePromo] DOM updated, calling createBottomLeftAd");
-      crazyGamesSDK.createBottomLeftAd();
     });
   }
 
@@ -145,13 +117,6 @@ export class InGamePromo extends LitElement implements Controller {
     }
     this.adsVisible = false;
     this.destroyBottomRail();
-
-    if (crazyGamesSDK.isOnCrazyGames()) {
-      crazyGamesSDK.clearBottomLeftAd();
-      this.shouldShow = false;
-      this.requestUpdate();
-      return;
-    }
 
     if (!window.ramp) {
       console.warn("Playwire RAMP not available for in-game ad");


### PR DESCRIPTION
## Summary

- Remove the bottom-left 300×250 CrazyGames banner ad shown during gameplay (created when the spawn phase ends in `InGamePromo`), including its cleanup path in `hideAd()`
- Remove the now-unused `createBottomLeftAd()` / `clearBottomLeftAd()` wrappers and the `banner` portion of the CrazyGames SDK type declaration

On CrazyGames, `window.adsEnabled` is already forced to `false` (Main.ts), so the Playwire in-game path can't activate there — with this change the game screen shows no ads at all on the CrazyGames platform. Midgame video interstitials (singleplayer start, game exit) are unchanged.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] ESLint passes on touched files
- [ ] On CrazyGames: no banner appears bottom-left after spawn phase ends

🤖 Generated with [Claude Code](https://claude.com/claude-code)