### PR TITLE
Remove ARCADE_MAPS restriction so arcade maps appear in all playlists 🎮

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -25,16 +25,6 @@ import { getMapLandTiles } from "./MapLandTiles";
 
 const log = logger.child({});
 
-// Arcade-style maps only appear in the "special" playlist.
-const ARCADE_MAPS = new Set<GameMapType>([
-  GameMapType.TheBox,
-  GameMapType.ChoppingBlock,
-  GameMapType.Didier,
-  GameMapType.DidierFrance,
-  GameMapType.Labyrinth,
-  GameMapType.Sierpinski,
-  GameMapType.Onion,
-]);
 const SPECIAL_ONLY_MAPS = new Set<GameMapType>([GameMapType.ArchipelagoSea]);
 
 // Hard cap on player count for performance. Applied after compact-map reduction.
@@ -535,10 +525,7 @@ export class MapPlaylist {
     const maps: GameMapType[] = [];
     allMaps.forEach((mapInfo) => {
       const map = mapInfo.type;
-      if (
-        type !== "special" &&
-        (ARCADE_MAPS.has(map) || SPECIAL_ONLY_MAPS.has(map))
-      ) {
+      if (type !== "special" && SPECIAL_ONLY_MAPS.has(map)) {
         return;
       }
       let freq = mapInfo.multiplayerFrequency;


### PR DESCRIPTION
## Description:

Removed the `ARCADE_MAPS` set and its filtering logic in `MapPlaylist.buildMapsList()`. Previously, 7 arcade maps (TheBox, ChoppingBlock, Didier, DidierFrance, Labyrinth, Sierpinski, Onion) were restricted to only appear in the "special" playlist. They now appear in FFA and Team playlists like any other map, governed by their normal `multiplayerFrequency`.

Tristar requested it :)
And I think we no longer need that restriction

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin