### PR TITLE
fix: destroy corner video ad when the game starts

### DIFF
--- a/src/client/HomepagePromos.ts
+++ b/src/client/HomepagePromos.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { adGatekeeper } from "./AdGatekeeper";
 
 // ─── Gutter Ads ──────────────────────────────────────────────────────────────
 
@@ -72,8 +73,13 @@ export class HomepagePromos extends LitElement {
     } catch (e) {
       console.error("error destroying gutter ads", e);
     }
-    // The corner video must not keep playing during the game.
-    this.destroyCornerAdVideo();
+    // Adblock-detected users get NO in-game ads (the AdGatekeeper latch is
+    // permanent, surviving the blocker being disabled), so the corner video
+    // must not keep playing into the game for them. Blocker-free users keep
+    // it — same policy as InGamePromo's bottom-left ad.
+    if (!adGatekeeper.canShowAds) {
+      this.destroyCornerAdVideo();
+    }
   }
 
   public loadBottomRail(): void {

--- a/src/client/HomepagePromos.ts
+++ b/src/client/HomepagePromos.ts
@@ -8,6 +8,7 @@ export class HomepagePromos extends LitElement {
   @state() private isVisible: boolean = false;
   @state() private adLoaded: boolean = false;
   private cornerAdLoaded: boolean = false;
+  private cornerAdDestroyed: boolean = false;
 
   private onUserMeResponse = () => {
     if (window.adsEnabled) {
@@ -64,13 +65,15 @@ export class HomepagePromos extends LitElement {
     this.isVisible = false;
     this.adLoaded = false;
     try {
-      // Only destroy gutter ads; bottom_rail persists into spawn phase.
+      // Destroy gutter ads; bottom_rail persists into spawn phase.
       window.ramp.destroyUnits(this.leftAdType);
       window.ramp.destroyUnits(this.rightAdType);
       console.log("successfully destroyed gutter ads");
     } catch (e) {
       console.error("error destroying gutter ads", e);
     }
+    // The corner video must not keep playing during the game.
+    this.destroyCornerAdVideo();
   }
 
   public loadBottomRail(): void {
@@ -149,7 +152,7 @@ export class HomepagePromos extends LitElement {
   }
 
   private loadCornerAdVideo(): void {
-    if (this.cornerAdLoaded) return;
+    if (this.cornerAdLoaded || this.cornerAdDestroyed) return;
     if (window.innerWidth < 1280) return;
     if (!window.ramp) {
       console.warn("Playwire RAMP not available for corner_ad_video");
@@ -161,6 +164,8 @@ export class HomepagePromos extends LitElement {
           window.ramp
             .addUnits([{ type: "corner_ad_video" }])
             .then(() => {
+              // Game started while the unit was still loading — never show it.
+              if (this.cornerAdDestroyed) return;
               this.cornerAdLoaded = true;
               window.ramp.displayUnits();
               console.log("corner_ad_video loaded");
@@ -174,6 +179,27 @@ export class HomepagePromos extends LitElement {
       });
     } catch (error) {
       console.error("Failed to load corner_ad_video:", error);
+    }
+  }
+
+  private destroyCornerAdVideo(): void {
+    // Latch first so an addUnits call still in flight skips displayUnits.
+    this.cornerAdDestroyed = true;
+    if (!this.cornerAdLoaded) return;
+    this.cornerAdLoaded = false;
+    try {
+      window.ramp
+        .destroyUnits("corner_ad_video")
+        // No-selector units can be registered under a pw-oop- id (see
+        // destroyBottomRail); retry with the prefixed name if the plain
+        // type isn't recognized.
+        .catch(() => window.ramp.destroyUnits("pw-oop-corner_ad_video"))
+        .then(() => console.log("corner_ad_video destroyed"))
+        .catch((e: unknown) => {
+          console.error("Error destroying corner_ad_video:", e);
+        });
+    } catch (e) {
+      console.error("Error destroying corner_ad_video:", e);
     }
   }
 


### PR DESCRIPTION
## Problem

The bottom-corner video ad (`corner_ad_video`) is loaded on the homepage by `HomepagePromos` and was never destroyed — an old comment in `close()` even said "Keep corner video ad alive." So it kept playing through entire games.

The `AdGatekeeper` latch only gates the in-game bottom-left ad in `InGamePromo`, so users we permanently suppress in-game ads for (anyone ever detected running an adblocker, even after disabling it) still had the corner video playing mid-game.

## Fix

- `HomepagePromos.close()` — already invoked at game prestart from `Main.ts` — now destroys the corner video unit for users the `AdGatekeeper` has latched as adblock-detected (`!adGatekeeper.canShowAds`). Blocker-free users keep the corner ad during games, same as before — this matches the policy `InGamePromo` already applies to the bottom-left in-game ad.
- A `cornerAdDestroyed` latch prevents a unit still mid-load (RAMP script racing a quick game join) from ever calling `displayUnits()`.
- Returning to the homepage after a game is a full page reload, so the corner ad still loads fresh on the homepage as before.

## Note for verification

Playwire's docs don't state the destroy id for no-selector video units, and ads don't run in dev. The code tries `destroyUnits("corner_ad_video")` and falls back to `"pw-oop-corner_ad_video"` (the same prefix quirk `bottom_rail` needed). After deploy, the console at game start (with the adblock latch set) should log `corner_ad_video destroyed`; if it logs an error instead, the unit id needs to be read from `window.ramp.settings.slots` in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
