### PR TITLE
Fix MapConsistency test: normalize custom_tribes key order to match gen-maps output 🧪

### DIFF
--- a/tests/MapConsistency.test.ts
+++ b/tests/MapConsistency.test.ts
@@ -73,7 +73,11 @@ function normalizeCustomTribes(raw: unknown): CustomTribe[] | undefined {
   if (!Array.isArray(raw) || raw.length === 0) return undefined;
   return raw.map((entry) => {
     if (typeof entry === "string") return { name: entry };
-    return entry as CustomTribe;
+    const obj = entry as { name?: string; coordinates?: [number, number] };
+    // Reconstruct with consistent key order (name first) to match gen-maps output
+    if (obj.coordinates)
+      return { name: obj.name!, coordinates: obj.coordinates };
+    return { name: obj.name! };
   });
 }
 

--- a/tests/MapConsistency.test.ts
+++ b/tests/MapConsistency.test.ts
@@ -71,13 +71,30 @@ function orOmitted(value: unknown): unknown {
  */
 function normalizeCustomTribes(raw: unknown): CustomTribe[] | undefined {
   if (!Array.isArray(raw) || raw.length === 0) return undefined;
-  return raw.map((entry) => {
-    if (typeof entry === "string") return { name: entry };
-    const obj = entry as { name?: string; coordinates?: [number, number] };
-    // Reconstruct with consistent key order (name first) to match gen-maps output
-    if (obj.coordinates)
-      return { name: obj.name!, coordinates: obj.coordinates };
-    return { name: obj.name! };
+  return raw.map((entry, i) => {
+    if (typeof entry === "string") {
+      if (entry === "") throw new Error(`custom_tribes[${i}]: empty string`);
+      return { name: entry };
+    }
+    if (entry === null || typeof entry !== "object")
+      throw new Error(`custom_tribes[${i}]: invalid entry`);
+    const obj = entry as { name?: unknown; coordinates?: unknown };
+    if (typeof obj.name !== "string" || obj.name === "")
+      throw new Error(`custom_tribes[${i}]: name must be a non-empty string`);
+    if (obj.coordinates !== undefined) {
+      if (
+        !Array.isArray(obj.coordinates) ||
+        obj.coordinates.length !== 2 ||
+        typeof obj.coordinates[0] !== "number" ||
+        typeof obj.coordinates[1] !== "number"
+      )
+        throw new Error(`custom_tribes[${i}]: coordinates must be [x, y]`);
+      return {
+        name: obj.name,
+        coordinates: obj.coordinates as [number, number],
+      };
+    }
+    return { name: obj.name };
   });
 }
 


### PR DESCRIPTION
## Description:

The `info.json metadata matches the generated Maps.gen.ts` test in MapConsistency was comparing custom_tribes via `JSON.stringify`, which is key-order-sensitive. Info.json files store tribes as `{"coordinates":[...],"name":"..."}` while the gen-maps codegen always outputs `{name: "...", coordinates: [...]}` (name first). The `normalizeCustomTribes` function passed through raw objects without reordering keys, causing semantically identical data to fail the string comparison.

This fix explicitly reconstructs custom tribe objects in `normalizeCustomTribes` with consistent key ordering (`name` first, then `coordinates`) to match the gen-maps output format.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin