### PR TITLE
Add clan preference to ranked 2v2 matchmaking

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1148,8 +1148,10 @@
     "play_ranked": "1v1 Ranked Matchmaking"
   },
   "matchmaking_modal": {
+    "clan_verification_failed": "Clan membership could not be verified. Please try matchmaking again.",
     "connecting": "Connecting to matchmaking server...",
     "elo": "Your ELO: {elo}",
+    "invalid_clan": "Your selected clan is no longer valid. Please select a current clan and queue again.",
     "limit_reached": "You're out of free ranked matches.",
     "limit_reached_info": "Free matches refill daily. Subscribe for unlimited ranked play.",
     "limit_upsell": "Get unlimited ranked",

--- a/src/client/Matchmaking.ts
+++ b/src/client/Matchmaking.ts
@@ -2,14 +2,21 @@ import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ClientEnv } from "src/client/ClientEnv";
 import { UserMeResponse } from "../core/ApiSchemas";
-import { getUserMe, hasLinkedAccount } from "./Api";
+import { getUserMe, hasLinkedAccount, invalidateUserMe } from "./Api";
 import { getPlayToken } from "./Auth";
 import { BaseModal } from "./components/BaseModal";
 import "./components/Difficulties";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
-import { JoinLobbyEvent } from "./Main";
+import type { JoinLobbyEvent } from "./Main";
+import type { UsernameInput } from "./UsernameInput";
 import { translateText } from "./Utils";
+
+type MatchmakingJoin = {
+  type: "join";
+  jwt: string;
+  clanTag?: string;
+};
 
 @customElement("matchmaking-modal")
 export class MatchmakingModal extends BaseModal {
@@ -27,6 +34,7 @@ export class MatchmakingModal extends BaseModal {
   @state() private gameID: string | null = null;
   @state() private limitReached = false;
   @state() private queueSize: number | null = null;
+  private selectedClanTag: string | null = null;
   private elo: number | string = "...";
 
   constructor() {
@@ -172,6 +180,57 @@ export class MatchmakingModal extends BaseModal {
     }
   }
 
+  private selectedClanFrom(userMe: UserMeResponse): string | null {
+    if (this.mode !== "2v2") {
+      return null;
+    }
+    const selectedTag = document
+      .querySelector<UsernameInput>("username-input")
+      ?.getClanTag();
+    if (selectedTag === null || selectedTag === undefined) {
+      return null;
+    }
+    return (
+      userMe.player.clans?.find(
+        (clan) => clan.tag.toUpperCase() === selectedTag.toUpperCase(),
+      )?.tag ?? null
+    );
+  }
+
+  private showMatchmakingError(messageKey: string) {
+    window.dispatchEvent(
+      new CustomEvent("show-message", {
+        detail: {
+          message: translateText(messageKey),
+          color: "red",
+          duration: 5000,
+        },
+      }),
+    );
+  }
+
+  private handleInvalidClan() {
+    const rejectedClanTag = this.selectedClanTag;
+    this.connected = false;
+    this.close();
+    this.showMatchmakingError("matchmaking_modal.invalid_clan");
+
+    invalidateUserMe();
+    void getUserMe().then((userMe) => {
+      if (userMe === false || rejectedClanTag === null) {
+        return;
+      }
+      const stillMember = userMe.player.clans?.some(
+        (clan) => clan.tag.toUpperCase() === rejectedClanTag.toUpperCase(),
+      );
+      if (!stillMember) {
+        document
+          .querySelector<UsernameInput>("username-input")
+          ?.clearClanTag(rejectedClanTag);
+      }
+    });
+  }
+
   private async connect() {
     // Pending timers from a previous socket must not fire on this one.
     this.clearWatchdog();
@@ -211,12 +270,14 @@ export class MatchmakingModal extends BaseModal {
         // otherwise the "searching" message will be shown immediately.
         // Also wait so people who back out immediately aren't added
         // to the matchmaking queue.
-        this.socket.send(
-          JSON.stringify({
-            type: "join",
-            jwt: await getPlayToken(),
-          }),
-        );
+        const message: MatchmakingJoin = {
+          type: "join",
+          jwt: await getPlayToken(),
+          ...(this.selectedClanTag === null
+            ? {}
+            : { clanTag: this.selectedClanTag }),
+        };
+        this.socket.send(JSON.stringify(message));
         this.connected = true;
         // The server starts broadcasting queue-size once we're queued;
         // from here on, silence means the connection is dead.
@@ -259,6 +320,16 @@ export class MatchmakingModal extends BaseModal {
       if (event.code === 1008 && event.reason === "ranked_limit_reached") {
         this.connected = false;
         this.limitReached = true;
+        return;
+      }
+      if (event.code === 1008 && event.reason === "invalid_clan") {
+        this.handleInvalidClan();
+        return;
+      }
+      if (event.code === 1011 && event.reason === "clan_verification_failed") {
+        this.connected = false;
+        this.close();
+        this.showMatchmakingError("matchmaking_modal.clan_verification_failed");
         return;
       }
       if (event.code === 1000) {
@@ -326,6 +397,7 @@ export class MatchmakingModal extends BaseModal {
         ? userMe.player.leaderboard?.twoVtwo
         : userMe.player.leaderboard?.oneVone;
     this.elo = row?.elo ?? translateText("matchmaking_modal.no_elo");
+    this.selectedClanTag = this.selectedClanFrom(userMe);
 
     this.connected = false;
     this.gameID = null;

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -159,6 +159,20 @@ export class UsernameInput extends LitElement {
       : null;
   }
 
+  public clearClanTag(expectedTag?: string): void {
+    if (
+      expectedTag !== undefined &&
+      this.clanTag.toUpperCase() !== expectedTag.toUpperCase()
+    ) {
+      return;
+    }
+    this.clanTag = "";
+    this.clanTagOwnershipError = "";
+    this.validateAndStore();
+    this.startClanCheck();
+    this.requestUpdate();
+  }
+
   // Resolves to the clan tag to actually submit (null when it should be
   // dropped). The join flow awaits this so the ownership check — kicked off on
   // input — can run in parallel with the WebSocket handshake.

--- a/tests/client/Matchmaking.test.ts
+++ b/tests/client/Matchmaking.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { UserMeResponse } from "../../src/core/ApiSchemas";
+
+const apiMocks = vi.hoisted(() => ({
+  getUserMe: vi.fn(),
+  invalidateUserMe: vi.fn(),
+}));
+
+vi.mock("../../src/client/Api", () => ({
+  getUserMe: apiMocks.getUserMe,
+  hasLinkedAccount: vi.fn(() => true),
+  invalidateUserMe: apiMocks.invalidateUserMe,
+}));
+
+vi.mock("../../src/client/Auth", () => ({
+  getPlayToken: vi.fn(async () => "play-token"),
+}));
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: {
+    instanceId: vi.fn(() => "test-instance"),
+    jwtIssuer: vi.fn(() => "ws://matchmaking.test"),
+    workerPath: vi.fn(() => "w0"),
+  },
+}));
+
+vi.mock("../../src/client/CrazyGamesSDK", () => ({
+  crazyGamesSDK: {
+    isOnCrazyGames: vi.fn(() => false),
+    getUserProfile: vi.fn(async () => null),
+  },
+}));
+
+vi.mock("../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+}));
+
+import { MatchmakingModal } from "../../src/client/Matchmaking";
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSED = 3;
+
+  readonly url: string;
+  readyState = FakeWebSocket.CONNECTING;
+  sent: string[] = [];
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(url: string | URL) {
+    this.url = String(url);
+    sockets.push(this);
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  serverClose(code: number, reason: string) {
+    this.readyState = FakeWebSocket.CLOSED;
+    this.onclose?.({ code, reason });
+  }
+}
+
+const sockets: FakeWebSocket[] = [];
+
+function userMe(clanTags: string[] = []): UserMeResponse {
+  return {
+    user: { email: "player@example.com" },
+    player: {
+      publicId: "player-id",
+      adfree: false,
+      unlimitedRanked: false,
+      canCreatePublicLobbies: false,
+      achievements: { singleplayerMap: [] },
+      clans: clanTags.map((tag) => ({
+        tag,
+        name: `Clan ${tag}`,
+        role: "member" as const,
+        joinedAt: "2026-01-01T00:00:00.000Z",
+        memberCount: 2,
+      })),
+      friends: [],
+      subscription: null,
+    },
+  };
+}
+
+function installClanSelection(tag: string | null) {
+  const input = document.createElement("div") as HTMLDivElement & {
+    getClanTag: () => string | null;
+    clearClanTag: ReturnType<typeof vi.fn>;
+  };
+  input.setAttribute("data-test-username-input", "");
+  input.getClanTag = () => tag;
+  input.clearClanTag = vi.fn();
+  vi.spyOn(document, "querySelector").mockImplementation((selector) =>
+    selector === "username-input" ? input : null,
+  );
+  return input;
+}
+
+async function openAndJoin(mode: "1v1" | "2v2") {
+  const modal = new MatchmakingModal();
+  modal.mode = mode;
+  modal.open();
+  await vi.waitFor(() => expect(sockets).toHaveLength(1));
+
+  sockets[0].open();
+  await vi.advanceTimersByTimeAsync(2000);
+  expect(sockets[0].sent).toHaveLength(1);
+  return {
+    modal,
+    socket: sockets[0],
+    message: JSON.parse(sockets[0].sent[0]) as Record<string, unknown>,
+  };
+}
+
+describe("MatchmakingModal clan-aware joins", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    sockets.length = 0;
+    apiMocks.getUserMe.mockReset();
+    apiMocks.invalidateUserMe.mockReset();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("sends the selected current membership for 2v2", async () => {
+    apiMocks.getUserMe.mockResolvedValue(userMe(["ALLY", "BETA"]));
+    installClanSelection("ally");
+
+    const { message } = await openAndJoin("2v2");
+
+    expect(message).toEqual({
+      type: "join",
+      jwt: "play-token",
+      clanTag: "ALLY",
+    });
+  });
+
+  it("omits clanTag when 2v2 has no selected current membership", async () => {
+    apiMocks.getUserMe.mockResolvedValue(userMe(["ALLY"]));
+    installClanSelection("STALE");
+
+    const { message } = await openAndJoin("2v2");
+
+    expect(message).toEqual({ type: "join", jwt: "play-token" });
+    expect(message).not.toHaveProperty("clanTag");
+  });
+
+  it("leaves 1v1 joins unchanged", async () => {
+    apiMocks.getUserMe.mockResolvedValue(userMe(["ALLY"]));
+    installClanSelection("ALLY");
+
+    const { message } = await openAndJoin("1v1");
+
+    expect(message).toEqual({ type: "join", jwt: "play-token" });
+    expect(message).not.toHaveProperty("clanTag");
+  });
+
+  it("refreshes memberships and clears a stale selection on invalid_clan", async () => {
+    apiMocks.getUserMe
+      .mockResolvedValueOnce(userMe(["ALLY"]))
+      .mockResolvedValueOnce(userMe());
+    const input = installClanSelection("ALLY");
+    const showMessage = vi.fn();
+    window.addEventListener("show-message", showMessage);
+
+    const { modal, socket } = await openAndJoin("2v2");
+    socket.serverClose(1008, "invalid_clan");
+
+    await vi.waitFor(() => expect(apiMocks.getUserMe).toHaveBeenCalledTimes(2));
+    await vi.waitFor(() =>
+      expect(input.clearClanTag).toHaveBeenCalledWith("ALLY"),
+    );
+    expect(apiMocks.invalidateUserMe).toHaveBeenCalledOnce();
+    expect(modal.isOpen()).toBe(false);
+    expect(showMessage).toHaveBeenCalledOnce();
+    expect(sockets).toHaveLength(1);
+    window.removeEventListener("show-message", showMessage);
+  });
+
+  it("shows a retryable error without reconnecting on verification failure", async () => {
+    apiMocks.getUserMe.mockResolvedValue(userMe(["ALLY"]));
+    installClanSelection("ALLY");
+    const showMessage = vi.fn();
+    window.addEventListener("show-message", showMessage);
+
+    const { modal, socket } = await openAndJoin("2v2");
+    socket.serverClose(1011, "clan_verification_failed");
+    await vi.runAllTimersAsync();
+
+    expect(modal.isOpen()).toBe(false);
+    expect(apiMocks.invalidateUserMe).not.toHaveBeenCalled();
+    expect(showMessage).toHaveBeenCalledOnce();
+    expect(sockets).toHaveLength(1);
+    window.removeEventListener("show-message", showMessage);
+  });
+});

--- a/tests/client/UsernameInput.steam.test.ts
+++ b/tests/client/UsernameInput.steam.test.ts
@@ -65,3 +65,26 @@ describe("UsernameInput Steam seeding", () => {
     expect(generated.length).toBeGreaterThan(0);
   });
 });
+
+describe("UsernameInput clan selection", () => {
+  it("clears the selected clan when it matches the rejected tag", () => {
+    const el = new UsernameInput();
+    Object.assign(el, { baseUsername: "Player", clanTag: "ALLY" });
+    localStorage.setItem("username", "Player");
+    localStorage.setItem("clanTag", "ALLY");
+
+    el.clearClanTag("ally");
+
+    expect(el.getClanTag()).toBeNull();
+    expect(localStorage.getItem("clanTag")).toBe("");
+  });
+
+  it("preserves a newer clan selection", () => {
+    const el = new UsernameInput();
+    Object.assign(el, { baseUsername: "Player", clanTag: "BETA" });
+
+    el.clearClanTag("ALLY");
+
+    expect(el.getClanTag()).toBe("BETA");
+  });
+});


### PR DESCRIPTION
Summary: Send a verified selected clan tag in ranked 2v2 join messages, handle invalid or temporarily unverifiable clan memberships, preserve 1v1 and no-clan behavior, and add focused client coverage. Testing: 743 client tests passed; TypeScript, ESLint, Prettier, and diff checks passed.