### PR TITLE
Chore(deps): Remove unused override from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,8 +112,5 @@
     "ws": "^8.21.0",
     "zod": "^4.4.2"
   },
-  "overrides": {
-    "sanitize-html": ">=2.17.4"
-  },
   "type": "module"
 }


### PR DESCRIPTION
## Description:

Remove unused override for  `sanitize-html` from package.json. It overrode a sub dependency of `lit-markdown`, when we still used lit-markdown. We don't anymore and there are no other dependencies using sanitize-html either.

The override was added in: https://github.com/openfrontio/OpenFrontIO/commit/b8137927a62a6991d680ac3049f68efd429aff7d

It is no longer needed since: https://github.com/openfrontio/OpenFrontIO/commit/94f22931498486305bc2f96c494f77e5617f42a5

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33