### PR TITLE
Ranked 2v2: increase PvP immunity to 1 minute

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -459,7 +459,7 @@ export class MapPlaylist {
       gameMode: GameMode.Team,
       playerTeams: 2,
       bots: isCompact ? 100 : 400,
-      spawnImmunityDuration: 30 * 10,
+      spawnImmunityDuration: 60 * 10,
       disabledUnits: [],
     } satisfies GameConfig;
   }


### PR DESCRIPTION
## Summary

Ranked 2v2 games now start with a 1-minute PvP immunity instead of 30 seconds, giving teams more time to establish themselves before players can attack each other.

One-line change in `MapPlaylist.get2v2Config()`: `spawnImmunityDuration` 300 → 600 ticks. The existing spawn-immunity mechanism already does the rest:

- Only human attackers respect the immunity (`PlayerImpl.canAttackPlayer`), so expanding into bots during the first minute is unaffected.
- The HUD immunity countdown and join-lobby modal read the duration from the game config, so they display 60 seconds automatically.

Ranked 1v1 keeps its 30-second immunity.

## Test plan

- Config-value-only change; no logic touched. Covered by existing spawn-immunity behavior/tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)