### PR TITLE
feat(matchmaking): show queue size and reconnect on silent disconnects

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1150,6 +1150,7 @@
     "limit_reached_info": "Free matches refill daily. Subscribe for unlimited ranked play.",
     "limit_upsell": "Get unlimited ranked",
     "no_elo": "No ELO yet",
+    "queue_size": "Players in queue: {count}",
     "replaced": "You joined matchmaking from another tab or window.",
     "searching": "Searching for game...",
     "title": "1v1 Ranked Matchmaking (ALPHA)",

--- a/src/client/Matchmaking.ts
+++ b/src/client/Matchmaking.ts
@@ -16,6 +16,7 @@ export class MatchmakingModal extends BaseModal {
   private gameCheckInterval: ReturnType<typeof setInterval> | null = null;
   private connectTimeout: ReturnType<typeof setTimeout> | null = null;
   private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private watchdogTimeout: ReturnType<typeof setTimeout> | null = null;
   private reconnectAttempts = 0;
   private intentionalClose = false;
   // Which queue to join; set by Main from the open-matchmaking event
@@ -25,6 +26,7 @@ export class MatchmakingModal extends BaseModal {
   @state() private socket: WebSocket | null = null;
   @state() private gameID: string | null = null;
   @state() private limitReached = false;
+  @state() private queueSize: number | null = null;
   private elo: number | string = "...";
 
   constructor() {
@@ -87,10 +89,21 @@ export class MatchmakingModal extends BaseModal {
       );
     }
     if (this.gameID === null) {
-      return this.renderLoadingSpinner(
-        translateText("matchmaking_modal.searching"),
-        "green",
-      );
+      return html`
+        ${this.queueSize !== null
+          ? html`
+              <p class="text-center text-white/60">
+                ${translateText("matchmaking_modal.queue_size", {
+                  count: this.queueSize,
+                })}
+              </p>
+            `
+          : ""}
+        ${this.renderLoadingSpinner(
+          translateText("matchmaking_modal.searching"),
+          "green",
+        )}
+      `;
     } else {
       return this.renderLoadingSpinner(
         translateText("matchmaking_modal.waiting_for_game"),
@@ -106,8 +119,39 @@ export class MatchmakingModal extends BaseModal {
     window.location.hash = "modal=store&tab=subscriptions";
   };
 
+  // The lobby writes to every queued socket every ~3s (queue-size), so
+  // prolonged silence means the connection died without a close frame
+  // (locked phone, dropped wifi). Left alone, that leaves a ghost in the
+  // queue and games start short-handed — only the client can detect this,
+  // so reconnect. Rejoining is safe: one account holds one queue slot.
+  private resetWatchdog() {
+    this.clearWatchdog();
+    this.watchdogTimeout = setTimeout(() => {
+      console.warn("[Matchmaking] no server message for 15s, reconnecting");
+      if (this.socket) {
+        // A dead socket can take a long time to emit its close event;
+        // detach handlers so it can't trigger a second reconnect later.
+        this.socket.onclose = null;
+        this.socket.onmessage = null;
+        this.socket.onerror = null;
+        this.socket.close();
+      }
+      this.connected = false;
+      this.queueSize = null;
+      this.connect();
+    }, 15000);
+  }
+
+  private clearWatchdog() {
+    if (this.watchdogTimeout) {
+      clearTimeout(this.watchdogTimeout);
+      this.watchdogTimeout = null;
+    }
+  }
+
   private async connect() {
-    // A pending join timer from a previous socket must not fire on this one.
+    // Pending timers from a previous socket must not fire on this one.
+    this.clearWatchdog();
     if (this.connectTimeout) {
       clearTimeout(this.connectTimeout);
       this.connectTimeout = null;
@@ -133,13 +177,22 @@ export class MatchmakingModal extends BaseModal {
           }),
         );
         this.connected = true;
+        // The server starts broadcasting queue-size once we're queued;
+        // from here on, silence means the connection is dead.
+        this.resetWatchdog();
         this.requestUpdate();
       }, 2000);
     };
     this.socket.onmessage = (event) => {
       console.log(event.data);
+      this.resetWatchdog();
       const data = JSON.parse(event.data);
+      if (data.type === "queue-size") {
+        this.queueSize = data.count;
+        return;
+      }
       if (data.type === "match-assignment") {
+        this.clearWatchdog();
         this.intentionalClose = true;
         this.socket?.close();
         console.log(`matchmaking: got game ID: ${data.gameId}`);
@@ -154,6 +207,8 @@ export class MatchmakingModal extends BaseModal {
       console.log(
         `Matchmaking server closed connection: code=${event.code} reason=${event.reason}`,
       );
+      this.clearWatchdog();
+      this.queueSize = null;
       if (this.intentionalClose || this.gameID !== null) {
         return;
       }
@@ -235,6 +290,7 @@ export class MatchmakingModal extends BaseModal {
     this.gameID = null;
     this.intentionalClose = false;
     this.limitReached = false;
+    this.queueSize = null;
     this.reconnectAttempts = 0;
     this.connect();
   }
@@ -243,6 +299,7 @@ export class MatchmakingModal extends BaseModal {
     this.connected = false;
     this.intentionalClose = true;
     this.socket?.close();
+    this.clearWatchdog();
     if (this.connectTimeout) {
       clearTimeout(this.connectTimeout);
       this.connectTimeout = null;


### PR DESCRIPTION
## Summary

Client side of the matchmaking `queue-size` broadcast (server side ships with infra #478).

- **Queue size in the UI** — handle the new `queue-size` message and show "Players in queue: N" above the spinner while searching. It's rendered as a pool size (not a position or ETA), only appears once the first broadcast arrives, and unknown message types are still ignored so future protocol additions stay safe.
- **Liveness watchdog** — the lobby writes to every queued socket every ~3s, so 15s of total silence means the connection died without a close frame (locked phone, dropped wifi). Left alone, that leaves a ghost in the queue the server can't distinguish from a live player, and matches start short-handed (the "2v2 with 3 players" bug). The server-side races were fixed in #476; this half-open case can only be detected client-side.

## Watchdog details

- Armed only after the `join` frame is sent (before that the server legitimately sends nothing); reset by every incoming message of any kind.
- On fire: detach the dead socket's handlers before closing it — a half-open socket can take minutes to emit its close event, and letting it fire later would trigger a duplicate reconnect — then reconnect immediately. No backoff on this path (the link was healthy moments ago); if the reconnect itself fails, the new socket's close event lands in the existing backoff path.
- Cleared at the top of `onclose`, on `match-assignment`, at the start of `connect()`, and on modal close. Rejoining is always safe: one account holds one queue slot, newest connection wins.
- The stale count is reset on every disconnect so it never flashes after a reconnect.

## Test plan

- [x] ESLint, Prettier, `tsc --noEmit` all pass
- [ ] Manual: queue up, toggle wifi off ~20s → client logs the watchdog warning, reconnects, and rejoins the queue
- [ ] Manual: queue with two accounts → count shows and updates every ~3s

🤖 Generated with [Claude Code](https://claude.com/claude-code)