### PR TITLE
Adds "New" tag to new map Branching Paths

### DIFF
--- a/map-generator/assets/maps/branchingpaths/info.json
+++ b/map-generator/assets/maps/branchingpaths/info.json
@@ -2,7 +2,7 @@
   "id": "BranchingPaths",
   "name": "Branching Paths",
   "translation_key": "map.branchingpaths",
-  "categories": ["arcade", "fictional"],
+  "categories": ["arcade", "fictional", "new"],
   "multiplayer_frequency": 3,
   "special_team_count": 2,
   "nations": [

--- a/resources/maps/branchingpaths/manifest.json
+++ b/resources/maps/branchingpaths/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["arcade", "fictional"],
+  "categories": ["arcade", "fictional", "new"],
   "id": "BranchingPaths",
   "map": {
     "height": 2148,

--- a/src/core/game/Maps.gen.ts
+++ b/src/core/game/Maps.gen.ts
@@ -326,7 +326,7 @@ export const maps: readonly MapInfo[] = [
     id: "BranchingPaths",
     type: GameMapType.BranchingPaths,
     translationKey: "map.branchingpaths",
-    categories: ["arcade", "fictional"],
+    categories: ["arcade", "fictional", "new"],
     multiplayerFrequency: 3,
     specialTeamCount: 2,
   },


### PR DESCRIPTION
Fixes issue #4668 by properly adding the "new" tag to the map Branching Paths, should display properly now when looking through the map lists.

<img width="536" height="271" alt="Screenshot 2026-07-23 162859" src="https://github.com/user-attachments/assets/ffe10f17-93e6-4736-b30e-2b97466dec28" />

## Please complete the following:


- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

TheGamingFish