### PR TITLE
Reuse cached TradeShip paths for motion plans

### DIFF
--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -138,10 +138,7 @@ export class TradeShipExecution implements Execution {
         if (dst !== this.motionPlanDst) {
           this.motionPlanId++;
           const from = result.node;
-          const path = this.pathFinder.findPath(from, dst) ?? [from];
-          if (path.length === 0 || path[0] !== from) {
-            path.unshift(from);
-          }
+          const path = this.pathFinder.pathForTraversal(from, dst);
 
           this.mg.recordMotionPlan({
             kind: "grid",

--- a/src/core/pathfinding/PathFinder.ts
+++ b/src/core/pathfinding/PathFinder.ts
@@ -127,7 +127,7 @@ export class PathFinding {
  * waterGraphVersion to stagger when each ship invalidates its cached path.
  */
 export class WaterPathFinder implements SteppingPathFinder<TileRef> {
-  private stepper: SteppingPathFinder<TileRef>;
+  private stepper: PathFinderStepper<TileRef>;
   private _waterGraphVersion: number;
   private _rebuilt = false;
 
@@ -195,9 +195,23 @@ export class WaterPathFinder implements SteppingPathFinder<TileRef> {
     return this.stepper.next(from, to, dist);
   }
 
+  /** Runs a one-shot query without changing the path consumed by next(). */
   findPath(from: TileRef | TileRef[], to: TileRef): TileRef[] | null {
     this.ensureFresh();
     return this.stepper.findPath(from, to);
+  }
+
+  /**
+   * Returns the route following a successful next() call, starting at `from`.
+   * If refreshing the water graph replaced the stepper, fall back to the same
+   * one-shot query used before traversal paths were reusable.
+   */
+  pathForTraversal(from: TileRef, to: TileRef): TileRef[] | Uint32Array {
+    this.ensureFresh();
+    const path =
+      this.stepper.pathAfterNext() ?? this.stepper.findPath(from, to);
+    if (path === null || path.length === 0) return [from];
+    return path[0] === from ? path : [from, ...path];
   }
 
   invalidate(): void {

--- a/src/core/pathfinding/PathFinderStepper.ts
+++ b/src/core/pathfinding/PathFinderStepper.ts
@@ -108,6 +108,16 @@ export class PathFinderStepper<T> implements SteppingPathFinder<T> {
     this.lastTo = null;
   }
 
+  /**
+   * Returns a copy of the active path beginning at the node most recently
+   * returned by next(). Returns null when there is no active traversal.
+   */
+  pathAfterNext(): T[] | Uint32Array | null {
+    if (this.path === null || this.pathIndex === 0) return null;
+    return this.path.slice(this.pathIndex - 1);
+  }
+
+  /** Computes a one-shot route without changing the cached route. */
   findPath(from: T | T[], to: T): T[] | null {
     if (this.config.preCheck) {
       const fromArray = Array.isArray(from) ? from : [from];

--- a/tests/core/executions/TradeShipExecution.test.ts
+++ b/tests/core/executions/TradeShipExecution.test.ts
@@ -107,13 +107,17 @@ describe("TradeShipExecution", () => {
     tradeShipExecution["pathFinder"] = {
       next: vi.fn(() => ({ status: PathStatus.NEXT, node: 32 })),
       findPath: vi.fn((from: number) => [from]),
+      pathForTraversal: vi.fn(() => [32]),
     } as any;
     tradeShipExecution["tradeShip"] = tradeShip;
   });
 
   it("should initialize and tick without errors", () => {
+    const pathFinder = tradeShipExecution["pathFinder"];
     tradeShipExecution.tick(1);
     expect(tradeShipExecution.isActive()).toBe(true);
+    expect(pathFinder.pathForTraversal).toHaveBeenCalledOnce();
+    expect(pathFinder.findPath).not.toHaveBeenCalled();
   });
 
   it("should deactivate if tradeShip is not active", () => {
@@ -159,6 +163,7 @@ describe("TradeShipExecution", () => {
     tradeShipExecution["pathFinder"] = {
       next: vi.fn(() => ({ status: PathStatus.COMPLETE, node: 32 })),
       findPath: vi.fn((from: number) => [from]),
+      pathForTraversal: vi.fn(() => [32]),
     } as any;
     tradeShipExecution.tick(1);
     expect(tradeShip.delete).toHaveBeenCalledWith(false);

--- a/tests/core/pathfinding/PathFinderStepper.test.ts
+++ b/tests/core/pathfinding/PathFinderStepper.test.ts
@@ -125,6 +125,22 @@ describe("PathFinderStepper", () => {
     });
   });
 
+  describe("pathAfterNext", () => {
+    it("returns a copy of the cached remainder", () => {
+      const pathMap = new Map<string, number[]>([["1->5", [1, 2, 3, 4, 5]]]);
+      const stepper = new PathFinderStepper(createMockFinder(pathMap));
+
+      expect(stepper.pathAfterNext()).toBeNull();
+      expect(stepper.next(1, 5)).toEqual({ status: PathStatus.NEXT, node: 2 });
+      const path = stepper.pathAfterNext();
+      expect(path).toBeInstanceOf(Uint32Array);
+      expect(Array.from(path!)).toEqual([2, 3, 4, 5]);
+
+      path![0] = 99;
+      expect(stepper.next(2, 5)).toEqual({ status: PathStatus.NEXT, node: 3 });
+    });
+  });
+
   describe("findPath", () => {
     it("delegates to inner finder", () => {
       const pathMap = new Map<string, number[]>([["1->5", [1, 2, 3, 4, 5]]]);


### PR DESCRIPTION
**Approved and assigned issue:** #4643

Resolves #4643

## Description

`TradeShipExecution` currently calls `WaterPathFinder.next()` and then performs a second one-shot `findPath()` for the same destination when it records a motion plan. `next()` has already calculated and cached the traversal route, so the second call repeats the expensive water-path calculation solely to recreate the route for the client.

This change lets `PathFinderStepper` return a copy of the active path after `next()` advances it. Numeric paths remain `Uint32Array`s, matching the compact representation already used by the stepper and supported by motion-plan packing.

`WaterPathFinder.pathForTraversal()` retains the existing second water-graph freshness check. If the graph refresh replaces the stepper between `next()` and motion-plan recording, it falls back to the original one-shot query. Otherwise it returns the cached remainder. The method also normalizes the result to begin at the tile returned by `next()`, so `TradeShipExecution` does not need to mutate the path.

`findPath()` remains a stateless one-shot query. The change is limited to TradeShip and the minimal pathfinder support; it includes no TransportShip changes.

## Performance

Current upstream `main` (`da2e0918`) was compared with the same commit plus only this change. Each variant was run once per replay on macOS arm64 with CPU profiling disabled. The replay intents were identical between variants, and the current-client final hash and hash tick matched for every pair.

| Game ID | Workload | Whole replay | TradeShip execution | Throughput |
| --- | --- | ---: | ---: | ---: |
| `DWmULj4H` | Antarctica, TradeShip-heavy | 68.960 s → 60.271 s (**-12.60%**) | 18.981 s → 11.844 s (**-37.60%**) | 446 → 510 ticks/s |
| `efA7EZv9` | Australia | 14.660 s → 14.346 s (**-2.14%**) | 1.216 s → 0.920 s (**-24.34%**) | 441 → 450 ticks/s |
| `waxvMCue` | Svalmel | 16.666 s → 16.537 s (**-0.77%**) | 1.169 s → 0.931 s (**-20.36%**) | 551 → 555 ticks/s |

Matched current-client final hashes:

- `DWmULj4H`: `49212092378184090` at tick 31,060
- `efA7EZv9`: `82334231069422620` at tick 6,760
- `waxvMCue`: `34697926985435590` at tick 9,480

## Validation

- `npm run build-prod`
- Full Node 24 coverage suite: 174 test files and 2,091 tests passed
- Full ESLint check
- Full Prettier check
- Current-main baseline/patched replay hashes matched for all three benchmark games

## Checklist

- [x] No UI updates; screenshots are not applicable.
- [x] No user-facing text was added or changed.
- [x] Relevant tests were added.

## LLM disclosure

This change, PR description, and benchmark analysis were authored by **GPT-5.6 Sol**, an LLM, under human direction.
