### PR TITLE
Batch move_warship intents to stay under MAX_INTENT_SIZE

### DIFF
--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -12,6 +12,7 @@ import {
 import { TileRef } from "../core/game/GameMap";
 import {
   AllPlayersStats,
+  batchMoveWarshipUnitIds,
   ClientHashMessage,
   ClientIntentMessage,
   ClientJoinMessage,
@@ -649,11 +650,13 @@ export class Transport {
   }
 
   private onMoveWarshipEvent(event: MoveWarshipIntentEvent) {
-    this.sendIntent({
-      type: "move_warship",
-      unitIds: event.unitIds,
-      tile: event.tile,
-    });
+    for (const unitIds of batchMoveWarshipUnitIds(event.unitIds, event.tile)) {
+      this.sendIntent({
+        type: "move_warship",
+        unitIds,
+        tile: event.tile,
+      });
+    }
   }
 
   private onSendDeleteUnitIntent(event: SendDeleteUnitIntentEvent) {

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -538,6 +538,31 @@ export const MoveWarshipIntentSchema = z.object({
   tile: z.number(),
 });
 
+// Client messages larger than this get the client kicked by ClientMsgRateLimiter.
+export const MAX_INTENT_SIZE = 2000;
+
+export function batchMoveWarshipUnitIds(
+  unitIds: readonly number[],
+  tile: number,
+): number[][] {
+  const overhead = JSON.stringify({
+    type: "intent",
+    intent: { type: "move_warship", unitIds: [], tile },
+  } satisfies ClientIntentMessage).length;
+  const batches: number[][] = [];
+  let size = overhead;
+  for (const unitId of unitIds) {
+    const unitIdSize = String(unitId).length + 1;
+    if (batches.length === 0 || size + unitIdSize > MAX_INTENT_SIZE) {
+      batches.push([]);
+      size = overhead;
+    }
+    batches[batches.length - 1].push(unitId);
+    size += unitIdSize;
+  }
+  return batches;
+}
+
 export const DeleteUnitIntentSchema = z.object({
   type: z.literal("delete_unit"),
   unitId: z.number(),

--- a/src/server/ClientMsgRateLimiter.ts
+++ b/src/server/ClientMsgRateLimiter.ts
@@ -1,9 +1,8 @@
 import { RateLimiter } from "limiter";
-import { ClientID } from "../core/Schemas";
+import { ClientID, MAX_INTENT_SIZE } from "../core/Schemas";
 
 const INTENTS_PER_SECOND = 10;
 const INTENTS_PER_MINUTE = 150;
-const MAX_INTENT_SIZE = 2000;
 const TOTAL_BYTES = 5 * 1024 * 1024; // 5MB per client
 export type RateLimitResult = "ok" | "limit" | "kick";
 

--- a/tests/MoveWarshipIntentBatching.test.ts
+++ b/tests/MoveWarshipIntentBatching.test.ts
@@ -1,0 +1,56 @@
+import {
+  batchMoveWarshipUnitIds,
+  ClientIntentMessage,
+  ClientMessageSchema,
+  MAX_INTENT_SIZE,
+} from "../src/core/Schemas";
+import { replacer } from "../src/core/Util";
+
+const TILE = 250_000;
+
+function frame(unitIds: number[], tile: number): string {
+  return JSON.stringify(
+    {
+      type: "intent",
+      intent: { type: "move_warship", unitIds, tile },
+    } satisfies ClientIntentMessage,
+    replacer,
+  );
+}
+
+describe("batchMoveWarshipUnitIds", () => {
+  test("sends a small fleet as a single intent", () => {
+    const unitIds = [10000, 10003, 10006];
+    expect(batchMoveWarshipUnitIds(unitIds, TILE)).toEqual([unitIds]);
+  });
+
+  test("returns no batches for an empty selection", () => {
+    expect(batchMoveWarshipUnitIds([], TILE)).toEqual([]);
+  });
+
+  test.each([1, 400, 4000])(
+    "keeps every batch under the server cap (%i warships)",
+    (count) => {
+      const unitIds = Array.from({ length: count }, (_, i) => 900_000 + i * 3);
+      const batches = batchMoveWarshipUnitIds(unitIds, TILE);
+
+      for (const batch of batches) {
+        expect(batch.length).toBeGreaterThan(0);
+        expect(
+          Buffer.byteLength(frame(batch, TILE), "utf8"),
+        ).toBeLessThanOrEqual(MAX_INTENT_SIZE);
+      }
+      expect(batches.flat()).toEqual(unitIds);
+    },
+  );
+
+  test("every batch is a valid client intent message", () => {
+    const unitIds = Array.from({ length: 450 }, (_, i) => 10_000 + i * 3);
+
+    for (const batch of batchMoveWarshipUnitIds(unitIds, TILE)) {
+      expect(
+        ClientMessageSchema.safeParse(JSON.parse(frame(batch, TILE))).success,
+      ).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Resolves #4718

## Description:

`move_warship` sends every selected unit id in one intent, and past ~274-320 ships (id-width dependent) the frame exceeds `MAX_INTENT_SIZE`, so `ClientMsgRateLimiter` kicks the player.

As proposed in the issue: batches the order in `onMoveWarshipEvent` into intents that each fit under the cap, kept maximal so realistic orders stay well inside the 10/s intent budget (1 intent below ~274 ships, 4 at 1,000). Also bounds `unitIds` at `.max(1000)` in the schema — above the 964 ids a single conforming batch can physically hold — and adds the missing `kick_reason.too_much_data` entry to `en.json` so the modal shows text instead of the raw key. `MAX_INTENT_SIZE` moved to `Schemas.ts` so client and server share it.

`MoveWarshipExecution` applies each unit id independently and dedupes, so N intents are equivalent to one.


Hurdan