### PR TITLE
fix(core): reject spawn intents after the spawn phase (anti-teleport)

### DIFF
--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -47,6 +47,15 @@ export class SpawnExecution implements Execution {
       player = this.mg.addPlayer(this.playerInfo);
     }
 
+    // Security: a spawn intent may only place or relocate a player's starting
+    // territory during the spawn phase. Once the game is underway, an
+    // already-spawned player who sends a spawn intent is attempting to
+    // teleport — relinquishing their territory and re-conquering it elsewhere.
+    // Ignore it so the intent is a deterministic no-op on every client.
+    if (!this.mg.inSpawnPhase() && player.hasSpawned()) {
+      return;
+    }
+
     // Security: If random spawn is enabled, prevent players from re-rolling their spawn location
     if (this.mg.config().isRandomSpawn() && player.hasSpawned()) {
       return;

--- a/tests/core/execution/SpawnExecution.test.ts
+++ b/tests/core/execution/SpawnExecution.test.ts
@@ -94,14 +94,45 @@ describe("Spawn execution", () => {
 
     const game = await setup("half_land_half_ocean", {}, [playerInfo]);
 
-    game.addExecution(new SpawnExecution("game_id", playerInfo, 10));
     game.addExecution(new SpawnExecution("game_id", playerInfo, 20));
     game.executeNextTick();
     game.executeNextTick();
 
-    expect(game.playerByClientID("client_id")?.spawnTile()).toBe(20);
-    // Previous territory from first spawn should be relinquished
-    expect(game.owner(10).isPlayer()).toBe(false);
+    const player = game.playerByClientID("client_id")!;
+    expect(player.spawnTile()).toBe(20);
+    expect(player.numTilesOwned()).toBeGreaterThan(0);
+  });
+
+  test("Spawn intent after the spawn phase cannot relocate territory (anti-teleport)", async () => {
+    const playerInfo = new PlayerInfo(
+      `player`,
+      PlayerType.Human,
+      `client_id`,
+      `player_id`,
+    );
+
+    // setup() ends the spawn phase by default, so the game is already underway.
+    const game = await setup("half_land_half_ocean", {}, [playerInfo]);
+
+    // Establish the player's territory with a legitimate first spawn.
+    game.addExecution(new SpawnExecution("game_id", playerInfo, 20));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    const player = game.playerByClientID("client_id")!;
+    expect(player.spawnTile()).toBe(20);
+    const tilesBefore = player.numTilesOwned();
+    expect(tilesBefore).toBeGreaterThan(0);
+
+    // Malicious "teleport": a spawn intent to a new tile after the game has
+    // started must be a deterministic no-op — the player keeps their original
+    // spawn location and territory rather than relinquishing and re-conquering.
+    game.addExecution(new SpawnExecution("game_id", playerInfo, 10));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(player.spawnTile()).toBe(20);
+    expect(player.numTilesOwned()).toBe(tilesBefore);
   });
 
   test("Random spawn ignores client-specified tile", async () => {


### PR DESCRIPTION
## Problem
Patches sending the `spawn` intent over the game WebSocket while a match is underway:

```js
ws.send(JSON.stringify({ type: "intent", intent: { type: "spawn", tile: tileRef } }));
```

The server relays it like any intent, and `SpawnExecution.tick()` then **relinquishes the player's entire territory and re-conquers it at the target tile** — instant teleport anywhere on the map.

The root cause is that `SpawnExecution.tick()` had no spawn-phase gate (only a random-spawn re-roll guard), and the engine ticks the execution **both during and after** the spawn phase (`activeDuringSpawnPhase()` is `true`, and after the phase `!inSpawnPhase()` is also `true`).

## Fix

Ignore a spawn intent when the game is no longer in the spawn phase **and** the player has already spawned:

```js
if (!this.mg.inSpawnPhase() && player.hasSpawned()) {
  return;
}
```

Because `inSpawnPhase()` / `hasSpawned()` are deterministic game state, the intent becomes a no-op identically on every client — no desync.

Unaffected:
- First-time spawns (`hasSpawned()` is false)
- In-phase spawn picks and re-picks (`inSpawnPhase()` is true)
- Existing random-spawn re-roll protection (kept as-is)

## Tests

- Added `Spawn intent after the spawn phase cannot relocate territory (anti-teleport)` — establishes a player, then asserts a later `spawn` intent leaves `spawnTile()` and `numTilesOwned()` unchanged.
- Simplified `Spawn on specific tile` to a single first spawn (the previous version relied on an out-of-phase re-pick, which this fix now correctly forbids).
- Full `tests/core` suite green (259 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)