### PR TITLE
Fix: play sound for Missile Silo being built as happens for other buildings

### DIFF
--- a/src/client/controllers/SoundEffectController.ts
+++ b/src/client/controllers/SoundEffectController.ts
@@ -91,6 +91,9 @@ export class SoundEffectController implements Controller {
       case UnitType.SAMLauncher:
         if (unit.owner() === myPlayer) this.emit("sam-built");
         break;
+      case UnitType.MissileSilo:
+        if (unit.owner() === myPlayer) this.emit("silo-built");
+        break;
     }
   }
 

--- a/src/client/sound/Sounds.ts
+++ b/src/client/sound/Sounds.ts
@@ -15,6 +15,7 @@ export type SoundEffect =
   | "build-defense-post"
   | "build-warship"
   | "sam-built"
+  | "silo-built"
   | "message"
   | "click";
 
@@ -32,6 +33,7 @@ export const soundEffectUrls: ReadonlyMap<SoundEffect, string> = new Map([
   ["build-defense-post", assetUrl("sounds/effects/build-defense-post.mp3")],
   ["build-warship", assetUrl("sounds/effects/build-warship.mp3")],
   ["sam-built", assetUrl("sounds/effects/sam-built.mp3")],
+  ["silo-built", assetUrl("sounds/effects/silo-built.mp3")],
   ["message", assetUrl("sounds/effects/message.mp3")],
   ["click", assetUrl("sounds/effects/click.mp3")],
 ]);


### PR DESCRIPTION
## Description:

When a building is constructed, they almost all emit a sound. Port, city, etc. Except for missile silo which are built silently. 

But a sound effect was originally made by camclark when he made all the other sound effects. The sound file for silo-built is therefor actually [already present in the repo](https://github.com/openfrontio/OpenFrontIO/tree/main/resources/sounds/effects).

Add this existing, original, silo-built sound effect to the sound controller. 

The silo sound simply seems to have been overlooked when approving sounds in https://github.com/openfrontio/OpenFrontIO/pull/3394.

The other unapproved files seem to actually not (yet) be approved for a reason. Like i can imagine not wanting a sound on every sam missile fired. But all other buildings emit a sound on being built, just not the missile silo and that's why it genuinly seems overlooked.

_Missile Silo built sound was created in PR 3394 already and was "Waiting for approval" but actually seems to have been overlooked for approval, as the only building besides Factory where no sound is played currently:_
<img width="707" height="305" alt="image" src="https://github.com/user-attachments/assets/3e8fa760-f1b9-48aa-be98-c1c2c9a9adf8" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33