### PR TITLE
sec: require strict majority in 1v1 winner-vote consensus

### DIFF
--- a/src/server/VoteTally.ts
+++ b/src/server/VoteTally.ts
@@ -22,10 +22,13 @@ export class VoteRound<T> {
   }
 
   // Returns the winning value once some candidate holds a strict majority of
-  // `totalUniqueIPs` (votes * 2 >= total), else null.
+  // `totalUniqueIPs` (votes * 2 > total), else null. A tie (e.g. 1 of 2 IPs)
+  // does not count as a majority: with exactly 2 electors, both must agree,
+  // otherwise one of two players in a 1v1 could unilaterally declare
+  // themselves the winner. (#4136)
   result(totalUniqueIPs: number): { value: T; votes: number } | null {
     for (const candidate of this.candidates.values()) {
-      if (candidate.ips.size * 2 >= totalUniqueIPs) {
+      if (candidate.ips.size * 2 > totalUniqueIPs) {
         return { value: candidate.value, votes: candidate.ips.size };
       }
     }

--- a/tests/server/VoteTally.test.ts
+++ b/tests/server/VoteTally.test.ts
@@ -8,7 +8,7 @@ describe("VoteRound", () => {
     // 1 of 3 unique IPs -> no majority yet.
     expect(round.result(3)).toBeNull();
     round.add("a", "a", "2.2.2.2");
-    // 2 of 3 -> majority (2 * 2 >= 3).
+    // 2 of 3 -> majority (2 * 2 > 3).
     expect(round.result(3)).toEqual({ value: "a", votes: 2 });
   });
 
@@ -25,13 +25,30 @@ describe("VoteRound", () => {
     round.add("a", "a", "1.1.1.1");
     round.add("b", "b", "2.2.2.2");
     round.add("a", "a", "3.3.3.3");
-    // 'a' has 2 of 4 IPs (2 * 2 >= 4), 'b' has 1.
-    expect(round.result(4)).toEqual({ value: "a", votes: 2 });
+    // 'a' has 2 of 4 IPs, which is only half, not a strict majority (2 * 2 > 4 is false).
+    expect(round.result(4)).toBeNull();
+    round.add("a", "a", "4.4.4.4");
+    // 'a' now has 3 of 4 IPs (3 * 2 > 4) -> majority.
+    expect(round.result(4)).toEqual({ value: "a", votes: 3 });
   });
 
-  it("accepts with exactly half the electorate (ties pass)", () => {
+  it("rejects a tie (exactly half the electorate)", () => {
     const round = new VoteRound<string>();
     round.add("a", "a", "1.1.1.1");
-    expect(round.result(2)).toEqual({ value: "a", votes: 1 });
+    // 1 of 2 unique IPs is only half, not a strict majority - must not pass.
+    // Otherwise, in a 1v1 game, one player could unilaterally declare
+    // themselves the winner without the other player agreeing (#4136).
+    expect(round.result(2)).toBeNull();
+    round.add("a", "a", "2.2.2.2");
+    // 2 of 2 -> unanimous, now a strict majority.
+    expect(round.result(2)).toEqual({ value: "a", votes: 2 });
+  });
+
+  it("still resolves immediately for a lone remaining elector", () => {
+    const round = new VoteRound<string>();
+    round.add("a", "a", "1.1.1.1");
+    // If the electorate has shrunk to 1 (e.g. the other player disconnected),
+    // the sole remaining vote is a strict majority on its own.
+    expect(round.result(1)).toEqual({ value: "a", votes: 1 });
   });
 });


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #4136

## Description:

`VoteRound.result()` (used by `handleWinner` in `GameServer.ts` to reach consensus on a reported game winner) accepted an exact tie as a majority: `votes * 2 >= totalUniqueIPs`. In a 1v1 game the electorate is 2 unique IPs, so a single client's vote alone satisfied `1 * 2 >= 2` and was accepted immediately — letting one player unilaterally declare themselves the winner without any agreement from the other player, and without the server ever checking the report against the actual simulation outcome.

This fixes the comparison to require a strict majority (`votes * 2 > totalUniqueIPs`), so a 1v1 now requires both clients to agree. Legitimate forfeit-on-disconnect is unaffected: once a player actually disconnects, the electorate shrinks to 1 unique IP, and the sole remaining vote still resolves immediately (`1 * 2 > 1`).

Same fix as previously proposed in #4137, adapted to the current `VoteTally.ts` (which didn't exist at the time of that PR) plus corrected test coverage in `tests/server/VoteTally.test.ts` for the affected tie cases.

This targets `v32` for a hotfix deploy; a backport PR to `main` follows separately.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish