### PR TITLE
Chore(deps)/refactor: Use Node's native globSync to remove one devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,7 +68,6 @@
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-formatter-gha": "^2.0.1",
-        "glob": "^13.0.6",
         "globals": "^17.6.0",
         "husky": "^9.1.7",
         "jsdom": "^29.1.1",
@@ -5700,24 +5699,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/glob": {
-      "version": "13.0.6",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "minimatch": "^10.2.2",
-        "minipass": "^7.1.3",
-        "path-scurry": "^2.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -6984,16 +6965,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/minipass": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      }
-    },
     "node_modules/mkdirp-classic": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
@@ -7324,23 +7295,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/path-scurry": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "lru-cache": "^11.0.0",
-        "minipass": "^7.1.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/path-to-regexp": {

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-formatter-gha": "^2.0.1",
-    "glob": "^13.0.6",
     "globals": "^17.6.0",
     "husky": "^9.1.7",
     "jsdom": "^29.1.1",

--- a/src/server/PublicAssetManifest.ts
+++ b/src/server/PublicAssetManifest.ts
@@ -51,6 +51,15 @@ function toPosixPath(filePath: string): string {
   return filePath.split(path.sep).join(path.posix.sep);
 }
 
+function toRelativePosixPath(
+  rootDir: string,
+  dirent: { parentPath: string; name: string },
+): string {
+  // when cwd is used in globSync, dirent.parentPath is "."
+  const absolutePath = path.join(dirent.parentPath, dirent.name);
+  return toPosixPath(path.relative(rootDir, absolutePath));
+}
+
 function createContentHash(filePath: string): string {
   const content = fs.readFileSync(filePath);
   return createHash("sha256")
@@ -280,7 +289,7 @@ export function listHashedPublicAssetPaths(sourceDirs: string[]): string[] {
         exclude: ["**/.*", ".*"], // .gitignore etc (like dot: false)
       })) {
         if (dirent.isDirectory()) continue;
-        files.add(dirent.name); // pure filename with dirent.name so no normalizeAssetPath needed 
+        files.add(normalizeAssetPath(toRelativePosixPath(sourceDir, dirent))); // convert dirent (like posix:true)
       }
     }
   }
@@ -295,7 +304,9 @@ export function listRootPublicFiles(resourcesDir: string): string[] {
       exclude: ["**/.*", ".*"],
     })
     .filter((dirent) => !dirent.isDirectory())
-    .map((dirent) => dirent.name)
+    .map((dirent) =>
+      normalizeAssetPath(toRelativePosixPath(resourcesDir, dirent)),
+    )
     .filter((file) => shouldKeepRootPublicFile(file))
     .sort();
 }

--- a/src/server/PublicAssetManifest.ts
+++ b/src/server/PublicAssetManifest.ts
@@ -1,6 +1,5 @@
 import { createHash } from "crypto";
 import fs from "fs";
