### PR TITLE
fix(client): resolve map thumbnails by map id instead of display name

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -18,7 +18,11 @@ import { Platform } from "./Platform";
 export const TUTORIAL_VIDEO_URL = "https://www.youtube.com/embed/7J5zwb_s_Cg";
 
 export function normaliseMapKey(mapName: string): string {
-  return mapName.toLowerCase().replace(/[\s.]+/g, "");
+  // Asset dirs / translation keys are the map id lowercased. For most maps
+  // stripping spaces from the display name gives the same string, but not for
+  // the tourney maps (e.g. "Tourney 2 Teams" lives in maps/tourney1/).
+  const id = maps.find((m) => m.type === mapName)?.id;
+  return (id ?? mapName).toLowerCase().replace(/[\s.]+/g, "");
 }
 
 export function getMapName(mapName: string | undefined): string | null {

--- a/src/server/GamePreviewBuilder.ts
+++ b/src/server/GamePreviewBuilder.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { buildAssetUrl } from "../core/AssetUrls";
 import { ClanTagSchema, GameInfo, UsernameSchema } from "../core/Schemas";
 import { formatPlayerDisplayName } from "../core/Util";
-import { GameMode } from "../core/game/Game";
+import { GameMode, maps } from "../core/game/Game";
 import { getRuntimeAssetManifest } from "./RuntimeAssetManifest";
 import { ServerEnv } from "./ServerEnv";
 
@@ -191,8 +191,12 @@ export async function buildPreview(
   const winner = parseWinner(publicInfo?.info?.winner, players);
   const duration = publicInfo?.info?.duration;
 
-  // Normalize map name to match filesystem (lowercase, no spaces or special chars)
-  const normalizedMap = map ? map.toLowerCase().replace(/[\s.()]+/g, "") : null;
+  // Asset dirs are the map id lowercased; display names usually normalize to
+  // the same string, but not always (e.g. "Tourney 2 Teams" → maps/tourney1/).
+  const mapId = map ? (maps.find((m) => m.type === map)?.id ?? map) : null;
+  const normalizedMap = mapId
+    ? mapId.toLowerCase().replace(/[\s.()]+/g, "")
+    : null;
 
   const mapThumbnail = normalizedMap
     ? buildAbsoluteAssetUrl(

--- a/tests/client/Utils.mapKey.test.ts
+++ b/tests/client/Utils.mapKey.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { normaliseMapKey } from "../../src/client/Utils";
+import { GameMapType, maps } from "../../src/core/game/Game";
+
+describe("normaliseMapKey", () => {
+  it("resolves tourney maps to their asset directory, not their display name", () => {
+    expect(normaliseMapKey(GameMapType.Tourney1)).toBe("tourney1");
+    expect(normaliseMapKey(GameMapType.Tourney2)).toBe("tourney2");
+    expect(normaliseMapKey(GameMapType.Tourney3)).toBe("tourney3");
+    expect(normaliseMapKey(GameMapType.Tourney4)).toBe("tourney4");
+  });
+
+  it("matches the lowercased map id for every known map", () => {
+    for (const map of maps) {
+      expect(normaliseMapKey(map.type)).toBe(map.id.toLowerCase());
+    }
+  });
+
+  it("falls back to stripping spaces and dots for unknown map names", () => {
+    expect(normaliseMapKey("Some. Unknown Map")).toBe("someunknownmap");
+  });
+});


### PR DESCRIPTION
## Problem

When a listed private game on a tournament map shows up in the join-lobby modal, the map image is missing.

The thumbnail URL is built by normalizing the map's **display name** (lowercase, strip spaces/dots). For every other map that happens to match the asset directory ("Las Vegas Strip" → `lasvegasstrip`), but the tourney maps are the only maps whose display name diverges from their id: `Tourney1 = "Tourney 2 Teams"` normalizes to `tourney2teams`, while the assets live in `maps/tourney1/`. The request 404s and the `@error` handler hides the `<img>`.

## Fix

Resolve the asset key from the map's **id** (via the generated `maps` list), which is what `FetchGameMapLoader` already does, falling back to the old display-name stripping only for unknown map names:

- `normaliseMapKey` in `src/client/Utils.ts` — fixes both thumbnail sites in `JoinLobbyModal` (hosted-lobby rows and the tracked-lobby preview)
- `GamePreviewBuilder` on the server had the same bug for the social-embed `og:image`; same id lookup applied there (server imports from core, not from the client helper)

Renaming the asset dirs to match the display names was considered and rejected: the id/name split is deliberate in the map pipeline (`info.json` has separate `id` and `name` fields), and a rename would churn CDN paths, Crowdin translation keys, and both asset trees while re-coupling display names to asset paths.

## Testing

- New `tests/client/Utils.mapKey.test.ts`: tourney maps resolve to `tourney1`–`tourney4`, every known map resolves to its lowercased id, unknown names fall back to the old normalization
- Existing `JoinLobbyModal` tests, ESLint, `tsc --noEmit` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)