### PR TITLE
Handle ranked play limits in the client

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -399,6 +399,7 @@
     "rare": "Rare",
     "soft": "Caps",
     "uncommon": "Uncommon",
+    "unlimited_ranked": "Unlimited ranked",
     "usd_value": "Value: {usd}"
   },
   "difficulty": {
@@ -1073,6 +1074,9 @@
   "matchmaking_modal": {
     "connecting": "Connecting to matchmaking server...",
     "elo": "Your ELO: {elo}",
+    "limit_reached": "You're out of free ranked matches.",
+    "limit_reached_info": "Free matches refill daily. Subscribe for unlimited ranked play.",
+    "limit_upsell": "Get unlimited ranked",
     "no_elo": "No ELO yet",
     "replaced": "You joined matchmaking from another tab or window.",
     "searching": "Searching for game...",

--- a/src/client/Matchmaking.ts
+++ b/src/client/Matchmaking.ts
@@ -24,6 +24,7 @@ export class MatchmakingModal extends BaseModal {
   @state() private connected = false;
   @state() private socket: WebSocket | null = null;
   @state() private gameID: string | null = null;
+  @state() private limitReached = false;
   private elo: number | string = "...";
 
   constructor() {
@@ -61,6 +62,24 @@ export class MatchmakingModal extends BaseModal {
   }
 
   private renderInner() {
+    if (this.limitReached) {
+      return html`
+        <div class="flex flex-col items-center gap-4 text-center">
+          <p class="text-white font-bold">
+            ${translateText("matchmaking_modal.limit_reached")}
+          </p>
+          <p class="text-sm text-white/60">
+            ${translateText("matchmaking_modal.limit_reached_info")}
+          </p>
+          <button
+            @click=${this.openSubscriptions}
+            class="px-6 py-3 bg-purple-600 hover:bg-purple-500 text-white font-bold uppercase tracking-wider rounded-xl transition-colors"
+          >
+            ${translateText("matchmaking_modal.limit_upsell")}
+          </button>
+        </div>
+      `;
+    }
     if (!this.connected) {
       return this.renderLoadingSpinner(
         translateText("matchmaking_modal.connecting"),
@@ -79,6 +98,13 @@ export class MatchmakingModal extends BaseModal {
       );
     }
   }
+
+  private openSubscriptions = () => {
+    // The matchmaking modal isn't registered with the modal router, so it
+    // won't be closed by the store opening from the hash change.
+    this.close();
+    window.location.hash = "modal=store&tab=subscriptions";
+  };
 
   private async connect() {
     // A pending join timer from a previous socket must not fire on this one.
@@ -129,6 +155,14 @@ export class MatchmakingModal extends BaseModal {
         `Matchmaking server closed connection: code=${event.code} reason=${event.reason}`,
       );
       if (this.intentionalClose || this.gameID !== null) {
+        return;
+      }
+      // 1008 is also used for auth failures ("Invalid session"), so match on
+      // the reason. Out of free ranked plays — the server will keep refusing
+      // until the next UTC day (or a subscription), so don't reconnect.
+      if (event.code === 1008 && event.reason === "ranked_limit_reached") {
+        this.connected = false;
+        this.limitReached = true;
         return;
       }
       if (event.code === 1000) {
@@ -200,6 +234,7 @@ export class MatchmakingModal extends BaseModal {
     this.connected = false;
     this.gameID = null;
     this.intentionalClose = false;
+    this.limitReached = false;
     this.reconnectAttempts = 0;
     this.connect();
   }

--- a/src/client/components/CosmeticButton.ts
+++ b/src/client/components/CosmeticButton.ts
@@ -272,6 +272,12 @@ export class CosmeticButton extends LitElement {
               >${translateText("cosmetics.per_day")}</span
             >
           </div>
+          ${sub.unlimitedRanked
+            ? html`<span
+                class="text-[10px] font-bold text-purple-300 uppercase tracking-wide"
+                >${translateText("cosmetics.unlimited_ranked")}</span
+              >`
+            : nothing}
         </div>
       </div>`;
     }

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -117,6 +117,9 @@ export const UserMeResponseSchema = z.object({
   player: z.object({
     publicId: z.string(),
     adfree: z.boolean(),
+    // True when the player's active subscription tier exempts them from the
+    // free-ranked-play limits.
+    unlimitedRanked: z.boolean(),
     flares: z.string().array().optional(),
     achievements: z.object({
       singleplayerMap: z.array(SingleplayerMapAchievementSchema),

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -353,6 +353,9 @@ export const SubscriptionSchema = CosmeticSchema.extend({
   priceMonthly: z.number(),
   dailySoftCurrency: z.number(),
   dailyHardCurrency: z.number(),
+  // Whether this tier exempts subscribers from the free-ranked-play limits
+  // (advertised on the store tile).
+  unlimitedRanked: z.boolean(),
 });
 
 // Schema for resources/cosmetics/cosmetics.json

--- a/tests/ApiSchemas.test.ts
+++ b/tests/ApiSchemas.test.ts
@@ -256,6 +256,7 @@ describe("UserMeResponseSchema rewards", () => {
   const basePlayer = {
     publicId: "p1",
     adfree: false,
+    unlimitedRanked: false,
     achievements: { singleplayerMap: [] },
     friends: [],
     subscription: null,
@@ -287,6 +288,33 @@ describe("UserMeResponseSchema rewards", () => {
     expect(
       UserMeResponseSchema.safeParse({ user: {}, player: basePlayer }).success,
     ).toBe(true);
+  });
+});
+
+describe("UserMeResponseSchema unlimitedRanked", () => {
+  const basePlayer = {
+    publicId: "p1",
+    adfree: false,
+    achievements: { singleplayerMap: [] },
+    friends: [],
+    subscription: null,
+  };
+
+  it("accepts a player exempt from ranked play limits", () => {
+    const result = UserMeResponseSchema.safeParse({
+      user: {},
+      player: { ...basePlayer, unlimitedRanked: true },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.player.unlimitedRanked).toBe(true);
+    }
+  });
+
+  it("rejects a response without unlimitedRanked", () => {
+    expect(
+      UserMeResponseSchema.safeParse({ user: {}, player: basePlayer }).success,
+    ).toBe(false);
   });
 });
 
@@ -346,6 +374,7 @@ describe("hasActiveSubscription", () => {
       player: {
         publicId: "p1",
         adfree: false,
+        unlimitedRanked: false,
         achievements: { singleplayerMap: [] },
         friends: [],
         subscription,

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -10,6 +10,7 @@ import {
   isNukeExplosionEffect,
   isTrailEffect,
   NukeExplosionAttributesSchema,
+  SubscriptionSchema,
   TrailEffectAttributesSchema,
 } from "../src/core/CosmeticSchemas";
 import { PlayerEffectSchema } from "../src/core/Schemas";
@@ -782,5 +783,38 @@ describe("effect selection slots", () => {
     expect(findEffectForSlot(catalog, "bogus", "atom_boom")).toBeUndefined();
     // No catalog (failed load) resolves nothing.
     expect(findEffectForSlot(null, "atom", "atom_boom")).toBeUndefined();
+  });
+});
+
+describe("SubscriptionSchema unlimitedRanked", () => {
+  const base = {
+    name: "gold",
+    product: null,
+    rarity: "epic",
+    description: "Gold tier",
+    priceMonthly: 5,
+    dailySoftCurrency: 100,
+    dailyHardCurrency: 10,
+  };
+
+  it("rejects a tier without unlimitedRanked", () => {
+    expect(SubscriptionSchema.safeParse(base).success).toBe(false);
+  });
+
+  it("accepts a tier with unlimitedRanked", () => {
+    const result = SubscriptionSchema.safeParse({
+      ...base,
+      unlimitedRanked: true,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.unlimitedRanked).toBe(true);
+    }
+  });
+
+  it("rejects a non-boolean unlimitedRanked", () => {
+    expect(
+      SubscriptionSchema.safeParse({ ...base, unlimitedRanked: "yes" }).success,
+    ).toBe(false);
   });
 });

--- a/tests/ResolveCosmetics.test.ts
+++ b/tests/ResolveCosmetics.test.ts
@@ -23,6 +23,7 @@ function makeUserMe(flares: string[] = []): UserMeResponse {
     player: {
       publicId: "test",
       adfree: false,
+      unlimitedRanked: false,
       flares,
       achievements: { singleplayerMap: [] },
       friends: [],

--- a/tests/client/clan/ClanApiQueries.test.ts
+++ b/tests/client/clan/ClanApiQueries.test.ts
@@ -28,6 +28,7 @@ const userWithClans = (tags: string[]): UserMeResponse =>
     player: {
       publicId: "p1",
       adfree: false,
+      unlimitedRanked: false,
       flares: [],
       achievements: { singleplayerMap: [] },
       friends: [],


### PR DESCRIPTION
## Summary

Client-side handling for the new server-enforced ranked play limits (infra#427): free players get a lifetime allowance of ranked matches, then a small daily allowance; subscribers on tiers with the `unlimitedRanked` entitlement are never limited.

- **Queue rejection**: the matchmaking socket closing with code 1008 and reason `ranked_limit_reached` now renders a limit-reached view in the matchmaking modal (message + "Get unlimited ranked" button that opens the store on the subscriptions tab) and does **not** auto-reconnect. Auth-failure 1008 (`Invalid session`) is disambiguated by the reason string and keeps the existing reconnect-with-refreshed-token path; code 1000 ("replaced by another tab") is unchanged. Both 1v1 and 2v2 go through the same modal, so both queues get identical handling.
- **`/users/@me`**: added required `player.unlimitedRanked: boolean` to `UserMeResponseSchema`.
- **cosmetics.json**: added required `unlimitedRanked: boolean` to `SubscriptionSchema`; store subscription tiles now show an "Unlimited ranked" perk line for tiers that include it.

Display copy avoids hardcoding the limit numbers since the server constants may be tuned.

## ⚠️ Deploy ordering

Both new schema fields are **required**, so this must ship **after** the API starts serving them (infra#427). Against the current API, `/users/@me` parsing fails (players appear logged out) and a catalog without the subscription field fails the whole cosmetics parse.

## Testing

- Schema tests for both new fields (present / rejected-when-missing) in `tests/ApiSchemas.test.ts` and `tests/CosmeticSchemas.test.ts`; full suite, tsc, ESLint, Prettier all pass.
- Verified in the running app (headless Chromium): forced the modal into the limit-reached state, confirmed the rendered view, and confirmed the upsell click closes matchmaking and opens the store on the subscriptions tab.
- Not verifiable locally (needs deployed infra#427): the real close frame, the midnight-UTC reset, and the perk line against a real catalog — covered by the handoff QA checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)