### PR TITLE
feat: add "Unbind All" button to keybind settings

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1667,6 +1667,7 @@
     "toggle_view_desc": "Alternate view (terrain/countries)",
     "toggle_visibility": "Toggle Visibility",
     "unbind": "Unbind",
+    "unbind_all": "Unbind All",
     "view_options": "View Options",
     "zoom_controls": "Zoom Controls",
     "zoom_in": "Zoom In",

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -73,6 +73,12 @@ export class UserSettingModal extends BaseModal {
     this.userKeybinds = validated;
   }
 
+  private unbindAllKeybinds() {
+    this.userSettings.unbindAllKeybinds(Platform.isMac);
+    this.loadKeybindsFromStorage();
+    this.requestUpdate();
+  }
+
   private handleKeybindChange(
     e: CustomEvent<{
       action: string;
@@ -365,6 +371,13 @@ export class UserSettingModal extends BaseModal {
         </svg>
         ${translateText("user_setting.keybinds_hint")}
       </div>
+
+      <button
+        class="text-xs font-bold uppercase tracking-wider bg-white/5 hover:bg-red-500/20 border border-white/10 hover:border-red-500/50 px-4 py-2 rounded text-white/70 hover:text-red-200 transition-colors mt-3"
+        @click=${this.unbindAllKeybinds}
+      >
+        ${translateText("user_setting.unbind_all")}
+      </button>
 
       <h2
         class="text-blue-200 text-xl font-bold mt-4 mb-3 border-b border-white/10 pb-2"

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -551,6 +551,18 @@ export class UserSettings {
     }
   }
 
+  /**
+   * Unbind every keybind at once: set each default action to "Null" (the same
+   * sentinel a single per-key Unbind uses), so keybinds() drops them all.
+   */
+  unbindAllKeybinds(isMac: boolean): void {
+    const unbound: Record<string, string> = {};
+    for (const action of Object.keys(getDefaultKeybinds(isMac))) {
+      unbound[action] = "Null";
+    }
+    this.setKeybinds(unbound);
+  }
+
   soundEffectsVolume(): number {
     return this.getFloat("settings.soundEffectsVolume", 0);
   }

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -1,5 +1,6 @@
 import {
   EFFECTS_KEY,
+  getDefaultKeybinds,
   PLAYER_STATS_COLUMNS_KEY,
   TEAM_STATS_COLUMNS_KEY,
   UserSettings,
@@ -133,5 +134,28 @@ describe("UserSettings stats columns", () => {
     expect(s.statsColumns("player")).toEqual(["gold"]);
     expect(s.statsColumns("team")).toEqual(["warships"]);
     expect(localStorage.getItem(TEAM_STATS_COLUMNS_KEY)).toBe('["warships"]');
+  });
+});
+
+describe("UserSettings unbindAllKeybinds (#4309)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (
+      UserSettings as unknown as { cache: Map<string, string | null> }
+    ).cache.clear();
+  });
+
+  it("sets every default keybind action to Null so nothing stays bound", () => {
+    const s = new UserSettings();
+    s.unbindAllKeybinds(false);
+
+    const parsed = s.parsedUserKeybinds();
+    const defaults = getDefaultKeybinds(false);
+    expect(Object.keys(defaults).length).toBeGreaterThan(0);
+    for (const action of Object.keys(defaults)) {
+      expect(parsed[action]).toBe("Null");
+    }
+    // keybinds() drops "Null" entries, so no action resolves to a key.
+    expect(Object.keys(s.keybinds(false))).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Resolves #4309

## Problem
Rebinding on a fresh install/version meant clearing every key one by one first — there was no way to unbind everything at once.

## Fix
Add an "Unbind All" button to the keybind settings tab. `UserSettings.unbindAllKeybinds()` sets each default action to the `"Null"` sentinel (the same one a single per-key Unbind uses), so `keybinds()` drops them all. The modal button calls it, reloads state, and re-renders. Matches the existing per-key Unbind pattern (no confirmation dialog) to keep it focused.

## Testing
- Unit test in `tests/UserSettings.test.ts`: every default action becomes `"Null"` and `keybinds()` resolves to empty.
- Full suite passes (`npm test`), `tsc --noEmit` clean.
- Verified live: clicking the button cleared all 36 keybinds (incl. seeded custom binds); every row showed "None".

Discord: granster9