### PR TITLE
fix: put missile silo on cooldown when launching a MIRV

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -94,6 +94,14 @@ export class MirvExecution implements Execution {
         MessageType.MIRV_INBOUND,
         this.targetPlayer.id(),
       );
+
+      // after sending a nuke set the missilesilo on cooldown
+      const silo = this.player
+        .units(UnitType.MissileSilo)
+        .find((silo) => silo.tile() === spawn);
+      if (silo) {
+        silo.launch();
+      }
     }
 
     const result = this.pathFinder.next(

--- a/tests/MissileSilo.test.ts
+++ b/tests/MissileSilo.test.ts
@@ -1,3 +1,4 @@
+import { MirvExecution } from "../src/core/execution/MIRVExecution";
 import { NukeExecution } from "../src/core/execution/NukeExecution";
 import { SpawnExecution } from "../src/core/execution/SpawnExecution";
 import { UpgradeStructureExecution } from "../src/core/execution/UpgradeStructureExecution";
@@ -90,6 +91,32 @@ describe("MissileSilo", () => {
     executeTicks(game, 2);
 
     expect(attacker.units(UnitType.MissileSilo)[0].isInCooldown()).toBeFalsy();
+  });
+
+  test("missilesilo should cooldown after launching MIRV", async () => {
+    // MIRVs can only target player-owned tiles
+    const target_info = new PlayerInfo(
+      "target_id",
+      PlayerType.Human,
+      null,
+      "target_id",
+    );
+    game.addPlayer(target_info);
+    const target = game.player("target_id");
+    target.conquer(game.ref(50, 50));
+
+    expect(attacker.units(UnitType.MissileSilo)[0].isInCooldown()).toBeFalsy();
+
+    game.addExecution(new MirvExecution(attacker, game.ref(50, 50)));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(attacker.units(UnitType.MIRV)).toHaveLength(1);
+    expect(attacker.units(UnitType.MissileSilo)[0].isInCooldown()).toBeTruthy();
+
+    // the silo is on cooldown, so it cannot launch another nuke
+    attackerBuildsNuke(null, game.ref(7, 7));
+    expect(attacker.units(UnitType.AtomBomb)).toHaveLength(0);
   });
 
   test("missilesilo should have increased level after upgrade", async () => {


### PR DESCRIPTION
Resolves #4594

## Description:

Launching a MIRV required an available missile silo (via `canBuild`) but never consumed one of the silo's missile slots, so the same level 1 silo could immediately launch another atom bomb, hydrogen bomb, or MIRV with no cooldown.

`NukeExecution` already handles this for atom/hydrogen bombs: after building the nuke it finds the silo at the spawn tile and calls `silo.launch()`. This PR mirrors that exact block in `MirvExecution` after the MIRV unit is built.

Added a regression test to `MissileSilo.test.ts` that reproduces the issue's scenario: launch a MIRV from a level 1 silo, assert the silo is now in cooldown, then attempt an atom bomb launch and assert it fails to build. The test fails without the fix.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — core simulation change only)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — no user-visible text)
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

evanpelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
