### PR TITLE
feat(client): checkmarked perk list on subscription store tiles

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -412,14 +412,18 @@
     "hard": "Plutonium",
     "legendary": "Legendary",
     "per_day": "/day",
-    "public_lobbies": "Create public lobbies",
+    "public_lobbies": "Public lobbies",
+    "public_lobbies_info": "Host custom lobbies that are publicly listed for anyone to join.",
     "rare": "Rare",
     "search": "Search...",
     "soft": "Caps",
     "title": "Cosmetics",
     "uncommon": "Uncommon",
     "unlimited_ranked": "Unlimited ranked",
-    "usd_value": "Value: {usd}"
+    "unlimited_ranked_info": "No limit on how many ranked games you can play.",
+    "usd_value": "Value: {usd}",
+    "verified_name": "Verified username",
+    "verified_name_info": "Your username is reserved for your account and shows a verified badge in-game."
   },
   "difficulty": {
     "difficulty": "Nation difficulty",

--- a/src/client/components/CosmeticButton.ts
+++ b/src/client/components/CosmeticButton.ts
@@ -271,12 +271,9 @@ export class CosmeticButton extends LitElement {
     if (this.activeResolved.type === "subscription") {
       const sub = this.activeResolved.cosmetic as Subscription;
       return html`<div
-        class="flex flex-col items-center justify-between h-full w-full text-center gap-2 p-1"
+        class="flex flex-col items-center justify-center h-full w-full text-center gap-2 p-1"
       >
-        <span class="text-xs text-white/70 line-clamp-3 px-1"
-          >${sub.description}</span
-        >
-        <div class="flex flex-col items-center gap-1">
+        <div class="flex flex-col items-center gap-1 w-full">
           <div class="flex items-center gap-1.5">
             <plutonium-icon .size=${24}></plutonium-icon>
             <span class="text-sm font-bold text-green-400"
@@ -295,16 +292,26 @@ export class CosmeticButton extends LitElement {
               >${translateText("cosmetics.per_day")}</span
             >
           </div>
+          <span
+            class="self-start text-left text-[10px] font-bold text-purple-300 uppercase tracking-wide"
+            ><span class="text-green-400">✓</span> ${translateText(
+              "cosmetics.verified_name",
+            )}</span
+          >
           ${sub.unlimitedRanked
             ? html`<span
-                class="text-[10px] font-bold text-purple-300 uppercase tracking-wide"
-                >${translateText("cosmetics.unlimited_ranked")}</span
+                class="self-start text-left text-[10px] font-bold text-purple-300 uppercase tracking-wide"
+                ><span class="text-green-400">✓</span> ${translateText(
+                  "cosmetics.unlimited_ranked",
+                )}</span
               >`
             : nothing}
           ${sub.canCreatePublicLobbies
             ? html`<span
-                class="text-[10px] font-bold text-purple-300 uppercase tracking-wide"
-                >${translateText("cosmetics.public_lobbies")}</span
+                class="self-start text-left text-[10px] font-bold text-purple-300 uppercase tracking-wide"
+                ><span class="text-green-400">✓</span> ${translateText(
+                  "cosmetics.public_lobbies",
+                )}</span
               >`
             : nothing}
         </div>
@@ -326,6 +333,31 @@ export class CosmeticButton extends LitElement {
         }
       }}
     />`;
+  }
+
+  /** Perk labels + in-depth explanations shown in the "?" tooltip. */
+  private subscriptionPerks(): Array<{ label: string; info: string }> {
+    if (this.activeResolved.type !== "subscription") return [];
+    const sub = this.activeResolved.cosmetic as Subscription;
+    const perks = [
+      {
+        label: translateText("cosmetics.verified_name"),
+        info: translateText("cosmetics.verified_name_info"),
+      },
+    ];
+    if (sub.unlimitedRanked) {
+      perks.push({
+        label: translateText("cosmetics.unlimited_ranked"),
+        info: translateText("cosmetics.unlimited_ranked_info"),
+      });
+    }
+    if (sub.canCreatePublicLobbies) {
+      perks.push({
+        label: translateText("cosmetics.public_lobbies"),
+        info: translateText("cosmetics.public_lobbies_info"),
+      });
+    }
+    return perks;
   }
 
   render() {
@@ -397,6 +429,7 @@ export class CosmeticButton extends LitElement {
                 .colorPalette=${active.colorPalette?.name}
                 .showAdFree=${isPurchasable}
                 .usdValue=${usdValue}
+                .perks=${this.subscriptionPerks()}
               ></cosmetic-info>`
             : nothing}
 

--- a/src/client/components/CosmeticContainer.ts
+++ b/src/client/components/CosmeticContainer.ts
@@ -219,7 +219,6 @@ export class CosmeticContainer extends LitElement {
     this._hasBorderSweep = !!cfg.borderSweep;
 
     this.style.position = "relative";
-    this.style.overflow = "hidden";
     this.style.background = `linear-gradient(to top, ${cfg.gradient} 0%, rgba(15,15,20,0.85) 100%)`;
     this.style.border = `1px solid ${this.selected ? cfg.glow : cfg.border}`;
     this.style.backdropFilter = "blur(8px)";
@@ -243,8 +242,18 @@ export class CosmeticContainer extends LitElement {
   private _ensureLegendaryElements() {
     if (this._shimmer || this._borderSweep) return;
 
-    // Shimmer sweep — epic and legendary
+    // Shimmer sweep — epic and legendary. Clipped by its own rounded wrapper
+    // (not host overflow) so tooltips can extend outside the card.
     if (this._hasGlint) {
+      const shimmerClip = document.createElement("div");
+      shimmerClip.style.cssText = `
+        pointer-events: none;
+        position: absolute;
+        inset: 0;
+        border-radius: 0.75rem;
+        overflow: hidden;
+        z-index: 10;
+      `;
       const shimmer = document.createElement("div");
       shimmer.className = "legendary-shimmer";
       shimmer.style.cssText = `
@@ -256,10 +265,10 @@ export class CosmeticContainer extends LitElement {
         height: 100%;
         background: linear-gradient(90deg, transparent 0%, rgba(${(rarityConfig[this.rarity] ?? fallback).shimmerColor ?? "255,200,80"},0.45) 50%, transparent 100%);
         transform: skewX(-15deg);
-        z-index: 10;
         display: none;
       `;
-      this.appendChild(shimmer);
+      shimmerClip.appendChild(shimmer);
+      this.appendChild(shimmerClip);
       this._shimmer = shimmer;
     }
 
@@ -392,9 +401,10 @@ export class CosmeticContainer extends LitElement {
     if (this._hasGlint || this._hasBorderSweep) {
       this._ensureLegendaryElements();
     }
+    // Above sibling tiles so the "?" tooltip can extend past the card edge.
+    this.style.zIndex = "10";
     if (this._isLegendary) {
       this.style.transform = "scale(1.12)";
-      this.style.zIndex = "10";
       this.classList.add("legendary-hovered");
       this._sparkles.forEach((s) => (s.style.display = "block"));
       CosmeticContainer._ensureBackdrop().style.background = "rgba(0,0,0,0.6)";
@@ -414,9 +424,9 @@ export class CosmeticContainer extends LitElement {
   };
 
   private _onMouseLeave = () => {
+    this.style.zIndex = "0";
     if (this._isLegendary) {
       this.style.transform = "";
-      this.style.zIndex = "0";
       this.classList.remove("legendary-hovered");
       this._sparkles.forEach((s) => (s.style.display = "none"));
       if (CosmeticContainer._backdrop) {

--- a/src/client/components/CosmeticInfo.ts
+++ b/src/client/components/CosmeticInfo.ts
@@ -29,12 +29,21 @@ export class CosmeticInfo extends LitElement {
   @property({ type: Number })
   usdValue?: number;
 
+  /** Subscription perks, each with an in-depth explanation. */
+  @property({ type: Array })
+  perks: Array<{ label: string; info: string }> = [];
+
   createRenderRoot() {
     return this;
   }
 
   render() {
-    if (!this.artist && !this.rarity && !this.colorPalette) {
+    if (
+      !this.artist &&
+      !this.rarity &&
+      !this.colorPalette &&
+      this.perks.length === 0
+    ) {
       return nothing;
     }
 
@@ -72,6 +81,13 @@ export class CosmeticInfo extends LitElement {
                 })}
               </div>`
             : nothing}
+          ${this.perks.map(
+            (perk) =>
+              html`<div class="whitespace-normal w-56">
+                <span class="font-bold text-purple-300">${perk.label}:</span>
+                <span class="text-white/80">${perk.info}</span>
+              </div>`,
+          )}
           ${this.colorPalette
             ? html`<div>
                 ${translateText("cosmetics.color_label")}


### PR DESCRIPTION
## Summary

Reworks the subscription tiles in the store's Subscriptions tab to advertise perks more clearly:

- **"Verified username" added as a benefit on every tier** — subscribers get their account username reserved plus a verified badge in-game.
- Perks render as a **left-aligned list with green checkmarks**, one line each ("Verified username", "Unlimited ranked", "Public lobbies" — the latter two still shown only on tiers that include them).
- The tile no longer renders the subscription description; the freed space centers the daily currency amounts + perk list.
- **In-depth perk explanations moved to the "?" hover tooltip** (`cosmetic-info`), each as a bold label + sentence, wrapping at a fixed width.

## Tooltip clipping fix

The "?" tooltip was clipped at the card boundary because `cosmetic-container` sets `overflow: hidden` on its host (needed to clip the epic/legendary shimmer sweep). Now:

- The host allows overflow; the shimmer is clipped by its own rounded `inset: 0` wrapper instead, so the sweep still cuts off exactly at the card edge.
- Any hovered tile raises its `z-index` above siblings (previously only legendary tiles did, for the scale-up effect) so the tooltip paints above neighboring cards.

## i18n

New keys in `en.json`: `cosmetics.verified_name`, plus `*_info` explanations for verified username, unlimited ranked, and public lobbies. `cosmetics.public_lobbies` shortened to "Public lobbies".

## Test plan

- [ ] Store → Subscriptions: tiles show checkmarked one-line perks, no description
- [ ] Hover "?" on a subscription tile: tooltip shows perk explanations, extends past the card without clipping, and renders above neighboring tiles
- [ ] Epic/legendary pattern tiles: shimmer sweep still clips at rounded card edges

🤖 Generated with [Claude Code](https://claude.com/claude-code)