### PR TITLE
feat(playlist): add the Doomsday Clock to the public modifier rotation

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1244,6 +1244,8 @@
     "crowded": "Crowded",
     "disable_alliances": "Alliances Disabled",
     "disable_alliances_label": "Alliances",
+    "doomsday_clock": "Doomsday Clock",
+    "doomsday_clock_label": "Doomsday Clock",
     "gold_multiplier": "x{amount} Gold Multiplier",
     "hard_nations": "Hard Nations",
     "nukes_disabled": "Nukes Disabled",

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -220,6 +220,12 @@ export function getActiveModifiers(
       badgeKey: "public_game_modifier.water_nukes",
     });
   }
+  if (modifiers.isDoomsdayClock) {
+    result.push({
+      labelKey: "public_game_modifier.doomsday_clock_label",
+      badgeKey: "public_game_modifier.doomsday_clock",
+    });
+  }
   return result;
 }
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -328,6 +328,7 @@ export const GameConfigSchema = z.object({
       isSAMsDisabled: z.boolean().optional(),
       isPeaceTime: z.boolean().optional(),
       isWaterNukes: z.boolean().optional(),
+      isDoomsdayClock: z.boolean().optional(),
     })
     .optional(),
   nations: z

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -148,6 +148,7 @@ export interface PublicGameModifiers {
   isSAMsDisabled?: boolean;
   isPeaceTime?: boolean;
   isWaterNukes?: boolean;
+  isDoomsdayClock?: boolean;
 }
 
 export interface UnitInfo {

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -100,6 +100,16 @@ const SPECIAL_MODIFIER_POOL: ModifierKey[] = [
   ...Array<ModifierKey>(2).fill("isDoomsdayClock"),
 ];
 
+// Speeds the Doomsday Clock can roll at when it lands in the rotation. Picked
+// per game (see getSpecialConfig) so the pacing varies instead of always being
+// the same preset.
+const DOOMSDAY_ROTATION_SPEEDS = [
+  "slow",
+  "normal",
+  "fast",
+  "veryfast",
+] as const;
+
 // Maps where water nukes have a higher chance on top of the normal pool
 // Water nukes are especially fun here
 const WATER_NUKES_BOOSTED_MAPS: ReadonlySet<GameMapType> = new Set([
@@ -364,10 +374,16 @@ export class MapPlaylist {
         isWaterNukes,
         isDoomsdayClock,
       },
-      // Rolled into the rotation: enable the anti-stall clock at the default
-      // pace. Speed is fixed here (not from the pool) to keep the badge simple.
+      // Rolled into the rotation: enable the anti-stall clock at a speed picked
+      // per game so the pacing varies across the presets.
       doomsdayClock: isDoomsdayClock
-        ? { enabled: true, speed: "normal" }
+        ? {
+            enabled: true,
+            speed:
+              DOOMSDAY_ROTATION_SPEEDS[
+                Math.floor(Math.random() * DOOMSDAY_ROTATION_SPEEDS.length)
+              ],
+          }
         : undefined,
       startingGold,
       goldMultiplier,

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -97,7 +97,7 @@ const SPECIAL_MODIFIER_POOL: ModifierKey[] = [
   ...Array<ModifierKey>(1).fill("isSAMsDisabled"),
   ...Array<ModifierKey>(1).fill("isPeaceTime"),
   ...Array<ModifierKey>(4).fill("isWaterNukes"),
-  ...Array<ModifierKey>(2).fill("isDoomsdayClock"),
+  ...Array<ModifierKey>(4).fill("isDoomsdayClock"),
 ];
 
 // Speeds the Doomsday Clock can roll at when it lands in the rotation. Picked

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -78,7 +78,8 @@ type ModifierKey =
   | "isNukesDisabled"
   | "isSAMsDisabled"
   | "isPeaceTime"
-  | "isWaterNukes";
+  | "isWaterNukes"
+  | "isDoomsdayClock";
 
 // Each entry represents one "ticket" in the pool. More tickets = higher chance of selection.
 // Weights are roughly informed by the community "favorite modifier" poll.
@@ -96,6 +97,7 @@ const SPECIAL_MODIFIER_POOL: ModifierKey[] = [
   ...Array<ModifierKey>(1).fill("isSAMsDisabled"),
   ...Array<ModifierKey>(1).fill("isPeaceTime"),
   ...Array<ModifierKey>(4).fill("isWaterNukes"),
+  ...Array<ModifierKey>(2).fill("isDoomsdayClock"),
 ];
 
 // Maps where water nukes have a higher chance on top of the normal pool
@@ -258,6 +260,7 @@ export class MapPlaylist {
       isSAMsDisabled,
       isPeaceTime,
       isWaterNukes,
+      isDoomsdayClock,
     } = poolResult;
     if (boostWaterNukes) {
       isWaterNukes = true;
@@ -284,7 +287,8 @@ export class MapPlaylist {
           !isNukesDisabled &&
           !isSAMsDisabled &&
           !isPeaceTime &&
-          !isWaterNukes
+          !isWaterNukes &&
+          !isDoomsdayClock
         ) {
           excludedModifiers.push("isCrowded");
           const fallback = this.getRandomSpecialGameModifiers(
@@ -301,6 +305,7 @@ export class MapPlaylist {
             isSAMsDisabled,
             isPeaceTime,
             isWaterNukes,
+            isDoomsdayClock,
           } = fallback);
           ({ isHardNations } = fallback);
         }
@@ -357,7 +362,13 @@ export class MapPlaylist {
         isSAMsDisabled,
         isPeaceTime,
         isWaterNukes,
+        isDoomsdayClock,
       },
+      // Rolled into the rotation: enable the anti-stall clock at the default
+      // pace. Speed is fixed here (not from the pool) to keep the badge simple.
+      doomsdayClock: isDoomsdayClock
+        ? { enabled: true, speed: "normal" }
+        : undefined,
       startingGold,
       goldMultiplier,
       disableAlliances: isAlliancesDisabled ? true : undefined,
@@ -561,6 +572,7 @@ export class MapPlaylist {
       isSAMsDisabled: selected.has("isSAMsDisabled") || undefined,
       isPeaceTime: selected.has("isPeaceTime") || undefined,
       isWaterNukes: selected.has("isWaterNukes") || undefined,
+      isDoomsdayClock: selected.has("isDoomsdayClock") || undefined,
     };
   }
 

--- a/tests/client/DoomsdayModifierBadge.test.ts
+++ b/tests/client/DoomsdayModifierBadge.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { getActiveModifiers } from "../../src/client/Utils";
+
+// The doomsday clock is part of the public "special" modifier rotation, so an
+// active isDoomsdayClock modifier must surface a lobby badge like every other
+// rotation modifier.
+describe("doomsday clock public modifier", () => {
+  it("surfaces a doomsday-clock badge when the modifier is active", () => {
+    const mods = getActiveModifiers({ isDoomsdayClock: true });
+    expect(mods).toHaveLength(1);
+    expect(mods[0].badgeKey).toBe("public_game_modifier.doomsday_clock");
+    expect(mods[0].labelKey).toBe("public_game_modifier.doomsday_clock_label");
+  });
+
+  it("omits the badge when the modifier is absent", () => {
+    expect(getActiveModifiers({})).toHaveLength(0);
+    expect(getActiveModifiers(undefined)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Description:

Adds the anti-stall **Doomsday Clock** to the public "special" modifier rotation, so it rolls into public games like the other spice modifiers, with a lobby badge.

- `MapPlaylist`: new `isDoomsdayClock` ticket in `SPECIAL_MODIFIER_POOL` (weight 4, ~20% of special games). When rolled, enables `doomsdayClock` at a speed picked per game (slow/normal/fast/veryfast).
- `PublicGameModifiers` (type + schema): `isDoomsdayClock` flag drives the badge.
- `getActiveModifiers` + `en.json`: a "Doomsday Clock" badge/label.
- Test covering the badge wiring.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory
