### PR TITLE
fix(leaderboard): stop the infinite retry at the end of the ranked list

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -743,6 +743,21 @@ export async function fetchGameById(
   }
 }
 
+// The API answers a page past the end of the ranked leaderboard with a 400
+// instead of an empty list, so the end is only detectable from the error body.
+// Its wording is part of the contract; the bounds vary with the page cap.
+const PAGE_BOUNDS_MESSAGE = /^Page must be between \d+ and \d+$/;
+
+export function isPageBoundsMessage(body: unknown): boolean {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    "message" in body &&
+    typeof body.message === "string" &&
+    PAGE_BOUNDS_MESSAGE.test(body.message)
+  );
+}
+
 export async function fetchPlayerLeaderboard(
   page: number,
 ): Promise<RankedLeaderboardResponse | "reached_limit" | false> {
@@ -754,6 +769,12 @@ export async function fetchPlayerLeaderboard(
     });
 
     if (!res.ok) {
+      if (res.status === 400) {
+        const body = await res.json().catch(() => null);
+        if (isPageBoundsMessage(body)) {
+          return "reached_limit";
+        }
+      }
       console.warn(
         "fetchPlayerLeaderboard: unexpected status",
         res.status,
@@ -762,13 +783,8 @@ export async function fetchPlayerLeaderboard(
       return false;
     }
 
-    const json = await res.json();
-    const parsed = RankedLeaderboardResponseSchema.safeParse(json);
+    const parsed = RankedLeaderboardResponseSchema.safeParse(await res.json());
     if (!parsed.success) {
-      // Handle "Page must be between X and Y" error as end of list
-      if (json?.message?.includes?.("Page must be between")) {
-        return "reached_limit";
-      }
       console.warn(
         "fetchPlayerLeaderboard: Zod validation failed",
         parsed.error.toString(),

--- a/src/client/components/leaderboard/LeaderboardPlayerList.ts
+++ b/src/client/components/leaderboard/LeaderboardPlayerList.ts
@@ -63,6 +63,7 @@ export class LeaderboardPlayerList extends LitElement {
         throw new Error("Failed to load player leaderboard");
       }
 
+      // Past the last page. Not an error: stop paging, leave the footer clear.
       if (result === "reached_limit") {
         this.playerHasMore = false;
         this.hasLoadedPlayers = true;

--- a/tests/client/ApiPlayerLeaderboard.test.ts
+++ b/tests/client/ApiPlayerLeaderboard.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: { jwtAudience: () => "localhost" },
+}));
+
+// fetchPlayerLeaderboard is unauthenticated; Auth is only mocked because
+// Api.ts imports it at module scope.
+vi.mock("../../src/client/Auth", () => ({
+  getAuthHeader: vi.fn(async () => ""),
+  getPlayToken: vi.fn(async () => null),
+  logOut: vi.fn(async () => {}),
+  userAuth: vi.fn(async () => false),
+}));
+
+import { fetchPlayerLeaderboard } from "../../src/client/Api";
+
+const entry = (rank: number) => ({
+  rank,
+  elo: 1500,
+  peakElo: 1600,
+  wins: 10,
+  losses: 5,
+  total: 15,
+  public_id: `player-${rank}`,
+  username: "Alpha",
+  accountUsername: "alpha.0001",
+});
+
+const res = (body: unknown, ok = true, status = 200) => ({
+  ok,
+  status,
+  statusText: ok ? "OK" : "Error",
+  json: async () => body,
+});
+
+beforeEach(() => {
+  // Short-circuits getApiBase before it reads localStorage.
+  process.env.API_DOMAIN = "api.test";
+  vi.stubGlobal("fetch", vi.fn());
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+describe("fetchPlayerLeaderboard", () => {
+  it("returns the parsed page", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      res({ "1v1": [entry(1)] }),
+    );
+
+    const result = await fetchPlayerLeaderboard(1);
+    expect(result).not.toBe(false);
+    expect(result).not.toBe("reached_limit");
+    expect((result as { "1v1": unknown[] })["1v1"]).toHaveLength(1);
+  });
+
+  it("requests the page it was asked for", async () => {
+    const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+    fetchMock.mockResolvedValueOnce(res({ "1v1": [] }));
+
+    await fetchPlayerLeaderboard(3);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("page=3");
+  });
+
+  it("reports a page past the end as reached_limit", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      res(
+        { error: "Bad request", message: "Page must be between 1 and 2" },
+        false,
+        400,
+      ),
+    );
+
+    expect(await fetchPlayerLeaderboard(3)).toBe("reached_limit");
+  });
+
+  // The bounds are open so a dynamic page cap keeps matching.
+  it("accepts any numeric bounds in the message", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      res(
+        { error: "Bad request", message: "Page must be between 1 and 137" },
+        false,
+        400,
+      ),
+    );
+
+    expect(await fetchPlayerLeaderboard(200)).toBe("reached_limit");
+  });
+
+  // Anything looser than the exact page-bounds wording would hide real errors.
+  it.each([
+    ["a 500", res({}, false, 500)],
+    ["a 400 with no message", res({ error: "Bad request" }, false, 400)],
+    [
+      "an unrelated 400 mentioning a page",
+      res(
+        { error: "Bad request", message: "Invalid page parameter" },
+        false,
+        400,
+      ),
+    ],
+    [
+      "a 400 with a non-string message",
+      res({ error: "Bad request", message: { page: 3 } }, false, 400),
+    ],
+    [
+      "a 400 that only embeds the bounds phrase",
+      res(
+        {
+          error: "Bad request",
+          message: "Upstream rejected the query: Page must be between 1 and 2",
+        },
+        false,
+        400,
+      ),
+    ],
+    [
+      "a 400 with the phrase but no bounds",
+      res(
+        { error: "Bad request", message: "Page must be between" },
+        false,
+        400,
+      ),
+    ],
+  ])("returns false for %s", async (_label, response) => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(response);
+    expect(await fetchPlayerLeaderboard(3)).toBe(false);
+  });
+
+  it("returns false when the error body is not JSON", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      statusText: "Bad Request",
+      json: async () => {
+        throw new SyntaxError("Unexpected token <");
+      },
+    });
+
+    expect(await fetchPlayerLeaderboard(3)).toBe(false);
+  });
+
+  it("returns false when the payload fails validation", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce(
+      res({ "1v1": [{ rank: "first" }] }),
+    );
+
+    expect(await fetchPlayerLeaderboard(1)).toBe(false);
+  });
+
+  it("returns false when the request throws", async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(
+      new TypeError("network down"),
+    );
+
+    expect(await fetchPlayerLeaderboard(1)).toBe(false);
+  });
+});

