### PR TITLE
feat(server): exempt Steam-authenticated clients from the Turnstile siteverify

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -336,9 +336,12 @@ class Client {
     modalRouter.register("cosmetics", { tag: "cosmetics-modal" });
     modalRouter.register("flag-input", { tag: "flag-input-modal" });
 
-    // Prefetch turnstile token so it is available when
-    // the user joins a lobby.
-    this.turnstileTokenPromise = getTurnstileToken();
+    // Prefetch turnstile token so it is available when the user joins a lobby.
+    // Desktop (Steam) has no Turnstile script and is server-side exempt, so
+    // skip it — otherwise getTurnstileToken() throws "Failed to load Turnstile
+    // script" after its load wait.
+    this.turnstileTokenPromise =
+      ClientEnv.instanceId() === "desktop" ? null : getTurnstileToken();
 
     // Wait for components to render before setting version
     await customElements.whenDefined("mobile-nav-bar");
@@ -1152,6 +1155,7 @@ class Client {
   ): Promise<string | null> {
     if (
       ClientEnv.env() === GameEnv.Dev ||
+      ClientEnv.instanceId() === "desktop" ||
       lobby.gameStartInfo?.config.gameType === GameType.Singleplayer
     ) {
       return null;

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -48,6 +48,7 @@ export const TokenPayloadSchema = z.object({
     // In case new roles are added in the future.
     .or(z.string())
     .optional(),
+  provider: z.string().optional(),
 });
 export type TokenPayload = z.infer<typeof TokenPayloadSchema>;
 

--- a/src/server/JoinVerify.ts
+++ b/src/server/JoinVerify.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { TokenPayload } from "../core/ApiSchemas";
 import { ServerEnv } from "./ServerEnv";
 
 const JoinVerifyVerdictSchema = z.discriminatedUnion("status", [
@@ -37,14 +38,35 @@ export type JoinVerifyPlan =
  * verdict could matter: identity updates apply only before the game starts,
  * and an unchanged identity was already screened when it was admitted. The
  * skips keep mass reconnects at game start off the API.
+ *
+ * Exception: a Steam-authenticated first join (`steamAuthed`, see
+ * isSteamAuthenticated) also verifies with a null token instead of
+ * rejecting for a missing Turnstile token — Steam ownership is the
+ * anti-abuse signal in that case, and the join still runs the name check.
  */
+// A join is Steam-authenticated when its verified JWT carries provider="steam"
+// (set by infra only after verifySteamTicket()). Never key this off the
+// client-supplied instanceId — that is forgeable.
+export function isSteamAuthenticated(claims: TokenPayload | null): boolean {
+  return claims?.provider === "steam";
+}
+
 export function planJoinVerify(args: {
   isReadmit: boolean;
   gameStarted: boolean;
   turnstileToken: string | null;
   identityUnchanged: boolean;
+  steamAuthed: boolean;
 }): JoinVerifyPlan {
   if (!args.isReadmit) {
+    // Steam-authenticated first joins skip the Turnstile siteverify — Steam
+    // ownership (a signed provider="steam" claim, set by infra only after
+    // verifySteamTicket()) is the anti-abuse signal. A null token still runs
+    // the API's name check, so banned/slur names are censored: the join is
+    // VERIFIED (never skipped), it just omits the bot challenge.
+    if (args.steamAuthed) {
+      return { action: "verify", token: null };
+    }
     if (!args.turnstileToken) {
       return { action: "reject" };
     }

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -25,7 +25,7 @@ import { Client } from "./Client";
 import { GameManager } from "./GameManager";
 import { registerGamePreviewRoute } from "./GamePreviewRoute";
 import type { GameServer } from "./GameServer";
-import { planJoinVerify, verifyJoin } from "./JoinVerify";
+import { isSteamAuthenticated, planJoinVerify, verifyJoin } from "./JoinVerify";
 import { getUserMe, verifyClientToken } from "./jwt";
 import { logger } from "./Logger";
 import { enforceVerifiedBadge } from "./Privilege";
@@ -513,18 +513,30 @@ export async function startWorker() {
         if (ServerEnv.env() !== GameEnv.Dev) {
           const game = gm.game(clientMsg.gameID);
           const stored = game?.storedIdentity(persistentId) ?? null;
+          const isReadmit = game?.wasAdmitted(persistentId) ?? false;
+          const steamAuthed = isSteamAuthenticated(claims);
           // SECURITY: the reject/skip/verify split (first joins must
           // present a token, only re-admits may omit it) lives in
-          // planJoinVerify — see its doc comment.
+          // planJoinVerify — see its doc comment. Steam-authenticated first
+          // joins are the one sanctioned null-token first join: Steam
+          // ownership (a signed, unforgeable provider="steam" claim) stands
+          // in for the bot check, and the name check still runs.
           const plan = planJoinVerify({
-            isReadmit: game?.wasAdmitted(persistentId) ?? false,
+            isReadmit,
             gameStarted: game?.hasStarted() ?? false,
             turnstileToken: clientMsg.turnstileToken ?? null,
             identityUnchanged:
               stored !== null &&
               stored.username === clientMsg.username &&
               stored.clanTag === (clientMsg.clanTag ?? null),
+            steamAuthed,
           });
+          if (steamAuthed && !isReadmit) {
+            log.info(
+              "Steam-authed join: skipping Turnstile siteverify (name check still runs)",
+              { persistentID: persistentId, gameID: clientMsg.gameID },
+            );
+          }
           if (plan.action === "reject") {
             log.warn("Unauthorized: missing Turnstile token", {
               persistentID: persistentId,

--- a/tests/server/JoinVerify.test.ts
+++ b/tests/server/JoinVerify.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import type { TokenPayload } from "../../src/core/ApiSchemas";
 import {
   isSteamAuthenticated,
   planJoinVerify,
   verifyJoin,
 } from "../../src/server/JoinVerify";
-import type { TokenPayload } from "../../src/core/ApiSchemas";
 
 // verifyJoin resolves its endpoint from ServerEnv.jwtIssuer(), which throws
 // if DOMAIN is unset.

--- a/tests/server/JoinVerify.test.ts
+++ b/tests/server/JoinVerify.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { planJoinVerify, verifyJoin } from "../../src/server/JoinVerify";
+import {
+  isSteamAuthenticated,
+  planJoinVerify,
+  verifyJoin,
+} from "../../src/server/JoinVerify";
+import type { TokenPayload } from "../../src/core/ApiSchemas";
 
 // verifyJoin resolves its endpoint from ServerEnv.jwtIssuer(), which throws
 // if DOMAIN is unset.
@@ -143,6 +148,7 @@ describe("planJoinVerify", () => {
     gameStarted: false,
     turnstileToken: "tok" as string | null,
     identityUnchanged: false,
+    steamAuthed: false,
   };
   const readmit = { ...firstJoin, isReadmit: true, turnstileToken: null };
 
@@ -205,5 +211,51 @@ describe("planJoinVerify", () => {
     expect(planJoinVerify({ ...readmit, identityUnchanged: true })).toEqual({
       action: "skip",
     });
+  });
+
+  it("verifies a Steam-authed first join with a null token (skips siteverify, keeps the name check)", () => {
+    expect(planJoinVerify({ ...firstJoin, steamAuthed: true })).toEqual({
+      action: "verify",
+      token: null,
+    });
+  });
+
+  // Steam ownership stands in for the token: a Steam-authed first join is never
+  // rejected for a missing token, and never skips the API (name check still runs).
+  it("verifies a Steam-authed first join with a null token even when no turnstile token is present", () => {
+    expect(
+      planJoinVerify({ ...firstJoin, steamAuthed: true, turnstileToken: null }),
+    ).toEqual({ action: "verify", token: null });
+  });
+
+  it("ignores steamAuthed on re-admits (they already went through the gate)", () => {
+    expect(planJoinVerify({ ...readmit, steamAuthed: true })).toEqual({
+      action: "verify",
+      token: null,
+    });
+  });
+});
+
+describe("isSteamAuthenticated", () => {
+  function claims(provider?: string): TokenPayload {
+    return {
+      jti: "j",
+      sub: "s",
+      iat: 0,
+      iss: "i",
+      aud: "openfront.io",
+      exp: 0,
+      ...(provider ? { provider } : {}),
+    } as TokenPayload;
+  }
+
+  it("is true only for a verified provider=steam claim", () => {
+    expect(isSteamAuthenticated(claims("steam"))).toBe(true);
+  });
+
+  it("is false for a missing provider, a non-steam provider, and null claims", () => {
+    expect(isSteamAuthenticated(claims())).toBe(false);
+    expect(isSteamAuthenticated(claims("discord"))).toBe(false);
+    expect(isSteamAuthenticated(null)).toBe(false);
   });
 });


### PR DESCRIPTION
## What

Exempt Steam-authenticated clients from the Turnstile bot-check at the join gate, keying off a signed `provider: "steam"` claim in the already-verified session JWT.

- `TokenPayloadSchema` gains an optional `provider` field (additive).
- `JoinVerify.ts`: `isSteamAuthenticated(claims)` (`claims?.provider === "steam"`), and `planJoinVerify` gains a required `steamAuthed` input. A Steam-authenticated **first** join is planned as `{action: "verify", token: null}` — it rides the existing null-token path that **skips the Turnstile siteverify but still runs the `/join_verify` name check**. First joins are never `skip`ped.
- `Worker.ts`: passes `steamAuthed: isSteamAuthenticated(claims)` and logs each exemption (`persistentID`/`gameID`).
- Client (`Main.ts`): the desktop instance skips Turnstile token acquisition (cosmetic — removes the "Failed to load Turnstile script" console error; grants nothing, the exemption is server-side).

## Why

The Steam desktop build can't produce valid prod Turnstile tokens, so Steam players could connect but not join online games. Steam ownership becomes the anti-abuse signal. The exemption keys **only** off the signed, server-verified claim — never the forgeable client `instanceId` — and Steam users are still name-censored.

## Testing

`tests/server/JoinVerify.test.ts` extended (20/20): Steam first-join → verify-with-null-token (never `reject`, never `skip`); non-Steam behavior unchanged; `isSteamAuthenticated` exact-match/null-safe. `tsc --noEmit` clean; full server suite green (235).

## Note

The `provider: "steam"` claim is minted by the closed auth API (deployed first). Until then this code is inert — no token carries the claim, so nothing is exempted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BWxUzYb2uqjcBFQuNSJhMy