### PR TITLE
Remove Discord URL placeholder from translations

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -206,7 +206,6 @@
     "discord_section_title": "Discord",
     "discord_url_hint": "Use an invite set to never expire.",
     "discord_url_label": "Discord Invite URL",
-    "discord_url_placeholder": "https://discord.gg/...",
     "error_already_member": "Already a member",
     "error_banned": "You are banned from this clan.",
     "error_banned_reason": "You are banned from this clan. Reason: {reason}",

--- a/src/client/components/clan/ClanManageView.ts
+++ b/src/client/components/clan/ClanManageView.ts
@@ -385,9 +385,7 @@ export class ClanManageView extends LitElement {
                       (this.manageDiscordUrl = (
                         e.target as HTMLInputElement
                       ).value)}
-                    placeholder=${translateText(
-                      "clan_modal.discord_url_placeholder",
-                    )}
+                    placeholder="https://discord.gg/..."
                     maxlength="255"
                     class="w-full px-4 py-3 bg-white/5 border border-white/10 rounded-xl text-white placeholder-white/20 focus:outline-none focus:ring-2 focus:ring-malibu-blue/50 focus:border-malibu-blue/50 transition-all font-medium hover:bg-white/10 text-sm"
                   />


### PR DESCRIPTION
## Description:

This value was a sample URL used as an input placeholder, and it was removed because translating it would be meaningless and could potentially alter the URL format incorrectly.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
