### PR TITLE
Custom tribe names in public games

### DIFF
--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -78,7 +78,12 @@ export async function createGameRunner(
 
   const gr = new GameRunner(
     game,
-    new Executor(game, gameStart.gameID, clientID),
+    new Executor(
+      game,
+      gameStart.gameID,
+      clientID,
+      gameStart.tribes?.map((t) => t.name),
+    ),
     callBack,
   );
   gr.init();

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -78,12 +78,7 @@ export async function createGameRunner(
 
   const gr = new GameRunner(
     game,
-    new Executor(
-      game,
-      gameStart.gameID,
-      clientID,
-      gameStart.tribes?.map((t) => t.name),
-    ),
+    new Executor(game, gameStart.gameID, clientID, gameStart.tribes),
     callBack,
   );
   gr.init();

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -78,7 +78,12 @@ export async function createGameRunner(
 
   const gr = new GameRunner(
     game,
-    new Executor(game, gameStart.gameID, clientID, gameStart.tribes),
+    new Executor(
+      game,
+      gameStart.gameID,
+      clientID,
+      gameStart.tribes?.map((t) => t.name),
+    ),
     callBack,
   );
   gr.init();

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -718,16 +718,9 @@ export const PlayerSchema = z.object({
   teamIndex: z.number().int().nonnegative().optional(),
 });
 
-// A purchased bot tribe name drawn for this game by the API. publicId is the
-// tribe name's stable id (never a player id); ownerClientId matches
-// players[].clientID in the same start info, null when the owner is not in
-// this game. Mirrors infra's TribeSchema — embed API objects verbatim.
-export const TribeSchema = z.object({
-  name: SafeString.min(1).max(64),
-  publicId: z.string().min(1).max(64),
-  ownerClientId: ID.nullable(),
-});
-export type Tribe = z.infer<typeof TribeSchema>;
+// A purchased bot tribe name drawn for this game by the API (active names
+// are globally unique, so the name alone identifies the tribe).
+export const TribeNameSchema = SafeString.min(1).max(64);
 
 export const GameStartInfoSchema = z.object({
   gameID: ID,
@@ -735,9 +728,9 @@ export const GameStartInfoSchema = z.object({
   visibleAt: z.number().optional(),
   config: GameConfigSchema,
   players: PlayerSchema.array(),
-  // Custom bot tribe names in use this game (public games only). Rides the
-  // analytics record to infra at game end for owner appearance stats.
-  tribes: z.array(TribeSchema).max(100).optional(),
+  // Purchased bot tribe names in use this game (public games only). Rides
+  // the analytics record to infra at game end for owner appearance stats.
+  tribes: z.array(TribeNameSchema).max(100).optional(),
 });
 
 export const WinnerSchema = z

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -718,9 +718,14 @@ export const PlayerSchema = z.object({
   teamIndex: z.number().int().nonnegative().optional(),
 });
 
-// A purchased bot tribe name drawn for this game by the API (active names
-// are globally unique, so the name alone identifies the tribe).
-export const TribeNameSchema = SafeString.min(1).max(64);
+// A purchased bot tribe name in use this game (active names are globally
+// unique, so the name alone identifies the tribe). Infra parses these
+// objects .loose() at analytics ingest — keep the object shape, and fields
+// may be added later without breaking record parsing.
+export const TribeSchema = z.object({
+  name: SafeString.min(1).max(64),
+});
+export type Tribe = z.infer<typeof TribeSchema>;
 
 export const GameStartInfoSchema = z.object({
   gameID: ID,
@@ -730,7 +735,7 @@ export const GameStartInfoSchema = z.object({
   players: PlayerSchema.array(),
   // Purchased bot tribe names in use this game (public games only). Rides
   // the analytics record to infra at game end for owner appearance stats.
-  tribes: z.array(TribeNameSchema).max(100).optional(),
+  tribes: z.array(TribeSchema).max(100).optional(),
 });
 
 export const WinnerSchema = z

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -719,12 +719,14 @@ export const PlayerSchema = z.object({
 });
 
 // A purchased bot tribe name in use this game (active names are globally
-// unique, so the name alone identifies the tribe). Infra parses these
-// objects .loose() at analytics ingest — keep the object shape, and fields
-// may be added later without breaking record parsing.
-export const TribeSchema = z.object({
-  name: SafeString.min(1).max(64),
-});
+// unique, so the name alone identifies the tribe). Loose to mirror infra's
+// analytics-ingest schema — a field the API adds later flows through to the
+// record without a game-side change, instead of being silently stripped.
+export const TribeSchema = z
+  .object({
+    name: SafeString.min(1).max(64),
+  })
+  .loose();
 export type Tribe = z.infer<typeof TribeSchema>;
 
 export const GameStartInfoSchema = z.object({

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -718,12 +718,26 @@ export const PlayerSchema = z.object({
   teamIndex: z.number().int().nonnegative().optional(),
 });
 
+// A purchased bot tribe name drawn for this game by the API. publicId is the
+// tribe name's stable id (never a player id); ownerClientId matches
+// players[].clientID in the same start info, null when the owner is not in
+// this game. Mirrors infra's TribeSchema — embed API objects verbatim.
+export const TribeSchema = z.object({
+  name: SafeString.min(1).max(64),
+  publicId: z.string().min(1).max(64),
+  ownerClientId: ID.nullable(),
+});
+export type Tribe = z.infer<typeof TribeSchema>;
+
 export const GameStartInfoSchema = z.object({
   gameID: ID,
   lobbyCreatedAt: z.number(),
   visibleAt: z.number().optional(),
   config: GameConfigSchema,
   players: PlayerSchema.array(),
+  // Custom bot tribe names in use this game (public games only). Rides the
+  // analytics record to infra at game end for owner appearance stats.
+  tribes: z.array(TribeSchema).max(100).optional(),
 });
 
 export const WinnerSchema = z

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -37,6 +37,8 @@ export class Executor {
     private mg: Game,
     private gameID: GameID,
     private clientID: ClientID | undefined,
+    // Purchased bot tribe names drawn for this game (GameStartInfo.tribes).
+    private purchasedTribeNames: string[] = [],
   ) {
     // Add one to avoid id collisions with tribes.
     this.random = new PseudoRandom(simpleHash(gameID) + 1);
@@ -133,6 +135,7 @@ export class Executor {
       .filter((c): c is NonNullable<typeof c> => c !== undefined);
     return new TribeSpawner(this.mg, this.gameID, nationCells).spawnTribes(
       numTribes,
+      this.purchasedTribeNames,
     );
   }
 

--- a/src/core/execution/TribeSpawner.ts
+++ b/src/core/execution/TribeSpawner.ts
@@ -49,6 +49,12 @@ export class TribeSpawner {
     // selected remaining slot; with fewer slots than names, drop from the
     // tail (the API's global-pool slice). Guarded so games without purchased
     // names consume the PRNG exactly as before — old replays must not shift.
+    //
+    // The analytics record assumes every passed name spawns: the server
+    // embeds the list capped only at the bot count, while positioned tribes
+    // shrink `remaining` here. No map ships positioned customTribes today,
+    // but one that does (with a low bot count) would make the record
+    // over-claim appearances for tail names that never spawned.
     const remaining = numTribes - tribes.length;
     let purchasedBySlot = new Map<number, string>();
     if (purchasedNames.length > 0 && remaining > 0) {

--- a/src/core/execution/TribeSpawner.ts
+++ b/src/core/execution/TribeSpawner.ts
@@ -25,7 +25,10 @@ export class TribeSpawner {
     this.nationTiles = new Set(nationCells.map((c) => gs.ref(c.x, c.y)));
   }
 
-  spawnTribes(numTribes: number): SpawnExecution[] {
+  spawnTribes(
+    numTribes: number,
+    purchasedNames: string[] = [],
+  ): SpawnExecution[] {
     const tribes: SpawnExecution[] = [];
     const { customTribes } = this.tribeNameData;
 
@@ -42,9 +45,26 @@ export class TribeSpawner {
       }
     }
 
+    // Purchased tribe names (GameStartInfo.tribes) each go to one randomly
+    // selected remaining slot; with fewer slots than names, drop from the
+    // tail (the API's global-pool slice). Guarded so games without purchased
+    // names consume the PRNG exactly as before — old replays must not shift.
+    const remaining = numTribes - tribes.length;
+    let purchasedBySlot = new Map<number, string>();
+    if (purchasedNames.length > 0 && remaining > 0) {
+      const used = purchasedNames.slice(0, remaining);
+      const slots = this.random
+        .shuffleArray([...Array(remaining).keys()])
+        .slice(0, used.length);
+      purchasedBySlot = new Map(slots.map((slot, i) => [slot, used[i]]));
+    }
+
     // Fill remaining slots with random-spawn tribes.
+    let slot = 0;
     while (tribes.length < numTribes) {
-      tribes.push(this.spawnTribe(this.randomTribeName()));
+      const purchased = purchasedBySlot.get(slot);
+      tribes.push(this.spawnTribe(purchased ?? this.randomTribeName()));
+      slot++;
     }
     return tribes;
   }

--- a/src/server/CustomTribes.ts
+++ b/src/server/CustomTribes.ts
@@ -1,9 +1,11 @@
 import { z } from "zod";
-import { Tribe, TribeSchema } from "../core/Schemas";
+import { TribeNameSchema } from "../core/Schemas";
 import { ServerEnv } from "./ServerEnv";
 
+// Any extra per-tribe fields the API sends are stripped — only the name is
+// used in games.
 const CustomTribesResponseSchema = z.object({
-  tribes: TribeSchema.array().max(100),
+  tribes: z.object({ name: TribeNameSchema }).array().max(100),
 });
 
 // A logged-in human in the lobby: in-game client id + account public id.
@@ -24,7 +26,7 @@ export interface TribePoolPlayer {
  */
 export async function fetchCustomTribes(
   players: TribePoolPlayer[],
-): Promise<Tribe[]> {
+): Promise<string[]> {
   const response = await fetch(`${ServerEnv.jwtIssuer()}/custom_tribes`, {
     method: "POST",
     signal: AbortSignal.timeout(1500),
@@ -43,5 +45,5 @@ export async function fetchCustomTribes(
       `custom_tribes returned malformed response: ${parsed.error.message}`,
     );
   }
-  return parsed.data.tribes;
+  return parsed.data.tribes.map((t) => t.name);
 }

--- a/src/server/CustomTribes.ts
+++ b/src/server/CustomTribes.ts
@@ -1,11 +1,11 @@
 import { z } from "zod";
-import { TribeNameSchema } from "../core/Schemas";
+import { Tribe, TribeSchema } from "../core/Schemas";
 import { ServerEnv } from "./ServerEnv";
 
 // Any extra per-tribe fields the API sends are stripped — only the name is
 // used in games.
 const CustomTribesResponseSchema = z.object({
-  tribes: z.object({ name: TribeNameSchema }).array().max(100),
+  tribes: TribeSchema.array().max(100),
 });
 
 // A logged-in human in the lobby: in-game client id + account public id.
@@ -26,7 +26,7 @@ export interface TribePoolPlayer {
  */
 export async function fetchCustomTribes(
   players: TribePoolPlayer[],
-): Promise<string[]> {
+): Promise<Tribe[]> {
   const response = await fetch(`${ServerEnv.jwtIssuer()}/custom_tribes`, {
     method: "POST",
     signal: AbortSignal.timeout(1500),
@@ -45,5 +45,5 @@ export async function fetchCustomTribes(
       `custom_tribes returned malformed response: ${parsed.error.message}`,
     );
   }
-  return parsed.data.tribes.map((t) => t.name);
+  return parsed.data.tribes;
 }

--- a/src/server/CustomTribes.ts
+++ b/src/server/CustomTribes.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { Tribe, TribeSchema } from "../core/Schemas";
 import { ServerEnv } from "./ServerEnv";
 
-// Any extra per-tribe fields the API sends are stripped — only the name is
-// used in games.
+// TribeSchema is loose: extra per-tribe fields the API sends pass through
+// into the game start info (and thus the analytics record) unchanged.
 const CustomTribesResponseSchema = z.object({
   tribes: TribeSchema.array().max(100),
 });

--- a/src/server/CustomTribes.ts
+++ b/src/server/CustomTribes.ts
@@ -1,0 +1,47 @@
+import { z } from "zod";
+import { Tribe, TribeSchema } from "../core/Schemas";
+import { ServerEnv } from "./ServerEnv";
+
+const CustomTribesResponseSchema = z.object({
+  tribes: TribeSchema.array().max(100),
+});
+
+// A logged-in human in the lobby: in-game client id + account public id.
+// Guests can't own tribe names and must be omitted.
+export interface TribePoolPlayer {
+  clientId: string;
+  publicId: string;
+}
+
+/**
+ * Fetch the boost-weighted pool of purchased bot tribe names for a game:
+ * up to 10 owned by lobby players, then up to 10 from the global pool
+ * (array order carries the slicing, so callers drop from the tail).
+ *
+ * Throws on timeout/non-200/malformed response — callers fail open and
+ * start the game with organic bot names. The timeout must fit inside the
+ * 2s prestart->start window (see GameManager.tick).
+ */
+export async function fetchCustomTribes(
+  players: TribePoolPlayer[],
+): Promise<Tribe[]> {
+  const response = await fetch(`${ServerEnv.jwtIssuer()}/custom_tribes`, {
+    method: "POST",
+    signal: AbortSignal.timeout(1500),
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": ServerEnv.apiKey(),
+    },
+    body: JSON.stringify({ players: players.slice(0, 500) }),
+  });
+  if (!response.ok) {
+    throw new Error(`custom_tribes returned ${response.status}`);
+  }
+  const parsed = CustomTribesResponseSchema.safeParse(await response.json());
+  if (!parsed.success) {
+    throw new Error(
+      `custom_tribes returned malformed response: ${parsed.error.message}`,
+    );
+  }
+  return parsed.data.tribes;
+}

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -31,12 +31,14 @@ import {
   ServerStartGameMessage,
   ServerTurnMessage,
   StampedIntent,
+  Tribe,
   Turn,
 } from "../core/Schemas";
 import { createPartialGameRecord, simpleHash } from "../core/Util";
 import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
 import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";
+import { fetchCustomTribes } from "./CustomTribes";
 import { ServerEnv } from "./ServerEnv";
 import {
   noopMatchTelemetryEmitter,
@@ -134,6 +136,10 @@ export class GameServer {
   private log: Logger;
 
   private _hasPrestarted = false;
+
+  // Purchased bot tribe names drawn for this game, set when the prestart
+  // fetch lands (undefined until then / on fetch failure / non-public games).
+  private tribes?: Tribe[];
 
   private kickedPersistentIds: Set<string> = new Set();
   private outOfSyncClients: Set<ClientID> = new Set();
@@ -1056,6 +1062,7 @@ export class GameServer {
       return;
     }
     this._hasPrestarted = true;
+    this.fetchTribes();
 
     const prestartMsg = ServerPrestartMessageSchema.safeParse({
       type: "prestart",
@@ -1083,6 +1090,34 @@ export class GameServer {
         c.ws.send(msg);
       }
     });
+  }
+
+  // Public games draw purchased bot tribe names from the API at prestart —
+  // its 1.5s timeout fits the 2s prestart->start gap, so the pool is
+  // normally in hand when start() builds the game start info. Best effort:
+  // on timeout/error the game starts with organic bot names.
+  private fetchTribes(): void {
+    if (!this.isPublic() || this.gameConfig.bots === 0) {
+      return;
+    }
+    // Logged-in humans only — guests can't own tribe names.
+    const players = this.activeClients.flatMap((c) =>
+      c.publicId !== undefined
+        ? [{ clientId: c.clientID, publicId: c.publicId }]
+        : [],
+    );
+    fetchCustomTribes(players)
+      .then((tribes) => {
+        // One tribe per bot: with fewer bots than tribes, drop from the
+        // tail (the global-pool slice).
+        const used = tribes.slice(0, this.gameConfig.bots);
+        if (used.length > 0) {
+          this.tribes = used;
+        }
+      })
+      .catch((error) => {
+        this.log.warn(`failed to fetch custom tribes: ${error}`);
+      });
   }
 
   private startLobbyInfoBroadcast() {
@@ -1184,6 +1219,7 @@ export class GameServer {
         friends: friendsFor(c),
         teamIndex: this.matchmakingTeamIndex(c),
       })),
+      tribes: this.tribes,
     });
     if (!result.success) {
       const error = z.prettifyError(result.error);

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -31,6 +31,7 @@ import {
   ServerStartGameMessage,
   ServerTurnMessage,
   StampedIntent,
+  Tribe,
   Turn,
 } from "../core/Schemas";
 import { createPartialGameRecord, simpleHash } from "../core/Util";
@@ -138,7 +139,7 @@ export class GameServer {
 
   // Purchased bot tribe names drawn for this game, set when the prestart
   // fetch lands (undefined until then / on fetch failure / non-public games).
-  private tribes?: string[];
+  private tribes?: Tribe[];
 
   private kickedPersistentIds: Set<string> = new Set();
   private outOfSyncClients: Set<ClientID> = new Set();

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -31,7 +31,6 @@ import {
   ServerStartGameMessage,
   ServerTurnMessage,
   StampedIntent,
-  Tribe,
   Turn,
 } from "../core/Schemas";
 import { createPartialGameRecord, simpleHash } from "../core/Util";
@@ -139,7 +138,7 @@ export class GameServer {
 
   // Purchased bot tribe names drawn for this game, set when the prestart
   // fetch lands (undefined until then / on fetch failure / non-public games).
-  private tribes?: Tribe[];
+  private tribes?: string[];
 
   private kickedPersistentIds: Set<string> = new Set();
   private outOfSyncClients: Set<ClientID> = new Set();

--- a/tests/core/execution/TribeSpawner.test.ts
+++ b/tests/core/execution/TribeSpawner.test.ts
@@ -217,6 +217,123 @@ describe("TribeSpawner", () => {
     }
   });
 
+  test("purchased names each go to exactly one tribe", async () => {
+    const game = await setup("plains", { bots: 5, gameMap: GameMapType.Asia });
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Alpha"],
+      suffixes: ["Tribe"],
+    });
+
+    const spawner = new TribeSpawner(game, GAME_ID);
+    const execs = spawner.spawnTribes(5, ["Dragon Riders", "Night Wolves"]);
+
+    expect(execs).toHaveLength(5);
+    const names = execs.map(
+      (e) => (e as unknown as { playerInfo: { name: string } }).playerInfo.name,
+    );
+    expect(names.filter((n) => n === "Dragon Riders")).toHaveLength(1);
+    expect(names.filter((n) => n === "Night Wolves")).toHaveLength(1);
+    expect(names.filter((n) => n === "Alpha Tribe")).toHaveLength(3);
+  });
+
+  test("purchased names beyond the open slots are dropped from the tail", async () => {
+    const game = await setup("plains", { bots: 2, gameMap: GameMapType.Asia });
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Alpha"],
+      suffixes: ["Tribe"],
+    });
+
+    const spawner = new TribeSpawner(game, GAME_ID);
+    const execs = spawner.spawnTribes(2, [
+      "First Name",
+      "Second Name",
+      "Third Name",
+    ]);
+
+    const names = execs.map(
+      (e) => (e as unknown as { playerInfo: { name: string } }).playerInfo.name,
+    );
+    expect(names).toContain("First Name");
+    expect(names).toContain("Second Name");
+    expect(names).not.toContain("Third Name");
+  });
+
+  test("positioned map tribes keep their slots ahead of purchased names", async () => {
+    const game = await setup("plains", { bots: 2, gameMap: GameMapType.Asia });
+    const tile = findLandTile(game);
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Alpha"],
+      suffixes: ["Tribe"],
+      customTribes: [
+        { name: "Positioned", coordinates: [game.x(tile), game.y(tile)] },
+      ],
+    });
+
+    const spawner = new TribeSpawner(game, GAME_ID);
+    const execs = spawner.spawnTribes(2, ["Bought One", "Bought Two"]);
+
+    const names = execs.map(
+      (e) => (e as unknown as { playerInfo: { name: string } }).playerInfo.name,
+    );
+    expect(names).toContain("Positioned");
+    expect(names).toContain("Bought One");
+    expect(names).not.toContain("Bought Two");
+  });
+
+  test("purchased assignment is identical for the same game id", async () => {
+    const game = await setup("plains", { bots: 6, gameMap: GameMapType.Asia });
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Alpha", "Beta", "Gamma"],
+      suffixes: ["Tribe", "Clan"],
+    });
+
+    const purchased = ["Dragon Riders", "Night Wolves"];
+    const spawn = () =>
+      new TribeSpawner(game, GAME_ID)
+        .spawnTribes(6, purchased)
+        .map(
+          (e) =>
+            (e as unknown as { playerInfo: { name: string; id: string } })
+              .playerInfo,
+        );
+
+    const first = spawn();
+    const second = spawn();
+    expect(second.map((p) => p.name)).toEqual(first.map((p) => p.name));
+    expect(second.map((p) => p.id)).toEqual(first.map((p) => p.id));
+  });
+
+  test("no purchased names leaves the organic sequence unchanged", async () => {
+    const game = await setup("plains", { bots: 4, gameMap: GameMapType.Asia });
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Alpha", "Beta", "Gamma"],
+      suffixes: ["Tribe", "Clan"],
+    });
+
+    const spawn = (purchased?: string[]) =>
+      purchased === undefined
+        ? new TribeSpawner(game, GAME_ID).spawnTribes(4)
+        : new TribeSpawner(game, GAME_ID).spawnTribes(4, purchased);
+    const infos = (execs: ReturnType<typeof spawn>) =>
+      execs.map(
+        (e) =>
+          (e as unknown as { playerInfo: { name: string; id: string } })
+            .playerInfo,
+      );
+
+    // An empty purchased list must not shift the PRNG stream — the names
+    // AND ids must match the no-argument (replay-compatible) path.
+    const withoutArg = infos(spawn());
+    const withEmpty = infos(spawn([]));
+    expect(withEmpty.map((p) => p.name)).toEqual(withoutArg.map((p) => p.name));
+    expect(withEmpty.map((p) => p.id)).toEqual(withoutArg.map((p) => p.id));
+  });
+
   test("all players spawn on valid land tiles", async () => {
     const game = await setup("plains", {
       bots: 0,

--- a/tests/server/CustomTribes.test.ts
+++ b/tests/server/CustomTribes.test.ts
@@ -34,16 +34,18 @@ describe("fetchCustomTribes", () => {
     expect(JSON.parse(init.body)).toEqual({ players });
   });
 
-  it("strips extra per-tribe fields the API sends", async () => {
+  it("passes extra per-tribe fields through for the analytics record", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(
         jsonResponse({
-          tribes: [{ name: "Dragon Riders", futureField: "ignored" }],
+          tribes: [{ name: "Dragon Riders", futureField: "kept" }],
         }),
       ),
     );
-    expect(await fetchCustomTribes([])).toEqual([{ name: "Dragon Riders" }]);
+    expect(await fetchCustomTribes([])).toEqual([
+      { name: "Dragon Riders", futureField: "kept" },
+    ]);
   });
 
   it("returns an empty pool for an empty lobby", async () => {

--- a/tests/server/CustomTribes.test.ts
+++ b/tests/server/CustomTribes.test.ts
@@ -14,7 +14,7 @@ describe("fetchCustomTribes", () => {
     vi.unstubAllGlobals();
   });
 
-  it("posts the lobby players and returns the tribe names", async () => {
+  it("posts the lobby players and returns the tribes", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       jsonResponse({
         tribes: [{ name: "Dragon Riders" }, { name: "Night Wolves" }],
@@ -24,8 +24,8 @@ describe("fetchCustomTribes", () => {
 
     const players = [{ clientId: "abcd1234", publicId: "pub-1" }];
     expect(await fetchCustomTribes(players)).toEqual([
-      "Dragon Riders",
-      "Night Wolves",
+      { name: "Dragon Riders" },
+      { name: "Night Wolves" },
     ]);
 
     const [url, init] = fetchMock.mock.calls[0];
@@ -43,7 +43,7 @@ describe("fetchCustomTribes", () => {
         }),
       ),
     );
-    expect(await fetchCustomTribes([])).toEqual(["Dragon Riders"]);
+    expect(await fetchCustomTribes([])).toEqual([{ name: "Dragon Riders" }]);
   });
 
   it("returns an empty pool for an empty lobby", async () => {

--- a/tests/server/CustomTribes.test.ts
+++ b/tests/server/CustomTribes.test.ts
@@ -9,35 +9,41 @@ function jsonResponse(body: unknown, status = 200) {
   return { ok: status < 300, status, json: async () => body };
 }
 
-const dragons = {
-  name: "Dragon Riders",
-  publicId: "AbC123xYz9AbC123xYz9Ab",
-  ownerClientId: "abcd1234",
-};
-const wolves = {
-  name: "Night Wolves",
-  publicId: "Zz9876543210Zz98765432",
-  ownerClientId: null,
-};
-
 describe("fetchCustomTribes", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
 
-  it("posts the lobby players and returns the parsed tribes", async () => {
-    const fetchMock = vi
-      .fn()
-      .mockResolvedValue(jsonResponse({ tribes: [dragons, wolves] }));
+  it("posts the lobby players and returns the tribe names", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse({
+        tribes: [{ name: "Dragon Riders" }, { name: "Night Wolves" }],
+      }),
+    );
     vi.stubGlobal("fetch", fetchMock);
 
     const players = [{ clientId: "abcd1234", publicId: "pub-1" }];
-    expect(await fetchCustomTribes(players)).toEqual([dragons, wolves]);
+    expect(await fetchCustomTribes(players)).toEqual([
+      "Dragon Riders",
+      "Night Wolves",
+    ]);
 
     const [url, init] = fetchMock.mock.calls[0];
     expect(url).toContain("/custom_tribes");
     expect(init.headers["x-api-key"]).toBeDefined();
     expect(JSON.parse(init.body)).toEqual({ players });
+  });
+
+  it("strips extra per-tribe fields the API sends", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse({
+          tribes: [{ name: "Dragon Riders", futureField: "ignored" }],
+        }),
+      ),
+    );
+    expect(await fetchCustomTribes([])).toEqual(["Dragon Riders"]);
   });
 
   it("returns an empty pool for an empty lobby", async () => {
@@ -78,7 +84,7 @@ describe("fetchCustomTribes", () => {
   });
 
   it("throws on a tribe that fails validation", async () => {
-    const badTribe = { name: "X", publicId: "", ownerClientId: null };
+    const badTribe = { name: "" };
     vi.stubGlobal(
       "fetch",
       vi.fn().mockResolvedValue(jsonResponse({ tribes: [badTribe] })),

--- a/tests/server/CustomTribes.test.ts
+++ b/tests/server/CustomTribes.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { fetchCustomTribes } from "../../src/server/CustomTribes";
+
+// fetchCustomTribes resolves its endpoint from ServerEnv.jwtIssuer(), which
+// throws if DOMAIN is unset.
+process.env.DOMAIN ??= "localhost";
+
+function jsonResponse(body: unknown, status = 200) {
+  return { ok: status < 300, status, json: async () => body };
+}
+
+const dragons = {
+  name: "Dragon Riders",
+  publicId: "AbC123xYz9AbC123xYz9Ab",
+  ownerClientId: "abcd1234",
+};
+const wolves = {
+  name: "Night Wolves",
+  publicId: "Zz9876543210Zz98765432",
+  ownerClientId: null,
+};
+
+describe("fetchCustomTribes", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("posts the lobby players and returns the parsed tribes", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ tribes: [dragons, wolves] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const players = [{ clientId: "abcd1234", publicId: "pub-1" }];
+    expect(await fetchCustomTribes(players)).toEqual([dragons, wolves]);
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toContain("/custom_tribes");
+    expect(init.headers["x-api-key"]).toBeDefined();
+    expect(JSON.parse(init.body)).toEqual({ players });
+  });
+
+  it("returns an empty pool for an empty lobby", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ tribes: [] })),
+    );
+    expect(await fetchCustomTribes([])).toEqual([]);
+  });
+
+  it("caps the posted players at 500", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse({ tribes: [] }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const players = Array.from({ length: 501 }, (_, i) => ({
+      clientId: `client_${i}`,
+      publicId: `pub_${i}`,
+    }));
+    await fetchCustomTribes(players);
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(JSON.parse(init.body).players).toHaveLength(500);
+  });
+
+  it("throws on a non-200 so the caller fails open", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(jsonResponse({}, 500)));
+    await expect(fetchCustomTribes([])).rejects.toThrow(
+      "custom_tribes returned 500",
+    );
+  });
+
+  it("throws on a malformed response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ tribes: "nope" })),
+    );
+    await expect(fetchCustomTribes([])).rejects.toThrow("malformed");
+  });
+
+  it("throws on a tribe that fails validation", async () => {
+    const badTribe = { name: "X", publicId: "", ownerClientId: null };
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(jsonResponse({ tribes: [badTribe] })),
+    );
+    await expect(fetchCustomTribes([])).rejects.toThrow("malformed");
+  });
+
+  it("propagates network errors", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("connect ECONNREFUSED")),
+    );
+    await expect(fetchCustomTribes([])).rejects.toThrow("ECONNREFUSED");
+  });
+});

--- a/tests/server/GameServerTribes.test.ts
+++ b/tests/server/GameServerTribes.test.ts
@@ -74,8 +74,8 @@ describe("GameServer custom tribes", () => {
 
   it("fetches the pool at prestart and embeds the tribes in the start info", async () => {
     vi.mocked(fetchCustomTribes).mockResolvedValue([
-      "Dragon Riders",
-      "Night Wolves",
+      { name: "Dragon Riders" },
+      { name: "Night Wolves" },
     ]);
     const game = makeGame();
     game.activeClients.push(
@@ -91,15 +91,15 @@ describe("GameServer custom tribes", () => {
       { clientId: "abcd1234", publicId: "pub-1" },
     ]);
     expect((game as any).gameStartInfo.tribes).toEqual([
-      "Dragon Riders",
-      "Night Wolves",
+      { name: "Dragon Riders" },
+      { name: "Night Wolves" },
     ]);
   });
 
   it("drops tribes from the tail when there are fewer bots", async () => {
     vi.mocked(fetchCustomTribes).mockResolvedValue([
-      "Dragon Riders",
-      "Night Wolves",
+      { name: "Dragon Riders" },
+      { name: "Night Wolves" },
     ]);
     const game = makeGame({ bots: 1 });
 
@@ -107,7 +107,9 @@ describe("GameServer custom tribes", () => {
     await flushMicrotasks();
     game.start();
 
-    expect((game as any).gameStartInfo.tribes).toEqual(["Dragon Riders"]);
+    expect((game as any).gameStartInfo.tribes).toEqual([
+      { name: "Dragon Riders" },
+    ]);
   });
 
   it("skips the fetch for non-public games", async () => {

--- a/tests/server/GameServerTribes.test.ts
+++ b/tests/server/GameServerTribes.test.ts
@@ -21,17 +21,6 @@ import { GameType } from "../../src/core/game/Game";
 import { fetchCustomTribes } from "../../src/server/CustomTribes";
 import { GameServer } from "../../src/server/GameServer";
 
-const dragons = {
-  name: "Dragon Riders",
-  publicId: "AbC123xYz9AbC123xYz9Ab",
-  ownerClientId: "abcd1234",
-};
-const wolves = {
-  name: "Night Wolves",
-  publicId: "Zz9876543210Zz98765432",
-  ownerClientId: null,
-};
-
 function fakeClient(clientID: string, publicId?: string) {
   return {
     clientID,
@@ -84,7 +73,10 @@ describe("GameServer custom tribes", () => {
   }
 
   it("fetches the pool at prestart and embeds the tribes in the start info", async () => {
-    vi.mocked(fetchCustomTribes).mockResolvedValue([dragons, wolves]);
+    vi.mocked(fetchCustomTribes).mockResolvedValue([
+      "Dragon Riders",
+      "Night Wolves",
+    ]);
     const game = makeGame();
     game.activeClients.push(
       fakeClient("abcd1234", "pub-1"),
@@ -98,18 +90,24 @@ describe("GameServer custom tribes", () => {
     expect(fetchCustomTribes).toHaveBeenCalledWith([
       { clientId: "abcd1234", publicId: "pub-1" },
     ]);
-    expect((game as any).gameStartInfo.tribes).toEqual([dragons, wolves]);
+    expect((game as any).gameStartInfo.tribes).toEqual([
+      "Dragon Riders",
+      "Night Wolves",
+    ]);
   });
 
   it("drops tribes from the tail when there are fewer bots", async () => {
-    vi.mocked(fetchCustomTribes).mockResolvedValue([dragons, wolves]);
+    vi.mocked(fetchCustomTribes).mockResolvedValue([
+      "Dragon Riders",
+      "Night Wolves",
+    ]);
     const game = makeGame({ bots: 1 });
 
     game.prestart();
     await flushMicrotasks();
     game.start();
 
-    expect((game as any).gameStartInfo.tribes).toEqual([dragons]);
+    expect((game as any).gameStartInfo.tribes).toEqual(["Dragon Riders"]);
   });
 
   it("skips the fetch for non-public games", async () => {

--- a/tests/server/GameServerTribes.test.ts
+++ b/tests/server/GameServerTribes.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/core/Schemas", async () => {
+  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
+  return {
+    ...actual,
+    GameStartInfoSchema: {
+      safeParse: (data: any) => ({ success: true, data: data }),
+    },
+    ServerPrestartMessageSchema: {
+      safeParse: (data: any) => ({ success: true, data: data }),
+    },
+  };
+});
+
+vi.mock("../../src/server/CustomTribes", () => ({
+  fetchCustomTribes: vi.fn(),
+}));
+
+import { GameType } from "../../src/core/game/Game";
+import { fetchCustomTribes } from "../../src/server/CustomTribes";
+import { GameServer } from "../../src/server/GameServer";
+
+const dragons = {
+  name: "Dragon Riders",
+  publicId: "AbC123xYz9AbC123xYz9Ab",
+  ownerClientId: "abcd1234",
+};
+const wolves = {
+  name: "Night Wolves",
+  publicId: "Zz9876543210Zz98765432",
+  ownerClientId: null,
+};
+
+function fakeClient(clientID: string, publicId?: string) {
+  return {
+    clientID,
+    persistentID: `persist-${clientID}`,
+    publicId,
+    friends: [],
+    username: clientID,
+    clanTag: null,
+    role: null,
+    cosmetics: undefined,
+    ws: { readyState: 3, send: vi.fn() },
+  } as any;
+}
+
+// Lets the fetchCustomTribes .then/.catch chain in fetchTribes() settle.
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("GameServer custom tribes", () => {
+  let mockLogger: any;
+
+  beforeEach(() => {
+    // restoreAllMocks doesn't touch vi.mock module mocks — reset the fetch
+    // mock's implementation and call history between tests explicitly.
+    vi.mocked(fetchCustomTribes).mockReset();
+    vi.useFakeTimers();
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  function makeGame(config: Record<string, unknown> = {}) {
+    return new GameServer("testgame", mockLogger, Date.now(), {
+      gameType: GameType.Public,
+      gameMap: "plains",
+      gameMapSize: 100,
+      bots: 400,
+      ...config,
+    } as any);
+  }
+
+  it("fetches the pool at prestart and embeds the tribes in the start info", async () => {
+    vi.mocked(fetchCustomTribes).mockResolvedValue([dragons, wolves]);
+    const game = makeGame();
+    game.activeClients.push(
+      fakeClient("abcd1234", "pub-1"),
+      fakeClient("efgh5678"), // guest — no account, must be omitted
+    );
+
+    game.prestart();
+    await flushMicrotasks();
+    game.start();
+
+    expect(fetchCustomTribes).toHaveBeenCalledWith([
+      { clientId: "abcd1234", publicId: "pub-1" },
+    ]);
+    expect((game as any).gameStartInfo.tribes).toEqual([dragons, wolves]);
+  });
+
+  it("drops tribes from the tail when there are fewer bots", async () => {
+    vi.mocked(fetchCustomTribes).mockResolvedValue([dragons, wolves]);
+    const game = makeGame({ bots: 1 });
+
+    game.prestart();
+    await flushMicrotasks();
+    game.start();
+
+    expect((game as any).gameStartInfo.tribes).toEqual([dragons]);
+  });
+
+  it("skips the fetch for non-public games", async () => {
+    const game = makeGame({ gameType: GameType.Private });
+
+    game.prestart();
+    await flushMicrotasks();
+    game.start();
+
+    expect(fetchCustomTribes).not.toHaveBeenCalled();
+    expect((game as any).gameStartInfo.tribes).toBeUndefined();
+  });
+
+  it("skips the fetch when bots are disabled", async () => {
+    const game = makeGame({ bots: 0 });
+
+    game.prestart();
+    await flushMicrotasks();
+
+    expect(fetchCustomTribes).not.toHaveBeenCalled();
+  });
+
+  it("starts without tribes when the fetch fails", async () => {
+    vi.mocked(fetchCustomTribes).mockRejectedValue(new Error("timeout"));
+    const game = makeGame();
+
+    game.prestart();
+    await flushMicrotasks();
+    game.start();
+
+    expect((game as any).gameStartInfo.tribes).toBeUndefined();
+    expect(mockLogger.warn).toHaveBeenCalledWith(
+      expect.stringContaining("failed to fetch custom tribes"),
+    );
+  });
+
+  it("omits tribes from the start info when the pool is empty", async () => {
+    vi.mocked(fetchCustomTribes).mockResolvedValue([]);
+    const game = makeGame();
+
+    game.prestart();
+    await flushMicrotasks();
+    game.start();
+
+    expect((game as any).gameStartInfo.tribes).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Purchased bot tribe names now appear in public games, end to end:

1. **Game server (prestart):** `GameServer.prestart()` fires a best-effort `POST /custom_tribes` with the lobby's logged-in players (`clientId` + account `publicId`; guests omitted, capped at 500). The returned tribes (loose `{ name }` objects — extra per-tribe fields the API adds later pass through to the record unchanged) are trimmed to the bot count (dropping from the tail — the API's global-pool slice) and embedded as `gameStartInfo.tribes`, matching the loose `{ name }` object shape infra parses at analytics ingest.
2. **Core (game start):** `TribeSpawner.spawnTribes()` assigns each purchased name to one randomly selected bot slot using the seeded PRNG, so every client deterministically picks the same bots. Map-positioned custom tribes (map lore) keep priority over purchased names.
3. **Analytics:** `tribes` rides `GameStartInfo` → `GameEndInfo` → the existing analytics record, so owner appearance stats need no extra end-of-game reporting (active names are globally unique, so the name alone identifies the tribe).

## Never blocks a game

Nothing awaits the fetch: prestart fires it and returns, and `start()` (2s later) snapshots whatever arrived. The request aborts itself at 1.5s, leaving 500ms headroom; on timeout / non-200 / malformed response the game starts on schedule with organic bot names and a warning in the logs.

## Replay / determinism safety

When a game has no purchased names (private games, singleplayer, API failure, all pre-feature replays), the spawner consumes the PRNG stream exactly as before — the slot shuffle only runs when names exist. A test pins this by comparing both names and generated player IDs against the no-argument path. `tribes` is optional on `GameStartInfoSchema`, so old records parse unchanged.

## Tests

- `tests/server/CustomTribes.test.ts` — request shape (players posted, `x-api-key`), 500-player cap, throws on non-200 / malformed / bad tribe / network error so the caller fails open.
- `tests/server/GameServerTribes.test.ts` — prestart wiring: guest exclusion, tail-trimming to bot count, public-only and bots>0 gates, fail-open on fetch error, empty pool omitted from start info.
- `tests/core/execution/TribeSpawner.test.ts` — one bot per name, overflow dropped from tail, positioned-tribe priority, same-seed determinism, PRNG-stream compatibility with the pre-feature path.

Full suite (2358 + 287), `tsc --noEmit`, eslint, prettier all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
