### PR TITLE
feat(featured-stream): off-web exclusion, ad-free close, keep through lobby wait

### DIFF
--- a/src/client/FeaturedStream.ts
+++ b/src/client/FeaturedStream.ts
@@ -146,13 +146,14 @@ export class FeaturedStream extends LitElement {
     const minDay = localStorage.getItem(MIN_KEY);
     this.minimized = minDay === todayKey();
     if (minDay && !this.minimized) localStorage.removeItem(MIN_KEY);
-    document.addEventListener("join-lobby", this.onJoin);
+    // Stay up through the lobby/queue wait; hide only once the game actually starts.
+    document.addEventListener("game-starting", this.onGameStart);
     document.addEventListener("leave-lobby", this.onLeave);
   }
 
   disconnectedCallback() {
     super.disconnectedCallback();
-    document.removeEventListener("join-lobby", this.onJoin);
+    document.removeEventListener("game-starting", this.onGameStart);
     document.removeEventListener("leave-lobby", this.onLeave);
     if (this.recheckTimer) clearTimeout(this.recheckTimer);
     this.recheckTimer = null;
@@ -183,11 +184,12 @@ export class FeaturedStream extends LitElement {
     void this.start();
   }
 
-  private onJoin = () => {
-    this.inGame = true; // hide while in a lobby/game
-    // Stop probing while in a game: a pending recheck (or a stream coming online) must not
-    // mount a fresh autoplaying player behind the hidden panel — an obscured embed (Twitch
-    // ToS). Cancel the recheck and pause the current player; we re-probe on leave.
+  // The panel stays up through the lobby/queue wait and hides only once the game actually
+  // starts (Main dispatches game-starting at prestart). Stop probing while in game: a pending
+  // recheck (or a stream coming online) must not mount a fresh autoplaying player behind the
+  // hidden panel — an obscured embed (Twitch ToS). Pause the current player; we re-probe on leave.
+  private onGameStart = () => {
+    this.inGame = true;
     if (this.recheckTimer) {
       clearTimeout(this.recheckTimer);
       this.recheckTimer = null;

--- a/src/client/FeaturedStream.ts
+++ b/src/client/FeaturedStream.ts
@@ -1,6 +1,8 @@
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { getFeaturedStream } from "./Api";
+import { crazyGamesSDK } from "./CrazyGamesSDK";
+import { isDesktopShell } from "./DesktopShell";
 import { translateText } from "./Utils";
 
 // Homepage "featured stream" panel: embeds a Twitch channel and shows ONLY while it is
@@ -43,7 +45,16 @@ declare global {
 export type Corner = "tl" | "tr" | "bl" | "br";
 const CORNER_KEY = "featured-stream-corner";
 const MIN_KEY = "featured-stream-minimized";
+const CLOSED_KEY = "featured-stream-closed"; // ad-free close, remembered for the current day
 const RECHECK_MS = 60_000; // re-probe interval when every channel is offline
+
+// Local calendar day, used to scope the "closed" and "minimized" states to the current stream:
+// each is stored with the day it was set and ignored once the day changes, so the panel resets
+// for the next day's stream instead of persisting forever.
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+}
 
 const CORNER_CLASS: Record<Corner, string> = {
   tl: "top-4 left-4",
@@ -108,7 +119,7 @@ export class FeaturedStream extends LitElement {
   @state() private minimized = false;
   @state() private corner: Corner = "br"; // which screen corner the panel snaps to
   @state() private dragPos: { x: number; y: number } | null = null; // free pos while dragging
-  @state() private dismissed = false; // mobile flick-off; page-visit only, not persisted
+  @state() private dismissed = false; // closed; ad-free close persists for the day, flick session-only
 
   private channels: string[] = [];
   private idx = 0;
@@ -130,7 +141,11 @@ export class FeaturedStream extends LitElement {
     const saved = localStorage.getItem(CORNER_KEY);
     if (saved === "tl" || saved === "tr" || saved === "bl" || saved === "br")
       this.corner = saved;
-    this.minimized = localStorage.getItem(MIN_KEY) === "true";
+    // Minimized state is scoped to the current day: restore it only if it was set today, and
+    // drop a stale value so the next day's stream starts expanded.
+    const minDay = localStorage.getItem(MIN_KEY);
+    this.minimized = minDay === todayKey();
+    if (minDay && !this.minimized) localStorage.removeItem(MIN_KEY);
     document.addEventListener("join-lobby", this.onJoin);
     document.addEventListener("leave-lobby", this.onLeave);
   }
@@ -145,6 +160,20 @@ export class FeaturedStream extends LitElement {
   }
 
   async firstUpdated() {
+    // Never on CrazyGames or the desktop (Steam) shell: a Twitch embed carries Twitch's own
+    // ads and is third-party content, which breaks CrazyGames' "SDK ads only" policy and
+    // Steam's no-in-game-ads rules (and can't satisfy Twitch's parent-domain check in the
+    // shell). Matches how the rest of the app suppresses promos off the open web.
+    if (crazyGamesSDK.isOnCrazyGames() || isDesktopShell()) return;
+    // An ad-free user who closed the panel stays closed for the rest of that day (only the
+    // ad-free x/flick writes this key, so it never suppresses the panel for ad-supported users).
+    // A value from an earlier day is stale: drop it so the next day's stream shows again.
+    const closedDay = localStorage.getItem(CLOSED_KEY);
+    if (closedDay === todayKey()) {
+      this.dismissed = true;
+      return;
+    }
+    if (closedDay) localStorage.removeItem(CLOSED_KEY);
     // Channels come from the served config (like news.json), with a bundled fallback.
     const cfg = await getFeaturedStream();
     if (!cfg.enabled || cfg.channels.length === 0) return; // off / nothing configured
@@ -183,6 +212,7 @@ export class FeaturedStream extends LitElement {
   };
 
   private start = async () => {
+    if (!this.channels.length) return; // feature off / gated: never load the Twitch SDK
     let Twitch: TwitchGlobal;
     try {
       Twitch = await loadTwitchSdk();
@@ -332,12 +362,13 @@ export class FeaturedStream extends LitElement {
       ) as HTMLElement | null;
       const cx = this.dragPos.x + (card?.offsetWidth ?? 360) / 2;
       const cy = this.dragPos.y + (card?.offsetHeight ?? 200) / 2;
-      // Touch only: flicking the panel off the edge dismisses it for this page visit.
+      // Touch only: flicking the panel off the edge closes it (persisted for ad-free users,
+      // session-only otherwise).
       if (
         isCoarsePointer() &&
         isOffFrame(cx, cy, window.innerWidth, window.innerHeight)
       ) {
-        this.dismiss();
+        this.dismiss(this.adFree);
         return;
       }
       this.corner = cornerFromCenter(
@@ -361,10 +392,12 @@ export class FeaturedStream extends LitElement {
     this.dragPos = null;
   };
 
-  // Hide the panel for the rest of this page visit. Deliberately NOT persisted: a refresh or
-  // the next visit brings it back (a light "not now", not a permanent opt-out). Stop probing
-  // and tear the player down so nothing keeps streaming behind the hidden panel.
-  private dismiss() {
+  // Close the panel. For ad-free users (the x button, or a flick) the close persists for the
+  // current day via CLOSED_KEY, so it stays gone across reloads that day and resets for the next
+  // day's stream; for ad-supported users the mobile flick is session-only. Either way, stop
+  // probing and tear the player down so nothing keeps streaming behind the hidden panel.
+  private dismiss(persist: boolean) {
+    if (persist) localStorage.setItem(CLOSED_KEY, todayKey());
     this.dismissed = true;
     this.dragPos = null;
     this.mountGen++; // stale player callbacks fail fresh() and become no-ops
@@ -377,9 +410,21 @@ export class FeaturedStream extends LitElement {
 
   private toggleMinimize = () => {
     this.minimized = !this.minimized;
-    localStorage.setItem(MIN_KEY, String(this.minimized));
+    // Scope the minimized state to the current day too (matches the close): store the day when
+    // collapsing, clear it when expanding.
+    if (this.minimized) localStorage.setItem(MIN_KEY, todayKey());
+    else localStorage.removeItem(MIN_KEY);
     this.kickPlay(); // resume playback after the resize either way
   };
+
+  // Only ad-free users get a close button (any shop purchase makes a user adfree for life,
+  // which zeroes window.adsEnabled); ad-supported users can only minimize. Checked with
+  // `=== false` so the button doesn't flash before /user/me resolves the entitlement.
+  private get adFree(): boolean {
+    return window.adsEnabled === false;
+  }
+
+  private onClose = () => this.dismiss(this.adFree);
 
   render() {
     if (!this.channels.length || this.dismissed) return html``;
@@ -430,15 +475,26 @@ export class FeaturedStream extends LitElement {
             >
             <span class="truncate font-bold">${channel}</span>
           </button>
-          <button
-            class="shrink-0 px-1 text-lg leading-none text-white/70 hover:text-white"
-            aria-label=${translateText(
-              min ? "featured_stream.expand" : "featured_stream.minimize",
-            )}
-            @click=${this.toggleMinimize}
-          >
-            ${min ? "⤢" : "–"}
-          </button>
+          <div class="flex shrink-0 items-center">
+            <button
+              class="px-1 text-lg leading-none text-white/70 hover:text-white"
+              aria-label=${translateText(
+                min ? "featured_stream.expand" : "featured_stream.minimize",
+              )}
+              @click=${this.toggleMinimize}
+            >
+              ${min ? "⤢" : "–"}
+            </button>
+            ${min && this.adFree
+              ? html`<button
+                  class="px-1 text-lg leading-none text-white/70 hover:text-white"
+                  aria-label=${translateText("common.close")}
+                  @click=${this.onClose}
+                >
+                  ✕
+                </button>`
+              : ""}
+          </div>
         </div>
         <div
           id="featured-stream-mount"

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -244,6 +244,7 @@ declare global {
     "open-matchmaking": CustomEvent<{ mode?: "1v1" | "2v2" } | undefined>;
     userMeResponse: CustomEvent<UserMeResponse | false>;
     "leave-lobby": CustomEvent;
+    "game-starting": CustomEvent;
     "update-game-config": CustomEvent;
   }
 }
@@ -964,6 +965,9 @@ class Client {
     this.lobbyHandle = newLobbyHandle;
 
     this.lobbyHandle.prestart.then(() => {
+      // The game is actually starting now (lobby wait is over). Let listeners that stay up
+      // through the wait (e.g. the featured-stream panel) hide at this point instead of on join.
+      document.dispatchEvent(new CustomEvent("game-starting"));
       console.log("Closing modals");
       document.getElementById("settings-button")?.classList.add("hidden");
       if (this.usernameInput) {


### PR DESCRIPTION
Three related changes to the homepage featured-stream panel.

## 1. Exclude the embed off the open web (ToS)
Never mount the Twitch embed on **CrazyGames** or the **desktop (Steam) shell**, and never load the Twitch SDK there. Matches how the app already suppresses its own promos off-web via `window.adsEnabled`:

- **CrazyGames:** [only SDK-served ads are allowed](https://docs.crazygames.com/requirements/ads/) and no external cross-promotion; a Twitch embed serves Twitch's own ads and is third-party content.
- **Steam:** Steam [does not support advertising models in games](https://partner.steamgames.com/doc/marketing/advertising); a live Twitch player carries Twitch ad breaks, and the desktop shell can't satisfy Twitch's `parent`-domain requirement.

## 2. Close button for ad-free users
Ad-free users (any shop purchase makes a user `adfree` for life, which zeroes `window.adsEnabled`) get an `×` in the minimized bar. The close is remembered **for the current day** (the day is stored in `localStorage`), so the panel stays gone across reloads that day and resets for the next day's stream. Ad-supported users keep minimize only; their mobile flick stays session-only. The minimized state is scoped to the day the same way.

## 3. Keep the panel through the lobby wait
The panel used to hide the moment you joined a lobby (`join-lobby`). Now it stays up through the **queue/lobby wait** and hides only once the game actually starts. `Main.ts` dispatches a new `game-starting` event at `prestart` (the real start moment); the panel hides on that instead of on `join-lobby`, and reappears on `leave-lobby`.

> Heads-up for maintainers: (1) and (2) couple this OFM widget to OF's own ad/entitlement signals (`crazyGamesSDK.isOnCrazyGames()`, `isDesktopShell()`, `window.adsEnabled`); (3) adds a small shared `game-starting` document event in `Main.ts`. Flagging in case you'd rather gate/signal differently.

## Tests
Verified locally: prettier, eslint, tsc, tests all green. Reuses the existing `common.close` i18n key (no locale-file changes).

Follow-up to #4335 / #4673. Sizing (Twitch's 400×300 minimum) landed in #4696.
