### PR TITLE
fix: respect "Disable emojis" setting in all emoji display paths

### DIFF
--- a/src/client/hud/layers/EventsDisplay.ts
+++ b/src/client/hud/layers/EventsDisplay.ts
@@ -16,6 +16,7 @@ import {
   TargetPlayerUpdate,
   UnitIncomingUpdate,
 } from "../../../core/game/GameUpdates";
+import { UserSettings } from "../../../core/game/UserSettings";
 import { Controller } from "../../Controller";
 import { SendAllianceRequestIntentEvent } from "../../Transport";
 
@@ -69,6 +70,7 @@ export class EventsDisplay extends LitElement implements Controller {
 
   private active: boolean = false;
   private events: GameEvent[] = [];
+  private userSettings = new UserSettings();
 
   @state() private _isVisible: boolean = false;
 
@@ -493,6 +495,9 @@ export class EventsDisplay extends LitElement implements Controller {
   }
 
   onEmojiMessageEvent(update: EmojiUpdate) {
+    // Honor the "Disable emojis" setting: don't surface received emojis in the
+    // events feed either (#4430).
+    if (!this.userSettings.emojis()) return;
     const myPlayer = this.game.myPlayer();
     if (!myPlayer) return;
 

--- a/src/client/view/PlayerView.ts
+++ b/src/client/view/PlayerView.ts
@@ -96,7 +96,9 @@ function stateFromUpdate(pu: PlayerUpdate): PlayerState {
     incomingAttacks: pu.incomingAttacks!,
     outgoingAllianceRequests: pu.outgoingAllianceRequests!.slice(),
     alliances: pu.alliances!,
-    outgoingEmojis: pu.outgoingEmojis!,
+    // Respect the client-side "Disable emojis" setting: when off, never surface
+    // emoji data to any renderer/overlay that reads this shared state (#4430).
+    outgoingEmojis: userSettings.emojis() ? pu.outgoingEmojis! : [],
   };
 }
 
@@ -266,6 +268,11 @@ export class PlayerView {
    */
   applyUpdate(pu: PlayerUpdate): void {
     applyStateUpdate(this.state, pu);
+    // applyStateUpdate refreshes outgoingEmojis every tick; re-apply the
+    // "Disable emojis" setting so live emojis stay hidden when it's off (#4430).
+    if (!userSettings.emojis()) {
+      this.state.outgoingEmojis = [];
+    }
   }
 
   /** Set the renderer-format embargoes (smallIDs). */

--- a/tests/client/graphics/layers/EventsDisplayEmoji.test.ts
+++ b/tests/client/graphics/layers/EventsDisplayEmoji.test.ts
@@ -1,0 +1,87 @@
+/**
+ * The "Disable emojis" setting must also suppress received emojis in the
+ * events feed (not just the in-world / overlay display). Regression test for
+ * #4430 — EventsDisplay.onEmojiMessageEvent must early-return when the setting
+ * is off.
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("lit/directive.js", () => ({}));
+vi.mock("lit/directives/unsafe-html.js", () => ({
+  unsafeHTML: (s: string) => s,
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  renderNumber: vi.fn(),
+  renderTroops: vi.fn(),
+  getMessageTypeClasses: vi.fn(() => ""),
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventsDisplay } from "../../../../src/client/hud/layers/EventsDisplay";
+import { GameUpdateType } from "../../../../src/core/game/GameUpdates";
+import { UserSettings } from "../../../../src/core/game/UserSettings";
+
+function resetSettings() {
+  localStorage.clear();
+  (
+    UserSettings as unknown as { cache: Map<string, string | null> }
+  ).cache.clear();
+}
+
+function setEmojisEnabled(enabled: boolean) {
+  localStorage.setItem("settings.emojis", String(enabled));
+  (
+    UserSettings as unknown as { cache: Map<string, string | null> }
+  ).cache.clear();
+}
+
+describe("EventsDisplay emoji setting (#4430)", () => {
+  let ed: EventsDisplay;
+  const myPlayer = { smallID: () => 1, displayName: () => "Me" };
+  const sender = { smallID: () => 2, displayName: () => "Bob" };
+
+  // A broadcast/direct emoji from Bob addressed to me (recipientID = my smallID).
+  const emojiUpdate = {
+    type: GameUpdateType.Emoji,
+    emoji: { message: "👍", senderID: 2, recipientID: 1, createdAt: 0 },
+  };
+
+  beforeEach(() => {
+    resetSettings();
+    ed = new EventsDisplay();
+    (ed as unknown as { game: unknown }).game = {
+      myPlayer: () => myPlayer,
+      playerBySmallID: (id: number) => (id === 1 ? myPlayer : sender),
+      ticks: () => 0,
+    };
+  });
+
+  it("adds a feed entry for a received emoji when the setting is on", () => {
+    ed.onEmojiMessageEvent(emojiUpdate as never);
+    expect((ed as unknown as { events: unknown[] }).events).toHaveLength(1);
+  });
+
+  it("adds nothing when the setting is off", () => {
+    setEmojisEnabled(false);
+    ed.onEmojiMessageEvent(emojiUpdate as never);
+    expect((ed as unknown as { events: unknown[] }).events).toHaveLength(0);
+  });
+});

--- a/tests/client/view/PlayerView.test.ts
+++ b/tests/client/view/PlayerView.test.ts
@@ -6,10 +6,15 @@
  * what the FrameBuilder relies on when populating PlayerState.
  */
 
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import { PlayerView } from "../../../src/client/view/PlayerView";
-import { PlayerType } from "../../../src/core/game/Game";
+import {
+  AllPlayers,
+  EmojiMessage,
+  PlayerType,
+} from "../../../src/core/game/Game";
 import { GameUpdateType } from "../../../src/core/game/GameUpdates";
+import { UserSettings } from "../../../src/core/game/UserSettings";
 import {
   makeEmptyGu,
   makeGameView,
@@ -281,5 +286,55 @@ describe("PlayerView in a GameView context", () => {
 
     expect(game.player("me").isMe()).toBe(true);
     expect(game.player("other").isMe()).toBe(false);
+  });
+});
+
+describe("PlayerView emoji display setting (#4430)", () => {
+  // Emoji data lives on the shared PlayerView.state.outgoingEmojis field, read
+  // both by the WebGL name-pass (floating emoji over players) and the player
+  // overlay. Disabling emojis must empty it at construction and every tick.
+  function resetSettings() {
+    localStorage.clear();
+    // UserSettings keeps a static cache shared across instances; clear it so
+    // reads see the freshly-set localStorage.
+    (
+      UserSettings as unknown as { cache: Map<string, string | null> }
+    ).cache.clear();
+  }
+
+  function setEmojisEnabled(enabled: boolean) {
+    localStorage.setItem("settings.emojis", String(enabled));
+    (
+      UserSettings as unknown as { cache: Map<string, string | null> }
+    ).cache.clear();
+  }
+
+  const broadcastEmoji: EmojiMessage = {
+    message: "👍",
+    senderID: 1,
+    recipientID: AllPlayers,
+    createdAt: 0,
+  };
+
+  beforeEach(resetSettings);
+
+  it("keeps outgoing emojis in view state when the setting is on (default)", () => {
+    const p = makePlayerView({ data: { outgoingEmojis: [broadcastEmoji] } });
+    expect(p.state.outgoingEmojis).toHaveLength(1);
+    expect(p.outgoingEmojis()).toHaveLength(1);
+  });
+
+  it("strips outgoing emojis at construction when the setting is off", () => {
+    setEmojisEnabled(false);
+    const p = makePlayerView({ data: { outgoingEmojis: [broadcastEmoji] } });
+    expect(p.state.outgoingEmojis).toEqual([]);
+    expect(p.outgoingEmojis()).toEqual([]);
+  });
+
+  it("strips emojis arriving via applyUpdate when the setting is off", () => {
+    setEmojisEnabled(false);
+    const p = makePlayerView();
+    p.applyUpdate(makePlayerUpdate({ outgoingEmojis: [broadcastEmoji] }));
+    expect(p.state.outgoingEmojis).toEqual([]);
   });
 });


### PR DESCRIPTION
Resolves #4430

## Problem
The "Disable emojis" setting only suppressed the player-overlay emoji (`PlayerIcons`). Emoji data also flows through the shared `PlayerView.state.outgoingEmojis` field, which is read by the WebGL name-pass (the floating emoji over players on the map) and by the events feed — neither of those checked the setting, so disabling emojis left them visible.

## Fix
- **`PlayerView`**: strip `outgoingEmojis` from the view state when the setting is off — at construction (`stateFromUpdate`) and on every tick (`applyUpdate`). This is a single choke point covering both the map emoji and the overlay, and keeps the WebGL pass a pure consumer of pushed data.
- **`EventsDisplay.onEmojiMessageEvent`**: early-return when the setting is off, so received emojis stay out of the events feed.

## Testing
- Added regression tests:
  - `tests/client/view/PlayerView.test.ts` — emojis retained in view state when on; stripped at construction and on update when off.
  - `tests/client/graphics/layers/EventsDisplayEmoji.test.ts` — feed entry added only when on.
- Full suite passes (`npm test`).
- Manually verified in a live singleplayer game: with emojis disabled, a broadcast emoji plus 30 bot nations produced zero rendered emojis across all players over several seconds; re-enabling, emojis appeared again.

Discord: granster9