### PR TITLE
Add opt-in "public profile" so players can expose their publicId in-game

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1451,8 +1451,6 @@
     "warship": "Warship"
   },
   "user_setting": {
-    "public_profile_label": "Public profile",
-    "public_profile_desc": "Let other players in your games see your public OpenFront ID, so stat-tracking tools can look you up. Off by default.",
     "alert_frame_desc": "Toggle the alert frame. When enabled, the frame will be displayed when you are betrayed or attacked over land.",
     "alert_frame_label": "Alert Frame",
     "ally_keybinds": "Ally Keybinds",
@@ -1557,6 +1555,8 @@
     "performance_overlay_desc": "Toggle the performance overlay. When enabled, the performance overlay will be displayed. Press shift-D during game to toggle.",
     "performance_overlay_label": "Performance Overlay",
     "press_a_key": "Press a key",
+    "public_profile_desc": "Let other players in your games see your public OpenFront ID, so stat-tracking tools can look you up. Off by default.",
+    "public_profile_label": "Public profile",
     "render_debug_gui": "Render Debug GUI",
     "render_debug_gui_desc": "Toggle the renderer tuning panel",
     "request_alliance": "Request Alliance",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1451,6 +1451,8 @@
     "warship": "Warship"
   },
   "user_setting": {
+    "public_profile_label": "Public profile",
+    "public_profile_desc": "Let other players in your games see your public OpenFront ID, so stat-tracking tools can look you up. Off by default.",
     "alert_frame_desc": "Toggle the alert frame. When enabled, the frame will be displayed when you are betrayed or attacked over land.",
     "alert_frame_label": "Alert Frame",
     "ally_keybinds": "Ally Keybinds",

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -27,6 +27,7 @@ import {
   ServerMessageSchema,
   Winner,
 } from "../core/Schemas";
+import { UserSettings } from "../core/game/UserSettings";
 import { replacer } from "../core/Util";
 import { getPlayToken } from "./Auth";
 import { LobbyConfig } from "./ClientGameRunner";
@@ -427,6 +428,7 @@ export class Transport {
       cosmetics: this.lobbyConfig.cosmetics,
       turnstileToken: this.lobbyConfig.turnstileToken,
       token: await getPlayToken(),
+      showPublicProfile: new UserSettings().showPublicProfile(),
     } satisfies ClientJoinMessage);
   }
 

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -10,6 +10,7 @@ import {
   UnitType,
 } from "../core/game/Game";
 import { TileRef } from "../core/game/GameMap";
+import { UserSettings } from "../core/game/UserSettings";
 import {
   AllPlayersStats,
   ClientHashMessage,
@@ -27,7 +28,6 @@ import {
   ServerMessageSchema,
   Winner,
 } from "../core/Schemas";
-import { UserSettings } from "../core/game/UserSettings";
 import { replacer } from "../core/Util";
 import { getPlayToken } from "./Auth";
 import { LobbyConfig } from "./ClientGameRunner";

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -266,6 +266,14 @@ export class UserSettingModal extends BaseModal {
     );
   }
 
