### PR TITLE
fix(leaderboard): drop the dead end-of-list sentinel from player paging

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -745,7 +745,7 @@ export async function fetchGameById(
 
 export async function fetchPlayerLeaderboard(
   page: number,
-): Promise<RankedLeaderboardResponse | "reached_limit" | false> {
+): Promise<RankedLeaderboardResponse | false> {
   try {
     const url = new URL(`${getApiBase()}/leaderboard/ranked`);
     url.searchParams.set("page", String(page));
@@ -762,13 +762,10 @@ export async function fetchPlayerLeaderboard(
       return false;
     }
 
-    const json = await res.json();
-    const parsed = RankedLeaderboardResponseSchema.safeParse(json);
+    // A page past the end of the leaderboard is an empty list, not an error —
+    // callers detect the end by receiving fewer entries than the page size.
+    const parsed = RankedLeaderboardResponseSchema.safeParse(await res.json());
     if (!parsed.success) {
-      // Handle "Page must be between X and Y" error as end of list
-      if (json?.message?.includes?.("Page must be between")) {
-        return "reached_limit";
-      }
       console.warn(
         "fetchPlayerLeaderboard: Zod validation failed",
         parsed.error.toString(),

--- a/src/client/components/leaderboard/LeaderboardPlayerList.ts
+++ b/src/client/components/leaderboard/LeaderboardPlayerList.ts
@@ -63,12 +63,6 @@ export class LeaderboardPlayerList extends LitElement {
         throw new Error("Failed to load player leaderboard");
       }
 
-      if (result === "reached_limit") {
-        this.playerHasMore = false;
-        this.hasLoadedPlayers = true;
-        return;
-      }
-
       const nextPlayers: PlayerLeaderboardEntry[] = result[
         RankedType.OneVOne
       ].map((entry) => ({

--- a/tests/client/LeaderboardModal.test.ts
+++ b/tests/client/LeaderboardModal.test.ts
@@ -44,21 +44,15 @@ vi.mock("../../src/client/Api", () => {
   return {
     getApiBase: vi.fn(getApiBase),
     getUserMe: vi.fn(async () => false),
+    // Mirrors src/client/Api.ts: any non-ok response is a failure. The end of
+    // the leaderboard is signalled by a short page, never by an error body.
     fetchPlayerLeaderboard: vi.fn(async (page: number) => {
       const url = new URL(`${getApiBase()}/leaderboard/ranked`);
       url.searchParams.set("page", String(page));
       const res = await fetch(url.toString(), {
         headers: { Accept: "application/json" },
       });
-      if (!res.ok) {
-        if (res.status === 400) {
-          const errorJson = await res.json().catch(() => null);
-          if (errorJson?.message?.includes("Page must be between")) {
-            return "reached_limit";
-          }
-        }
-        return false;
-      }
+      if (!res.ok) return false;
       return res.json();
     }),
   };
@@ -291,6 +285,65 @@ describe("LeaderboardModal", () => {
         }),
       );
       expect(playerList!.currentUserEntry?.playerId).toBe("player-2");
+    });
+  });
+
+  describe("Player Pagination", () => {
+    const rankedPage = (count: number, startRank: number) => ({
+      "1v1": Array.from({ length: count }, (_, i) => ({
+        rank: startRank + i,
+        elo: 2000 - (startRank + i),
+        peakElo: 2000,
+        wins: 5,
+        losses: 5,
+        total: 10,
+        public_id: `player-${startRank + i}`,
+        username: `Player${startRank + i}`,
+        accountUsername: null,
+        clanTag: null,
+      })),
+    });
+
+    // Regression for #4500: a full first page followed by a page past the end
+    // of the data must stop paging quietly. It used to be a 400, which surfaced
+    // as a permanent "Try Again" footer and an infinite retry loop.
+    it("stops paging on an empty page without showing an error", async () => {
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+      fetchMock
+        .mockResolvedValueOnce(jsonRes(rankedPage(50, 1)))
+        .mockResolvedValueOnce(jsonRes({ "1v1": [] }));
+
+      const playerList = getPlayerList()!;
+      await playerList.loadPlayerLeaderboard(true);
+      await playerList.updateComplete;
+      expect(playerList.playerData).toHaveLength(50);
+
+      await playerList.loadPlayerLeaderboard();
+      await playerList.updateComplete;
+
+      expect(playerList.playerData).toHaveLength(50);
+      expect(modal.textContent).not.toContain("Try Again");
+
+      // The end of the list is sticky: no further requests are made.
+      const callCount = fetchMock.mock.calls.length;
+      await playerList.loadPlayerLeaderboard();
+      expect(fetchMock.mock.calls.length).toBe(callCount);
+    });
+
+    it("shows Try Again when a page genuinely fails", async () => {
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+      fetchMock
+        .mockResolvedValueOnce(jsonRes(rankedPage(50, 1)))
+        .mockResolvedValueOnce(jsonRes({}, false, 500));
+
+      const playerList = getPlayerList()!;
+      await playerList.loadPlayerLeaderboard(true);
+      await playerList.updateComplete;
+
+      await playerList.loadPlayerLeaderboard();
+      await playerList.updateComplete;
+
+      expect(modal.textContent).toContain("Try Again");
     });
   });
 


### PR DESCRIPTION
Resolves #4500 

## Description:

fetchPlayerLeaderboard tried to detect the end of the ranked leaderboard by string-matching the API's "Page must be between X and Y" 400 body, but the check sat after an `if (!res.ok) return false` early return, so it has never run since the leaderboard shipped in #3008. Scrolling to the bottom therefore looped and left a permanent "Try Again" footer (#4500).

The API now returns an empty list for a page past the end (infra), which is what the caller already treats as the end of the data via its `receivedCount < pageSize` check. So the sentinel and its "reached_limit" return value are removed rather than repaired. Removing dead code cannot regress current behaviour, so this is safe to land ahead of the API deploy.

The modal test mocked its own copy of fetchPlayerLeaderboard that included the 400 handling the real function lacked, which is why the bug went unnoticed; the mock now mirrors the shipping implementation and covers both reaching the end and a genuine page failure.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n