### PR TITLE
Ranked 2v2: end game when a full team is dead or disconnected

### DIFF
--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -121,6 +121,29 @@ export class WinCheckExecution implements Execution {
 
   checkWinnerTeam(): void {
     if (this.mg === null) throw new Error("Not initialized");
+
+    if (this.mg.config().gameConfig().rankedType === RankedType.TwoVTwo) {
+      // players() only returns alive players, so a team drops out of this set
+      // once every member is dead or disconnected.
+      const teamsRemaining = new Set<Team>();
+      for (const player of this.mg.players()) {
+        if (player.type() !== PlayerType.Human || player.isDisconnected()) {
+          continue;
+        }
+        const team = player.team();
+        if (team !== null) {
+          teamsRemaining.add(team);
+        }
+      }
+      if (teamsRemaining.size === 1) {
+        const [winner] = teamsRemaining;
+        this.mg.setWinner(winner, this.mg.stats().stats());
+        console.log(`${winner} has won the game`);
+        this.active = false;
+        return;
+      }
+    }
+
     const teamToTiles = new Map<Team, number>();
     for (const player of this.mg.players()) {
       const team = player.team();

--- a/tests/core/executions/WinCheckExecution.test.ts
+++ b/tests/core/executions/WinCheckExecution.test.ts
@@ -2,9 +2,11 @@ import { WinCheckExecution } from "../../../src/core/execution/WinCheckExecution
 import {
   ColoredTeams,
   GameMode,
+  Player,
   PlayerInfo,
   PlayerType,
   RankedType,
+  Team,
 } from "../../../src/core/game/Game";
 import { playerInfo, setup } from "../../util/Setup";
 
@@ -551,5 +553,123 @@ describe("WinCheckExecution - 1v1 Ranked Mode", () => {
     // Verify human is declared winner (only one human player)
     expect(setWinnerSpy).toHaveBeenCalledWith(human, expect.anything());
     expect(winCheck.isActive()).toBe(false);
+  });
+});
+
+describe("WinCheckExecution - 2v2 Ranked Team Elimination", () => {
+  async function setup2v2(rankedType?: RankedType) {
+    const game = await setup(
+      "big_plains",
+      {
+        gameMode: GameMode.Team,
+        playerTeams: 2,
+        maxPlayers: 4,
+        rankedType,
+      },
+      [
+        playerInfo("P1", PlayerType.Human),
+        playerInfo("P2", PlayerType.Human),
+        playerInfo("P3", PlayerType.Human),
+        playerInfo("P4", PlayerType.Human),
+      ],
+    );
+
+    // Group the humans by their assigned team.
+    const byTeam = new Map<Team, Player[]>();
+    for (const id of ["P1", "P2", "P3", "P4"]) {
+      const player = game.player(id);
+      const team = player.team()!;
+      byTeam.set(team, [...(byTeam.get(team) ?? []), player]);
+    }
+    const [teamA, teamB] = Array.from(byTeam.values());
+    expect(teamA).toHaveLength(2);
+    expect(teamB).toHaveLength(2);
+
+    // Give every player territory so they are all alive.
+    const all = [...teamA, ...teamB];
+    let assigned = 0;
+    game.map().forEachTile((tile) => {
+      if (!game.map().isLand(tile)) return;
+      if (assigned >= all.length * 10) return;
+      all[Math.floor(assigned / 10)].conquer(tile);
+      assigned++;
+    });
+
+    const setWinnerSpy = vi.fn();
+    game.setWinner = setWinnerSpy;
+    const winCheck = new WinCheckExecution();
+    winCheck.init(game, 0);
+    return { teamA, teamB, setWinnerSpy, winCheck };
+  }
+
+  function kill(player: Player) {
+    player.tiles().forEach((t) => player.relinquish(t));
+    expect(player.isAlive()).toBe(false);
+  }
+
+  test("should set winning team when the other team's players disconnect", async () => {
+    const { teamA, teamB, setWinnerSpy, winCheck } = await setup2v2(
+      RankedType.TwoVTwo,
+    );
+
+    teamA.forEach((p) => p.markDisconnected(true));
+    winCheck.checkWinnerTeam();
+
+    expect(setWinnerSpy).toHaveBeenCalledWith(
+      teamB[0].team(),
+      expect.anything(),
+    );
+    expect(winCheck.isActive()).toBe(false);
+  });
+
+  test("should set winning team when the other team is dead or disconnected", async () => {
+    const { teamA, teamB, setWinnerSpy, winCheck } = await setup2v2(
+      RankedType.TwoVTwo,
+    );
+
+    kill(teamA[0]);
+    teamA[1].markDisconnected(true);
+    winCheck.checkWinnerTeam();
+
+    expect(setWinnerSpy).toHaveBeenCalledWith(
+      teamB[0].team(),
+      expect.anything(),
+    );
+    expect(winCheck.isActive()).toBe(false);
+  });
+
+  test("should not set winner while both teams have an active player", async () => {
+    const { teamA, setWinnerSpy, winCheck } = await setup2v2(
+      RankedType.TwoVTwo,
+    );
+
+    // One team is down a player but not fully out.
+    kill(teamA[0]);
+    winCheck.checkWinnerTeam();
+
+    expect(setWinnerSpy).not.toHaveBeenCalled();
+    expect(winCheck.isActive()).toBe(true);
+  });
+
+  test("should not set winner when no team has an active player", async () => {
+    const { teamA, teamB, setWinnerSpy, winCheck } = await setup2v2(
+      RankedType.TwoVTwo,
+    );
+
+    [...teamA, ...teamB].forEach((p) => p.markDisconnected(true));
+    winCheck.checkWinnerTeam();
+
+    expect(setWinnerSpy).not.toHaveBeenCalled();
+    expect(winCheck.isActive()).toBe(true);
+  });
+
+  test("should not eliminate teams in unranked team games", async () => {
+    const { teamA, setWinnerSpy, winCheck } = await setup2v2();
+
+    teamA.forEach((p) => p.markDisconnected(true));
+    winCheck.checkWinnerTeam();
+
+    expect(setWinnerSpy).not.toHaveBeenCalled();
+    expect(winCheck.isActive()).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

In ranked 2v2, if every player on one team is dead or disconnected, the other team now wins immediately instead of the game dragging on until the territory threshold or the game timer.

## Implementation

- `WinCheckExecution.checkWinnerTeam()` gains a check gated on `rankedType === RankedType.TwoVTwo`, mirroring the existing ranked 1v1 early-win check in `checkWinnerFFA()`:
  - Collect the set of teams that still have at least one **alive** (`players()` already filters out dead players), **connected** (`!isDisconnected()`, the same AFK signal the server sends via `mark_disconnected` intents) human player.
  - If exactly one team remains, set it as the winner and deactivate the execution.
- Bots don't interfere: only `PlayerType.Human` counts, so the bot team can never trigger or block the check.
- Edge behavior matches ranked 1v1: if *zero* teams have an active player, no winner is declared.
- Unranked team games are unaffected.

## Tests

New describe block in `WinCheckExecution.test.ts` sets up a real 4-human, 2-team game (grouping players by their runtime-assigned team) and covers:
- Win when both opposing players disconnect
- Win when the opposing team is one dead + one disconnected
- No winner while the losing team still has one active player
- No winner when no team has an active player
- No effect on unranked team games

🤖 Generated with [Claude Code](https://claude.com/claude-code)