### PR TITLE
Disable host pause in publicly listed games

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -528,6 +528,7 @@ async function createClientGame(
     lobbyConfig.gameStartInfo.config,
     userSettings,
     lobbyConfig.gameRecord !== undefined,
+    lobbyConfig.gameStartInfo.listed,
   );
   let gameMap: TerrainMapData;
 

--- a/src/client/hud/layers/GameRightSidebar.ts
+++ b/src/client/hud/layers/GameRightSidebar.ts
@@ -95,7 +95,10 @@ export class GameRightSidebar extends LitElement implements Controller {
     this.eventBus.on(TogglePauseIntentEvent, () => {
       const isReplayOrSingleplayer =
         this._isSinglePlayer || this.game?.config()?.isReplay();
-      if (isReplayOrSingleplayer || this.isLobbyCreator) {
+      if (
+        isReplayOrSingleplayer ||
+        (this.isLobbyCreator && !this.game.config().listed)
+      ) {
         this.onPauseButtonClick();
       }
     });
@@ -321,7 +324,9 @@ export class GameRightSidebar extends LitElement implements Controller {
   maybeRenderReplayButtons() {
     const isReplayOrSingleplayer =
       this._isSinglePlayer || this.game?.config()?.isReplay();
-    const showPauseButton = isReplayOrSingleplayer || this.isLobbyCreator;
+    const showPauseButton =
+      isReplayOrSingleplayer ||
+      (this.isLobbyCreator && !this.game.config().listed);
     // The host of a private lobby can start a fresh lobby at any time, without
     // waiting to die or for the game to end.
     const showNewLobbyButton = this.isLobbyCreator && this.isPrivateLobby;

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -38,7 +38,7 @@ export async function createGameRunner(
   mapLoader: GameMapLoader,
   callBack: (gu: GameUpdateViewData | ErrorUpdate) => void,
 ): Promise<GameRunner> {
-  const config = new Config(gameStart.config, null, false);
+  const config = new Config(gameStart.config, null, false, gameStart.listed);
   const gameMap = await loadGameMap(
     gameStart.config.gameMap,
     gameStart.config.gameMapSize,

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -737,6 +737,7 @@ export const GameStartInfoSchema = z.object({
   gameID: ID,
   lobbyCreatedAt: z.number(),
   visibleAt: z.number().optional(),
+  listed: z.boolean().optional(),
   config: GameConfigSchema,
   players: PlayerSchema.array(),
   // Purchased bot tribe names in use this game (public games only). Rides

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -119,6 +119,7 @@ export class Config {
     private _gameConfig: GameConfig,
     private _userSettings: UserSettings | null,
     private _isReplay: boolean,
+    public readonly listed: boolean = false,
   ) {}
 
   isReplay(): boolean {

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -595,6 +595,12 @@ export class GameServer {
             error: "only the lobby creator can pause",
           });
         }
+        if (this.isListed() && !actor.isAdminBot) {
+          return finish({
+            status: 403,
+            error: "the host cannot pause a publicly listed game",
+          });
+        }
         // Pausing only makes sense once the game is running.
         if (!this.hasStarted()) {
           return finish({ status: 409, error: "game not started" });
@@ -1274,15 +1280,19 @@ export class GameServer {
       buildHash: this.telemetryBuildHash,
       turnIntervalMs: ServerEnv.turnIntervalMs(),
     });
+    const wireGameStartInfo = {
+      ...this.gameStartInfo,
+      listed: this.listed,
+    };
     this.wireGameStartInfo = this.gameConfig.disableClanTags
       ? {
-          ...this.gameStartInfo,
+          ...wireGameStartInfo,
           players: this.gameStartInfo.players.map((p) => ({
             ...p,
             clanTag: null,
           })),
         }
-      : this.gameStartInfo;
+      : wireGameStartInfo;
 
     this.endTurnIntervalID = setInterval(
       () => this.endTurn(),

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -404,6 +404,24 @@ describe("listed lobby host powers", () => {
     expect(game.handleIntent(kick, asHost).status).toBe(200);
   });
 
+  it("blocks host pause controls while listed", () => {
+    const game = makeGame("g-pause");
+    (game as any)._hasStarted = true;
+    game.setListed(true);
+
+    const pause = { type: "toggle_pause", paused: true } as any;
+    expect(game.handleIntent(pause, asHost)).toEqual({
+      status: 403,
+      error: "the host cannot pause a publicly listed game",
+    });
+    expect((game as any).isPaused).toBe(false);
+
+    // Unlisting restores the host's pause control.
+    game.setListed(false);
+    expect(game.handleIntent(pause, asHost).status).toBe(200);
+    expect((game as any).isPaused).toBe(true);
+  });
+
   it("lets admins kick in a listed lobby", () => {
     const game = makeGame("g-admin-kick");
     game.joinClient(makeClient("host", CREATOR, fakeWs()));


### PR DESCRIPTION
## Description

Prevents a private-match host from pausing after the lobby has been publicly listed.

- Rejects host pause intents for listed games on the server.
- Carries the server-owned listing state through GameStartInfo into read-only client Config state.
- Hides the pause control and disables the pause keybind for the host in listed games.
- Restores normal pause behavior when a game is unlisted.

## Testing

- `npx vitest run tests/server/HostedLobbyListing.test.ts` (38 tests passed)
- `npx tsc --noEmit`
- Prettier checks for all changed files

## Checklist

- Screenshots: not applicable; this only removes an unavailable control in publicly listed matches.
- No new user-facing text was added.
- Relevant regression coverage was added.