--- a/tests/client/LeaderboardModal.test.ts
+++ b/tests/client/LeaderboardModal.test.ts
@@ -39,11 +39,17 @@ vi.mock("../../src/client/Utils", () => ({
   }),
 }));
 
-vi.mock("../../src/client/Api", () => {
+vi.mock("../../src/client/Api", async () => {
+  // Share the real end-of-list matcher so this mock cannot drift from it.
+  const { isPageBoundsMessage } = await vi.importActual<
+    typeof import("../../src/client/Api")
+  >("../../src/client/Api");
   const getApiBase = () => "http://localhost:3000";
   return {
     getApiBase: vi.fn(getApiBase),
     getUserMe: vi.fn(async () => false),
+    isPageBoundsMessage,
+    // Mirrors the control flow of the real fetchPlayerLeaderboard.
     fetchPlayerLeaderboard: vi.fn(async (page: number) => {
       const url = new URL(`${getApiBase()}/leaderboard/ranked`);
       url.searchParams.set("page", String(page));
@@ -52,10 +58,8 @@ vi.mock("../../src/client/Api", () => {
       });
       if (!res.ok) {
         if (res.status === 400) {
-          const errorJson = await res.json().catch(() => null);
-          if (errorJson?.message?.includes("Page must be between")) {
-            return "reached_limit";
-          }
+          const body = await res.json().catch(() => null);
+          if (isPageBoundsMessage(body)) return "reached_limit";
         }
         return false;
       }
@@ -291,6 +295,95 @@ describe("LeaderboardModal", () => {
         }),
       );
       expect(playerList!.currentUserEntry?.playerId).toBe("player-2");
+    });
+  });
+
+  describe("Player Pagination", () => {
+    const rankedPage = (count: number, startRank: number) => ({
+      "1v1": Array.from({ length: count }, (_, i) => ({
+        rank: startRank + i,
+        elo: 2000 - (startRank + i),
+        peakElo: 2000,
+        wins: 5,
+        losses: 5,
+        total: 10,
+        public_id: `player-${startRank + i}`,
+        username: `Player${startRank + i}`,
+        accountUsername: null,
+        clanTag: null,
+      })),
+    });
+
+    // The body the API actually sends for a page past the end.
+    const pastEnd = jsonRes(
+      { error: "Bad request", message: "Page must be between 1 and 2" },
+      false,
+      400,
+    );
+
+    it("stops paging past the last page without showing an error", async () => {
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+      fetchMock
+        .mockResolvedValueOnce(jsonRes(rankedPage(50, 1)))
+        .mockResolvedValueOnce(pastEnd);
+
+      const playerList = getPlayerList()!;
+      await playerList.loadPlayerLeaderboard(true);
+      await playerList.updateComplete;
+      expect(playerList.playerData).toHaveLength(50);
+
+      await playerList.loadPlayerLeaderboard();
+      await playerList.updateComplete;
+
+      expect(playerList.playerData).toHaveLength(50);
+      expect(modal.textContent).not.toContain("Try Again");
+
+      // The end of the list is sticky: no further requests are made.
+      const callCount = fetchMock.mock.calls.length;
+      await playerList.loadPlayerLeaderboard();
+      expect(fetchMock.mock.calls.length).toBe(callCount);
+    });
+
+    it("stops paging on a short page", async () => {
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+      fetchMock.mockResolvedValueOnce(jsonRes(rankedPage(20, 1)));
+
+      const playerList = getPlayerList()!;
+      await playerList.loadPlayerLeaderboard(true);
+      await playerList.updateComplete;
+
+      const callCount = fetchMock.mock.calls.length;
+      await playerList.loadPlayerLeaderboard();
+      expect(fetchMock.mock.calls.length).toBe(callCount);
+      expect(modal.textContent).not.toContain("Try Again");
+    });
+
+    // Only the page-bounds 400 means "end of data".
+    it.each([
+      ["500", jsonRes({}, false, 500)],
+      ["unrelated 400", jsonRes({ error: "Bad request" }, false, 400)],
+      [
+        "400 mentioning a page",
+        jsonRes(
+          { error: "Bad request", message: "Invalid page parameter" },
+          false,
+          400,
+        ),
+      ],
+    ])("shows Try Again when a page genuinely fails (%s)", async (_, bad) => {
+      const fetchMock = global.fetch as ReturnType<typeof vi.fn>;
+      fetchMock
+        .mockResolvedValueOnce(jsonRes(rankedPage(50, 1)))
+        .mockResolvedValueOnce(bad);
+
+      const playerList = getPlayerList()!;
+      await playerList.loadPlayerLeaderboard(true);
+      await playerList.updateComplete;
+
+      await playerList.loadPlayerLeaderboard();
+      await playerList.updateComplete;
+
+      expect(modal.textContent).toContain("Try Again");
     });
   });
 


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #4500

## Description:

Scrolling to the bottom of the 1v1 Ranked leaderboard fetched forever and left a permanent "Try Again" button in the footer.

`fetchPlayerLeaderboard` already tried to detect the end of the list by matching the API's `"Page must be between X and Y"` 400 body — but the check sat _after_ `if (!res.ok) return false`, so it has been unreachable since the leaderboard shipped in #3008. Every request past the last page fell through to the generic failure path, which the infinite-scroll caller treats as a retryable error.

Moved the check into the branch that actually sees the 400, and deleted the unreachable copy.

The match stays pinned to the exact page-bounds wording. Anything looser — any 400, or any message merely containing "page" — would report genuine failures as the end of the data and silently truncate the leaderboard.

### Why the tests didn't catch this

`tests/client/LeaderboardModal.test.ts` mocks the whole `Api` module with a hand-written copy of `fetchPlayerLeaderboard`, and that copy already contained the 400 handling the real function was missing. The suite was testing a correct reimplementation of a broken function.

The mock now mirrors what actually ships, and `fetchPlayerLeaderboard` gets direct tests in `tests/client/ApiPlayerLeaderboard.test.ts`:

- page-bounds 400 → end of list
- 500, bare 400, unrelated 400 mentioning a page, non-string `message`, non-JSON error body, schema rejection, thrown request → failure

Confirmed the new test fails against the old implementation and passes against the fix, with no other test moving.

### Note for reviewers

This is a client-side workaround for an API that answers an out-of-range page with a 400. Having the API return an empty list instead would remove the need to string-match an error message at all, and would fix already-deployed clients without a client release. Worth doing separately if there's appetite.

Overlaps #4501, which fixes the same bug. This version additionally removes the dead duplicate check, keeps the match narrow rather than `includes("page")`, and adds the regression tests.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

No UI or string changes — this only stops an error footer from appearing.

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
