### PR TITLE
fix: NUL-delimit asset keys so apostrophe filenames upload to R2

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -106,7 +106,9 @@ else
     # KEY from the manifest is URL-encoded per segment (e.g. flags/C%C3%B4te.png).
     # Files on disk live at the *decoded* path, so decode KEY before reading the
     # file, then encode the whole decoded path as one URL segment for the POST.
-    if ! echo "$MISSING" | xargs -P 16 -I{} bash -euc '
+    # NUL-delimit the keys: xargs's default tokenizer treats quotes specially,
+    # so a key with an apostrophe (e.g. flags/Mi'"'"'kmaq.svg) aborts the batch.
+    if ! echo "$MISSING" | tr '\n' '\0' | xargs -0 -P 16 -I{} bash -euc '
         KEY="$1"
         # Validate KEY: only chars that encodeURIComponent leaves literal
         # (A-Z a-z 0-9 - _ . ! ~ * ( ) plus apostrophe), "/" between segments,


### PR DESCRIPTION
## Description

The staging deploy failed at the R2 asset upload step:

```
xargs: unmatched single quote; by default quotes are special to xargs unless you use the -0 option
❌ One or more asset uploads failed.
```

Manifest keys are encoded per segment like `encodeURIComponent`, which leaves apostrophes literal (the script's own key-validation regex already allows them for this reason). The new `flags/Mi'kmaq.svg` asset was among the missing keys, and `echo "$MISSING" | xargs -P 16 ...` uses xargs's default tokenizer, which treats quotes specially — the lone `'` aborted the whole upload batch before any request was made.

## Fix

NUL-delimit the key stream (`tr '\n' '\0' | xargs -0`), which disables xargs quote processing entirely. The downstream `bash -euc` worker was already safe (the key is passed as a positional argument, never interpolated), so no other changes are needed.

Verified locally by running the full inner pipeline (validation regex → %HH decode → `@uri` re-encode) over `_assets/flags/Mi'kmaq.abc123.svg` and a combined `%HH` + apostrophe key — both pass through correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)