### PR TITLE
fix(server): keep allowlist publicIds out of the game record and start message

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1205,11 +1205,19 @@ export class GameServer {
 
     const friendsFor = this.buildFriendsLookup();
 
+    // allowedPublicIds / nameRevealPublicIds hold account publicIds and are
+    // enforced server-side against this.gameConfig (joinClient / seesReal).
+    // Keep them out of gameStartInfo: its config goes to every client in the
+    // start message and into the publicly downloadable game record.
+    const config = { ...this.gameConfig };
+    delete config.allowedPublicIds;
+    delete config.nameRevealPublicIds;
+
     const result = GameStartInfoSchema.safeParse({
       gameID: this.id,
       lobbyCreatedAt: this.createdAt,
       visibleAt: this.visibleAt,
-      config: this.gameConfig,
+      config,
       players: this.activeClients.map((c) => ({
         username: c.username,
         clanTag: c.clanTag ?? null,

--- a/tests/server/AllowlistJoin.test.ts
+++ b/tests/server/AllowlistJoin.test.ts
@@ -111,4 +111,20 @@ describe("GameServer - allowlist (allowedPublicIds)", () => {
     const game = makeGame(["pub-ok"]);
     expect((game.gameConfig as any).allowedPublicIds).toEqual(["pub-ok"]);
   });
+
+  it("keeps publicId lists out of the start info (wire + archived record)", () => {
+    const game = new GameServer("test-game", mockLogger, Date.now(), {
+      gameType: GameType.Private,
+      allowedPublicIds: ["pub-ok"],
+      nameRevealPublicIds: ["pub-reveal"],
+    } as any);
+    expect(game.joinClient(makeClient("c1", "p1", "pub-ok"))).toBe("joined");
+    game.start();
+
+    const config = (game as any).gameStartInfo.config;
+    expect(config.allowedPublicIds).toBeUndefined();
+    expect(config.nameRevealPublicIds).toBeUndefined();
+    // The server still enforces the allowlist from its own config.
+    expect((game.gameConfig as any).allowedPublicIds).toEqual(["pub-ok"]);
+  });
 });


### PR DESCRIPTION
## Problem

When a lobby is configured with a join whitelist (`allowedPublicIds`), the full list of account publicIds leaks:

- `start()` snapshots the entire `gameConfig` into `gameStartInfo`
- `gameStartInfo.config` is sent to **every client** in the `start` message
- `archiveGame()` writes the same config into the **archived game record**, which is publicly downloadable — anyone with the game ID could pull the full allowlist, including invitees who never joined

`nameRevealPublicIds` (caster/observer account ids) leaked the same way.

## Fix

Strip both publicId lists from the config at the single point `gameStartInfo` is built. That cleans everything downstream: the wire start message and the archived record.

**Enforcement is unaffected** — the server reads its own `this.gameConfig` for join gating (`joinClient`) and name-reveal resolution (`seesReal`).

**Replay-safe** — the core sim never reads either field, so old and new records simulate identically. `hostCheats` (which the sim does read) and `nameReveals` (clientIDs, used by lobby UI) stay in the record untouched. All clients receive an identical sanitized config, so no desync risk.

**Telemetry** — the internal pipeline already receives the full config via `match_opened`, so nothing is lost there.

This mirrors the existing sanitization in `WorkerLobbyService.publicLobbyGameConfig`, which already strips these fields from the public lobby listing.

## Testing

- New test in `AllowlistJoin.test.ts`: start-info config carries neither list while the server's stored config keeps enforcing the allowlist
- All server tests pass (30 files, 288 tests), lint + typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)