### PR TITLE
perf(featured-stream): stop probing Twitch on every page load (avoid rate limits)

### DIFF
--- a/src/client/FeaturedStream.ts
+++ b/src/client/FeaturedStream.ts
@@ -260,10 +260,14 @@ export class FeaturedStream extends LitElement {
     } catch (e) {
       // SDK blocked (extension, network): try again on the next poll rather than never.
       console.error("featured-stream: Twitch SDK load failed", e);
+      if (this.dismissed) return;
       this.goOffline();
       this.schedulePoll();
       return;
     }
+    // A close (or a game start) during the SDK load must not mount, and must not leave a
+    // poll scheduled behind it.
+    if (this.inGame || this.dismissed) return;
     if (this.channel !== channel) return; // superseded while the SDK loaded
     const host = this.querySelector(
       "#featured-stream-mount",

--- a/src/client/FeaturedStream.ts
+++ b/src/client/FeaturedStream.ts
@@ -1,5 +1,6 @@
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
+import { FeaturedStreamConfig } from "../core/ApiSchemas";
 import { getFeaturedStream } from "./Api";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { isDesktopShell } from "./DesktopShell";
@@ -8,15 +9,21 @@ import { translateText } from "./Utils";
 // Homepage "featured stream" panel: embeds a Twitch channel and shows ONLY while it is
 // actually live, then hides. Config comes from getFeaturedStream() (a JSON the API serves
 // like news.json, with a bundled fallback in resources/featured-stream.json): an `enabled`
-// toggle + a `channels` list. Disabled or no channels = feature off (renders nothing).
-// With several channels, the first one that is live wins (e.g. the OFM channel for
-// tournaments + the OF channel for releases).
+// toggle + a `channels` list, ordered by priority (e.g. the OFM channel for tournaments
+// ahead of the OF channel for releases). Disabled or empty = feature off (renders nothing).
 //
-// Live detection is client-side via the Twitch Embed SDK (no backend, no API secret).
-// Quirks handled: an offline-at-load channel fires READY -> ENDED (no OFFLINE), so we read
-// the initial state synchronously with getEnded() on READY; events from a superseded
-// player are ignored via a mount generation counter; and if every channel is offline we
-// re-check periodically so the panel still appears when a stream goes live later.
+// Liveness is decided server-side: the API polls Twitch Helix on a cron and lists only
+// channels that are live right now, so `channels[0]` is simply what to embed. The client
+// used to work this out itself by mounting a real autoplaying Twitch.Player per configured
+// channel and reading its ONLINE/OFFLINE events, which cost ~300 Twitch requests on every
+// page load (measured) while the panel stayed invisible, and put an offline-and-hidden
+// player on the page. Now nothing Twitch-related loads until there is a live channel, and
+// an offline period costs one small JSON poll per minute.
+//
+// The player is still watched once mounted: OFFLINE/ENDED hides the panel, which covers
+// the stream ending mid-session and the ~3 min worst-case staleness of the served config
+// (2 min cron + 60s edge cache). An offline-at-load channel fires READY -> ENDED with no
+// OFFLINE, so the initial state is read synchronously with getEnded() on READY.
 
 interface TwitchPlayer {
   addEventListener(event: string, cb: () => void): void;
@@ -46,7 +53,9 @@ export type Corner = "tl" | "tr" | "bl" | "br";
 const CORNER_KEY = "featured-stream-corner";
 const MIN_KEY = "featured-stream-minimized";
 const CLOSED_KEY = "featured-stream-closed"; // ad-free close, remembered for the current day
-const RECHECK_MS = 60_000; // re-probe interval when every channel is offline
+// How often to re-ask the served config who is live while nothing is showing. This is one
+// small JSON fetch against our own API (60s edge cache), not a Twitch request.
+const POLL_MS = 60_000;
 
 // Local calendar day, used to scope the "closed" and "minimized" states to the current stream:
 // each is stored with the day it was set and ignored once the day changes, so the panel resets
@@ -82,6 +91,13 @@ export function isOffFrame(
   vh: number,
 ): boolean {
   return cx < 0 || cx > vw || cy < 0 || cy > vh;
+}
+
+// Which channel to embed for a served config, or null for "embed nothing". The API lists
+// only channels its Helix poll currently sees live, in priority order, so this is just the
+// first entry — no client-side probing. Pure for tests.
+export function channelToEmbed(cfg: FeaturedStreamConfig): string | null {
+  return cfg.enabled ? (cfg.channels[0] ?? null) : null;
 }
 
 // Touch devices report a coarse pointer; flick-to-dismiss is enabled only there (on desktop
@@ -120,12 +136,11 @@ export class FeaturedStream extends LitElement {
   @state() private corner: Corner = "br"; // which screen corner the panel snaps to
   @state() private dragPos: { x: number; y: number } | null = null; // free pos while dragging
   @state() private dismissed = false; // closed; ad-free close persists for the day, flick session-only
+  @state() private channel: string | null = null; // channel the API reports live, or none
 
-  private channels: string[] = [];
-  private idx = 0;
   private player?: TwitchPlayer;
   private mountGen = 0; // bumped each mount; events from older mounts are ignored
-  private recheckTimer: ReturnType<typeof setTimeout> | null = null;
+  private pollTimer: ReturnType<typeof setTimeout> | null = null;
   private dragOff = { x: 0, y: 0 };
   private dragStart = { x: 0, y: 0 };
   private dragging = false;
@@ -155,8 +170,7 @@ export class FeaturedStream extends LitElement {
     super.disconnectedCallback();
     document.removeEventListener("game-starting", this.onGameStart);
     document.removeEventListener("leave-lobby", this.onLeave);
-    if (this.recheckTimer) clearTimeout(this.recheckTimer);
-    this.recheckTimer = null;
+    this.clearPoll();
     this.teardownPlayer();
   }
 
@@ -175,25 +189,16 @@ export class FeaturedStream extends LitElement {
       return;
     }
     if (closedDay) localStorage.removeItem(CLOSED_KEY);
-    // Channels come from the served config (like news.json), with a bundled fallback.
-    const cfg = await getFeaturedStream();
-    if (!cfg.enabled || cfg.channels.length === 0) return; // off / nothing configured
-    this.channels = cfg.channels;
-    this.requestUpdate(); // channels is not reactive; force the card (+ mount node) to render
-    await this.updateComplete;
-    void this.start();
+    void this.poll();
   }
 
   // The panel stays up through the lobby/queue wait and hides only once the game actually
-  // starts (Main dispatches game-starting at prestart). Stop probing while in game: a pending
-  // recheck (or a stream coming online) must not mount a fresh autoplaying player behind the
-  // hidden panel — an obscured embed (Twitch ToS). Pause the current player; we re-probe on leave.
+  // starts (Main dispatches game-starting at prestart). Stop polling while in game: a stream
+  // coming online must not mount an autoplaying player behind the hidden panel — an obscured
+  // embed (Twitch ToS). Pause the current player; we re-poll on leave.
   private onGameStart = () => {
     this.inGame = true;
-    if (this.recheckTimer) {
-      clearTimeout(this.recheckTimer);
-      this.recheckTimer = null;
-    }
+    this.clearPoll();
     try {
       this.player?.pause();
     } catch {
@@ -203,35 +208,70 @@ export class FeaturedStream extends LitElement {
   private onLeave = () => {
     this.inGame = false;
     if (this.dismissed) return; // dismissed for this page visit: don't resurrect it
-    // Back on the homepage: re-probe from the top so liveness is fresh and the panel only
-    // reappears (and starts streaming) if a channel is actually live right now.
-    if (this.recheckTimer) {
-      clearTimeout(this.recheckTimer);
-      this.recheckTimer = null;
-    }
-    this.idx = 0;
-    void this.start();
+    // Back on the homepage: re-read the config so the panel only reappears (and starts
+    // streaming) if a channel is live right now.
+    void this.poll();
   };
 
-  private start = async () => {
-    if (!this.channels.length) return; // feature off / gated: never load the Twitch SDK
+  // Ask the API who is live. While a stream is showing there is nothing to poll for — the
+  // player's own OFFLINE/ENDED tells us when it ends, and we resume polling then.
+  private poll = async () => {
+    this.clearPoll();
+    if (this.inGame || this.dismissed) return;
+    const channel = channelToEmbed(await getFeaturedStream());
+    if (this.inGame || this.dismissed) return; // state can change across the await
+    if (channel === null) {
+      this.goOffline();
+      this.schedulePoll();
+      return;
+    }
+    if (channel === this.channel && this.player) {
+      this.kickPlay(); // already embedding it; resume if a game had paused it
+      return;
+    }
+    this.channel = channel;
+    await this.updateComplete; // render the card so the mount node exists
+    await this.mountPlayer(channel);
+  };
+
+  private schedulePoll() {
+    this.clearPoll();
+    this.pollTimer = setTimeout(() => void this.poll(), POLL_MS);
+  }
+
+  private clearPoll() {
+    if (this.pollTimer) clearTimeout(this.pollTimer);
+    this.pollTimer = null;
+  }
+
+  // Nothing to show: drop the card (and the mount node with it) and stop streaming.
+  private goOffline() {
+    this.channel = null;
+    this.live = false;
+    this.mountGen++; // stale player callbacks fail fresh() and become no-ops
+    this.teardownPlayer();
+  }
+
+  private async mountPlayer(channel: string) {
+    if (this.inGame || this.dismissed) return; // never mount behind a hidden/dismissed panel
     let Twitch: TwitchGlobal;
     try {
       Twitch = await loadTwitchSdk();
     } catch (e) {
+      // SDK blocked (extension, network): try again on the next poll rather than never.
       console.error("featured-stream: Twitch SDK load failed", e);
+      this.goOffline();
+      this.schedulePoll();
       return;
     }
-    this.mountPlayer(Twitch, this.idx);
-  };
-
-  private mountPlayer(Twitch: TwitchGlobal, i: number) {
-    if (this.inGame || this.dismissed) return; // never mount behind a hidden/dismissed panel
+    if (this.channel !== channel) return; // superseded while the SDK loaded
     const host = this.querySelector(
       "#featured-stream-mount",
     ) as HTMLElement | null;
-    const channel = this.channels[i];
-    if (!host || !channel) return;
+    if (!host) {
+      this.schedulePoll(); // no mount node: retry rather than stalling the panel forever
+      return;
+    }
     this.teardownPlayer(); // destroy the previous player so its listeners can't fire
     host.innerHTML = "";
     const gen = ++this.mountGen;
@@ -246,15 +286,22 @@ export class FeaturedStream extends LitElement {
     });
     this.player = player;
     const P = Twitch.Player;
+    // The API already said this channel is live, so these events are about it *stopping*
+    // (or the config being stale). Either way: hide and go back to polling.
+    const ended = () => {
+      if (!fresh()) return;
+      this.goOffline();
+      this.schedulePoll();
+    };
     player.addEventListener(P.READY, () => {
       if (!fresh()) return;
       // offline-at-load = READY -> ENDED (no OFFLINE); read state synchronously here
-      if (player.getEnded()) this.advance(Twitch);
-      else this.setLive(i);
+      if (player.getEnded()) ended();
+      else this.setLive();
     });
-    player.addEventListener(P.ONLINE, () => fresh() && this.setLive(i));
-    player.addEventListener(P.OFFLINE, () => fresh() && this.advance(Twitch));
-    player.addEventListener(P.ENDED, () => fresh() && this.advance(Twitch));
+    player.addEventListener(P.ONLINE, () => fresh() && this.setLive());
+    player.addEventListener(P.OFFLINE, ended);
+    player.addEventListener(P.ENDED, ended);
   }
 
   private teardownPlayer() {
@@ -266,34 +313,9 @@ export class FeaturedStream extends LitElement {
     this.player = undefined;
   }
 
-  private setLive(i: number) {
-    this.idx = i;
+  private setLive() {
     this.live = true;
     this.kickPlay();
-  }
-
-  // Current channel offline -> try the next configured one. Bumping mountGen first makes
-  // the current player's remaining events no-ops (so a duplicate OFFLINE/ENDED can't skip
-  // a channel). If all channels are offline, re-probe later so the panel can still appear.
-  private advance(Twitch: TwitchGlobal) {
-    this.mountGen++;
-    this.live = false;
-    this.idx++;
-    if (this.idx < this.channels.length) {
-      this.mountPlayer(Twitch, this.idx);
-    } else {
-      this.teardownPlayer();
-      this.scheduleRecheck(Twitch);
-    }
-  }
-
-  private scheduleRecheck(Twitch: TwitchGlobal) {
-    if (this.recheckTimer) clearTimeout(this.recheckTimer);
-    this.recheckTimer = setTimeout(() => {
-      this.recheckTimer = null;
-      this.idx = 0;
-      this.mountPlayer(Twitch, 0);
-    }, RECHECK_MS);
   }
 
   // Autoplay can be blocked while the panel is hidden; once it's visible, nudge playback.
@@ -317,9 +339,8 @@ export class FeaturedStream extends LitElement {
   }
 
   private openStream = () => {
-    const channel = this.channels[this.idx];
-    if (channel)
-      window.open(`https://twitch.tv/${channel}`, "_blank", "noopener");
+    if (this.channel)
+      window.open(`https://twitch.tv/${this.channel}`, "_blank", "noopener");
   };
 
   // The header is a drag handle: a click (no drag) opens the stream, a drag (past a small
@@ -403,10 +424,7 @@ export class FeaturedStream extends LitElement {
     this.dismissed = true;
     this.dragPos = null;
     this.mountGen++; // stale player callbacks fail fresh() and become no-ops
-    if (this.recheckTimer) {
-      clearTimeout(this.recheckTimer);
-      this.recheckTimer = null;
-    }
+    this.clearPoll();
     this.teardownPlayer();
   }
 
@@ -429,8 +447,8 @@ export class FeaturedStream extends LitElement {
   private onClose = () => this.dismiss(this.adFree);
 
   render() {
-    if (!this.channels.length || this.dismissed) return html``;
-    const channel = this.channels[this.idx] ?? "";
+    if (this.channel === null || this.dismissed) return html``;
+    const channel = this.channel;
     const min = this.minimized;
     // Twitch pauses the player when it's off-screen/clipped (and hiding the embed violates
     // Twitch ToS), so "minimized" stays a small but still-visible corner thumbnail that

--- a/tests/client/components/FeaturedStream.test.ts
+++ b/tests/client/components/FeaturedStream.test.ts
@@ -3,6 +3,7 @@ import featuredStream from "../../../resources/featured-stream.json";
 import { getFeaturedStream } from "../../../src/client/Api";
 import { ClientEnv } from "../../../src/client/ClientEnv";
 import {
+  channelToEmbed,
   cornerFromCenter,
   isOffFrame,
 } from "../../../src/client/FeaturedStream";
@@ -130,6 +131,28 @@ describe("FeaturedStream", () => {
     it("falls back when the request rejects (network error)", async () => {
       stubFetch(() => Promise.reject(new Error("network down")));
       expect(await getFeaturedStream()).toEqual(off);
+    });
+  });
+
+  describe("channelToEmbed", () => {
+    const cfg = (enabled: boolean, channels: string[]) =>
+      FeaturedStreamSchema.parse({ enabled, channels });
+
+    it("embeds nothing when the API reports no live channel", () => {
+      // The API lists only channels its Helix poll sees live, so an empty list means
+      // "nobody is live" — the client must not load the Twitch SDK or a player at all.
+      expect(channelToEmbed(cfg(false, []))).toBeNull();
+      expect(channelToEmbed(cfg(true, []))).toBeNull();
+    });
+
+    it("embeds nothing when disabled, even with channels listed", () => {
+      expect(channelToEmbed(cfg(false, ["openfrontmasters"]))).toBeNull();
+    });
+
+    it("takes the first channel as the API's priority order", () => {
+      expect(channelToEmbed(cfg(true, ["openfrontmasters", "openfront"]))).toBe(
+        "openfrontmasters",
+      );
     });
   });
 

--- a/tests/client/components/FeaturedStreamPanel.test.ts
+++ b/tests/client/components/FeaturedStreamPanel.test.ts
@@ -52,6 +52,9 @@ const cfg = (
 
 describe("featured-stream panel", () => {
   beforeEach(async () => {
+    // shouldAdvanceTime keeps awaited microtask/0ms hops working while still letting a test
+    // inspect pending timers and jump the poll interval.
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     FakePlayer.constructed = [];
     FakePlayer.last = undefined;
     localStorage.clear();
@@ -64,6 +67,8 @@ describe("featured-stream panel", () => {
   afterEach(() => {
     document.body.innerHTML = "";
     delete (window as unknown as { Twitch?: unknown }).Twitch;
+    delete (window as unknown as { adsEnabled?: boolean }).adsEnabled;
+    vi.useRealTimers();
     vi.clearAllMocks();
   });
 
@@ -117,6 +122,59 @@ describe("featured-stream panel", () => {
     FakePlayer.last!.fire(FakePlayer.READY);
     await el.updateComplete;
     expect(card()).toBeNull();
+  });
+
+  // Closing must stop everything: no poll left scheduled, no player rebuilt. Minimizing
+  // deliberately does not, because Twitch's terms disallow an obscured embed, so the
+  // minimized panel stays a visible thumbnail that keeps playing.
+  describe("after the user closes the panel", () => {
+    const clickByLabel = (el: HTMLElement, label: string) => {
+      const btn = el.querySelector(
+        `[aria-label="${label}"]`,
+      ) as HTMLElement | null;
+      expect(btn, `no button labelled ${label}`).not.toBeNull();
+      btn!.click();
+    };
+
+    const openThenClose = async () => {
+      // The x only exists for ad-free users, and only once minimized.
+      (window as unknown as { adsEnabled?: boolean }).adsEnabled = false;
+      const el = await mount(cfg(true, ["openfrontmasters"]));
+      FakePlayer.last!.fire(FakePlayer.READY);
+      await el.updateComplete;
+      clickByLabel(el, "featured_stream.minimize");
+      await el.updateComplete;
+      clickByLabel(el, "common.close");
+      await el.updateComplete;
+      return el;
+    };
+
+    it("removes the panel and stops polling entirely", async () => {
+      await openThenClose();
+      expect(card()).toBeNull();
+      const before = getFeaturedStream.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      expect(getFeaturedStream).toHaveBeenCalledTimes(before); // no further requests
+      expect(FakePlayer.constructed).toEqual(["openfrontmasters"]); // no new player
+    });
+
+    // Positive control: the same 10 minute jump does keep polling while the panel is only
+    // waiting for someone to go live, so the assertion above is not vacuous.
+    it("(control) keeps polling while nobody is live", async () => {
+      await mount(cfg(true, []));
+      const before = getFeaturedStream.mock.calls.length;
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      expect(getFeaturedStream.mock.calls.length).toBeGreaterThan(before);
+    });
+
+    it("does not come back when a game ends", async () => {
+      const el = await openThenClose();
+      document.dispatchEvent(new CustomEvent("leave-lobby"));
+      await el.updateComplete;
+      await vi.advanceTimersByTimeAsync(10 * 60_000);
+      expect(card()).toBeNull();
+      expect(FakePlayer.constructed).toEqual(["openfrontmasters"]);
+    });
   });
 
   it("hides the panel when a live stream ends mid-session", async () => {

--- a/tests/client/components/FeaturedStreamPanel.test.ts
+++ b/tests/client/components/FeaturedStreamPanel.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FeaturedStreamConfig } from "../../../src/core/ApiSchemas";
+
+// Mounting behaviour of the <featured-stream> panel. The point of these tests is the
+// request cost: liveness used to be detected in the browser by constructing a real
+// autoplaying Twitch.Player for each configured channel and reading its ONLINE/OFFLINE
+// events, which cost ~300 Twitch requests on every homepage load even when nobody was
+// live and the panel stayed invisible. The API now serves only live channels, so an empty
+// list must construct no player at all.
+const getFeaturedStream = vi.fn<() => Promise<FeaturedStreamConfig>>();
+vi.mock("../../../src/client/Api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../src/client/Api")>()),
+  getFeaturedStream: () => getFeaturedStream(),
+}));
+
+// Stand-in for the Twitch Embed SDK: records every player constructed and lets a test
+// drive the player events the real embed fires.
+class FakePlayer {
+  static readonly READY = "ready";
+  static readonly ONLINE = "online";
+  static readonly OFFLINE = "offline";
+  static readonly ENDED = "ended";
+  static constructed: string[] = [];
+  static last: FakePlayer | undefined;
+
+  ended = false;
+  private handlers = new Map<string, () => void>();
+
+  constructor(_el: HTMLElement, opts: Record<string, unknown>) {
+    FakePlayer.constructed.push(String(opts.channel));
+    FakePlayer.last = this;
+  }
+  addEventListener(event: string, cb: () => void) {
+    this.handlers.set(event, cb);
+  }
+  getEnded() {
+    return this.ended;
+  }
+  play() {}
+  pause() {}
+  setMuted() {}
+  destroy() {}
+  fire(event: string) {
+    this.handlers.get(event)?.();
+  }
+}
+
+const cfg = (
+  enabled: boolean,
+  channels: string[] = [],
+): FeaturedStreamConfig => ({ enabled, channels });
+
+describe("featured-stream panel", () => {
+  beforeEach(async () => {
+    FakePlayer.constructed = [];
+    FakePlayer.last = undefined;
+    localStorage.clear();
+    (window as unknown as { Twitch: unknown }).Twitch = { Player: FakePlayer };
+    // Importing registers the custom element; the SDK loader short-circuits on the
+    // window.Twitch set above, so no script tag is ever appended.
+    await import("../../../src/client/FeaturedStream");
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    delete (window as unknown as { Twitch?: unknown }).Twitch;
+    vi.clearAllMocks();
+  });
+
+  const mount = async (config: FeaturedStreamConfig) => {
+    getFeaturedStream.mockResolvedValue(config);
+    const el = document.createElement("featured-stream") as HTMLElement & {
+      updateComplete: Promise<boolean>;
+    };
+    document.body.appendChild(el);
+    await el.updateComplete;
+    await vi.waitFor(() => expect(getFeaturedStream).toHaveBeenCalled());
+    await new Promise((r) => setTimeout(r, 0)); // let the async mount chain settle
+    await el.updateComplete;
+    return el;
+  };
+
+  const card = () => document.querySelector("#featured-stream-card");
+
+  it("constructs no Twitch player when the API reports nobody live", async () => {
+    await mount(cfg(true, []));
+    expect(FakePlayer.constructed).toEqual([]);
+    expect(card()).toBeNull();
+  });
+
+  it("constructs no Twitch player when the feature is off", async () => {
+    await mount(cfg(false, ["openfrontmasters"]));
+    expect(FakePlayer.constructed).toEqual([]);
+    expect(card()).toBeNull();
+  });
+
+  it("embeds exactly one player for the channel the API reports live", async () => {
+    await mount(cfg(true, ["openfrontmasters", "openfront"]));
+    // One mount, not one per configured channel: the API already did the liveness check.
+    expect(FakePlayer.constructed).toEqual(["openfrontmasters"]);
+    expect(card()).not.toBeNull();
+  });
+
+  it("shows the panel once the player reports it is playing", async () => {
+    const el = await mount(cfg(true, ["openfrontmasters"]));
+    expect(card()?.className).toContain("opacity-0"); // hidden while the player boots
+    FakePlayer.last!.fire(FakePlayer.READY);
+    await el.updateComplete;
+    expect(card()?.className).toContain("opacity-100");
+  });
+
+  it("hides the panel when the served config was stale and the channel is offline", async () => {
+    // Worst case of server-side liveness: the stream ended between the cron tick and this
+    // page load. An offline-at-load channel fires READY with getEnded() already true.
+    const el = await mount(cfg(true, ["openfrontmasters"]));
+    FakePlayer.last!.ended = true;
+    FakePlayer.last!.fire(FakePlayer.READY);
+    await el.updateComplete;
+    expect(card()).toBeNull();
+  });
+
+  it("hides the panel when a live stream ends mid-session", async () => {
+    const el = await mount(cfg(true, ["openfrontmasters"]));
+    FakePlayer.last!.fire(FakePlayer.READY);
+    await el.updateComplete;
+    expect(card()).not.toBeNull();
+
+    FakePlayer.last!.fire(FakePlayer.ENDED);
+    await el.updateComplete;
+    expect(card()).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

The featured-stream panel no longer works out liveness itself. `featured-stream.json` now lists only channels the API's Helix cron sees live, in priority order, so `channels[0]` is simply what to embed. Nothing Twitch-related loads until there is something to show.

Pairs with openfrontio/infra#488.

## Why

Liveness was detected by constructing a **real autoplaying `Twitch.Player`** for each configured channel and reading its `ONLINE`/`OFFLINE` events, walking the list until one was live. With 3 channels configured and none live, that boots three players behind an `opacity-0` panel.

Meaning many requests were constantly being sent out.. That is not page breaking considering not much is happening on the main page. But still not the cleanest architecture..

## Result

Same measurement method, after:

| Scenario | Before | After |
|---|---|---|
| Nobody live | 327 | **0** — the SDK is never even fetched |
| Stale config, listed channel just went offline | 327 | 125 — one player boot, then the panel hides |

An offline period now costs **one small JSON poll per minute** against our own API (60s edge cache) instead of a player mount per channel.

## Correctness

The mounted player is still watched, so this does not depend on the served config being perfectly fresh:

- `OFFLINE` / `ENDED` hides the panel and resumes polling. Covers a stream ending mid-session.
- An offline-at-load channel fires `READY` with `getEnded()` already true (no `OFFLINE`), read synchronously as before. Covers the ~3 min worst case staleness of the served config (2 min cron + 60s edge cache).

Unchanged: the CrazyGames/desktop-shell exclusion, the ad-free close and its per-day persistence, minimize, drag/corner snapping, flick-to-dismiss, and staying up through the lobby wait.

Two side benefits:
- The embed is now only ever constructed when it **will be visible**, which sits better with Twitch's rule against obscured embeds. Previously an offline player sat on the page hidden.
- Visitors' IPs and player fingerprints only reach Twitch when a stream is actually being shown to them.

## Deploy order

Merge openfrontio/infra#488 first. If this ships first the API still serves the unfiltered list; the panel then embeds `channels[0]` and hides it if it turns out to be offline, so nothing breaks, but the multi-channel walk is gone until infra lands (a lower-priority live channel would not be picked up).

## Tests

`npx vitest run tests/client` — 65 files, 777 passed.

New `tests/client/components/FeaturedStreamPanel.test.ts` mounts the component with a fake SDK and asserts the regression directly:
- **no `Twitch.Player` is constructed when the API reports nobody live** (and none when the feature is off)
- exactly one player for the live channel, not one per configured channel
- panel appears once the player reports playing
- panel hides on a stale config, and on a stream ending mid-session

Plus `channelToEmbed` unit tests for the config-to-channel decision.