### PR TITLE
fix: add .gitattributes so Windows checkouts do not corrupt binary maps

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Prevent Git's text/EOL handling from corrupting binary assets.
+#
+# The repo previously had no .gitattributes, so on a default Windows clone
+# (core.autocrlf=true, the Git for Windows installer default) checkout applied
+# LF->CRLF conversion to binary map data: every 0x0A byte gained a 0x0D prefix,
+# the file no longer matched width*height, and the game crashed on map load.
+# Marking these types `binary` (a macro for `-text -diff`) makes Git check them
+# out verbatim on every platform. (#4601)
+
+# Map terrain data
+*.bin binary
+
+# Images
+*.png binary
+*.webp binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+
+# Audio
+*.mp3 binary
+*.ogg binary
+*.wav binary
+
+# Fonts
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary


### PR DESCRIPTION
Resolves #4601

## Problem
The repo had no `.gitattributes`, so on a default Windows clone (`core.autocrlf=true`, the Git for Windows installer default) checkout applied LF→CRLF conversion to binary map `.bin` data: every `0x0A` byte gained a `0x0D` prefix, the file no longer matched `width*height`, and the game crashed on map load.

## Fix
Add a `.gitattributes` marking binary asset types (map data, images, audio, fonts) as `binary` (a macro for `-text -diff`), so Git checks them out verbatim on every platform. Deliberately scoped to binaries only — no `* text=auto`, to avoid renormalizing existing text files.

## Verification
- `git check-attr -a` on a `.bin` reports `binary: set`, `text: unset` (verbatim); `.svg`/`.ts` remain unaffected.
- Adding the file produces no renormalization of existing tracked files.
- Note: the corruption is Windows-specific (`autocrlf=true`), so it was verified via `git check-attr` rather than a Windows checkout.

Discord: granster9