### PR TITLE
accept # as . in adding friends

### DIFF
--- a/src/client/components/FriendsList.ts
+++ b/src/client/components/FriendsList.ts
@@ -96,7 +96,9 @@ export class FriendsList extends LitElement {
   }
 
   private async handleSend(): Promise<void> {
-    const target = this.addInput.trim();
+    // Names render as `wonder#5005` but resolve on the stored `wonder.5005`
+    // form, so accept either. Public ids never contain "#".
+    const target = this.addInput.trim().replace(/#/g, ".");
     if (!target) return;
     if (target === this.myPublicId) {
       showToast(translateText("friends.cannot_friend_self"), "red");

--- a/src/client/components/FriendsList.ts
+++ b/src/client/components/FriendsList.ts
@@ -96,9 +96,11 @@ export class FriendsList extends LitElement {
   }
 
   private async handleSend(): Promise<void> {
-    // Names render as `wonder#5005` but resolve on the stored `wonder.5005`
-    // form, so accept either. Public ids never contain "#".
-    const target = this.addInput.trim().replace(/#/g, ".");
+    // Names render as `wonder #5005` — with a non-breaking space (see
+    // usernameText) that survives a copy-paste — but resolve on the stored
+    // `wonder.5005` form, so accept either. `\s` covers the nbsp. Public ids
+    // never contain "#".
+    const target = this.addInput.trim().replace(/\s*#\s*/g, ".");
     if (!target) return;
     if (target === this.myPublicId) {
       showToast(translateText("friends.cannot_friend_self"), "red");


### PR DESCRIPTION
## Description:

replace(/\s*#\s*/g, "."). JS \s matches U+00A0, so wonder\u00a0#5005, wonder #5005, wonder#5005, and wonder.5005 all normalize to wonder.5005

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
