### PR TITLE
Make MIRV warheads standard nukes: real flight, normal SAM interception, per-type speeds

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -505,7 +505,6 @@
     "focus": "Focus",
     "hydrogen_bomb_detonated": "{name} - hydrogen bomb detonated",
     "ignore": "Ignore",
-    "mirv_warheads_intercepted": "{count, plural, one {{count} MIRV warhead intercepted} other {{count} MIRV warheads intercepted}}",
     "missile_intercepted": "Missile intercepted {unit}",
     "no_boats_available": "No boats available, max {max}",
     "received_gold_from_captured_ship": "Received {gold} gold from ship captured from {name}",

--- a/src/client/controllers/SoundEffectController.ts
+++ b/src/client/controllers/SoundEffectController.ts
@@ -5,7 +5,13 @@ import { Controller } from "../Controller";
 import { PlaySoundEffectEvent, SoundEffect } from "../sound/Sounds";
 import { GameView, UnitView } from "../view";
 
+// A MIRV rains hundreds of warheads over a few seconds; playing a boom per
+// warhead churns the audio pipeline. Play at most one warhead boom per interval.
+const MIRV_HIT_SOUND_INTERVAL_TICKS = 5;
+
 export class SoundEffectController implements Controller {
+  private lastMirvHitSoundTick = -Infinity;
+
   constructor(
     private readonly game: GameView,
     private readonly eventBus: EventBus,
@@ -36,13 +42,26 @@ export class SoundEffectController implements Controller {
     }
     switch (unit.type()) {
       case UnitType.AtomBomb:
-      case UnitType.MIRVWarhead:
         this.onNukeDetonation(unit, "atom-hit");
+        break;
+      case UnitType.MIRVWarhead:
+        this.onMirvWarheadDetonation(unit);
         break;
       case UnitType.HydrogenBomb:
         this.onNukeDetonation(unit, "hydrogen-hit");
         break;
     }
+  }
+
+  private onMirvWarheadDetonation(unit: UnitView): void {
+    if (unit.isActive()) return;
+    if (!unit.reachedTarget()) return;
+    const tick = this.game.ticks();
+    if (tick - this.lastMirvHitSoundTick < MIRV_HIT_SOUND_INTERVAL_TICKS) {
+      return;
+    }
+    this.lastMirvHitSoundTick = tick;
+    this.emit("atom-hit");
   }
 
   private onCreated(unit: UnitView): void {

--- a/src/client/render/frame/TrailManager.ts
+++ b/src/client/render/frame/TrailManager.ts
@@ -4,8 +4,15 @@
  * Each tick, for each tracked unit, stamps tiles between lastPos and pos
  * (bresenham) with a 16-bit value: owner smallID in bits 0-11, plus a nuke bit
  * (bit 12) so nuke trails can be colored by a different cosmetic effect than
- * boat trails. When a unit dies its tiles are cleared, with overlapping tiles
- * repainted from any surviving unit (preserving that survivor's full value).
+ * boat trails. Each tile also carries a live-trail refcount; when a unit dies
+ * its tiles are released and a texel is cleared only when its last claimant
+ * dies. A tile shared with surviving trails keeps its last-stamped value — if
+ * the overlapping trails carried different values (different owners, or boat
+ * vs nuke), the crossing pixels can keep the dead trail's value until the
+ * survivors die too. That pixel-level inexactness is the tradeoff for O(own
+ * tiles) death cleanup: repainting from survivors would rescan every surviving
+ * trail per death, which goes quadratic during MIRV strikes (hundreds of
+ * long-trailed warheads dying in waves).
  *
  * Simpler than the original openfront-workspace TrailManager (no MotionPlanStore
  * dependency). Since we run in the main thread reading GameView directly, we
@@ -29,6 +36,9 @@ interface UnitTrail {
 
 export class TrailManager {
   private readonly trailState: Uint16Array;
+  // Number of live trails claiming each tile — a texel is cleared only when
+  // its count drops to zero.
+  private readonly trailCounts: Uint16Array;
   private readonly unitTrails = new Map<number, UnitTrail>();
   private readonly mapW: number;
 
@@ -38,6 +48,7 @@ export class TrailManager {
   constructor(mapW: number, mapH: number) {
     this.mapW = mapW;
     this.trailState = new Uint16Array(mapW * mapH);
+    this.trailCounts = new Uint16Array(mapW * mapH);
   }
 
   getTrailState(): Uint16Array {
@@ -59,6 +70,7 @@ export class TrailManager {
   reset(): void {
     this.unitTrails.clear();
     this.trailState.fill(0);
+    this.trailCounts.fill(0);
     this._dirtyRowMin = Infinity;
     this._dirtyRowMax = -1;
   }
@@ -86,8 +98,7 @@ export class TrailManager {
       const head = isNuke ? unit.lastPos : unit.pos;
       if (trail.lastPosStamped === -1) {
         // First sighting — just stamp the current head
-        this.stamp(head, trail.value);
-        trail.tiles.add(head);
+        this.claim(head, trail);
         trail.lastPosStamped = head;
       } else if (trail.lastPosStamped !== head) {
         this.bresenham(trail.lastPosStamped, head, trail);
@@ -99,17 +110,22 @@ export class TrailManager {
   private clearDeadUnits(units: Map<number, UnitState>): void {
     for (const [id, trail] of this.unitTrails) {
       if (units.has(id)) continue;
-      const deadTiles = trail.tiles;
-      for (const ref of deadTiles) this.stamp(ref, 0);
       this.unitTrails.delete(id);
-      // Repaint any tiles that overlap surviving trails — with the survivor's
-      // full value so its nuke bit (and owner) is preserved, not just the owner.
-      for (const other of this.unitTrails.values()) {
-        for (const ref of deadTiles) {
-          if (other.tiles.has(ref)) this.stamp(ref, other.value);
-        }
+      // Release each tile: clear the texel only when the last claimant dies.
+      // Tiles still claimed by a surviving trail keep their last-stamped value.
+      for (const ref of trail.tiles) {
+        if (--this.trailCounts[ref] === 0) this.stamp(ref, 0);
       }
     }
+  }
+
+  /** Stamp a tile for a trail, counting it once per trail for death cleanup. */
+  private claim(ref: number, trail: UnitTrail): void {
+    if (!trail.tiles.has(ref)) {
+      trail.tiles.add(ref);
+      this.trailCounts[ref]++;
+    }
+    this.stamp(ref, trail.value);
   }
 
   private stamp(ref: number, value: number): void {
@@ -132,8 +148,7 @@ export class TrailManager {
     let err = dx + dy;
     for (;;) {
       const ref = y0 * w + x0;
-      trail.tiles.add(ref);
-      this.stamp(ref, trail.value);
+      this.claim(ref, trail);
       if (x0 === x1 && y0 === y1) break;
       const e2 = 2 * err;
       if (e2 >= dy) {

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -908,8 +908,17 @@ export class Config {
     return 100;
   }
 
-  defaultNukeSpeed(): number {
-    return 10;
+  nukeSpeed(unitType: UnitType): number {
+    switch (unitType) {
+      case UnitType.AtomBomb:
+      case UnitType.HydrogenBomb:
+        return 10;
+      case UnitType.MIRV:
+        return 15;
+      case UnitType.MIRVWarhead:
+        return 22;
+    }
+    throw new Error(`Unknown nuke type: ${unitType}`);
   }
 
   defaultNukeTargetableRange(): number {

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -50,7 +50,7 @@ export class MirvExecution implements Execution {
     this.random = new PseudoRandom(mg.ticks() + simpleHash(this.player.id()));
     this.mg = mg;
     this.targetPlayer = this.mg.owner(this.dst);
-    this.speed = this.mg.config().defaultNukeSpeed();
+    this.speed = this.mg.config().nukeSpeed(UnitType.MIRV);
     this.pathFinder = UniversalPathFinding.Parabola(mg, {
       increment: this.speed,
     });
@@ -121,6 +121,7 @@ export class MirvExecution implements Execution {
     this.baseY = this.mg.y(this.dst);
 
     const destinations = this.selectDestinations();
+    const warheadSpeed = this.mg.config().nukeSpeed(UnitType.MIRVWarhead);
     for (const [i, dst] of destinations.entries()) {
       this.mg.addExecution(
         new NukeExecution(
@@ -128,7 +129,7 @@ export class MirvExecution implements Execution {
           this.player,
           dst,
           this.nuke.tile(),
-          15 + Math.floor((i / this.warheadCount) * 5),
+          warheadSpeed + Math.floor((i / this.warheadCount) * 5),
           //   this.random.nextInt(5, 9),
           this.random.nextInt(0, 15),
         ),

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -39,11 +39,10 @@ export class NukeExecution implements Execution {
   init(mg: Game, ticks: number): void {
     this.mg = mg;
     if (this.speed === -1) {
-      this.speed = this.mg.config().defaultNukeSpeed();
+      this.speed = this.mg.config().nukeSpeed(this.nukeType);
     }
     this.pathFinder = UniversalPathFinding.Parabola(mg, {
       increment: this.speed,
-      distanceBasedHeight: this.nukeType !== UnitType.MIRVWarhead,
       directionUp: this.rocketDirectionUp,
     });
   }
@@ -189,11 +188,13 @@ export class NukeExecution implements Execution {
         this.active = false;
         return;
       }
-      this.src = spawn;
+      // The launch tile can be overridden by the caller (e.g. MIRV warheads
+      // launch from the MIRV separation point, not a silo).
+      this.src ??= spawn;
       // Nuke trajectories cannot pass over impassable terrain, just as they
       // cannot exceed the map border. Check the full parabola path before
       // launching; if any tile is impassable, abort the launch.
-      const path = this.pathFinder.findPath(spawn, this.dst) ?? [];
+      const path = this.pathFinder.findPath(this.src, this.dst) ?? [];
       for (const tile of path) {
         if (this.mg.isImpassable(tile)) {
           console.warn(`nuke trajectory crosses impassable terrain`);
@@ -201,7 +202,7 @@ export class NukeExecution implements Execution {
           return;
         }
       }
-      this.nuke = this.player.buildUnit(this.nukeType, spawn, {
+      this.nuke = this.player.buildUnit(this.nukeType, this.src, {
         targetTile: this.dst,
         trajectory: this.getTrajectory(this.dst),
       });
@@ -286,7 +287,6 @@ export class NukeExecution implements Execution {
     }
     const pathFinder = UniversalPathFinding.Parabola(this.mg, {
       increment: this.speed,
-      distanceBasedHeight: this.nukeType !== UnitType.MIRVWarhead,
       directionUp: this.rocketDirectionUp,
     });
     const path: TileRef[] = [this.src];

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -1,12 +1,4 @@
-import {
-  Execution,
-  Game,
-  isUnit,
-  MessageType,
-  Player,
-  Unit,
-  UnitType,
-} from "../game/Game";
+import { Execution, Game, isUnit, Player, Unit, UnitType } from "../game/Game";
 import { TileRef } from "../game/GameMap";
 import { PseudoRandom } from "../PseudoRandom";
 import { SAMMissileExecution } from "./SAMMissileExecution";
@@ -114,7 +106,7 @@ class SAMTargetingSystem {
     const nukes = this.mg.nearbyUnits(
       samTile,
       detectionRange,
-      [UnitType.AtomBomb, UnitType.HydrogenBomb],
+      [UnitType.AtomBomb, UnitType.HydrogenBomb, UnitType.MIRVWarhead],
       ({ unit }) => {
         if (!isUnit(unit) || unit.targetedBySAM()) return false;
         if (unit.owner() === this.sam.owner()) return false;
@@ -203,10 +195,6 @@ export class SAMLauncherExecution implements Execution {
   private mg: Game;
   private active: boolean = true;
 
-  // As MIRV go very fast we have to detect them very early but we only
-  // shoot the one targeting very close (MIRVWarheadProtectionRadius)
-  private MIRVWarheadSearchRadius = 400;
-  private MIRVWarheadProtectionRadius = 50;
   private targetingSystem: SAMTargetingSystem;
 
   private pseudoRandom: PseudoRandom | undefined;
@@ -271,87 +259,20 @@ export class SAMLauncherExecution implements Execution {
 
     this.pseudoRandom ??= new PseudoRandom(this.sam.id());
 
-    const mirvWarheadTargets = this.mg.nearbyUnits(
-      this.sam.tile(),
-      this.MIRVWarheadSearchRadius,
-      UnitType.MIRVWarhead,
-      ({ unit }) => {
-        if (!isUnit(unit)) return false;
-        if (unit.owner() === this.player) return false;
-
-        // After game-over in team games, SAMs also target teammate MIRVs (aftergame fun)
-        const nukeOwner = unit.owner();
-        if (this.player.isFriendly(nukeOwner)) {
-          if (
-            this.mg.getWinner() === null ||
-            !this.player.isOnSameTeam(nukeOwner)
-          ) {
-            return false;
-          }
-        }
-
-        const dst = unit.targetTile();
-        return (
-          this.sam !== null &&
-          dst !== undefined &&
-          this.mg.manhattanDist(dst, this.sam.tile()) <
-            this.MIRVWarheadProtectionRadius
-        );
-      },
-    );
-
-    let target: Target | null = null;
-    if (mirvWarheadTargets.length === 0) {
-      target = this.targetingSystem.getSingleTarget(ticks);
-    }
-
     // target is already filtered to exclude nukes targeted by other SAMs
-    if (target || mirvWarheadTargets.length > 0) {
+    const target = this.targetingSystem.getSingleTarget(ticks);
+    if (target !== null) {
       this.sam.launch();
-      const type =
-        mirvWarheadTargets.length > 0
-          ? UnitType.MIRVWarhead
-          : target?.unit.type();
-      if (type === undefined) throw new Error("Unknown unit type");
-      if (mirvWarheadTargets.length > 0) {
-        const samOwner = this.sam.owner();
-
-        // Message
-        this.mg.displayMessage(
-          "events_display.mirv_warheads_intercepted",
-          MessageType.SAM_HIT,
-          samOwner.id(),
-          undefined,
-          { count: mirvWarheadTargets.length },
-        );
-
-        mirvWarheadTargets.forEach(({ unit: u }) => {
-          // Delete warheads
-          u.delete();
-        });
-
-        // Record stats
-        this.mg
-          .stats()
-          .bombIntercept(
-            samOwner,
-            UnitType.MIRVWarhead,
-            mirvWarheadTargets.length,
-          );
-      } else if (target !== null) {
-        target.unit.setTargetedBySAM(true);
-        this.mg.addExecution(
-          new SAMMissileExecution(
-            this.sam.tile(),
-            this.sam.owner(),
-            this.sam,
-            target.unit,
-            target.tile,
-          ),
-        );
-      } else {
-        throw new Error("target is null");
-      }
+      target.unit.setTargetedBySAM(true);
+      this.mg.addExecution(
+        new SAMMissileExecution(
+          this.sam.tile(),
+          this.sam.owner(),
+          this.sam,
+          target.unit,
+          target.tile,
+        ),
+      );
     }
   }
 

--- a/src/core/execution/SAMMissileExecution.ts
+++ b/src/core/execution/SAMMissileExecution.ts
@@ -42,8 +42,12 @@ export class SAMMissileExecution implements Execution {
       this.active = false;
       return;
     }
-    // Mirv warheads are too fast, and mirv shouldn't be stopped ever
-    const nukesWhitelist = [UnitType.AtomBomb, UnitType.HydrogenBomb];
+    // The MIRV carrier itself can't be intercepted, only its warheads
+    const nukesWhitelist = [
+      UnitType.AtomBomb,
+      UnitType.HydrogenBomb,
+      UnitType.MIRVWarhead,
+    ];
     if (
       !this.target.isActive() ||
       !this.ownerUnit.isActive() ||

--- a/src/core/execution/nation/NationNukeBehavior.ts
+++ b/src/core/execution/nation/NationNukeBehavior.ts
@@ -555,7 +555,7 @@ export class NationNukeBehavior {
     targetTile: TileRef,
     excludedSamIds?: Set<number>,
   ): boolean {
-    const speed = this.game.config().defaultNukeSpeed();
+    const speed = this.game.config().nukeSpeed(UnitType.AtomBomb);
     const pathFinder = UniversalPathFinding.Parabola(this.game, {
       increment: speed,
       distanceBasedHeight: true, // Atom/Hydrogen bombs use distance-based height
@@ -643,7 +643,7 @@ export class NationNukeBehavior {
     targetTile: TileRef,
   ): boolean {
     const pathFinder = UniversalPathFinding.Parabola(this.game, {
-      increment: this.game.config().defaultNukeSpeed(),
+      increment: this.game.config().nukeSpeed(UnitType.AtomBomb),
       distanceBasedHeight: true,
       directionUp: true,
     });
@@ -859,7 +859,7 @@ export class NationNukeBehavior {
       // distance to target (via nukeSpawn). Our planning must mirror that order.
       // Silos with interceptable trajectories will still be picked first by
       // NukeExecution — their bombs launch but get intercepted, "wasting" slots.
-      const nukeSpeed = this.game.config().defaultNukeSpeed();
+      const nukeSpeed = this.game.config().nukeSpeed(UnitType.AtomBomb);
       const allAvailableSilos: {
         silo: Unit;
         slots: number;

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -291,6 +291,7 @@ export interface UnitParamsMap {
 
   [UnitType.MIRVWarhead]: {
     targetTile?: number;
+    trajectory: TrajectoryTile[];
   };
 }
 

--- a/tests/NukeSpeed.test.ts
+++ b/tests/NukeSpeed.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import { Config } from "../src/core/configuration/Config";
+import { UnitType } from "../src/core/game/Game";
+import { GameConfig } from "../src/core/Schemas";
+
+const cfg = new Config({} as unknown as GameConfig, null, false);
+
+describe("nukeSpeed", () => {
+  it("maps each nuke type to its speed", () => {
+    expect(cfg.nukeSpeed(UnitType.AtomBomb)).toBe(10);
+    expect(cfg.nukeSpeed(UnitType.HydrogenBomb)).toBe(10);
+    expect(cfg.nukeSpeed(UnitType.MIRV)).toBe(15);
+    expect(cfg.nukeSpeed(UnitType.MIRVWarhead)).toBe(22);
+  });
+
+  it("throws for non-nuke unit types", () => {
+    expect(() => cfg.nukeSpeed(UnitType.Warship)).toThrow();
+  });
+});

--- a/tests/client/controllers/SoundEffectController.test.ts
+++ b/tests/client/controllers/SoundEffectController.test.ts
@@ -1,0 +1,79 @@
+import { SoundEffectController } from "../../../src/client/controllers/SoundEffectController";
+import { PlaySoundEffectEvent } from "../../../src/client/sound/Sounds";
+import { EventBus } from "../../../src/core/EventBus";
+import { UnitType } from "../../../src/core/game/Game";
+import { GameUpdateType } from "../../../src/core/game/GameUpdates";
+
+describe("SoundEffectController", () => {
+  let eventBus: EventBus;
+  let played: string[];
+  let tick: number;
+  let units: Map<number, any>;
+  let game: any;
+  let controller: SoundEffectController;
+
+  function makeDetonatedWarhead(id: number) {
+    return {
+      id: () => id,
+      type: () => UnitType.MIRVWarhead,
+      isActive: () => false,
+      reachedTarget: () => true,
+      createdAt: () => 0,
+      owner: () => ({}),
+    };
+  }
+
+  function tickWithUnits(...us: Array<{ id: () => number }>) {
+    tick++;
+    units = new Map(us.map((u) => [u.id(), u]));
+    game.updatesSinceLastTick = () => ({
+      [GameUpdateType.Unit]: us.map((u) => ({ id: u.id() })),
+    });
+    controller.tick();
+  }
+
+  beforeEach(() => {
+    eventBus = new EventBus();
+    played = [];
+    eventBus.on(PlaySoundEffectEvent, (e) => played.push(e.effect));
+    tick = 0;
+    game = {
+      ticks: () => tick,
+      unit: (id: number) => units.get(id),
+      myPlayer: () => null,
+      updatesSinceLastTick: () => undefined,
+    };
+    controller = new SoundEffectController(game, eventBus);
+  });
+
+  it("plays at most one warhead boom per interval", () => {
+    // 10 warheads detonate on the same tick — one boom.
+    tickWithUnits(
+      ...Array.from({ length: 10 }, (_, i) => makeDetonatedWarhead(i)),
+    );
+    expect(played).toEqual(["atom-hit"]);
+
+    // More warheads land on the next few ticks — still inside the interval.
+    tickWithUnits(makeDetonatedWarhead(20));
+    tickWithUnits(makeDetonatedWarhead(21));
+    expect(played).toEqual(["atom-hit"]);
+
+    // Once the interval has passed, the next detonation booms again.
+    tick += 5;
+    tickWithUnits(makeDetonatedWarhead(30));
+    expect(played).toEqual(["atom-hit", "atom-hit"]);
+  });
+
+  it("does not play a boom for intercepted warheads", () => {
+    const intercepted = {
+      id: () => 1,
+      type: () => UnitType.MIRVWarhead,
+      isActive: () => false,
+      reachedTarget: () => false,
+      createdAt: () => 0,
+      owner: () => ({}),
+    };
+    tickWithUnits(intercepted);
+    expect(played).toEqual([]);
+  });
+});

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -131,6 +131,43 @@ describe("SAM", () => {
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(1);
   });
 
+  test("one sam should take down one MIRV warhead", async () => {
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    attacker.buildUnit(UnitType.MIRVWarhead, game.ref(1, 1), {
+      targetTile: game.ref(3, 1),
+      trajectory: [
+        { tile: game.ref(1, 1), targetable: true },
+        { tile: game.ref(2, 1), targetable: true },
+        { tile: game.ref(3, 1), targetable: true },
+      ],
+    });
+    executeTicks(game, 3);
+
+    expect(attacker.units(UnitType.MIRVWarhead)).toHaveLength(0);
+  });
+
+  test("sam should intercept an in-flight MIRV warhead like any other nuke", async () => {
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Warhead launched from a distant separation point at a tile near the SAM
+    const nukeExecution = new NukeExecution(
+      UnitType.MIRVWarhead,
+      attacker,
+      game.ref(3, 3),
+      game.ref(60, 60),
+    );
+    game.addExecution(nukeExecution);
+
+    executeTicks(game, 40);
+
+    expect(nukeExecution.isActive()).toBeFalsy();
+    expect(attacker.units(UnitType.MIRVWarhead)).toHaveLength(0);
+    expect(sam.isInCooldown()).toBeTruthy();
+  });
+
   test("sam should cooldown as long as configured", async () => {
     const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
 
@@ -194,7 +231,7 @@ describe("SAM", () => {
     game.addExecution(nukeExecution);
     // Long distance nuke: compute the proper number of ticks
     const ticksToExecute = Math.ceil(
-      targetDistance / game.config().defaultNukeSpeed() + 1,
+      targetDistance / game.config().nukeSpeed(UnitType.AtomBomb) + 1,
     );
     executeTicks(game, ticksToExecute);
 
@@ -229,7 +266,7 @@ describe("SAM", () => {
     game.addExecution(nukeExecution);
     // Long distance nuke: compute the proper number of ticks
     const ticksToExecute = Math.ceil(
-      targetDistance / game.config().defaultNukeSpeed() + 1,
+      targetDistance / game.config().nukeSpeed(UnitType.AtomBomb) + 1,
     );
     executeTicks(game, ticksToExecute);
     expect(nukeExecution.isActive()).toBeFalsy();

--- a/tests/util/TestConfig.ts
+++ b/tests/util/TestConfig.ts
@@ -39,7 +39,8 @@ export class TestConfig extends Config {
     this._defaultNukeSpeed = speed;
   }
 
-  defaultNukeSpeed(): number {
+  // Flat speed for all nuke types so test tick counts stay predictable.
+  nukeSpeed(_: UnitType): number {
     return this._defaultNukeSpeed;
   }
 


### PR DESCRIPTION
fixes #4508

## Summary

MIRV warheads previously had no real flight in the simulation: they spawned directly **on their target tile** (the separation-point `src` passed by `MirvExecution` was silently discarded by `NukeExecution`) and detonated 0–15 ticks later. Because there was nothing a SAM missile could ever intercept, `SAMLauncherExecution` carried a special batch path that instantly deleted every warhead aimed within 50 tiles of the SAM in a single launch.

This PR makes warheads just another nuke type and removes that special-casing:

### Core simulation
- `NukeExecution` now honors a caller-provided launch tile (`src ??= spawn`), so warheads fly a real parabola from the MIRV separation point down to their targets, with a recorded trajectory and motion plan. The `distanceBasedHeight` special case is gone.
- The SAM batch-interception block (search/protection radii, batch delete, special message + stats) is deleted. `MIRVWarhead` joins the standard preshot targeting list and the `SAMMissileExecution` whitelist: SAMs fire **one missile per warhead**, respecting range and cooldown. The MIRV carrier itself remains un-interceptable.
- Nuke speeds move from a flat `defaultNukeSpeed()` to a per-type map `Config.nukeSpeed(unitType)`, with MIRV (10 → 15) and warheads (base 15 → 22, plus the existing 0–4 stagger) **50% faster**; atom/hydro unchanged at 10.
- Intentionally unchanged: the MIRV-specific population-reduction formula (drives troops toward 3% of max), blast radii, alliance semantics (warheads still don't break alliances; the MIRV betrays at launch), and event messages (no per-warhead inbound/detonated spam).

### Balance notes
- MIRVs are substantially stronger against SAM-heavy defense: a SAM now downs individual warheads on its normal cooldown instead of vaporizing every warhead targeting its protection radius in one shot.
- Warheads now abort at launch if their trajectory crosses impassable terrain, like other nukes.
- Impacts spread over real flight time instead of all landing within ~1.6s.

### Client fallout from warheads spending real time in the air
- **TrailManager**: death cleanup was quadratic (every dead warhead rescanned every surviving trail per tile) and hit ~50% CPU during multi-MIRV strikes. Trail tiles now carry a live-trail refcount; a texel clears when its last claimant dies. Benchmarked at two-MIRVs-in-flight scale: **81.2ms → 1.2ms per tick (~68×)**. Tradeoff (documented in the header): where trails with *different* texel values cross, the crossing pixels can keep the dead trail's value until survivors die too; same-owner warhead fans clear pixel-perfectly.
- **Sounds**: warhead detonations are rate-limited to one `atom-hit` per 5 ticks so a 350-warhead rain doesn't churn a `howl.play()` per impact (`SoundManager` caps concurrency at 8, but each play still cost CPU).
- Removed the now-unused `mirv_warheads_intercepted` message key from `en.json`.

## Tests
- New: SAM takes down a stationary warhead; SAM intercepts an in-flight warhead end-to-end via the normal pipeline.
- New: `SoundEffectController` boom rate-limit + intercepted-warheads-stay-silent.
- New: `nukeSpeed` config map values.
- Full suite passes (2189 + 230 server), lint + tsc clean. TrailManager overlap-repaint and SAM/Nuke/Nation MIRV tests all pass unchanged (TestConfig keeps a flat test speed so existing tick counts stay valid).

🤖 Generated with [Claude Code](https://claude.com/claude-code)