### PR TITLE
feat(store): show plutonium and caps balances in store header

### DIFF
--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -6,6 +6,7 @@ import { Cosmetics } from "../core/CosmeticSchemas";
 import { UserSettings } from "../core/game/UserSettings";
 import { BaseModal } from "./components/BaseModal";
 import "./components/CosmeticButton";
+import "./components/CurrencyDisplay";
 import "./components/CustomCurrencyCard";
 import "./components/EffectsGrid";
 import "./components/NotLoggedInWarning";
@@ -60,11 +61,23 @@ export class StoreModal extends BaseModal {
   }
 
   private renderHeader(): TemplateResult {
+    const currency =
+      this.userMeResponse === false
+        ? undefined
+        : this.userMeResponse.player.currency;
     return modalHeader({
       title: translateText("store.title"),
       onBack: () => this.close(),
       ariaLabel: translateText("common.back"),
-      rightContent: html`<not-logged-in-warning></not-logged-in-warning>`,
+      rightContent: html`<div class="flex items-center gap-4">
+        ${currency
+          ? html`<currency-display
+              .hard=${currency.hard}
+              .soft=${currency.soft}
+            ></currency-display>`
+          : ""}
+        <not-logged-in-warning></not-logged-in-warning>
+      </div>`,
     });
   }
 


### PR DESCRIPTION
## Summary
- Show the player's plutonium (hard) and caps (soft) balances on the right side of the store modal's title bar, next to the existing not-logged-in warning
- Reuses the existing `currency-display` component from the account modal
- Renders only when the user is logged in and has currency data (`player.currency` is optional in the API schema); balances stay current via the `userMeResponse` document event the store already listens to

## Test plan
- [ ] Open the store while logged in with currency balances — plutonium and caps appear to the right of the title
- [ ] Open the store while logged out — only the not-logged-in warning shows, no currency display

🤖 Generated with [Claude Code](https://claude.com/claude-code)