### PR TITLE
fix(core): pin tile refs and unit ids to integers in intent schemas

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -451,13 +451,17 @@ export const AttackIntentSchema = z.object({
 
 export const SpawnIntentSchema = z.object({
   type: z.literal("spawn"),
-  tile: z.number(),
+  // A TileRef indexes the typed-array terrain buffers, so it must be a
+  // non-negative integer. Fractional refs silently corrupt those lookups.
+  tile: z.number().int().nonnegative(),
 });
 
 export const BoatAttackIntentSchema = z.object({
   type: z.literal("boat"),
+  // Not .int(): troops are fractional throughout the sim (attackRatio *
+  // troops(), combat attrition), and the client sends the raw float.
   troops: z.number().nonnegative(),
-  dst: z.number(),
+  dst: z.number().int().nonnegative(),
 });
 
 export const AllianceRequestIntentSchema = z.object({
@@ -512,14 +516,14 @@ export const DonateTroopIntentSchema = z.object({
 export const BuildUnitIntentSchema = z.object({
   type: z.literal("build_unit"),
   unit: z.enum(UnitType),
-  tile: z.number(),
+  tile: z.number().int().nonnegative(),
   rocketDirectionUp: z.boolean().optional(),
 });
 
 export const UpgradeStructureIntentSchema = z.object({
   type: z.literal("upgrade_structure"),
   unit: z.enum(UnitType),
-  unitId: z.number(),
+  unitId: z.number().int().nonnegative(),
 });
 
 export const CancelAttackIntentSchema = z.object({
@@ -529,18 +533,18 @@ export const CancelAttackIntentSchema = z.object({
 
 export const CancelBoatIntentSchema = z.object({
   type: z.literal("cancel_boat"),
-  unitID: z.number(),
+  unitID: z.number().int().nonnegative(),
 });
 
 export const MoveWarshipIntentSchema = z.object({
   type: z.literal("move_warship"),
   unitIds: z.array(z.number().int()).nonempty(),
-  tile: z.number(),
+  tile: z.number().int().nonnegative(),
 });
 
 export const DeleteUnitIntentSchema = z.object({
   type: z.literal("delete_unit"),
-  unitId: z.number(),
+  unitId: z.number().int().nonnegative(),
 });
 
 export const QuickChatIntentSchema = z.object({

--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -40,6 +40,15 @@ export class SpawnExecution implements Execution {
   tick(ticks: number) {
     this.active = false;
 
+    // Security: `tile` arrives straight off a spawn intent. A fractional or
+    // out-of-range ref indexes past the terrain buffers, so downstream lookups
+    // read back undefined instead of failing. Reject it before relinquishing
+    // any territory, so a malformed intent is a clean no-op on every client.
+    if (this.tile !== undefined && !this.mg.isValidRef(this.tile)) {
+      console.warn(`SpawnExecution: invalid spawn tile ${this.tile}`);
+      return;
+    }
+
     let player: Player | null = null;
     if (this.mg.hasPlayer(this.playerInfo.id)) {
       player = this.mg.player(this.playerInfo.id);

--- a/src/core/pathfinding/spatial/SpatialQuery.ts
+++ b/src/core/pathfinding/spatial/SpatialQuery.ts
@@ -36,6 +36,12 @@ export class SpatialQuery {
     predicate: (t: TileRef) => boolean,
   ): TileRef | null {
     const map = this.game.map();
+    // `from` can trace back to a network intent. `visited` is a Uint32Array, so
+    // a fractional ref makes `visited[t] = gen` a silent no-op that always reads
+    // back undefined — the dedup fails and the stack grows until it OOMs. Every
+    // caller is individually guarded today; this keeps the trap from being
+    // re-armed by a future one.
+    if (!map.isValidRef(from)) return null;
     const scratch = tileTraversalScratch(this.game);
     const gen = bumpTraversalGeneration(scratch);
     const visited = scratch.visited;

--- a/tests/core/IntentTileRefSchemas.test.ts
+++ b/tests/core/IntentTileRefSchemas.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import {
+  AttackIntentSchema,
+  BoatAttackIntentSchema,
+  BuildUnitIntentSchema,
+  CancelBoatIntentSchema,
+  DeleteUnitIntentSchema,
+  DonateGoldIntentSchema,
+  DonateTroopIntentSchema,
+  MoveWarshipIntentSchema,
+  SpawnIntentSchema,
+  UpgradeStructureIntentSchema,
+} from "../../src/core/Schemas";
+
+const RECIPIENT = "aaaaaaaa";
+
+// A TileRef indexes Uint8Array/Uint32Array terrain and traversal buffers. A
+// fractional ref passes a bare range check but silently corrupts every one of
+// those lookups, so the wire format has to reject it outright.
+const tileRefCases = [
+  {
+    name: "spawn",
+    schema: SpawnIntentSchema,
+    build: (tile: number) => ({ type: "spawn", tile }),
+  },
+  {
+    name: "boat",
+    schema: BoatAttackIntentSchema,
+    build: (dst: number) => ({ type: "boat", troops: 1, dst }),
+  },
+  {
+    name: "build_unit",
+    schema: BuildUnitIntentSchema,
+    build: (tile: number) => ({ type: "build_unit", unit: "City", tile }),
+  },
+  {
+    name: "move_warship",
+    schema: MoveWarshipIntentSchema,
+    build: (tile: number) => ({ type: "move_warship", unitIds: [1], tile }),
+  },
+];
+
+describe("intent schemas: tile refs are non-negative integers", () => {
+  for (const { name, schema, build } of tileRefCases) {
+    it(`${name} accepts integer refs`, () => {
+      expect(schema.safeParse(build(0)).success).toBe(true);
+      expect(schema.safeParse(build(4040)).success).toBe(true);
+    });
+
+    it(`${name} rejects fractional refs`, () => {
+      expect(schema.safeParse(build(4040.5)).success).toBe(false);
+      expect(schema.safeParse(build(0.0000001)).success).toBe(false);
+    });
+
+    it(`${name} rejects negative, NaN and infinite refs`, () => {
+      expect(schema.safeParse(build(-1)).success).toBe(false);
+      expect(schema.safeParse(build(NaN)).success).toBe(false);
+      expect(schema.safeParse(build(Infinity)).success).toBe(false);
+      expect(schema.safeParse(build(-Infinity)).success).toBe(false);
+    });
+  }
+});
+
+describe("intent schemas: unit ids are non-negative integers", () => {
+  it("upgrade_structure", () => {
+    const ok = { type: "upgrade_structure", unit: "City", unitId: 3 };
+    expect(UpgradeStructureIntentSchema.safeParse(ok).success).toBe(true);
+    const bad = { ...ok, unitId: 3.5 };
+    expect(UpgradeStructureIntentSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("cancel_boat", () => {
+    const ok = { type: "cancel_boat", unitID: 3 };
+    expect(CancelBoatIntentSchema.safeParse(ok).success).toBe(true);
+    const bad = { type: "cancel_boat", unitID: 3.5 };
+    expect(CancelBoatIntentSchema.safeParse(bad).success).toBe(false);
+  });
+
+  it("delete_unit", () => {
+    const ok = { type: "delete_unit", unitId: 3 };
+    expect(DeleteUnitIntentSchema.safeParse(ok).success).toBe(true);
+    const bad = { type: "delete_unit", unitId: 3.5 };
+    expect(DeleteUnitIntentSchema.safeParse(bad).success).toBe(false);
+  });
+});
+
+// Troops and gold are deliberately NOT integers. Attack troops are
+// `attackRatio * player.troops()` on the client and combat attrition keeps them
+// fractional in the sim, so pinning these to .int() would reject every honest
+// attack. This locks the looser contract in place.
+describe("intent schemas: troop and gold amounts stay fractional", () => {
+  it("attack accepts fractional troops", () => {
+    const intent = { type: "attack", targetID: null, troops: 12.5 };
+    expect(AttackIntentSchema.safeParse(intent).success).toBe(true);
+  });
+
+  it("boat accepts fractional troops", () => {
+    const intent = { type: "boat", troops: 12.5, dst: 10 };
+    expect(BoatAttackIntentSchema.safeParse(intent).success).toBe(true);
+  });
+
+  it("donations accept fractional amounts", () => {
+    const troops = {
+      type: "donate_troops",
+      recipient: RECIPIENT,
+      troops: 12.5,
+    };
+    expect(DonateTroopIntentSchema.safeParse(troops).success).toBe(true);
+
+    const gold = { type: "donate_gold", recipient: RECIPIENT, gold: 12.5 };
+    expect(DonateGoldIntentSchema.safeParse(gold).success).toBe(true);
+  });
+
+  // Non-finite rejection here comes from Zod 4's base number type, not from a
+  // modifier we spell out. If this ever fails, add an explicit finiteness
+  // refinement to the troop/gold fields rather than deleting the assertion.
+  it("still rejects negative and non-finite amounts", () => {
+    for (const troops of [-1, NaN, Infinity]) {
+      const intent = { type: "attack", targetID: null, troops };
+      expect(AttackIntentSchema.safeParse(intent).success).toBe(false);
+    }
+  });
+});

--- a/tests/core/execution/SpawnExecutionInvalidTile.test.ts
+++ b/tests/core/execution/SpawnExecutionInvalidTile.test.ts
@@ -1,0 +1,89 @@
+import path from "path";
+import { beforeEach, describe, expect, test } from "vitest";
+import { SpawnExecution } from "../../../src/core/execution/SpawnExecution";
+import { Game, PlayerInfo, PlayerType } from "../../../src/core/game/Game";
+import { GameID } from "../../../src/core/Schemas";
+import { setup } from "../../util/Setup";
+import { TestConfig } from "../../util/TestConfig";
+
+const gameID: GameID = "test_game";
+
+// Map paths inside setup() resolve relative to tests/util, so point currentDir
+// there when overriding later positional args.
+const setupDir = path.join(__dirname, "../../util");
+
+describe("SpawnExecution rejects invalid tile refs", () => {
+  let game: Game;
+  let info: PlayerInfo;
+  let validTile: number;
+
+  beforeEach(async () => {
+    game = await setup("ocean_and_land");
+    info = new PlayerInfo("spawner", PlayerType.Human, null, "spawner");
+    game.addPlayer(info);
+    validTile = game.ref(0, 10);
+  });
+
+  test("a valid spawn tile still spawns the player", () => {
+    game.addExecution(new SpawnExecution(gameID, info, validTile));
+    game.executeNextTick();
+
+    const player = game.player(info.id);
+    expect(player.hasSpawned()).toBe(true);
+    expect(player.numTilesOwned()).toBeGreaterThan(0);
+  });
+
+  // A fractional ref passes a bare range check but indexes past the typed-array
+  // terrain buffers, so it must never place territory.
+  test("a fractional spawn tile is a no-op", () => {
+    game.addExecution(new SpawnExecution(gameID, info, validTile + 0.5));
+    game.executeNextTick();
+
+    const player = game.player(info.id);
+    expect(player.hasSpawned()).toBe(false);
+    expect(player.numTilesOwned()).toBe(0);
+  });
+
+  test("an out-of-range spawn tile is a no-op", () => {
+    const outOfRange = game.map().width() * game.map().height();
+    game.addExecution(new SpawnExecution(gameID, info, outOfRange));
+    game.executeNextTick();
+
+    const player = game.player(info.id);
+    expect(player.hasSpawned()).toBe(false);
+    expect(player.numTilesOwned()).toBe(0);
+  });
+});
+
+// During the spawn phase a player may legitimately move their spawn, so
+// SpawnExecution relinquishes their tiles before picking the new location.
+// The ref check has to run before that, or a malformed intent costs the sender
+// their starting territory with nothing placed in its stead.
+describe("SpawnExecution validates before relinquishing territory", () => {
+  test("a malformed re-spawn leaves existing territory intact", async () => {
+    const game = await setup(
+      "ocean_and_land",
+      {},
+      [],
+      setupDir,
+      TestConfig,
+      false,
+    );
+    expect(game.inSpawnPhase()).toBe(true);
+
+    const info = new PlayerInfo("spawner", PlayerType.Human, null, "spawner");
+    game.addPlayer(info);
+
+    game.addExecution(new SpawnExecution(gameID, info, game.ref(0, 10)));
+    game.executeNextTick();
+
+    const player = game.player(info.id);
+    const owned = player.numTilesOwned();
+    expect(owned).toBeGreaterThan(0);
+
+    game.addExecution(new SpawnExecution(gameID, info, game.ref(0, 10) + 0.5));
+    game.executeNextTick();
+
+    expect(player.numTilesOwned()).toBe(owned);
+  });
+});

--- a/tests/core/execution/SpawnExecutionInvalidTile.test.ts
+++ b/tests/core/execution/SpawnExecutionInvalidTile.test.ts
@@ -12,6 +12,22 @@ const gameID: GameID = "test_game";
 // there when overriding later positional args.
 const setupDir = path.join(__dirname, "../../util");
 
+// executeNextTick() ticks already-inited executions first and only then inits
+// newly added ones, so a freshly added execution does not actually run until
+// the second call.
+function runPendingExecutions(game: Game): void {
+  game.executeNextTick();
+  game.executeNextTick();
+}
+
+function firstSpawnableTile(game: Game): number {
+  const map = game.map();
+  for (let ref = 0; ref < map.width() * map.height(); ref++) {
+    if (map.isLand(ref) && !map.isImpassable(ref)) return ref;
+  }
+  throw new Error("no spawnable land tile on test map");
+}
+
 describe("SpawnExecution rejects invalid tile refs", () => {
   let game: Game;
   let info: PlayerInfo;
@@ -21,12 +37,12 @@ describe("SpawnExecution rejects invalid tile refs", () => {
     game = await setup("ocean_and_land");
     info = new PlayerInfo("spawner", PlayerType.Human, null, "spawner");
     game.addPlayer(info);
-    validTile = game.ref(0, 10);
+    validTile = firstSpawnableTile(game);
   });
 
   test("a valid spawn tile still spawns the player", () => {
     game.addExecution(new SpawnExecution(gameID, info, validTile));
-    game.executeNextTick();
+    runPendingExecutions(game);
 
     const player = game.player(info.id);
     expect(player.hasSpawned()).toBe(true);
@@ -37,7 +53,7 @@ describe("SpawnExecution rejects invalid tile refs", () => {
   // terrain buffers, so it must never place territory.
   test("a fractional spawn tile is a no-op", () => {
     game.addExecution(new SpawnExecution(gameID, info, validTile + 0.5));
-    game.executeNextTick();
+    runPendingExecutions(game);
 
     const player = game.player(info.id);
     expect(player.hasSpawned()).toBe(false);
@@ -47,7 +63,7 @@ describe("SpawnExecution rejects invalid tile refs", () => {
   test("an out-of-range spawn tile is a no-op", () => {
     const outOfRange = game.map().width() * game.map().height();
     game.addExecution(new SpawnExecution(gameID, info, outOfRange));
-    game.executeNextTick();
+    runPendingExecutions(game);
 
     const player = game.player(info.id);
     expect(player.hasSpawned()).toBe(false);
@@ -73,16 +89,17 @@ describe("SpawnExecution validates before relinquishing territory", () => {
 
     const info = new PlayerInfo("spawner", PlayerType.Human, null, "spawner");
     game.addPlayer(info);
+    const validTile = firstSpawnableTile(game);
 
-    game.addExecution(new SpawnExecution(gameID, info, game.ref(0, 10)));
-    game.executeNextTick();
+    game.addExecution(new SpawnExecution(gameID, info, validTile));
+    runPendingExecutions(game);
 
     const player = game.player(info.id);
     const owned = player.numTilesOwned();
     expect(owned).toBeGreaterThan(0);
 
-    game.addExecution(new SpawnExecution(gameID, info, game.ref(0, 10) + 0.5));
-    game.executeNextTick();
+    game.addExecution(new SpawnExecution(gameID, info, validTile + 0.5));
+    runPendingExecutions(game);
 
     expect(player.numTilesOwned()).toBe(owned);
   });


### PR DESCRIPTION
## Problem

Follow-up hardening to #4720, which made `GameMap.isValidRef` reject non-integer refs.

That fix closed the hang itself — a fractional `TileRef` from a network intent indexes past the typed-array terrain buffers, and `SpatialQuery.bfsNearest` / `WarshipExecution.randomTile` spin or OOM on it. But the surrounding surface was left as-is:

- The intent schemas still accepted any `z.number()` for tile refs and unit ids, so the whole defense rested on every consumer remembering to call `isValidRef`.
- `SpawnExecution` never had that call.
- `bfsNearest` is still structurally unsafe — it just happens to have no unguarded callers today.

## Changes

**`src/core/Schemas.ts`** — pin the network-facing tile refs and unit ids to `.int().nonnegative()`:

| Field | Was |
| --- | --- |
| `SpawnIntentSchema.tile` | `z.number()` |
| `BoatAttackIntentSchema.dst` | `z.number()` |
| `BuildUnitIntentSchema.tile` | `z.number()` |
| `MoveWarshipIntentSchema.tile` | `z.number()` |
| `UpgradeStructureIntentSchema.unitId` | `z.number()` |
| `CancelBoatIntentSchema.unitID` | `z.number()` |
| `DeleteUnitIntentSchema.unitId` | `z.number()` |

**`src/core/execution/SpawnExecution.ts`** — add the missing `isValidRef` guard. It runs before the `player.tiles().forEach(relinquish)` loop, so a malformed spawn intent can't cost the sender their starting territory during the spawn phase.

**`src/core/pathfinding/spatial/SpatialQuery.ts`** — guard `from` in `bfsNearest`. `visited` is a `Uint32Array`, so a fractional ref makes `visited[t] = gen` a silent no-op that always reads back `undefined`; the dedup fails and the stack grows until it OOMs. Every caller is individually guarded today — this keeps the trap from being re-armed by a future one.

## Troops and gold are deliberately *not* pinned to `.int()`

They're fractional by design, and `.int()` would reject every honest attack:

- `attackRatio * player.troops()` on the client — `PlayerActionHandler.ts:30`, `ClientGameRunner.ts:1261`, `AttacksDisplay.ts:206`
- combat attrition in the sim — `deaths = attack.troops() * (malusPercent / 100)`, `AttackExecution.ts:201`
- donation amounts go through `within(proposed, 0, hardMax)` with no flooring — `SendResourceModal.ts:155`

They keep `z.number().nonnegative()`, which still rejects negative, `NaN`, and (via Zod 4's finite-only number type) infinite values. Tests assert they *still accept* fractional values so this doesn't get tightened by mistake later.

## Tests

- `tests/core/IntentTileRefSchemas.test.ts` — tile refs and unit ids reject fractional / negative / `NaN` / `Infinity`; troops and gold still accept fractional amounts.
- `tests/core/execution/SpawnExecutionInvalidTile.test.ts` — valid tile spawns; fractional and out-of-range tiles are no-ops; and a spawn-phase test (`setup(..., autoEndSpawnPhase: false)`) proving a malformed re-spawn no longer relinquishes existing territory.

## Notes for review

- **I could not run the test suite locally** — `npm ci` fails in my environment with `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` against the registry, so `node_modules` is empty. Everything here is written against the source and needs CI (or a local `npm test`) to confirm. Formatting hasn't been through Prettier either.
- One assertion — non-finite troop amounts being rejected — relies on Zod 4's base number type being finite-only rather than a modifier spelled out in the schema. If it fails, add an explicit finiteness refinement rather than dropping the assertion; there's a comment saying so.
- Minor behavior change: in random-spawn mode `getSpawn` ignores `this.tile`, so a bogus tile was previously harmless there and is now rejected outright. The only actor affected is a client sending a malformed ref, which denies only its own spawn.
- The fractional/out-of-range spawn no-op tests would also have passed before this change (`getSpawnTiles` already filtered everything out and bailed). They're behavior locks; the relinquish test is the one that isolates the new guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
