### PR TITLE
Minor updates for the map "Branching Paths"

### DIFF
--- a/map-generator/assets/maps/branchingpaths/info.json
+++ b/map-generator/assets/maps/branchingpaths/info.json
@@ -2,8 +2,8 @@
   "id": "BranchingPaths",
   "name": "Branching Paths",
   "translation_key": "map.branchingpaths",
-  "categories": ["arcade", "fictional", "new"],
-  "multiplayer_frequency": 3,
+  "categories": ["fictional", "new"],
+  "multiplayer_frequency": 7,
   "special_team_count": 3,
   "nations": [
     {

--- a/resources/maps/branchingpaths/manifest.json
+++ b/resources/maps/branchingpaths/manifest.json
@@ -1,5 +1,5 @@
 {
-  "categories": ["arcade", "fictional", "new"],
+  "categories": ["fictional", "new"],
   "id": "BranchingPaths",
   "map": {
     "height": 2148,
@@ -16,7 +16,7 @@
     "num_land_tiles": 514307,
     "width": 1240
   },
-  "multiplayer_frequency": 3,
+  "multiplayer_frequency": 7,
   "name": "Branching Paths",
   "nations": [
     {

--- a/src/core/game/Maps.gen.ts
+++ b/src/core/game/Maps.gen.ts
@@ -346,8 +346,8 @@ export const maps: readonly MapInfo[] = [
     id: "BranchingPaths",
     type: GameMapType.BranchingPaths,
     translationKey: "map.branchingpaths",
-    categories: ["arcade", "fictional", "new"],
-    multiplayerFrequency: 3,
+    categories: ["fictional", "new"],
+    multiplayerFrequency: 7,
     specialTeamCount: 3,
   },
   {


### PR DESCRIPTION
Solves issue #4775

"Arcade" tag has been removed from the map "Branching Pathes" This will allow for the map to generate in public lobbies without modifiers.

Minor change was also added (see second comment on issue #4775) where the map's "multiplayer_frequency" has been rased from 3 to 7 to bring it more in line with newer / larger maps.

"special_team_count" was already set to 3 as part of a batch of map edits done earlier, so no change is needed there.

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.




## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

thegamingfish
