### PR TITLE
feat(matchmaking): make ranked 2v2 compact only 50% of the time

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -462,7 +462,7 @@ export class MapPlaylist {
       rankedType: RankedType.TwoVTwo,
       infiniteGold: false,
       infiniteTroops: false,
-      maxTimerValue: 15,
+      maxTimerValue: 10,
       instantBuild: false,
       randomSpawn: false,
       nations: "disabled",

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -450,24 +450,25 @@ export class MapPlaylist {
       GameMapType.Asia, // 20%
       GameMapType.EuropeClassic, // 20%
     ];
+    const isCompact = Math.random() < 0.5;
     return {
       donateGold: true,
       donateTroops: true,
       gameMap: maps[Math.floor(Math.random() * maps.length)],
       maxPlayers: 4,
       gameType: GameType.Public,
-      gameMapSize: GameMapSize.Compact,
+      gameMapSize: isCompact ? GameMapSize.Compact : GameMapSize.Normal,
       difficulty: Difficulty.Medium, // Doesn't matter, nations are disabled
       rankedType: RankedType.TwoVTwo,
       infiniteGold: false,
       infiniteTroops: false,
-      maxTimerValue: 10,
+      maxTimerValue: 15,
       instantBuild: false,
       randomSpawn: false,
       nations: "disabled",
       gameMode: GameMode.Team,
       playerTeams: 2,
-      bots: 100,
+      bots: isCompact ? 100 : 400,
       spawnImmunityDuration: 30 * 10,
       disabledUnits: [],
     } satisfies GameConfig;

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -462,7 +462,7 @@ export class MapPlaylist {
       rankedType: RankedType.TwoVTwo,
       infiniteGold: false,
       infiniteTroops: false,
-      maxTimerValue: 10,
+      maxTimerValue: isCompact ? 10 : 15,
       instantBuild: false,
       randomSpawn: false,
       nations: "disabled",


### PR DESCRIPTION
## Summary

Ranked 2v2 games were always Compact with a 10-minute timer. This PR brings the 2v2 config in line with the 1v1 patterns:

- Rolls 50/50 between Compact and Normal map size per game (`Math.random() < 0.5`)
- `maxTimerValue: isCompact ? 10 : 15`, same split as 1v1
- Scales bots with map size (`100` Compact / `400` Normal), matching `get1v1Config()` and the public-game config

🤖 Generated with [Claude Code](https://claude.com/claude-code)