+  private toggleShowPublicProfile() {
+    this.userSettings.toggleShowPublicProfile();
+    console.log(
+      "🪪 Public Profile:",
+      this.userSettings.showPublicProfile() ? "ON" : "OFF",
+    );
+  }
+
   private toggleLobbyIdVisibility() {
     this.userSettings.toggleLobbyIdVisibility();
     console.log(
@@ -824,6 +832,15 @@ export class UserSettingModal extends BaseModal {
         id="anonymous-names-toggle"
         .checked=${this.userSettings.anonymousNames()}
         @change=${this.toggleAnonymousNames}
+      ></setting-toggle>
+
+      <!-- 🪪 Public Profile -->
+      <setting-toggle
+        label="${translateText("user_setting.public_profile_label")}"
+        description="${translateText("user_setting.public_profile_desc")}"
+        id="public-profile-toggle"
+        .checked=${this.userSettings.showPublicProfile()}
+        @change=${this.toggleShowPublicProfile}
       ></setting-toggle>
 
       <!-- 👁️ Hidden Lobby IDs -->

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -199,6 +199,9 @@ const ClientInfoSchema = z.object({
   username: UsernameSchema,
   clanTag: ClanTagSchema,
   friends: z.array(z.string()).optional(),
+  // Opt-in only: the player's stable account publicId, included when they
+  // enabled "public profile". Lets other clients look up their public stats.
+  publicId: z.string().optional(),
 });
 
 export const GameInfoSchema = z.object({
@@ -852,6 +855,9 @@ export const ClientJoinMessageSchema = z.object({
   // Server replaces the refs with the actual cosmetic data.
   cosmetics: PlayerCosmeticRefsSchema.optional(),
   turnstileToken: z.string().nullable(),
+  // Opt-in: when true the player consents to exposing their account publicId to
+  // other clients in this game (see UserSettings.showPublicProfile).
+  showPublicProfile: z.boolean().optional(),
 });
 
 export const ClientRejoinMessageSchema = z.object({

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -158,6 +158,14 @@ export class UserSettings {
     return this.getBool("settings.anonymousNames", false);
   }
 
+  showPublicProfile() {
+    return this.getBool("settings.showPublicProfile", false);
+  }
+
+  toggleShowPublicProfile() {
+    this.setBool("settings.showPublicProfile", !this.showPublicProfile());
+  }
+
   lobbyIdVisibility() {
     return this.getBool("settings.lobbyIdVisibility", true);
   }

--- a/src/server/Client.ts
+++ b/src/server/Client.ts
@@ -23,5 +23,7 @@ export class Client {
     public readonly cosmetics: PlayerCosmetics | undefined,
     public readonly publicId: string | undefined,
     public readonly friends: string[],
+    // Opt-in: player consented to exposing their publicId to others in-game.
+    public readonly showPublicProfile: boolean = false,
   ) {}
 }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1209,11 +1209,13 @@ export class GameServer {
               clanTag: hideClanTags ? null : (c.clanTag ?? null),
               clientID: c.clientID,
               friends: friendsFor(c),
+              publicId: c.showPublicProfile ? c.publicId : undefined,
             }
           : {
               username: this.anonName(viewer, c.clientID),
               clanTag: null,
               clientID: c.clientID,
+              publicId: c.showPublicProfile ? c.publicId : undefined,
             },
       ),
       lobbyCreatorClientID: this.lobbyCreatorID,

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -624,6 +624,7 @@ export async function startWorker() {
           cosmeticResult.cosmetics,
           publicId,
           friends,
+          clientMsg.showPublicProfile ?? false,
         );
 
         const joinResult = gm.joinClient(client, clientMsg.gameID);

--- a/tests/server/PublicProfile.test.ts
+++ b/tests/server/PublicProfile.test.ts
@@ -1,0 +1,82 @@
+import { GameType } from "../../src/core/game/Game";
+import { Client } from "../../src/server/Client";
+import { GameServer } from "../../src/server/GameServer";
+
+function makeMockWs() {
+  return {
+    on: () => {},
+    removeAllListeners: () => {},
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+  };
+}
+
+function makeClient(
+  clientID: string,
+  publicId: string | undefined,
+  showPublicProfile: boolean,
+): Client {
+  return new Client(
+    clientID,
+    `${clientID}-pid`,
+    null,
+    null,
+    undefined,
+    "127.0.0.1",
+    `${clientID}Name`,
+    null,
+    makeMockWs() as any,
+    undefined,
+    publicId,
+    [],
+    showPublicProfile,
+  );
+}
+
+function makeGame(anonymizeNames = false) {
+  const logger: any = {
+    child: vi.fn().mockReturnThis(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+  const game = new GameServer(
+    "g1",
+    logger,
+    Date.now(),
+    { gameType: GameType.Private, anonymizeNames } as any,
+    "opted-pid",
+  );
+  [
+    makeClient("opted", "opted-pub", true),
+    makeClient("private", "private-pub", false),
+  ].forEach((c) => game.joinClient(c));
+  return game;
+}
+
+const byId = (info: any, id: string) =>
+  info.clients.find((c: any) => c.clientID === id);
+
+describe("public profile: gameInfo exposes publicId only when opted in", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("includes publicId for a client that opted in", () => {
+    const info = makeGame().gameInfo("opted");
+    expect(byId(info, "opted").publicId).toBe("opted-pub");
+  });
+
+  it("omits publicId for a client that did not opt in", () => {
+    const info = makeGame().gameInfo("opted");
+    expect(byId(info, "private").publicId).toBeUndefined();
+  });
+
+  it("still exposes an opted-in player's publicId when names are anonymized", () => {
+    const info = makeGame(true).gameInfo("private");
+    expect(byId(info, "opted").publicId).toBe("opted-pub");
+  });
+});


### PR DESCRIPTION
**Approved & assigned issue:** none yet — happy to open an issue / discuss on Discord first if the maintainers prefer.

## Description:

Adds an opt-in **"Public profile"** user setting (off by default). When enabled, the player's account `publicId` is included in the game's broadcast client roster (`gameInfo()`), so other clients — and stat-tracking tools — can resolve them to their public stats via the existing player API.

Today a player's `publicId` is never shared with other clients, so there's no way to identify who's in a lobby for stats/rank lookups. This makes it possible **only with the player's consent**, mirroring the existing name-reveal model. `persistentID` (the auth-bearing secret) is never touched. No change to default behavior.

**Changes**
- Schemas: `ClientInfoSchema.publicId?` (broadcast) and `ClientJoinMessageSchema.showPublicProfile?` (consent on join).
- Server: `Client` carries `showPublicProfile`; `Worker` threads it from the join message; `GameServer.gameInfo()` includes `publicId` only for opted-in clients.
- Client: `UserSettings.showPublicProfile()` + toggle, a settings-modal entry, and `Transport.joinGame()` sends the flag. Added i18n label/description.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

granster9
