### PR TITLE
refactor(server): replace remote banned-words fetch with static fallback matcher

### DIFF
--- a/src/server/Privilege.ts
+++ b/src/server/Privilege.ts
@@ -50,24 +50,45 @@ export const shadowNames = [
   "AlmostPottyTrained",
 ];
 
-function buildDataset(bannedWords: string[], dedup: boolean) {
+// Basic obscenity check. Full username moderation happens in the API
+// (username_check); this static list plus the obscenity englishDataset is
+// only a fallback for when the API is unavailable.
+//
+// Every word here is needed even when englishDataset also covers it: the
+// dataset has no hate/extremism terms (hitler, nazi, spic, ...), and its
+// patterns are partly word-anchored and keep double letters, so only the
+// unanchored + deduped patterns built from this list catch substring and
+// repeated-character bypasses ("xXfaggotXx", "niiiigger").
+const bannedWords = [
+  "nigger",
+  "nigga",
+  "chink",
+  "spic",
+  "kike",
+  "faggot",
+  "retard",
+  "hitler",
+  "adolf",
+  "nazi",
+  "auschwitz",
+  "whitepower",
+  "heil",
+];
+
+function buildDataset(dedup: boolean) {
   const dataset = new DataSet<{ originalWord: string }>().addAll(
     englishDataset,
   );
   for (const word of bannedWords) {
-    try {
-      const w = dedup ? word.toLowerCase().replace(/(.)\1+/g, "$1") : word;
-      dataset.addPhrase((phrase) =>
-        phrase.setMetadata({ originalWord: word }).addPattern(pattern`${w}`),
-      );
-    } catch (e) {
-      console.error(`Invalid banned word pattern "${word}": ${e}`);
-    }
+    const w = dedup ? word.replace(/(.)\1+/g, "$1") : word;
+    dataset.addPhrase((phrase) =>
+      phrase.setMetadata({ originalWord: word }).addPattern(pattern`${w}`),
+    );
   }
   return dataset.build();
 }
 
-export function createMatcher(bannedWords: string[]): RegExpMatcher {
+function createMatcher(): RegExpMatcher {
   const baseTransformers = [
     toAsciiLowerCaseTransformer(),
     resolveConfusablesTransformer(),
@@ -78,14 +99,14 @@ export function createMatcher(bannedWords: string[]): RegExpMatcher {
   // skipNonAlphabeticTransformer is applied last to catch punctuation-separated bypasses
   // like "n.i.g.g.e.r".
   const substringMatcher = new RegExpMatcher({
-    ...buildDataset(bannedWords, false),
+    ...buildDataset(false),
     blacklistMatcherTransformers: [
       ...baseTransformers,
       skipNonAlphabeticTransformer(),
     ],
   });
   const collapseMatcher = new RegExpMatcher({
-    ...buildDataset(bannedWords, true),
+    ...buildDataset(true),
     blacklistMatcherTransformers: [
       ...baseTransformers,
       collapseDuplicatesTransformer(),
@@ -103,6 +124,8 @@ export function createMatcher(bannedWords: string[]): RegExpMatcher {
     ],
   } as unknown as RegExpMatcher;
 }
+
+export const profanityMatcher = createMatcher();
 
 /**
  * Sanitizes and censors profane usernames and clan tags separately.
@@ -123,16 +146,15 @@ export function createMatcher(bannedWords: string[]): RegExpMatcher {
 function censorWithMatcher(
   username: string,
   clanTag: string | null,
-  matcher: RegExpMatcher,
 ): { username: string; clanTag: string | null } {
-  const usernameIsProfane = matcher.hasMatch(username);
+  const usernameIsProfane = profanityMatcher.hasMatch(username);
   const clanTagIsProfane = clanTag
-    ? matcher.hasMatch(clanTag) || clanTag.toLowerCase() === "ss"
+    ? profanityMatcher.hasMatch(clanTag) || clanTag.toLowerCase() === "ss"
     : false;
   // Catch slurs split across clan tag and username (e.g. clanTag="HIT", username="LER")
   // by looking for a match that spans the clan/name boundary.
   const combinedSlurAcrossBoundary = clanTag
-    ? matcher.getAllMatches(clanTag + username).some(
+    ? profanityMatcher.getAllMatches(clanTag + username).some(
         (match) =>
           // Match must start in the clan and extend into the name — otherwise
           // it's already handled by the clan-only or name-only checks above.
@@ -201,18 +223,13 @@ export interface PrivilegeChecker {
 }
 
 export class PrivilegeCheckerImpl implements PrivilegeChecker {
-  private matcher: RegExpMatcher;
-
   constructor(
     private cosmetics: Cosmetics,
     private b64urlDecode: (base64: string) => Uint8Array,
-    bannedWords: string[],
     // Every registered clan tag (uppercase). Polled by PrivilegeRefresher so
     // ownership is resolved in memory — no per-join existence probe.
     private reservedClanTags: Set<string> = new Set(),
-  ) {
-    this.matcher = createMatcher(bannedWords);
-  }
+  ) {}
 
   resolveClanTag(
     censoredTag: string | null,
@@ -404,15 +421,9 @@ export class PrivilegeCheckerImpl implements PrivilegeChecker {
     username: string,
     clanTag: string | null,
   ): { username: string; clanTag: string | null } {
-    return censorWithMatcher(username, clanTag, this.matcher);
+    return censorWithMatcher(username, clanTag);
   }
 }
-
-// Words the englishDataset misses or only catches as standalone tokens.
-// These are always enforced even when the remote banned-words list is unavailable.
-const baselineBannedWords = ["nigger", "nigga", "chink", "spic", "kike"];
-
-const defaultMatcher = createMatcher(baselineBannedWords);
 
 export class FailOpenPrivilegeChecker implements PrivilegeChecker {
   isAllowed(flares: string[], refs: PlayerCosmeticRefs): CosmeticResult {
@@ -429,7 +440,7 @@ export class FailOpenPrivilegeChecker implements PrivilegeChecker {
     username: string,
     clanTag: string | null,
   ): { username: string; clanTag: string | null } {
-    return censorWithMatcher(username, clanTag, defaultMatcher);
+    return censorWithMatcher(username, clanTag);
   }
 
   // No reserved-tag list while cosmetics infra is unavailable (e.g. during

--- a/src/server/PrivilegeRefresher.ts
+++ b/src/server/PrivilegeRefresher.ts
@@ -21,7 +21,6 @@ export class PrivilegeRefresher {
 
   constructor(
     private cosmeticsEndpoint: string,
-    private profaneWordsEndpoint: string,
     private apiKey: string,
     private reservedClanTagsEndpoint: string,
     parentLog: Logger,
@@ -60,13 +59,8 @@ export class PrivilegeRefresher {
         }
       };
 
-      const [
-        cosmeticsResponse,
-        profaneWordsResponse,
-        reservedClanTagsResponse,
-      ] = await Promise.all([
+      const [cosmeticsResponse, reservedClanTagsResponse] = await Promise.all([
         fetchWithTimeout(this.cosmeticsEndpoint),
-        fetchWithTimeout(this.profaneWordsEndpoint),
         fetchWithTimeout(this.reservedClanTagsEndpoint),
       ]);
 
@@ -103,26 +97,9 @@ export class PrivilegeRefresher {
         reservedClanTagsResult.data.map((tag) => tag.toUpperCase()),
       );
 
-      let bannedWords: string[] = [];
-      if (profaneWordsResponse && profaneWordsResponse.ok) {
-        try {
-          bannedWords = await profaneWordsResponse.json();
-          this.log.info(
-            `Loaded ${bannedWords.length} profane words from ${this.profaneWordsEndpoint}`,
-          );
-        } catch (error) {
-          this.log.warn(`Failed to parse profane words JSON, using empty list`);
-        }
-      } else {
-        this.log.warn(
-          `Failed to fetch profane words (status ${profaneWordsResponse?.status ?? "network error"}), using empty list`,
-        );
-      }
-
       this.privilegeChecker = new PrivilegeCheckerImpl(
         result.data,
         base64url.decode,
-        bannedWords,
         reservedClanTags,
       );
       this.cosmeticFlagUrls = new Set(

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -75,7 +75,6 @@ export async function startWorker() {
 
   const privilegeRefresher = new PrivilegeRefresher(
     ServerEnv.jwtIssuer() + "/cosmetics.json",
-    ServerEnv.jwtIssuer() + "/profane_words_game_server",
     ServerEnv.apiKey(),
     ServerEnv.jwtIssuer() + "/reserved_clan_tags",
     log,

--- a/tests/Privilege.test.ts
+++ b/tests/Privilege.test.ts
@@ -1,40 +1,15 @@
 import {
-  createMatcher,
   enforceVerifiedBadge,
   FailOpenPrivilegeChecker,
+  profanityMatcher as matcher,
   PrivilegeCheckerImpl,
   shadowNames,
 } from "../src/server/Privilege";
 
-const bannedWords = [
-  "hitler",
-  "adolf",
-  "nazi",
-  "jew",
-  "auschwitz",
-  "whitepower",
-  "heil",
-  "nigger",
-  "nigga",
-  "chink",
-  "spic",
-  "kike",
-  "faggot",
-  "retard",
-  "chair", // Test word to verify custom banned words work
-];
-
-const matcher = createMatcher(bannedWords);
-
 // Create a minimal PrivilegeCheckerImpl for testing censor
 const mockCosmetics = { patterns: {}, colorPalettes: {}, flags: {} };
 const mockDecoder = () => new Uint8Array();
-const checker = new PrivilegeCheckerImpl(
-  mockCosmetics,
-  mockDecoder,
-  bannedWords,
-);
-const emptyChecker = new PrivilegeCheckerImpl(mockCosmetics, mockDecoder, []);
+const checker = new PrivilegeCheckerImpl(mockCosmetics, mockDecoder);
 
 const flagCosmetics = {
   patterns: {},
@@ -52,11 +27,7 @@ const flagCosmetics = {
     },
   },
 };
-const flagChecker = new PrivilegeCheckerImpl(
-  flagCosmetics,
-  mockDecoder,
-  bannedWords,
-);
+const flagChecker = new PrivilegeCheckerImpl(flagCosmetics, mockDecoder);
 
 const skinCosmetics = {
   patterns: {},
@@ -83,11 +54,7 @@ const skinCosmetics = {
     },
   },
 };
-const skinChecker = new PrivilegeCheckerImpl(
-  skinCosmetics,
-  mockDecoder,
-  bannedWords,
-);
+const skinChecker = new PrivilegeCheckerImpl(skinCosmetics, mockDecoder);
 
 const crownCosmetics = {
   patterns: {},
@@ -114,11 +81,7 @@ const crownCosmetics = {
     },
   },
 };
-const crownChecker = new PrivilegeCheckerImpl(
-  crownCosmetics,
-  mockDecoder,
-  bannedWords,
-);
+const crownChecker = new PrivilegeCheckerImpl(crownCosmetics, mockDecoder);
 
 const effectCosmetics = {
   patterns: {},
@@ -184,11 +147,7 @@ const effectCosmetics = {
     },
   },
 };
-const effectChecker = new PrivilegeCheckerImpl(
-  effectCosmetics,
-  mockDecoder,
-  bannedWords,
-);
+const effectChecker = new PrivilegeCheckerImpl(effectCosmetics, mockDecoder);
 
 describe("UsernameCensor", () => {
   describe("isProfane (via matcher.hasMatch)", () => {
@@ -245,7 +204,6 @@ describe("UsernameCensor", () => {
       expect(matcher.hasMatch("xnazix")).toBe(true);
       expect(matcher.hasMatch("faggotry")).toBe(true);
       expect(matcher.hasMatch("retarded")).toBe(true);
-      expect(matcher.hasMatch("MyChairName")).toBe(true);
     });
 
     test("detects banned words with non-alphabetic characters mixed in", () => {
@@ -334,8 +292,8 @@ describe("UsernameCensor", () => {
       });
 
       test("removes clan tag containing banned word as substring (≤5 chars)", () => {
-        expect(checker.censor("CoolPlayer", "JEWS").clanTag).toBeNull();
-        expect(checker.censor("CoolPlayer", "NAZI").clanTag).toBeNull();
+        expect(checker.censor("CoolPlayer", "NAZIS").clanTag).toBeNull();
+        expect(checker.censor("CoolPlayer", "HEILS").clanTag).toBeNull();
       });
 
       test("removes [SS] clan tag", () => {
@@ -427,11 +385,8 @@ describe("UsernameCensor", () => {
       );
     });
 
-    test("empty banned words list still catches englishDataset profanity", () => {
-      expect(emptyChecker.censor("CoolPlayer", null).username).toBe(
-        "CoolPlayer",
-      );
-      const result = emptyChecker.censor("fuck", null);
+    test("catches englishDataset profanity beyond the static banned words", () => {
+      const result = checker.censor("fuck", null);
       expect(shadowNames).toContain(result.username);
     });
   });
@@ -964,7 +919,6 @@ describe("Effect validation in isAllowed", () => {
         },
       },
       mockDecoder,
-      bannedWords,
     );
     const result = checker.isAllowed(["effect:spectrum"], {
       effects: { transportShipTrail: "spectrum" },
@@ -982,12 +936,7 @@ describe("Effect validation in isAllowed", () => {
 describe("PrivilegeCheckerImpl#resolveClanTag", () => {
   // Reserved tags are stored uppercase, exactly as PrivilegeRefresher loads them.
   const makeChecker = (reservedTags: string[]) =>
-    new PrivilegeCheckerImpl(
-      mockCosmetics,
-      mockDecoder,
-      bannedWords,
-      new Set(reservedTags),
-    );
+    new PrivilegeCheckerImpl(mockCosmetics, mockDecoder, new Set(reservedTags));
 
   it("passes a null tag through unchanged", () => {
     const result = makeChecker(["ABC"]).resolveClanTag(null, []);


### PR DESCRIPTION
## Summary

Full username moderation is moving to the API's batch `username_check` endpoint, so the game server no longer needs the mod-curated banned-words list. This PR removes the `/profane_words_game_server` fetch and reduces the local check to a simple static fallback for when the API is unavailable.

- `PrivilegeRefresher` no longer fetches profane words; it only polls cosmetics and reserved clan tags.
- `Privilege.ts` now builds a single module-level `profanityMatcher` from a static word list + obscenity's `englishDataset`, shared by `PrivilegeCheckerImpl` and `FailOpenPrivilegeChecker` (the old `baselineBannedWords`/`defaultMatcher` split is gone).
- `PrivilegeCheckerImpl` no longer takes a `bannedWords` constructor argument.

The static list folds in the hate terms the remote list covered (hitler, nazi, adolf, auschwitz, whitepower, heil, spic, ...). This is necessary: `englishDataset` contains no extremism terms, and its patterns are partly word-anchored with double letters kept, so only the unanchored + deduped patterns built from this list catch substring and repeated-character bypasses ("xXfaggotXx", "niiiigger"). "jew" was deliberately dropped — as a raw substring it censors names like "Jewel", and unlike the API there is no LLM pass locally to clear false positives.

## Test plan

- `tests/Privilege.test.ts` updated to exercise the real static matcher (was a custom test word list); custom-word and empty-list cases removed.
- Full suite passes (2148 + 176 tests), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)