### PR TITLE
Better info.json documentation 🗺️

### DIFF
--- a/docs/Maps.md
+++ b/docs/Maps.md
@@ -1,0 +1,11 @@
+# Maps
+
+OpenFront maps are created and maintained with the Go-based [MapGenerator](../map-generator/README.md).
+
+See the MapGenerator README for information about
+
+- [Creating a new map](../map-generator/README.md#creating-a-new-map)
+- [`info.json` schema](../map-generator/README.md#create-infojson)
+- [Impassable terrain](../map-generator/README.md#impassable-terrain)
+- [Output files](../map-generator/README.md#output-files)
+- [Command line flags](../map-generator/README.md#command-line-flags)

--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -103,51 +103,86 @@ In-Game, the color of a tile is determined dynamically based on its **Terrain Ty
 
 ## Create info.json
 
-The map-generator will process your input file at `assets/maps/<map_name>/info.json` to determine the
-position of Nations, their starting coordinates, and any flags.
+The map-generator reads `assets/maps/<map_name>/info.json` to determine nation positions, starting coordinates, flags, and other map metadata.
 
-Example:
+### Example
 
 ```json
 {
   "id": "MySampleMap",
   "name": "My Sample Map",
   "translation_key": "map.mysamplemap",
-  "categories": ["europe"],
+  "categories": ["europe", "featured"],
   "multiplayer_frequency": 4,
+  "featured_rank": 5,
+  "layers": [
+    {
+      "id": "roads",
+      "placement": "land",
+      "nukeable": true
+    }
+  ],
   "nations": [
     {
       "coordinates": [396, 364],
       "name": "United States",
       "flag": "us"
+    },
+    {
+      "coordinates": [512, 280],
+      "name": "Canada",
+      "flag": "ca"
     }
   ]
 }
 ```
 
-`coordinates` is x/y position of the nation spawn on the map. Origin is at top left, with x extending right and y extending down
+### Fields
 
-`id` is the `CamelCaseName` of your map. It must match the `assets/maps/<map_name>` folder name (lowercased) and becomes the `GameMapType` enum key.
+| Field                   | Required | Description                                                                                                                                                                                                                      |
+| ----------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`                    | ✅       | `CamelCaseName` of the map. Must match the `assets/maps/<map_name>` folder name (case-insensitive). Becomes the `GameMapType` enum key.                                                                                          |
+| `name`                  | ✅       | Canonical name — the `GameMapType` enum value. **Must never change** once the map ships (it is part of the wire format and stored in game records).                                                                              |
+| `translation_key`       | ✅       | Key in `../resources/lang/en.json`. Must be `map.<foldername>`.                                                                                                                                                                  |
+| `categories`            | ✅       | One or more category strings (see below). No duplicates. Must have at least one entry. Groups the map in the map picker.                                                                                                         |
+| `multiplayer_frequency` |          | How often the map appears in the public multiplayer playlist. Use `0` (or omit) to exclude from rotation.                                                                                                                        |
+| `display_name`          |          | English display name written to `../resources/lang/en.json`. Defaults to `name`. Set only when the display name differs from the canonical name (e.g. `"MENA"`, `"Europe (Classic)"`).                                           |
+| `featured_rank`         |          | Position in the featured grid (`1` = first). Requires `"featured"` in `categories`. Unranked featured maps sort after ranked ones, alphabetically.                                                                               |
+| `special_team_count`    |          | Preferred team count for team/special games — see `SPECIAL_TEAM_MAPS` in `../src/server/MapPlaylist.ts`. Must be `0` or `≥ 2` (1 is not allowed).                                                                                |
+| `custom_tribes`         |          | Array of tribe names or `{ "name": "...", "coordinates": [x, y] }` objects. Coordinates are optional (omit for random spawn). Tribe names must be unique and must not collide with `nations[].name`. Empty strings are rejected. |
+| `themes`                |          | Array of theme strings for tribe name generation.                                                                                                                                                                                |
+| `layers`                |          | Array of map layer definitions rendered between terrain and territory (see below).                                                                                                                                               |
+| `nations`               |          | Array of nation objects (see below).                                                                                                                                                                                             |
 
-`name` is the map's canonical name — the `GameMapType` enum value. It must never change once the map ships (it is part of the wire format and stored in game records).
+### Categories
 
-`display_name` (optional) is the English display name written to the `map` section of `../resources/lang/en.json`. It defaults to `name` — set it only when the display name should differ from the canonical name (e.g. `MENA`, `Europe (Classic)`).
+Each entry in `categories` must be one of:
 
-`translation_key` is the key of the map's display name in `../resources/lang/en.json`. It must be `map.<map_name>`.
+`featured`, `new`, `world`, `continental`, `europe`, `asia`, `north_america`, `africa`, `south_america`, `oceania`, `antarctica`, `countries`, `cosmic`, `fictional`, `arcade`, `tournament`
 
-`categories` groups the map in the map picker. Each entry must be one of: `new`, `featured`, `continental`, `world`, `europe`, `asia`, `north_america`, `africa`, `south_america`, `oceania`, `antarctica`, `countries`, `cosmic`, `tournament`, `fictional`, `arcade`. Maps that straddle regions (e.g. Black Sea, Bering Strait) can list more than one. Add `featured` to show the map in the featured section of the map picker.
+Maps that straddle regions (e.g. Black Sea, Bering Strait) can list more than one. Add `featured` to show the map in the featured section of the map picker.
 
-`multiplayer_frequency` is how many times the map appears in the public multiplayer playlist. Use 0 (or omit) to keep the map out of the regular rotation.
+### Nations
 
-`featured_rank` (optional, featured maps only) is the map's position in the featured grid (1 = first). Featured maps without a rank sort after ranked ones, alphabetically.
+Each nation object has:
 
-`special_team_count` (optional) is the map's preferred team count in team / special games — see `SPECIAL_TEAM_MAPS` in `../src/server/MapPlaylist.ts`. Omit it for no preference.
+| Field         | Required | Description                                                                                                                                                                                                                                       |
+| ------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`        | ✅       | Display name of the nation.                                                                                                                                                                                                                       |
+| `coordinates` |          | `[x, y]` position of the nation spawn. Origin is top-left, x extends right, y extends down. Omit for random spawn.                                                                                                                                |
+| `flag`        |          | ISO 3166 country code (e.g. `"us"`, `"ca"`, `"de"`). The full list of supported codes is in `../src/client/data/countries.json`. For quick reference, see [ISO 3166 country codes](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes). |
 
-`flag` is the code for a country
+### Layers
 
-- The full list of supported codes can be seen in `../src/client/data/countries.json` - all ISO_3166 codes are supported, with several additions.
+Layers are PNG overlays rendered between terrain and territory, useful for decorations. Each layer is a separate PNG file in `assets/maps/<map_name>/` named `<id>.png`.
 
-- For quick reference, [Use country codes found here](https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes)
+| Field       | Required | Description                                                                                                                                           |
+| ----------- | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`        | ✅       | Unique identifier for the layer. Also the PNG filename (without extension). Must be alphanumeric (hyphens allowed). Must not be `"image"` (reserved). |
+| `placement` | ✅       | `"land"` or `"water"` — whether the layer sits on land (and impassable terrain) or water tiles.                                                       |
+| `nukeable`  |          | If `true`, the layer is permanently destroyed in nuke impact radii. Defaults to `false`.                                                              |
+
+Layer display names are stored in the `map_layers` section of `../resources/lang/en.json` (keyed by layer id). Players can disable layers in the graphics settings.
 
 ## Update CREDITS.md
 


### PR DESCRIPTION
## Description:

Restructured the `## Create info.json` section in the map-generator README with proper sub-headings and tables, documented all fields (including previously missing `custom_tribes`, `themes`, and the new `layers` option), and created a new `docs/Maps.md` entry point linking into the MapGenerator README.

Changes:
- `map-generator/README.md`: Reorganized the info.json docs into `### Fields`, `### Categories`, `### Nations`, and `### Layers` sub-sections with tables. Added `layers` field documentation (id, placement, nukeable) and an example in the JSON sample. Marked nation `coordinates` as optional (omit for random spawn). Added `custom_tribes` and `themes` fields that were previously undocumented.
- `docs/Maps.md`: New file that links to the MapGenerator README sections for map creation, info.json schema, impassable terrain, output files, and CLI flags.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin