### PR TITLE
fix(client): fallback to full border recompute on massive tile changes

### DIFF
--- a/src/client/render/gl/passes/BorderComputePass.ts
+++ b/src/client/render/gl/passes/BorderComputePass.ts
@@ -196,6 +196,12 @@ export class BorderComputePass {
    * of that.
    */
   patchTile(x: number, y: number, prevOwner: number, newOwner: number): void {
+    if (this.globalDirty) return;
+    if (this.scatter.count > 2048) {
+      this.globalDirty = true;
+      this.scatter.clear();
+      return;
+    }
     this.scatter.pushWithNeighbors(x, y, prevOwner, newOwner);
   }
 


### PR DESCRIPTION

### **Add approved & assigned issue number here:**

Resolves #3604
(related)
## Description:

Fixes severe client-side lag spikes (framerate dropping to single digits) when multiple nuclear bombs detonate close to each other with `"isWaterNukes": true` enabled.
* Water nukes convert land to water on detonation. For an Atom Bomb (radius 30), this changes up to 2,800 tiles.
* The client splits these changes across 16 frames (`dripBuckets`), processing ~150 tile changes per frame.
* For each tile change, `BorderComputePass.patchTile` computes updates. If the victim's territory is highlighted, the pass expands the repaint area of each tile change to a `highlightThicken` Chebyshev box of radius 4 (meaning `9x9 = 81` points).
* This forces the CPU to calculate and push up to `150 * 81 = 12,150` points *per frame* to the border scatter buffer, uploading it, and rendering it as thousands of overlapping GPU `POINTS` using the complex border shader.
* Under consecutive detonations, this completely freezes the client rendering thread, leading to disconnections.

* Optimizes `BorderComputePass.ts` to fallback to a full-screen quad border recompute if the scatter point count exceeds a threshold of `2,048` points.
* Bypasses the expensive CPU coordinate expansions and array resizing for subsequent tile updates in the same frame.
* The GPU renders a simple fullscreen quad to rebuild all borders, which is extremely parallelized and executes in **`<0.1ms`**, keeping gameplay smooth.

## Please complete the following:

- [x] I have added screenshots for all UI updates (N/A)
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A)
- [x] I have added relevant tests to the test directory (N/A)

## Please put your Discord username so you can be contacted if a bug or regression is found:

blontd6