-import { globSync } from "glob";
 import path from "path";
 import {
   type AssetManifest,
@@ -272,16 +271,16 @@ export function shouldKeepRootPublicFile(relativePath: string): boolean {
 
 export function listHashedPublicAssetPaths(sourceDirs: string[]): string[] {
   const files = new Set<string>();
-  for (const dir of sourceDirs) {
-    if (!fs.existsSync(dir)) continue;
+  for (const sourceDir of sourceDirs) {
+    if (!fs.existsSync(sourceDir)) continue;
     for (const pattern of HASHED_PUBLIC_ASSET_GLOBS) {
-      for (const file of globSync(pattern, {
-        cwd: dir,
-        nodir: true,
-        dot: false,
-        posix: true,
+      for (const dirent of fs.globSync(pattern, {
+        cwd: sourceDir,
+        withFileTypes: true, // return dirent to exclude directories (like nodir: true)
+        exclude: ["**/.*", ".*"], // .gitignore etc (like dot: false)
       })) {
-        files.add(normalizeAssetPath(file));
+        if (dirent.isDirectory()) continue;
+        files.add(dirent.name); // pure filename with dirent.name so no normalizeAssetPath needed 
       }
     }
   }
@@ -289,13 +288,14 @@ export function listHashedPublicAssetPaths(sourceDirs: string[]): string[] {
 }
 
 export function listRootPublicFiles(resourcesDir: string): string[] {
-  return globSync("**/*", {
-    cwd: resourcesDir,
-    nodir: true,
-    dot: false,
-    posix: true,
-  })
-    .map((file) => normalizeAssetPath(file))
+  return fs
+    .globSync("**/*", {
+      cwd: resourcesDir,
+      withFileTypes: true,
+      exclude: ["**/.*", ".*"],
+    })
+    .filter((dirent) => !dirent.isDirectory())
+    .map((dirent) => dirent.name)
     .filter((file) => shouldKeepRootPublicFile(file))
     .sort();
 }

--- a/tests/MapManifestFlags.test.ts
+++ b/tests/MapManifestFlags.test.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import { globSync } from "glob";
 import path from "path";
 
 type Nation = {
@@ -12,7 +11,7 @@ type Manifest = {
 
 describe("Map manifests: nation flags exist", () => {
   test("All nations' flags reference existing SVG files", () => {
-    const manifestPaths = globSync("resources/maps/**/manifest.json");
+    const manifestPaths = fs.globSync("resources/maps/**/manifest.json");
 
     expect(manifestPaths.length).toBeGreaterThan(0);
 

--- a/tests/NationName.test.ts
+++ b/tests/NationName.test.ts
@@ -1,5 +1,4 @@
 import fs from "fs";
-import { globSync } from "glob";
 
 type Nation = {
   name?: string;
@@ -11,7 +10,7 @@ type Manifest = {
 
 describe("Map manifests: nation name constraints", () => {
   test("All nations' names must be ≤ 27 printable Extended-ASCII characters", () => {
-    const manifestPaths = globSync("resources/maps/**/manifest.json");
+    const manifestPaths = fs.globSync("resources/maps/**/manifest.json");
 
     expect(manifestPaths.length).toBeGreaterThan(0);
 

--- a/tests/perf/run-all.ts
+++ b/tests/perf/run-all.ts
@@ -1,9 +1,10 @@
 import { execSync } from "child_process";
-import { globSync } from "glob";
+import { globSync } from "fs";
+import path from "path";
 
 // "perf": "npx tsx tests/perf/*.ts" doesn't work on Windows
-const files = globSync("tests/perf/*.ts").filter((f) => !f.includes("run-all"));
-for (const file of files) {
-  console.log(`\nRunning ${file}...`);
-  execSync(`tsx "${file}"`, { stdio: "inherit" });
+const files = globSync("tests/perf/*.ts");
+for (const file of files.filter((f) => !f.includes("run-all"))) {
+  console.log(`\nRunning ${path.basename(file)}...`);
+  execSync(`tsx "${path.normalize(file)}"`, { stdio: "inherit" });
 }


### PR DESCRIPTION
Resolves #4733

## Description:

Instead of dependency "glob", we can use Node's native (since v22) globSync: https://nodejs.org/api/fs.html#fsglobpattern-options-callback

Another option would have been to move from "glob" to "tinyglobby", which is faster and much smaller and already installed via vitest anyway. But using native capabilities seems even better.

**For PublicAssetManifest.ts:**
Node's globSync knows no "nodir", "dot" and "posix" parameters. To replace "nodir:true", we use "withFileTypes" to return a dirent to filter out directories. To replace "dot:false" we use its "exclude" option. "posix:true" normally needs no replacement, but since we need to use "withFileTypes:true", we need to convert the dirent to relative path.

dirent.parentPath is present since Node v22 and will soon be added to Electron v42 and up: https://github.com/electron/electron/pull/51845. So we can safely assume it'll be present once we start to use Electron? Otherwise a temporary fallback (dirent.parentPath ?? rootDir) could be needed if it is undefined within Electron.

**For run-all.ts:**
Move the filter for 'run-all'. Make output prettier by getting just the filename with path.basename, and normalize the file's path. Tested and still works on Windows, which was the reason for creating run-all.ts in the first place.

**For MapManifestFlags.test.ts and NationName.test.ts:**
No change needed beyond changing to using node's fs for globSync too.

All tests pass.

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33