### PR TITLE
Highlight small players: on by default

### DIFF
--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -140,7 +140,7 @@ export class UserSettings {
   }
 
   highlightSmallPlayers() {
-    return this.getBool("settings.highlightSmallPlayers", false);
+    return this.getBool("settings.highlightSmallPlayers", true);
   }
 
   performanceOverlay() {

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -67,22 +67,22 @@ describe("UserSettings highlight small players", () => {
     ).cache.clear();
   });
 
-  it("defaults to off", () => {
-    expect(new UserSettings().highlightSmallPlayers()).toBe(false);
+  it("defaults to on", () => {
+    expect(new UserSettings().highlightSmallPlayers()).toBe(true);
   });
 
-  it("toggles on and off", () => {
+  it("toggles off and on", () => {
     const s = new UserSettings();
     s.toggleHighlightSmallPlayers();
-    expect(s.highlightSmallPlayers()).toBe(true);
-    s.toggleHighlightSmallPlayers();
     expect(s.highlightSmallPlayers()).toBe(false);
+    s.toggleHighlightSmallPlayers();
+    expect(s.highlightSmallPlayers()).toBe(true);
   });
 
   it("shares state across instances via the static cache", () => {
     // The settings modal and the renderer's frame builder each hold their own
     // UserSettings; a toggle in one must be visible to the other.
     new UserSettings().toggleHighlightSmallPlayers();
-    expect(new UserSettings().highlightSmallPlayers()).toBe(true);
+    expect(new UserSettings().highlightSmallPlayers()).toBe(false);
   });
 });


### PR DESCRIPTION
## Description:

Follow-up to #4525: the small-player highlight now defaults to **on** for everyone. Players can still turn it off in Settings — only the default flips.

One-line change in `UserSettings.highlightSmallPlayers()` (default `false` → `true`), plus the matching test updates.