### PR TITLE
fix(featured-stream): keep the Twitch embed at its 400x300 minimum

### DIFF
--- a/src/client/FeaturedStream.ts
+++ b/src/client/FeaturedStream.ts
@@ -335,7 +335,9 @@ export class FeaturedStream extends LitElement {
     const min = this.minimized;
     // Twitch pauses the player when it's off-screen/clipped (and hiding the embed violates
     // Twitch ToS), so "minimized" stays a small but still-visible corner thumbnail that
-    // keeps streaming. z above the footer (z-50) and content so it overlays everything.
+    // keeps streaming. The player must be >=400x300 in every state (Twitch's documented embed
+    // minimum; below it autoplay is blocked), so width is floored at 400px and the mount at
+    // 300px tall. z above the footer (z-50) and content so it overlays everything.
     return html`
       <div
         id="featured-stream-card"
@@ -346,8 +348,8 @@ export class FeaturedStream extends LitElement {
             CORNER_CLASS[this.corner]} ${this.present()
           ? "opacity-100"
           : "pointer-events-none opacity-0"} ${min
-          ? "w-[360px]"
-          : "w-[clamp(340px,40vw,720px)] max-w-[92vw]"}"
+          ? "w-[400px]"
+          : "w-[clamp(400px,40vw,720px)]"} max-w-[92vw]"
         style=${this.dragPos
           ? `left:${this.dragPos.x}px;top:${this.dragPos.y}px`
           : ""}
@@ -388,7 +390,7 @@ export class FeaturedStream extends LitElement {
         </div>
         <div
           id="featured-stream-mount"
-          class="aspect-video w-full bg-black"
+          class="aspect-video min-h-[300px] w-full bg-black"
         ></div>
       </div>
     `;


### PR DESCRIPTION
## What

Keep the featured-stream Twitch embed at Twitch's documented **400×300** minimum in every state.

## Why

Twitch's embed docs state a minimum player size of **400px wide × 300px tall**, and that *"minimum size requirements and visibility are necessary for autoplay to begin."* Below it, autoplay is blocked (this is the `requirement not met` console message some of us saw).

The panel was under the minimum:
- **Minimized** was `360px` wide → ~203px tall at 16:9. Under on both axes.
- **Expanded** used a 16:9 player, which only reaches 300px tall at ~534px wide, so on narrower viewports it dropped below 300px tall.

## Fix

- Floor the card width at **400px** in both minimized and expanded states.
- Give the player mount a **`min-h-[300px]`**, so the 16:9 region never falls below 300px tall (it letterboxes between 400 and ~534px wide).

Net: the embed is `≥400×300` wherever autoplay applies (desktop). `max-w-[92vw]` still guards against horizontal overflow on very narrow screens; Twitch disables autoplay on mobile regardless, so the size floor there is moot.

## Twitch ToS audit (while I was in here)

Checked the embed against Twitch's full [embedding requirements](https://dev.twitch.tv/docs/embed/). Everything else already complies:

| Requirement | Status |
|---|---|
| Min size 400×300 | **fixed here** |
| Player not obscured/hidden while playing | ✅ (high z-index; paused + unmounted while in a game; only a transient muted `opacity-0` during liveness detection) |
| Domain uses SSL | ✅ (HTTPS) |
| `parent` parameter set | ✅ |
| Only approved, unmodified player | ✅ (no overlay on the video) |
| Autoplay is muted | ✅ (`muted: true`) |
| Ads not blocked/obscured | ✅ (we only ever pause the whole player) |

## Tests

No behavior change beyond sizing; existing FeaturedStream tests pass. Verified locally: prettier, eslint, tsc, tests all green.

Follow-up to #4335.
