### PR TITLE
Fix trackpad pinch zoom in Safari

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -61,6 +61,9 @@ export class ContextMenuEvent implements GameEvent {
   ) {}
 }
 
+/** Zoom sensitivity: scale is divided by `1 + delta / ZOOM_DELTA_DIVISOR`. */
+export const ZOOM_DELTA_DIVISOR = 600;
+
 export class ZoomEvent implements GameEvent {
   constructor(
     public readonly x: number,
@@ -198,6 +201,20 @@ interface KeybindEntry {
   conditions: Array<(e: KeyboardEvent) => boolean>;
 }
 
+/**
+ * WebKit's non-standard `GestureEvent`, fired for trackpad pinch in Safari.
+ * Other browsers synthesize a ctrl+wheel event instead, handled in onScroll.
+ * Not in `lib.dom.d.ts`, so declared here.
+ *
+ * @see https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html
+ */
+interface WebKitGestureEvent extends Event {
+  /** Cumulative pinch scale since `gesturestart`, which reports 1.0. */
+  readonly scale: number;
+  readonly clientX: number;
+  readonly clientY: number;
+}
+
 export class InputHandler {
   private lastPointerX: number = 0;
   private lastPointerY: number = 0;
@@ -208,6 +225,9 @@ export class InputHandler {
   private pointers: Map<number, PointerEvent> = new Map();
 
   private lastPinchDistance: number = 0;
+
+  // Scale of the in-progress Safari pinch, or null when no gesture is active.
+  private lastGestureScale: number | null = null;
 
   private pointerDown: boolean = false;
 
@@ -435,6 +455,31 @@ export class InputHandler {
       },
       { passive: false },
     );
+    // Safari trackpad pinch, which fires no ctrl+wheel event.
+    this.canvas.addEventListener(
+      "gesturestart",
+      (e) => {
+        e.preventDefault();
+        this.lastGestureScale = (e as WebKitGestureEvent).scale;
+      },
+      { passive: false },
+    );
+    this.canvas.addEventListener(
+      "gesturechange",
+      (e) => {
+        e.preventDefault();
+        this.onGestureChange(e as WebKitGestureEvent);
+      },
+      { passive: false },
+    );
+    this.canvas.addEventListener(
+      "gestureend",
+      (e) => {
+        e.preventDefault();
+        this.lastGestureScale = null;
+      },
+      { passive: false },
+    );
     window.addEventListener("pointermove", this.onPointerMove.bind(this));
     this.canvas.addEventListener("contextmenu", (e) => this.onContextMenu(e));
     window.addEventListener("mousemove", (e) => {
@@ -454,6 +499,7 @@ export class InputHandler {
       }
       this.pointerDown = false;
       this.pointers.clear();
+      this.lastGestureScale = null;
       if (this.longPressTimer !== null) {
         clearTimeout(this.longPressTimer);
         this.longPressTimer = null;
@@ -837,6 +883,29 @@ export class InputHandler {
     }
   }
 
+  /**
+   * `scale` is cumulative since gesturestart, so the per-event ratio is
+   * `scale / lastGestureScale`. onZoom divides by `1 + delta / DIVISOR`, so
+   * inverting that gives the delta reproducing the pinch ratio exactly.
+   */
+  private onGestureChange(event: WebKitGestureEvent) {
+    if (this.lastGestureScale === null) return;
+
+    const ratio = event.scale / this.lastGestureScale;
+    if (!Number.isFinite(ratio) || ratio <= 0) return;
+    // Advance the scale before the pointer guard: if a pointer lifts mid-gesture,
+    // the next event must measure from here, not re-apply zoom from gesturestart.
+    this.lastGestureScale = event.scale;
+
+    // iOS sends these alongside pointer events, which onPointerMove already
+    // zooms from. A trackpad pinch registers no pointers.
+    if (this.pointers.size >= 2) return;
+
+    const delta = ZOOM_DELTA_DIVISOR * (1 / ratio - 1);
+    if (delta === 0) return;
+    this.eventBus.emit(new ZoomEvent(event.clientX, event.clientY, delta));
+  }
+
   private onShiftScroll(event: WheelEvent) {
     if (event.shiftKey) {
       const scrollValue = event.deltaY === 0 ? event.deltaX : event.deltaY;
@@ -1081,6 +1150,7 @@ export class InputHandler {
       clearInterval(this.moveInterval);
     }
     this.activeKeys.clear();
+    this.lastGestureScale = null;
     this.keybindAndEvent = [];
   }
 }

--- a/src/client/TransformHandler.ts
+++ b/src/client/TransformHandler.ts
@@ -1,6 +1,11 @@
 import { EventBus, GameEvent } from "../core/EventBus";
 import { Cell } from "../core/game/Game";
-import { CenterCameraEvent, DragEvent, ZoomEvent } from "./InputHandler";
+import {
+  CenterCameraEvent,
+  DragEvent,
+  ZOOM_DELTA_DIVISOR,
+  ZoomEvent,
+} from "./InputHandler";
 import { GameView, PlayerView, UnitView } from "./view";
 
 export class GoToPlayerEvent implements GameEvent {
@@ -295,7 +300,7 @@ export class TransformHandler {
   onZoom(event: ZoomEvent) {
     this.clearTarget();
     const oldScale = this.scale;
-    const zoomFactor = 1 + event.delta / 600;
+    const zoomFactor = 1 + event.delta / ZOOM_DELTA_DIVISOR;
     this.scale /= zoomFactor;
 
     // Clamp the scale to prevent extreme zooming

--- a/tests/client/InputHandlerGestureZoom.test.ts
+++ b/tests/client/InputHandlerGestureZoom.test.ts
@@ -1,0 +1,190 @@
+import {
+  InputHandler,
+  ZOOM_DELTA_DIVISOR,
+  ZoomEvent,
+} from "../../src/client/InputHandler";
+import type { UIState } from "../../src/client/UIState";
+import type { GameView } from "../../src/client/view";
+import { EventBus } from "../../src/core/EventBus";
+
+/** jsdom has no GestureEvent, so fake one with a plain cancelable Event. */
+function dispatchGesture(
+  target: EventTarget,
+  type: string,
+  props: { scale?: number; clientX?: number; clientY?: number } = {},
+): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  Object.assign(event, { scale: 1, clientX: 0, clientY: 0, ...props });
+  target.dispatchEvent(event);
+  return event;
+}
+
+/** Same, for pointers — jsdom's PointerEvent drops pointerId/pointerType. */
+function dispatchPointerDown(
+  target: EventTarget,
+  pointerId: number,
+  props: { clientX?: number; clientY?: number } = {},
+): void {
+  const event = new Event("pointerdown", { bubbles: true, cancelable: true });
+  Object.assign(event, {
+    pointerId,
+    pointerType: "touch",
+    button: 0,
+    clientX: 0,
+    clientY: 0,
+    ...props,
+  });
+  target.dispatchEvent(event);
+}
+
+function dispatchPointerUp(target: EventTarget, pointerId: number): void {
+  const event = new Event("pointerup", { bubbles: true, cancelable: true });
+  Object.assign(event, { pointerId, pointerType: "touch", button: 0 });
+  target.dispatchEvent(event);
+}
+
+function setup() {
+  const canvas = document.createElement("div");
+  document.body.appendChild(canvas);
+
+  const eventBus = new EventBus();
+  const zooms: ZoomEvent[] = [];
+  eventBus.on(ZoomEvent, (e) => zooms.push(e));
+
+  const gameView = { inSpawnPhase: () => false } as unknown as GameView;
+  const handler = new InputHandler(gameView, {} as UIState, canvas, eventBus);
+  handler.initialize();
+
+  return { canvas, handler, zooms };
+}
+
+describe("InputHandler Safari trackpad pinch", () => {
+  let ctx: ReturnType<typeof setup>;
+
+  beforeEach(() => {
+    ctx = setup();
+  });
+
+  afterEach(() => {
+    ctx.handler.destroy();
+    ctx.canvas.remove();
+  });
+
+  it("emits a negative delta when pinching out (zoom in)", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.2 });
+
+    expect(ctx.zooms).toHaveLength(1);
+    expect(ctx.zooms[0].delta).toBeLessThan(0);
+  });
+
+  it("emits a positive delta when pinching in (zoom out)", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 0.8 });
+
+    expect(ctx.zooms).toHaveLength(1);
+    expect(ctx.zooms[0].delta).toBeGreaterThan(0);
+  });
+
+  it("converts the pinch ratio using the TransformHandler.onZoom convention", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.5 });
+
+    // A 1.5x pinch must produce a zoomFactor of 1/1.5.
+    const zoomFactor = 1 + ctx.zooms[0].delta / ZOOM_DELTA_DIVISOR;
+    expect(zoomFactor).toBeCloseTo(1 / 1.5, 10);
+  });
+
+  it("treats scale as cumulative, not per-event", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.2 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.44 });
+
+    // Both steps are the same 1.2x ratio, so both deltas must match.
+    expect(ctx.zooms).toHaveLength(2);
+    expect(ctx.zooms[1].delta).toBeCloseTo(ctx.zooms[0].delta, 10);
+  });
+
+  it("uses the gesture position as the zoom focal point", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", {
+      scale: 1.2,
+      clientX: 321,
+      clientY: 123,
+    });
+
+    expect(ctx.zooms[0].x).toBe(321);
+    expect(ctx.zooms[0].y).toBe(123);
+  });
+
+  it("ignores gesturechange with no gesture in progress", () => {
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.2 });
+
+    expect(ctx.zooms).toHaveLength(0);
+  });
+
+  it("does not carry scale across a completed gesture", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 4 });
+    dispatchGesture(ctx.canvas, "gestureend", { scale: 4 });
+    ctx.zooms.length = 0;
+
+    // Without the reset this reads as a 1.2/4 ratio and zooms the wrong way.
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.2 });
+
+    expect(ctx.zooms).toHaveLength(1);
+    expect(ctx.zooms[0].delta).toBeLessThan(0);
+  });
+
+  it("defers to the pointer pinch path when two pointers are down", () => {
+    dispatchPointerDown(ctx.canvas, 1, { clientX: 100, clientY: 100 });
+    dispatchPointerDown(ctx.canvas, 2, { clientX: 200, clientY: 200 });
+
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.2 });
+
+    expect(ctx.zooms).toHaveLength(0);
+  });
+
+  it("advances the scale during a pointer pinch so a lift does not re-zoom", () => {
+    dispatchPointerDown(ctx.canvas, 1, { clientX: 100, clientY: 100 });
+    dispatchPointerDown(ctx.canvas, 2, { clientX: 200, clientY: 200 });
+
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    // Deferred to the pointer path, but the scale must still advance to 2.
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 2 });
+    expect(ctx.zooms).toHaveLength(0);
+
+    dispatchPointerUp(ctx.canvas, 1);
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 2.2 });
+
+    // Ratio must be 2.2/2, not 2.2/1 — the 1→2 zoom was already handled.
+    expect(ctx.zooms).toHaveLength(1);
+    const zoomFactor = 1 + ctx.zooms[0].delta / ZOOM_DELTA_DIVISOR;
+    expect(zoomFactor).toBeCloseTo(1 / 1.1, 10);
+  });
+
+  it("still zooms for a trackpad pinch, which registers no pointers", () => {
+    dispatchPointerDown(ctx.canvas, 1, { clientX: 100, clientY: 100 });
+
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1.2 });
+
+    expect(ctx.zooms).toHaveLength(1);
+  });
+
+  it("emits nothing when the pinch has not moved", () => {
+    dispatchGesture(ctx.canvas, "gesturestart", { scale: 1 });
+    dispatchGesture(ctx.canvas, "gesturechange", { scale: 1 });
+
+    expect(ctx.zooms).toHaveLength(0);
+  });
+
+  it("calls preventDefault so the page does not zoom", () => {
+    for (const type of ["gesturestart", "gesturechange", "gestureend"]) {
+      const event = dispatchGesture(ctx.canvas, type, { scale: 1.2 });
+      expect(event.defaultPrevented).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Resolves #4664

Submitting directly as a small bug fix, per the exception in CONTRIBUTING.md.

## Problem

Zoom is completely dead on macOS Safari with a trackpad.

Chrome and Firefox synthesize a `ctrl`+`wheel` event for a trackpad pinch, which
`InputHandler.onScroll` already handles. WebKit fires its non-standard
`gesturestart`/`gesturechange`/`gestureend` events instead, so that branch never
ran in Safari.

Nothing consumed those events either — `installSafariPinchZoomBlocker` only calls
`preventDefault()` on them to stop the *page* zooming, on the assumption that the
game's own pinch runs on pointer events. That holds on a touchscreen, but a
trackpad pinch produces no second pointer. Net effect: page zoom blocked, game
zoom never triggered, pinch does nothing.

## Fix

Handle the gesture events on the input overlay and convert them to a `ZoomEvent`.

`GestureEvent.scale` is cumulative from `gesturestart`, so the per-event ratio is
`scale / lastGestureScale`. `onZoom` divides the camera scale by
`1 + delta / 600`, so inverting that gives the delta which reproduces the pinch
ratio exactly — a 1.2× pinch zooms 1.2×, with no tuning factor.

That `600` was an unexplained literal in `TransformHandler`. Since the gesture
math has to invert it, it's now exported as `ZOOM_DELTA_DIVISOR` so retuning the
zoom sensitivity can't silently desync the two.

The document-level blocker in `DisableSafariPinchZoom.ts` stays as-is: it runs for
the page lifetime and also blocks page zoom on the lobby and menus, where no
`InputHandler` exists.

## Testing

Confirmed by hand on macOS:

- **Safari** — trackpad pinch now zooms; page zoom is still suppressed.
- **Chrome** — ctrl+wheel pinch and regular wheel zoom still work, no regression
  from the added listeners (Chrome doesn't fire GestureEvents).

Rebased on latest `main`; `npm test` passes (2221 + 235).

Added `tests/client/InputHandlerGestureZoom.test.ts` (12 tests): zoom direction
both ways, the ratio conversion checked against `onZoom`'s formula,
cumulative-not-per-event scale, focal point, both guard paths, `preventDefault`,
and the pointer-lift transition below. jsdom has no `GestureEvent`, so the tests
fake one with a plain cancelable event — same approach as the existing
`DisableSafariPinchZoom.test.ts`.

## Note for reviewers

iOS dispatches gesture events on top of the low-level per-touch events — Apple's
[Safari Web Content Guide](https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/HandlingEvents/HandlingEvents.html)
describes `GestureEvent`s as "also sent during a
multi-touch sequence", intended as an alternative to processing individual
touches. So `onGestureChange` bails out when two pointers are already tracked,
leaving that case to the existing pointer path rather than double-applying. It
still advances the cumulative scale before that guard, so if a pointer lifts
mid-gesture the next event measures from the last scale rather than re-applying
zoom the pointer path already handled.
