### PR TITLE
feat: warship cosmetic effect (gradient/transition recolor)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -460,7 +460,8 @@
       "nukeExplosion": "Nuke Explosion",
       "nukeTrail": "Nuke Trail",
       "structures": "Structures",
-      "transportShipTrail": "Boat Trail"
+      "transportShipTrail": "Boat Trail",
+      "warship": "Warship"
     }
   },
   "error_modal": {

--- a/src/client/WebGLFrameBuilder.ts
+++ b/src/client/WebGLFrameBuilder.ts
@@ -30,6 +30,7 @@ import {
   EFFECT_PALETTE_BLOCKS,
   MAX_TRAIL_COLORS,
   STRUCTURES_EFFECT_BLOCK,
+  WARSHIP_EFFECT_BLOCK,
 } from "./render/gl/utils/ColorUtils";
 import {
   UT_ATOM_BOMB,
@@ -51,15 +52,18 @@ const SMALL_PLAYER_GLOW_RESCAN_TICKS = 10;
 // The effect-palette block order: index = block (rows block·MAX_TRAIL_COLORS …).
 // trail.frag.glsl picks its block from the trail tile's nuke bit — block 0 =
 // transportShipTrail (nuke bit 0), block 1 = nukeTrail (nuke bit 1, set by
-// NUKE_TRAIL_BIT in TrailManager) — and structure.frag.glsl reads block
-// STRUCTURES_EFFECT_BLOCK (2). Reordering TRAIL_EFFECT_TYPES in CosmeticSchemas
-// (or moving the structures block) would silently swap effect colors, so these
-// guards fail the build if the shader-coupled order ever drifts.
+// NUKE_TRAIL_BIT in TrailManager) — structure.frag.glsl reads block
+// STRUCTURES_EFFECT_BLOCK (2), and unit.frag.glsl reads block
+// WARSHIP_EFFECT_BLOCK (3). Reordering TRAIL_EFFECT_TYPES in CosmeticSchemas
+// (or moving the structures/warship blocks) would silently swap effect colors,
+// so these guards fail the build if the shader-coupled order ever drifts.
 const _EFFECT_BLOCK_ORDER: readonly ["transportShipTrail", "nukeTrail"] =
   TRAIL_EFFECT_TYPES;
 void _EFFECT_BLOCK_ORDER;
 const _STRUCTURES_BLOCK_IS_2: 2 = STRUCTURES_EFFECT_BLOCK;
 void _STRUCTURES_BLOCK_IS_2;
+const _WARSHIP_BLOCK_IS_3: 3 = WARSHIP_EFFECT_BLOCK;
+void _WARSHIP_BLOCK_IS_3;
 
 // Attribute → render-param mappings:
 //   size      = the ring's final WIDTH (diameter) in world tiles when it fades
@@ -122,8 +126,9 @@ export class WebGLFrameBuilder {
   // Per-player effect palette, keyed by smallID. Layout is
   // 4096×(MAX_TRAIL_COLORS·EFFECT_PALETTE_BLOCKS): block 0 (rows 0–7) =
   // transportShipTrail, block 1 (rows 8–15) = nukeTrail, block 2 (rows 16–23)
-  // = structures. Consumed by TrailPass (block from the trail tile's nuke bit)
-  // and StructurePass (block 2).
+  // = structures, block 3 (rows 24–31) = warship. Consumed by TrailPass (block
+  // from the trail tile's nuke bit), StructurePass (block 2), and UnitPass
+  // (block 3).
   private readonly effectPalette: Float32Array;
   private readonly patternMeta: Float32Array;
   private readonly patternData: Uint8Array;
@@ -477,16 +482,25 @@ export class WebGLFrameBuilder {
       // Resolve each trail-styled effectType into its own block of the effect
       // palette. rowBase block*MAX_TRAIL_COLORS must match the consumer
       // shaders' block layout (ship=0, nuke=1 in trail.frag.glsl; structures=2
-      // in structure.frag.glsl) — see _EFFECT_BLOCK_ORDER above. nukeExplosion
-      // is not trail-styled and renders through the FX pass instead.
-      const blockOrder = [...TRAIL_EFFECT_TYPES, "structures"] as const;
+      // in structure.frag.glsl; warship=3 in unit.frag.glsl) — see
+      // _EFFECT_BLOCK_ORDER above. nukeExplosion is not trail-styled and
+      // renders through the FX pass instead.
+      const blockOrder = [
+        ...TRAIL_EFFECT_TYPES,
+        "structures",
+        "warship",
+      ] as const;
       blockOrder.forEach((effectType, block) => {
         const selected = p.cosmetics.effects?.[effectType];
         if (!selected) return;
         const effect = findEffect(catalog, effectType, selected.name);
         if (!effect || effect.effectType !== effectType) return;
-        // Narrows attributes to trail attrs (structures share the shape).
-        if (!isTrailEffect(effect) && effect.effectType !== "structures") {
+        // Narrows attributes to trail attrs (structures/warship share the shape).
+        if (
+          !isTrailEffect(effect) &&
+          effect.effectType !== "structures" &&
+          effect.effectType !== "warship"
+        ) {
           return;
         }
         // Spiral vortexes render as ribbon geometry (SpiralRibbonPass) —

--- a/src/client/components/EffectPreview.ts
+++ b/src/client/components/EffectPreview.ts
@@ -42,8 +42,10 @@ function spiralStrandPath(phase: number): string {
  * share the same gradient/transition/spiral attribute shapes), filling its
  * container.
  *
- * - gradient / single color: a static swatch (flat color or left-to-right
- *   gradient — a multi-color list reads as a rainbow).
+ * - gradient: a left-to-right wrapped palette cycle that scrolls at the
+ *   in-game pace (one cycle per colorSize · count / movementSpeed seconds,
+ *   clamped watchable; movementSpeed 0 stays static). Single color: a flat
+ *   static swatch.
  * - transition: cross-fades through the colors over time, mirroring the trail
  *   (each color step lasts 1/frequency seconds, matching the shader).
  * - spiral: neon sine strands on a dark backdrop (the helix seen side-on)
@@ -118,6 +120,7 @@ export class TrailSwatch extends LitElement {
       </div>`;
     }
     let background: string;
+    let backgroundSize = "";
     if (colors.length === 0) {
       background = EMPTY_BG;
     } else if (this.trail?.type === "transition") {
@@ -126,11 +129,15 @@ export class TrailSwatch extends LitElement {
     } else if (colors.length === 1) {
       background = colors[0];
     } else {
-      background = `linear-gradient(90deg,${colors.join(",")})`;
+      // The palette cycle doubled + wrapped at background-size 200%: the
+      // visible half is one full wrapped cycle, and the scroll animation (see
+      // updated) can slide a whole cycle before looping seamlessly.
+      background = `linear-gradient(90deg,${[...colors, ...colors, colors[0]].join(",")})`;
+      backgroundSize = "background-size:200% 100%;";
     }
     return html`<div
       class="w-full h-full rounded-md"
-      style="background:${background};"
+      style="background:${background};${backgroundSize}"
     ></div>`;
   }
 
@@ -158,6 +165,32 @@ export class TrailSwatch extends LitElement {
           iterations: Infinity,
           easing: "linear",
         }),
+      );
+      return;
+    }
+
+    if (attrs?.type === "gradient") {
+      const colors = attrs.colors;
+      if (colors.length < 2 || attrs.movementSpeed === 0) return;
+
+      const fill = this.querySelector<HTMLElement>("div");
+      if (!fill) return;
+
+      // Slide one full palette cycle per loop (the doubled background in
+      // render makes the wrap seamless) at the in-game pace — one cycle per
+      // colorSize · count / movementSpeed seconds — clamped so extreme
+      // catalog values still visibly move. A positive movementSpeed scrolls
+      // the bands forward (rightward here), negative reverses.
+      const periodS =
+        (attrs.colorSize * colors.length) / Math.abs(attrs.movementSpeed);
+      const durS = Math.min(Math.max(periodS, 0.8), 6);
+      const [from, to] =
+        attrs.movementSpeed > 0 ? ["100% 0%", "0% 0%"] : ["0% 0%", "100% 0%"];
+      this.animations.push(
+        fill.animate(
+          [{ backgroundPosition: from }, { backgroundPosition: to }],
+          { duration: durS * 1000, iterations: Infinity, easing: "linear" },
+        ),
       );
       return;
     }

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -285,8 +285,8 @@ export class GPURenderer {
 
     // Per-player effect texture: EFFECT_PALETTE_BLOCKS stacked blocks of
     // MAX_TRAIL_COLORS rows (block 0 = transportShipTrail, block 1 = nukeTrail,
-    // block 2 = structures). Starts zeroed (color count 0 everywhere = no
-    // effect → territory/player color).
+    // block 2 = structures, block 3 = warship). Starts zeroed (color count 0
+    // everywhere = no effect → territory/player color).
     const effectRows = MAX_TRAIL_COLORS * EFFECT_PALETTE_BLOCKS;
     this.effectTex = createTexture2D(gl, {
       width: palW,
@@ -547,6 +547,7 @@ export class GPURenderer {
       gl,
       header,
       this.paletteTex,
+      this.effectTex,
       this.settings,
       config,
     );

--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -53,7 +53,11 @@ import { DynamicInstanceBuffer } from "../DynamicBuffer";
 import type { RenderSettings } from "../RenderSettings";
 import unitFragSrc from "../shaders/unit/unit.frag.glsl?raw";
 import unitVertSrc from "../shaders/unit/unit.vert.glsl?raw";
-import { getPaletteSize } from "../utils/ColorUtils";
+import {
+  getPaletteSize,
+  MAX_TRAIL_COLORS,
+  WARSHIP_EFFECT_BLOCK,
+} from "../utils/ColorUtils";
 import { createProgram, shaderSrc } from "../utils/GlUtils";
 
 const unitAtlasUrl = assetUrl("atlases/unit-atlas.png");
@@ -86,6 +90,9 @@ const ATLAS_COLS = UNIT_ORDER.length;
 
 /** Atlas column of the hydrogen bomb — drives the GPU glow halo. */
 const HYDROGEN_BOMB_COL = UNIT_ORDER.indexOf(UT_HYDROGEN_BOMB);
+
+/** Atlas column of the warship — gates the warship cosmetic effect. */
+const WARSHIP_COL = UNIT_ORDER.indexOf(UT_WARSHIP);
 
 // ---------------------------------------------------------------------------
 // Instance data layout
@@ -193,6 +200,7 @@ export class UnitPass {
 
   private uCamera: WebGLUniformLocation;
   private uTick: WebGLUniformLocation;
+  private uTime: WebGLUniformLocation;
   private uUnitSize: WebGLUniformLocation;
   private uFlickerSpeed: WebGLUniformLocation;
   private uAngryColor: WebGLUniformLocation;
@@ -226,10 +234,14 @@ export class UnitPass {
 
   private quadBuf: WebGLBuffer;
   private paletteTex: WebGLTexture;
+  private effectTex: WebGLTexture;
   private atlasTex: WebGLTexture;
 
   /** Frame tick received from renderer — drives tick-based effects */
   private frameTick = 0;
+  /** Wall-clock start, for uTime (seconds) — matches StructurePass so the
+   *  warship effect animates at the same pace as the structures effect. */
+  private startTime = performance.now();
 
   /** unitType string → atlas column (0-11) */
   private typeToAtlasCol = new Map<string, number>();
@@ -244,6 +256,7 @@ export class UnitPass {
     gl: WebGL2RenderingContext,
     header: RendererConfig,
     paletteTex: WebGLTexture,
+    effectTex: WebGLTexture,
     settings: RenderSettings,
     config: Config,
   ) {
@@ -251,6 +264,7 @@ export class UnitPass {
     this.settings = settings;
     this.mapW = header.mapWidth;
     this.paletteTex = paletteTex;
+    this.effectTex = effectTex;
     this.tickIntervalMs = config.msPerTick();
 
     // Build unitType string → atlas column mapping
@@ -267,10 +281,16 @@ export class UnitPass {
     this.program = createProgram(
       gl,
       shaderSrc(unitVertSrc, { ATLAS_COLS, HYDROGEN_BOMB_COL }),
-      shaderSrc(unitFragSrc, { PALETTE_SIZE: getPaletteSize(), ATLAS_COLS }),
+      shaderSrc(unitFragSrc, {
+        PALETTE_SIZE: getPaletteSize(),
+        ATLAS_COLS,
+        WARSHIP_COL,
+        WARSHIP_EFFECT_ROW_BASE: WARSHIP_EFFECT_BLOCK * MAX_TRAIL_COLORS,
+      }),
     );
     this.uCamera = gl.getUniformLocation(this.program, "uCamera")!;
     this.uTick = gl.getUniformLocation(this.program, "uTick")!;
+    this.uTime = gl.getUniformLocation(this.program, "uTime")!;
     this.uUnitSize = gl.getUniformLocation(this.program, "uUnitSize")!;
     this.uFlickerSpeed = gl.getUniformLocation(this.program, "uFlickerSpeed")!;
     this.uAngryColor = gl.getUniformLocation(this.program, "uAngryColor")!;
@@ -302,6 +322,7 @@ export class UnitPass {
     gl.uniform1i(gl.getUniformLocation(this.program, "uPalette"), 0);
     gl.uniform1i(gl.getUniformLocation(this.program, "uAtlas"), 1);
     gl.uniform1i(gl.getUniformLocation(this.program, "uAffiliation"), 2);
+    gl.uniform1i(gl.getUniformLocation(this.program, "uEffect"), 3);
 
     // Create placeholder atlas texture (1x1 gray pixel)
     this.atlasTex = gl.createTexture()!;
@@ -546,6 +567,7 @@ export class UnitPass {
     const us = this.settings.unit;
     gl.uniformMatrix3fv(this.uCamera, false, cameraMatrix);
     gl.uniform1f(this.uTick, this.frameTick);
+    gl.uniform1f(this.uTime, (performance.now() - this.startTime) / 1000);
     gl.uniform1f(this.uUnitSize, us.unitSize);
     gl.uniform1f(this.uFlickerSpeed, us.flickerSpeed);
     gl.uniform3f(this.uAngryColor, us.angryR, us.angryG, us.angryB);
@@ -571,6 +593,9 @@ export class UnitPass {
       gl.activeTexture(gl.TEXTURE2);
       gl.bindTexture(gl.TEXTURE_2D, this.affiliationTex);
     }
+
+    gl.activeTexture(gl.TEXTURE3);
+    gl.bindTexture(gl.TEXTURE_2D, this.effectTex);
   }
 
   /** Draw ground/sea units (boats, trains). Render below structures. */

--- a/src/client/render/gl/shaders/unit/unit.frag.glsl
+++ b/src/client/render/gl/shaders/unit/unit.frag.glsl
@@ -4,6 +4,13 @@ precision highp float;
 uniform sampler2D uPalette;
 uniform sampler2D uAtlas;
 uniform sampler2D uAffiliation;   // 256×2 RGBA8 — row 1 = unit affiliation
+uniform sampler2D uEffect;        // RGBA32F — shared effect palette, keyed by
+                                  //   ownerID. The warship block starts at row
+                                  //   WARSHIP_EFFECT_ROW_BASE; same layout as
+                                  //   structure.frag.glsl (row r = color r's rgb;
+                                  //   row 0.a = count, 1.a = styleId,
+                                  //   2.a = scalar0, 3.a = scalar1)
+uniform float uTime;              // seconds, for animated effect styles
 uniform float uTick;
 uniform float uFlickerSpeed;
 uniform vec3  uAngryColor;
@@ -40,6 +47,47 @@ const vec3 FLICKER_COLORS[4] = vec3[4](
   vec3(1.0, 1.0, 0.0),   // yellow
   vec3(1.0, 1.0, 1.0)    // white
 );
+
+// The owner's warship cosmetic color, if equipped. Reads the warship block of
+// the shared effect palette; the gradient/transition math mirrors
+// structure.frag.glsl so the same catalog attributes look identical on both.
+// Returns false when the owner has no warship effect (count 0).
+bool warshipEffectColor(int owner, out vec3 color) {
+  const int rowBase = WARSHIP_EFFECT_ROW_BASE;
+  int count = int(texelFetch(uEffect, ivec2(owner, rowBase), 0).a + 0.5);
+  if (count <= 0) return false;
+  if (count == 1) {
+    // Single color — flat recolor.
+    color = texelFetch(uEffect, ivec2(owner, rowBase), 0).rgb;
+  } else if (int(texelFetch(uEffect, ivec2(owner, rowBase + 1), 0).a + 0.5) == 1) {
+    // transition — one color at a time, cross-fading through the list.
+    // frequency = color changes per second.
+    float frequency = texelFetch(uEffect, ivec2(owner, rowBase + 2), 0).a;
+    float t = uTime * frequency;
+    int i = int(t) % count;
+    int j = (i + 1) % count;
+    vec3 a = texelFetch(uEffect, ivec2(owner, rowBase + i), 0).rgb;
+    vec3 b = texelFetch(uEffect, ivec2(owner, rowBase + j), 0).rgb;
+    color = mix(a, b, fract(t));
+  } else {
+    // gradient — the palette spans the sprite's diagonal once (vCellUV is the
+    // sprite cell, 0..1), sliding one full cycle every
+    // colorSize · count / movementSpeed seconds — the same icon-space
+    // semantics as the structures effect.
+    float colorSize = max(texelFetch(uEffect, ivec2(owner, rowBase + 2), 0).a, 0.001);
+    float movementSpeed = texelFetch(uEffect, ivec2(owner, rowBase + 3), 0).a;
+    float dn = (vCellUV.x + vCellUV.y) * 0.5; // sprite diagonal, 0..1
+    float phase =
+      fract(dn - uTime * movementSpeed / (colorSize * float(count)));
+    float f = phase * float(count);
+    int i = int(f) % count;
+    int j = (i + 1) % count;
+    vec3 a = texelFetch(uEffect, ivec2(owner, rowBase + i), 0).rgb;
+    vec3 b = texelFetch(uEffect, ivec2(owner, rowBase + j), 0).rgb;
+    color = mix(a, b, fract(f));
+  }
+  return true;
+}
 
 void main() {
   // Untargetable nukes render translucent so players know SAMs can't hit them
@@ -87,6 +135,18 @@ void main() {
   float u = (vOwnerID + 0.5) / float(PALETTE_SIZE);
   vec3 territoryColor = texture(uPalette, vec2(u, 0.25)).rgb;
   vec3 borderColor    = texture(uPalette, vec2(u, 0.75)).rgb;
+
+  // warship cosmetic: recolor the warship's territory-color bands with the
+  // owner's effect (raw catalog colors, like trails). The border band keeps
+  // the player color so ownership stays readable, and combat signals win: the
+  // angry (attacking) override below replaces this with red, and the retreat
+  // blink still darkens the center band.
+  if (abs(vAtlasCol - float(WARSHIP_COL)) < 0.1) {
+    vec3 effectRGB;
+    if (warshipEffectColor(int(vOwnerID + 0.5), effectRGB)) {
+      territoryColor = effectRGB;
+    }
+  }
 
   // Flag states (uint8 passed as float via vertex attribute):
   //   0 = normal

--- a/src/client/render/gl/utils/ColorUtils.ts
+++ b/src/client/render/gl/utils/ColorUtils.ts
@@ -28,13 +28,17 @@ export const MAX_TRAIL_COLORS = 8;
  * The effect-palette texture stacks one MAX_TRAIL_COLORS-row block per
  * trail-styled effectType: block 0 = transportShipTrail, block 1 = nukeTrail
  * (matching the nuke bit in trail.frag.glsl), block 2 = structures (read by
- * structure.frag.glsl). Bump this if another trail-styled effectType is added
- * (and give its consumer shader the new rowBase).
+ * structure.frag.glsl), block 3 = warship (read by unit.frag.glsl). Bump this
+ * if another trail-styled effectType is added (and give its consumer shader
+ * the new rowBase).
  */
-export const EFFECT_PALETTE_BLOCKS = 3;
+export const EFFECT_PALETTE_BLOCKS = 4;
 
 /** Block index of the structures effect within the effect-palette texture. */
 export const STRUCTURES_EFFECT_BLOCK = 2;
+
+/** Block index of the warship effect within the effect-palette texture. */
+export const WARSHIP_EFFECT_BLOCK = 3;
 
 // ---------- Terrain ----------
 

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -11,8 +11,8 @@ export type Skin = z.infer<typeof SkinSchema>;
 export type Pack = z.infer<typeof PackSchema>;
 export type Subscription = z.infer<typeof SubscriptionSchema>;
 // An effect cosmetic of any type — discriminated on effectType (today
-// transportShipTrail + nukeTrail + nukeExplosion + structures; gains a member
-// per effectType).
+// transportShipTrail + nukeTrail + nukeExplosion + structures + warship;
+// gains a member per effectType).
 export type Effect = z.infer<typeof EffectSchema>;
 export type EffectType = z.infer<typeof EffectTypeSchema>;
 // Shared by every trail effectType (transportShipTrail, nukeTrail, …).
@@ -24,6 +24,10 @@ export type NukeExplosionAttributes = z.infer<
 // Attributes of a structures effect (recolors structure icons, not a trail).
 export type StructuresEffectAttributes = z.infer<
   typeof StructuresEffectAttributesSchema
+>;
+// Attributes of a warship effect (recolors warship sprites, not a trail).
+export type WarshipEffectAttributes = z.infer<
+  typeof WarshipEffectAttributesSchema
 >;
 export type PatternName = z.infer<typeof CosmeticNameSchema>;
 export type Product = z.infer<typeof ProductSchema>;
@@ -117,6 +121,7 @@ export const EFFECT_TYPES = [
   "nukeTrail",
   "nukeExplosion",
   "structures",
+  "warship",
 ] as const;
 export const EffectTypeSchema = z.enum(EFFECT_TYPES);
 
@@ -261,12 +266,29 @@ const StructuresEffectSchema = CosmeticSchema.extend({
   url: z.string().optional(),
 });
 
+// Warship-effect attributes: the same gradient/transition shapes and
+// icon-space semantics as the structures effect (the palette spans the sprite
+// once for "gradient"; "transition" cross-fades the whole sprite), so the
+// schema is shared rather than re-declared.
+export const WarshipEffectAttributesSchema = StructuresEffectAttributesSchema;
+
+// Recolors the owner's warships with gradient / transition styles. Unlike the
+// hover-gated structures effect, warships are few and mobile, so the effect
+// renders whenever the warship does; combat signals (the attacking-red
+// override, the retreat blink) take priority over the cosmetic.
+const WarshipEffectSchema = CosmeticSchema.extend({
+  effectType: z.literal("warship"),
+  attributes: WarshipEffectAttributesSchema,
+  url: z.string().optional(),
+});
+
 // Any catalog effect, discriminated on effectType. Add a member per effectType.
 export const EffectSchema = z.discriminatedUnion("effectType", [
   TransportShipTrailEffectSchema,
   NukeTrailEffectSchema,
   NukeExplosionEffectSchema,
   StructuresEffectSchema,
+  WarshipEffectSchema,
 ]);
 
 /**
@@ -290,7 +312,7 @@ export function isNukeExplosionEffect(
 
 /**
  * A player selects one effect per "slot". A slot is the effectType itself for
- * per-type effects (transportShipTrail, nukeTrail, structures) and the
+ * per-type effects (transportShipTrail, nukeTrail, structures, warship) and the
  * nukeType for nuke explosions (atom, hydro, mirvWarhead) — so a player can
  * equip a distinct explosion per bomb. Returns the effectType a slot resolves
  * to for catalog lookup, or undefined for an unknown/stale slot (e.g. a bare
@@ -405,6 +427,7 @@ export const CosmeticsSchema = z.object({
       nukeTrail: lenientRecord(NukeTrailEffectSchema).optional(),
       nukeExplosion: lenientRecord(NukeExplosionEffectSchema).optional(),
       structures: lenientRecord(StructuresEffectSchema).optional(),
+      warship: lenientRecord(WarshipEffectSchema).optional(),
     })
     .optional(),
   currencyPacks: z.record(z.string(), PackSchema).optional(),

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -734,6 +734,89 @@ describe("structures effects", () => {
   });
 });
 
+describe("warship effects", () => {
+  const gradient = {
+    name: "patriotic_warshipo",
+    effectType: "warship",
+    attributes: {
+      type: "gradient",
+      colors: ["#f00000", "#e6e6e6", "#1100ff"],
+      colorSize: 5,
+      movementSpeed: 10,
+    },
+    affiliateCode: null,
+    product: null,
+    priceHard: 10,
+    rarity: "common",
+  };
+  const transition = {
+    name: "warship_transition",
+    effectType: "warship",
+    attributes: {
+      type: "transition",
+      colors: ["#ff0000", "#ffffff", "#00ff88"],
+      frequency: 5,
+    },
+    affiliateCode: null,
+    product: null,
+    rarity: "common",
+  };
+
+  it("parses the gradient and transition catalog entries", () => {
+    const result = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: {
+        warship: {
+          patriotic_warshipo: gradient,
+          warship_transition: transition,
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(
+        result.data.effects?.warship?.patriotic_warshipo?.attributes.type,
+      ).toBe("gradient");
+      expect(
+        result.data.effects?.warship?.warship_transition?.attributes.type,
+      ).toBe("transition");
+    }
+  });
+
+  it("resolves the warship slot (slot = effectType)", () => {
+    expect(effectTypeForSlot("warship")).toBe("warship");
+    const parsed = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: { warship: { patriotic_warshipo: gradient } },
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(
+      findEffectForSlot(parsed.data, "warship", "patriotic_warshipo")?.name,
+    ).toBe("patriotic_warshipo");
+  });
+
+  it("shares trail attribute shapes but is not a trail effect", () => {
+    const eff = EffectSchema.parse(gradient);
+    // Renders through the warship palette block, not a trail block.
+    expect(isTrailEffect(eff)).toBe(false);
+    expect(effectMatchesSlot(eff, "warship")).toBe(true);
+    expect(effectMatchesSlot(eff, "structures")).toBe(false);
+    expect(effectMatchesSlot(eff, "transportShipTrail")).toBe(false);
+  });
+
+  it("rejects a warship effect with an unknown attribute type", () => {
+    expect(
+      EffectSchema.safeParse({
+        ...gradient,
+        attributes: { type: "sparkle", colors: [] },
+      }).success,
+    ).toBe(false);
+  });
+});
+
 describe("isTrailEffect", () => {
   it("is true for a trail effect and false for a nukeExplosion", () => {
     const trail = EffectSchema.parse({


### PR DESCRIPTION
## Summary

Adds a `warship` effectType mirroring the structures effect: catalog entries with gradient/transition attributes recolor the owner's warship sprites. The API side already supports it (`WarshipStyleSchema`, `warship` response key), so this completes the loop — catalog entries like the one below just work:

```json
"warship": {
  "patriotic_warshipo": {
    "name": "patriotic_warshipo",
    "effectType": "warship",
    "attributes": { "type": "gradient", "colors": ["#f00000", "#e6e6e6", "#1100ff"], "colorSize": 5, "movementSpeed": 10 }
  }
}
```

### Behavior

- Unlike the hover-gated structures effect, the warship effect is **always visible** — warships are few, mobile, and their trails already render constantly.
- **Combat signals win**: an attacking warship's red override replaces the effect entirely, and the retreat blink still darkens the center band. The border band keeps the player color so ownership stays readable.
- Gradient spans the sprite's diagonal and scrolls at the trail-equivalent pace; transition cross-fades the whole sprite — same math as `structure.frag.glsl`, so identical catalog attributes look identical on both.

### Implementation

- **CosmeticSchemas.ts**: `warship` in `EFFECT_TYPES` + catalog/effect schemas (attributes shared with structures). Slot machinery, server privilege checks, store tabs, and selection UI pick it up generically.
- **Effect palette** grows to 4 blocks (`WARSHIP_EFFECT_BLOCK = 3`); `WebGLFrameBuilder` resolves warship selections into it, with a build-time guard on the shader-coupled block order.
- **UnitPass** binds the shared effect texture + a `uTime` uniform; `unit.frag.glsl` applies the effect to warship instances only (gated on the warship atlas column).
- **Preview**: gradient swatches (`trail-swatch`) now scroll at the in-game pace (clamped watchable) via a seamless wrapped background animation — this animates trail/structures gradient tiles too.
- `effects.type.warship` label in `en.json`.

## Test plan

- [x] Schema tests mirroring the structures suite: catalog parse, slot resolution, not-a-trail narrowing, unknown-attribute rejection (`tests/CosmeticSchemas.test.ts`)
- [x] Full suite passes (2417 tests), tsc/eslint/prettier clean
- [x] Verified in a real game (headless Chromium, dev server): built a port + warship with a temp-injected catalog entry — the red/white/blue gradient renders across the sprite and animates; player colors elsewhere unaffected
- [x] Verified the gradient swatch preview scrolls seamlessly at 1.5 s/cycle for the example entry, transition preview unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)