### PR TITLE
fix: guard warship randomTile against a non-integer patrol tile

### DIFF
--- a/src/core/execution/WarshipExecution.ts
+++ b/src/core/execution/WarshipExecution.ts
@@ -764,7 +764,12 @@ export class WarshipExecution implements Execution {
     const warshipComponent = this.mg.getWaterComponent(this.warship.tile());
 
     const patrolTile = this.warship.warshipState().patrolTile;
-    if (patrolTile === undefined) {
+    // A non-integer or out-of-range patrolTile makes mg.x()/mg.y() return
+    // undefined, so every candidate coordinate below is NaN, isValidCoord is
+    // always false, and the loop's out-of-bounds `continue` (which does not
+    // advance expandCount) spins forever, hanging the whole synchronous sim.
+    // Bail out instead of trusting patrolTile is a valid tile.
+    if (patrolTile === undefined || !this.mg.isValidRef(patrolTile)) {
       return undefined;
     }
 

--- a/tests/WarshipPatrolTileGuard.test.ts
+++ b/tests/WarshipPatrolTileGuard.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { WarshipExecution } from "../src/core/execution/WarshipExecution";
+import {
+  Game,
+  PlayerInfo,
+  PlayerType,
+  Unit,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+
+// coastX matches the other warship tests: on "half_land_half_ocean" the water
+// starts just past this column, so tiles at (coastX + n, y) sit on the ocean.
+const coastX = 7;
+let game: Game;
+
+describe("WarshipExecution.randomTile patrol-tile guard", () => {
+  beforeEach(async () => {
+    game = await setup(
+      "half_land_half_ocean",
+      { infiniteGold: true, instantBuild: true },
+      [new PlayerInfo("p1", PlayerType.Human, null, "p1")],
+    );
+  });
+
+  function makeWarshipExec(patrolTile: number): {
+    exec: WarshipExecution;
+    warship: Unit;
+  } {
+    const player = game.player("p1");
+    const warship = player.buildUnit(
+      UnitType.Warship,
+      game.ref(coastX + 1, 10),
+      { patrolTile },
+    );
+    const exec = new WarshipExecution(warship);
+    exec.init(game, 0);
+    return { exec, warship };
+  }
+
+  it("returns a valid water tile for a normal integer patrol tile", () => {
+    const { exec } = makeWarshipExec(game.ref(coastX + 1, 10));
+    const tile = exec.randomTile();
+    expect(tile === undefined || game.isValidRef(tile)).toBe(true);
+    if (tile !== undefined) {
+      expect(Number.isInteger(tile)).toBe(true);
+    }
+  });
+
+  it("bails out (no hang) when patrolTile is a non-integer ref", () => {
+    // Poison the patrol tile directly, bypassing the intent-level isValidRef
+    // guard, to prove randomTile() itself can no longer spin forever.
+    const { exec, warship } = makeWarshipExec(game.ref(coastX + 1, 10));
+    warship.updateWarshipState({ patrolTile: game.ref(coastX + 2, 10) + 0.5 });
+
+    const t0 = performance.now();
+    const tile = exec.randomTile();
+    const ms = performance.now() - t0;
+
+    expect(tile).toBeUndefined();
+    expect(ms).toBeLessThan(1000);
+  });
+
+  it("bails out when patrolTile is out of range", () => {
+    const { exec, warship } = makeWarshipExec(game.ref(coastX + 1, 10));
+    warship.updateWarshipState({ patrolTile: game.width() * game.height() });
+    expect(exec.randomTile()).toBeUndefined();
+  });
+
+  it("a full warship tick does not hang with a poisoned patrol tile", () => {
+    const { exec, warship } = makeWarshipExec(game.ref(coastX + 1, 10));
+    warship.updateWarshipState({ patrolTile: game.ref(coastX + 2, 10) + 0.5 });
+    game.addExecution(exec);
+    const t0 = performance.now();
+    for (let i = 0; i < 20; i++) game.executeNextTick();
+    expect(performance.now() - t0).toBeLessThan(3000);
+  });
+});


### PR DESCRIPTION
## Background

Follow-up to #4720. While verifying that fix, I traced the actual freeze it prevents to a latent infinite loop in `WarshipExecution.randomTile()` that is worth closing on its own.

## The bug

`randomTile()` picks a patrol destination by sampling around the warship's `patrolTile`:

```ts
const x = this.mg.x(patrolTile) + this.random.nextInt(...);
const y = this.mg.y(patrolTile) + this.random.nextInt(...);
if (!this.mg.isValidCoord(x, y)) {
  continue;   // <-- does NOT advance attempts/expandCount
}
```

If `patrolTile` is not a valid integer ref, `mg.x()`/`mg.y()` are LUT misses returning `undefined`, so `x`/`y` are `NaN`, `isValidCoord` is always false, and the one `continue` branch that doesn't advance `expandCount` spins the `while (expandCount < 3)` loop **forever** — inside a single synchronous `executeNextTick()`. Because the sim runs identically on every client, one such tick hangs every client's worker on the same tick: a hard, lobby-wide freeze that not even a watchdog timer can recover (the event loop is blocked).

The trigger in practice was a `move_warship` intent with a fractional `tile` (its `tile` field is `z.number()`), which `MoveWarshipExecution` stored verbatim as `patrolTile`.

## Fix

#4720 already rejects the fractional tile at the intent boundary (`MoveWarshipExecution.init` calls `isValidRef`, now with `Number.isInteger`). This PR makes `randomTile()` robust regardless of how `patrolTile` got set — it bails out up front if the patrol tile isn't a valid ref, so the loop can never spin.

I chose the up-front guard over adding `attempts++` to the out-of-bounds branch specifically to avoid changing the PRNG sequence for valid patrol tiles near map edges (which would be a determinism-affecting behavior change). For a valid integer `patrolTile` the guard is a no-op — offset 0 is always reachable, so a valid tile always makes progress.

## Tests

New `tests/WarshipPatrolTileGuard.test.ts`:
- normal integer patrol tile still returns a valid water tile
- non-integer patrol tile → `randomTile()` returns `undefined` instead of hanging
- out-of-range patrol tile → same
- a full warship tick with a poisoned patrol tile completes fast

Verified the regression guard bites: with the fix reverted, the test run hangs (the synchronous loop blocks the event loop so even vitest's `testTimeout` can't fire); with the fix it passes in <1s. Existing `Warship`/`WarshipMultiSelection` suites still pass (42 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)