### PR TITLE
fix: right-click cancels warship/boat selection instead of opening the menu

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -237,6 +237,9 @@ export class InputHandler {
   private selectionBoxActive: boolean = false;
   // True while warships are selected via box (waiting for move target click)
   private multiSelectionActive: boolean = false;
+  // True while any warship/boat is selected (single or multi) — right-click
+  // cancels the selection instead of opening the context menu (#4692).
+  private unitSelectionActive: boolean = false;
 
   // Touch long-press state
   private longPressTimer: ReturnType<typeof setTimeout> | null = null;
@@ -426,6 +429,8 @@ export class InputHandler {
     }
     // Listen for warship selection to change cursor
     this.eventBus.on(UnitSelectionEvent, (e) => {
+      this.unitSelectionActive =
+        e.isSelected && (e.unit !== null || (e.units ?? []).length > 0);
       if (e.isSelected && (e.units ?? []).length > 0) {
         // Multi-selection active
         this.multiSelectionActive = true;
@@ -990,6 +995,12 @@ export class InputHandler {
     }
     if (this.uiState.ghostStructure !== null) {
       this.setGhostStructure(null);
+      return;
+    }
+    // If a warship/boat is selected, right-click cancels the selection rather
+    // than opening the context menu (#4692).
+    if (this.unitSelectionActive) {
+      this.eventBus.emit(new UnitSelectionEvent(null, false));
       return;
     }
     this.eventBus.emit(new ContextMenuEvent(event.clientX, event.clientY));

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -1,6 +1,7 @@
 import {
   AutoUpgradeEvent,
   ConfirmGhostStructureEvent,
+  ContextMenuEvent,
   InputHandler,
   UnitSelectionEvent,
   WarshipSelectionBoxCancelEvent,
@@ -1146,8 +1147,16 @@ describe("InputHandler right-click cancels unit selection (#4692)", () => {
     );
     const emit = vi.spyOn(eventBus, "emit");
     rightClick();
-    const types = emittedTypes(emit);
-    expect(types).toContain("UnitSelectionEvent"); // deselect emitted
-    expect(types).not.toContain("ContextMenuEvent"); // menu suppressed
+    const emitted = emit.mock.calls.map((c: unknown[]) => c[0]);
+    // A deselection specifically (unit === null, isSelected === false) must be
+    // emitted — not just any UnitSelectionEvent.
+    const deselect = emitted.find(
+      (e): e is UnitSelectionEvent => e instanceof UnitSelectionEvent,
+    );
+    expect(deselect).toBeDefined();
+    expect(deselect!.unit).toBeNull();
+    expect(deselect!.isSelected).toBe(false);
+    // ...and the context menu must NOT open.
+    expect(emitted.some((e) => e instanceof ContextMenuEvent)).toBe(false);
   });
 });

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -2,12 +2,13 @@ import {
   AutoUpgradeEvent,
   ConfirmGhostStructureEvent,
   InputHandler,
+  UnitSelectionEvent,
   WarshipSelectionBoxCancelEvent,
   WarshipSelectionBoxCompleteEvent,
   WarshipSelectionBoxUpdateEvent,
 } from "../src/client/InputHandler";
 import { UIState } from "../src/client/UIState";
-import { GameView, PlayerView } from "../src/client/view";
+import { GameView, PlayerView, UnitView } from "../src/client/view";
 import { EventBus } from "../src/core/EventBus";
 import { UnitType } from "../src/core/game/Game";
 import { KEYBINDS_KEY, UserSettings } from "../src/core/game/UserSettings";
@@ -1094,5 +1095,59 @@ describe("Warship box selection (Shift+drag)", () => {
     expect(mockCanvas.style.cursor).toBe("crosshair");
     window.dispatchEvent(new Event("blur"));
     expect(mockCanvas.style.cursor).toBe("");
+  });
+});
+
+describe("InputHandler right-click cancels unit selection (#4692)", () => {
+  let inputHandler: InputHandler;
+  let eventBus: EventBus;
+  let canvas: HTMLCanvasElement;
+
+  beforeEach(() => {
+    new UserSettings().removeCached(KEYBINDS_KEY, false);
+    canvas = document.createElement("canvas");
+    canvas.width = 800;
+    canvas.height = 600;
+    eventBus = new EventBus();
+    inputHandler = new InputHandler(
+      {
+        inSpawnPhase: () => false,
+        myPlayer: () => ({ isAlive: () => true }),
+      } as unknown as GameView,
+      { attackRatio: 20, ghostStructure: null, rocketDirectionUp: true },
+      canvas,
+      eventBus,
+    );
+    inputHandler.initialize();
+  });
+
+  afterEach(() => inputHandler.destroy());
+
+  const rightClick = () =>
+    inputHandler["onContextMenu"]({
+      preventDefault: () => {},
+      clientX: 100,
+      clientY: 100,
+    } as unknown as MouseEvent);
+
+  const emittedTypes = (spy: ReturnType<typeof vi.spyOn>) =>
+    spy.mock.calls.map((c: unknown[]) => (c[0] as object).constructor.name);
+
+  it("opens the context menu on right-click when nothing is selected", () => {
+    const emit = vi.spyOn(eventBus, "emit");
+    rightClick();
+    expect(emittedTypes(emit)).toContain("ContextMenuEvent");
+  });
+
+  it("cancels the selection and suppresses the context menu when a warship is selected", () => {
+    // Select a warship (wires unitSelectionActive via the real listener).
+    eventBus.emit(
+      new UnitSelectionEvent({ id: () => 1 } as unknown as UnitView, true),
+    );
+    const emit = vi.spyOn(eventBus, "emit");
+    rightClick();
+    const types = emittedTypes(emit);
+    expect(types).toContain("UnitSelectionEvent"); // deselect emitted
+    expect(types).not.toContain("ContextMenuEvent"); // menu suppressed
   });
 });


### PR DESCRIPTION
Resolves #4692

## Problem
With a warship/boat selected, right-clicking opened the radial context menu instead of cancelling the selection. `InputHandler.onContextMenu` emitted `ContextMenuEvent` unconditionally — there was no branch for an active unit selection, and the `EventBus` has no way for another listener to suppress the menu.

## Fix
`onContextMenu` already cancels an in-progress action on right-click — if a ghost structure is being placed, it clears it and returns instead of opening the menu. This applies the same pattern to unit selection:
- `InputHandler` already listens to `UnitSelectionEvent` (to set the cursor); it now also tracks `unitSelectionActive` (single **or** multi selection).
- In `onContextMenu`, if a unit is selected, emit a deselect and return **before** emitting `ContextMenuEvent`.

Fully contained in `InputHandler.ts` — no new shared state, no changes to the selection controller or renderer.

## Testing
- Added regression tests in `tests/InputHandler.test.ts`: right-click with a warship selected cancels the selection and does **not** open the menu; with nothing selected the menu still opens.
- Full suite passes (`npm test`).
- Verified live in a running game: real right-click on the input overlay with a warship selected fired only a deselect (no context-menu event, radial menu not shown); with nothing selected the radial menu opened normally.

Discord: granster9