### PR TITLE
fix(nukes): pick closest silo with a clear path around impassable terrain

### DIFF
--- a/src/client/controllers/BuildPreviewController.ts
+++ b/src/client/controllers/BuildPreviewController.ts
@@ -19,6 +19,7 @@ import {
 } from "../../core/game/Game";
 import { TileRef } from "../../core/game/GameMap";
 import { UserSettings } from "../../core/game/UserSettings";
+import { clearParabolaDirection } from "../../core/pathfinding/PathFinder.Parabola";
 import { Controller } from "../Controller";
 import {
   ConfirmGhostStructureEvent,
@@ -85,6 +86,7 @@ export class BuildPreviewController implements Controller {
   private nukeTrajectoryStatic: {
     srcX: number;
     srcY: number;
+    directionUp: boolean;
     sams: SAMInfo[];
     isBlocked: (x: number, y: number) => boolean;
   } | null = null;
@@ -149,7 +151,7 @@ export class BuildPreviewController implements Controller {
               w.x - 0.5,
               w.y - 0.5,
               this.game.height(),
-              this.uiState.rocketDirectionUp,
+              traj.directionUp,
               traj.sams,
               traj.isBlocked,
             ),
@@ -316,9 +318,10 @@ export class BuildPreviewController implements Controller {
 
     // Mirror PlayerImpl.nukeSpawn (the source NukeExecution actually fires
     // from): only silos that are active, not reloading, and not under
-    // construction are eligible, and the nearest is chosen by Manhattan
-    // distance. Keeping these in sync prevents the preview arc from
-    // originating from a silo the game wouldn't use.
+    // construction are eligible, and the nearest (Manhattan distance) whose
+    // parabola avoids impassable terrain on the up or down curve is chosen.
+    // Keeping these in sync prevents the preview arc from originating from
+    // a silo the game wouldn't use.
     const silos = myPlayer
       .units(UnitType.MissileSilo)
       .filter(
@@ -331,15 +334,31 @@ export class BuildPreviewController implements Controller {
 
     const dstX = this.game.x(tileRef);
     const dstY = this.game.y(tileRef);
+    silos.sort(
+      (a, b) =>
+        Math.abs(this.game.x(a.tile()) - dstX) +
+        Math.abs(this.game.y(a.tile()) - dstY) -
+        (Math.abs(this.game.x(b.tile()) - dstX) +
+          Math.abs(this.game.y(b.tile()) - dstY)),
+    );
+
+    // NukeExecution flies the requested curve direction if clear, otherwise
+    // the opposite one — resolve the direction the sim would actually use.
+    // If every silo is blocked both ways, fall back to the nearest silo and
+    // the requested direction so the arc renders red with the blocked X.
     let bestSilo = silos[0];
-    let bestDist = Infinity;
+    let directionUp = this.uiState.rocketDirectionUp;
     for (const s of silos) {
-      const sx = this.game.x(s.tile());
-      const sy = this.game.y(s.tile());
-      const d = Math.abs(sx - dstX) + Math.abs(sy - dstY);
-      if (d < bestDist) {
-        bestDist = d;
+      const dir = clearParabolaDirection(
+        this.game,
+        s.tile(),
+        tileRef,
+        this.uiState.rocketDirectionUp,
+      );
+      if (dir !== null) {
         bestSilo = s;
+        directionUp = dir;
+        break;
       }
     }
     const srcX = this.game.x(bestSilo.tile());
@@ -396,6 +415,7 @@ export class BuildPreviewController implements Controller {
     this.nukeTrajectoryStatic = {
       srcX,
       srcY,
+      directionUp,
       sams,
       isBlocked: (x: number, y: number) => {
         if (!this.game.isValidCoord(x, y)) return false;

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -12,7 +12,10 @@ import {
 } from "../game/Game";
 import { TileRef } from "../game/GameMap";
 import { UniversalPathFinding } from "../pathfinding/PathFinder";
-import { ParabolaUniversalPathFinder } from "../pathfinding/PathFinder.Parabola";
+import {
+  clearParabolaDirection,
+  ParabolaUniversalPathFinder,
+} from "../pathfinding/PathFinder.Parabola";
 import { PathStatus } from "../pathfinding/types";
 import { PseudoRandom } from "../PseudoRandom";
 import { NukeType } from "../StatsSchemas";
@@ -193,16 +196,27 @@ export class NukeExecution implements Execution {
       // launch from the MIRV separation point, not a silo).
       this.src ??= spawn;
       // Nuke trajectories cannot pass over impassable terrain unless they are MIRV warheads, just as they
-      // cannot exceed the map border. Check the full parabola path before
-      // launching; if any tile is impassable, abort the launch.
+      // cannot exceed the map border. Fly the requested curve direction if
+      // it is clear, otherwise the opposite one; if both curves cross
+      // impassable terrain, abort the launch.
       if (this.nukeType !== UnitType.MIRVWarhead) {
-        const path = this.pathFinder.findPath(this.src, this.dst) ?? [];
-        for (const tile of path) {
-          if (this.mg.isImpassable(tile)) {
-            console.warn(`nuke trajectory crosses impassable terrain`);
-            this.active = false;
-            return;
-          }
+        const direction = clearParabolaDirection(
+          this.mg,
+          this.src,
+          this.dst,
+          this.rocketDirectionUp,
+        );
+        if (direction === null) {
+          console.warn(`nuke trajectory crosses impassable terrain`);
+          this.active = false;
+          return;
+        }
+        if (direction !== this.rocketDirectionUp) {
+          this.rocketDirectionUp = direction;
+          this.pathFinder = UniversalPathFinding.Parabola(this.mg, {
+            increment: this.speed,
+            directionUp: direction,
+          });
         }
       }
       this.nuke = this.player.buildUnit(this.nukeType, this.src, {

--- a/src/core/execution/nation/NationNukeBehavior.ts
+++ b/src/core/execution/nation/NationNukeBehavior.ts
@@ -13,6 +13,7 @@ import {
 } from "../../game/Game";
 import { TileRef, euclDistFN } from "../../game/GameMap";
 import { UniversalPathFinding } from "../../pathfinding/PathFinder";
+import { clearParabolaDirection } from "../../pathfinding/PathFinder.Parabola";
 import { PseudoRandom } from "../../PseudoRandom";
 import { assertNever, boundingBoxTiles } from "../../Util";
 import { NukeExecution } from "../NukeExecution";
@@ -144,12 +145,6 @@ export class NationNukeBehavior {
           difficulty === Difficulty.Impossible) &&
         this.isTrajectoryInterceptableBySam(spawnTile, tile)
       ) {
-        continue;
-      }
-
-      // On all difficulties, avoid trajectories that cross impassable terrain
-      // (the simulation aborts such launches — see NukeExecution).
-      if (this.isTrajectoryBlockedByImpassable(spawnTile, tile)) {
         continue;
       }
 
@@ -635,25 +630,17 @@ export class NationNukeBehavior {
 
   /**
    * Check if the parabolic nuke trajectory from spawnTile to targetTile
-   * crosses any impassable terrain. Mirrors the check in NukeExecution that
-   * aborts such launches
+   * crosses impassable terrain on BOTH curve directions. Mirrors
+   * NukeExecution, which flips to the opposite curve when the requested one
+   * is blocked and aborts only when both are.
    */
   private isTrajectoryBlockedByImpassable(
     spawnTile: TileRef,
     targetTile: TileRef,
   ): boolean {
-    const pathFinder = UniversalPathFinding.Parabola(this.game, {
-      increment: this.game.config().nukeSpeed(UnitType.AtomBomb),
-      distanceBasedHeight: true,
-      directionUp: true,
-    });
-    const path = pathFinder.findPath(spawnTile, targetTile) ?? [];
-    for (const tile of path) {
-      if (this.game.isImpassable(tile)) {
-        return true;
-      }
-    }
-    return false;
+    return (
+      clearParabolaDirection(this.game, spawnTile, targetTile, true) === null
+    );
   }
 
   private isValidNukeTile(t: TileRef, nukeTarget: Player | null): boolean {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -8,6 +8,7 @@ import {
   toInt,
   within,
 } from "../Util";
+import { clearParabolaDirection } from "../pathfinding/PathFinder.Parabola";
 import { AttackImpl } from "./AttackImpl";
 import {
   Alliance,
@@ -1464,14 +1465,29 @@ export class PlayerImpl implements Player {
     }
 
     // only get missilesilos that are not on cooldown and not under construction
-    const bestSilo = findClosestBy(
-      this.units(UnitType.MissileSilo),
-      (silo) => mg.manhattanDist(silo.tile(), tile),
+    const readySilos = this.units(UnitType.MissileSilo).filter(
       (silo) =>
         silo.isActive() && !silo.isInCooldown() && !silo.isUnderConstruction(),
     );
+    readySilos.sort(
+      (a, b) =>
+        mg.manhattanDist(a.tile(), tile) - mg.manhattanDist(b.tile(), tile),
+    );
 
-    return bestSilo?.tile() ?? false;
+    if (nukeType === UnitType.MIRV) {
+      // MIRVs fly to a separation point high above the map and their
+      // warheads are exempt from impassable checks, so any silo works.
+      return readySilos[0]?.tile() ?? false;
+    }
+
+    // Closest silo whose trajectory (up or down curve) avoids impassable
+    // terrain. NukeExecution picks the actual curve direction.
+    for (const silo of readySilos) {
+      if (clearParabolaDirection(mg, silo.tile(), tile, true) !== null) {
+        return silo.tile();
+      }
+    }
+    return false;
   }
 
   portSpawn(tile: TileRef, validTiles: TileRef[] | null): TileRef | false {

--- a/src/core/pathfinding/PathFinder.Parabola.ts
+++ b/src/core/pathfinding/PathFinder.Parabola.ts
@@ -11,6 +11,55 @@ export interface ParabolaOptions {
 
 const PARABOLA_MIN_HEIGHT = 50;
 
+// Fine sampling increment for impassable checks — independent of nuke speed
+// so that a fast nuke cannot "skip over" a thin impassable strip that a slow
+// one would hit.
+const BLOCKED_CHECK_INCREMENT = 1;
+
+/**
+ * True if the parabola from `from` to `to` crosses impassable terrain.
+ * Uses the same curve construction as nuke flight but samples it finely,
+ * so the result does not depend on the nuke's speed.
+ */
+export function isParabolaBlocked(
+  gameMap: GameMap,
+  from: TileRef,
+  to: TileRef,
+  directionUp: boolean,
+): boolean {
+  const finder = new ParabolaUniversalPathFinder(gameMap, {
+    increment: BLOCKED_CHECK_INCREMENT,
+    directionUp,
+  });
+  const path = finder.findPath(from, to) ?? [];
+  for (const tile of path) {
+    if (gameMap.isImpassable(tile)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Pick a curve direction whose parabola avoids impassable terrain:
+ * the preferred direction if clear, otherwise the opposite direction if
+ * clear, otherwise null (no clear path).
+ */
+export function clearParabolaDirection(
+  gameMap: GameMap,
+  from: TileRef,
+  to: TileRef,
+  preferUp: boolean,
+): boolean | null {
+  if (!isParabolaBlocked(gameMap, from, to, preferUp)) {
+    return preferUp;
+  }
+  if (!isParabolaBlocked(gameMap, from, to, !preferUp)) {
+    return !preferUp;
+  }
+  return null;
+}
+
 export class ParabolaUniversalPathFinder implements SteppingPathFinder<TileRef> {
   private curve: DistanceBasedBezierCurve | null = null;
   private lastTo: TileRef | null = null;

--- a/tests/ImpassableTerrain.test.ts
+++ b/tests/ImpassableTerrain.test.ts
@@ -44,13 +44,20 @@ function buildTerrain(
   height: number,
   wallX: number,
   wallWidth: number,
+  wallYMin = 0,
+  wallYMax = height,
 ): { data: Uint8Array; numLandTiles: number } {
   const data = new Uint8Array(width * height);
   let numLandTiles = 0;
   for (let y = 0; y < height; y++) {
     for (let x = 0; x < width; x++) {
       const idx = y * width + x;
-      if (x >= wallX && x < wallX + wallWidth) {
+      if (
+        x >= wallX &&
+        x < wallX + wallWidth &&
+        y >= wallYMin &&
+        y < wallYMax
+      ) {
         data[idx] = IMPASSABLE;
         // Impassable tiles are NOT counted as land tiles.
       } else {
@@ -62,11 +69,30 @@ function buildTerrain(
   return { data, numLandTiles };
 }
 
-async function setupImpassableGame(humans: PlayerInfo[] = []): Promise<Game> {
+async function setupImpassableGame(
+  humans: PlayerInfo[] = [],
+  opts?: { wallYMin?: number; wallYMax?: number },
+): Promise<Game> {
   vi.spyOn(console, "debug").mockImplementation(() => {});
 
-  const full = buildTerrain(MAP_W, MAP_H, WALL_X, WALL_WIDTH);
-  const mini = buildTerrain(MINI_W, MINI_H, Math.floor(WALL_X / 2), 1);
+  const wallYMin = opts?.wallYMin ?? 0;
+  const wallYMax = opts?.wallYMax ?? MAP_H;
+  const full = buildTerrain(
+    MAP_W,
+    MAP_H,
+    WALL_X,
+    WALL_WIDTH,
+    wallYMin,
+    wallYMax,
+  );
+  const mini = buildTerrain(
+    MINI_W,
+    MINI_H,
+    Math.floor(WALL_X / 2),
+    1,
+    Math.floor(wallYMin / 2),
+    Math.ceil(wallYMax / 2),
+  );
 
   const gameMap = await genTerrainFromBin(
     { width: MAP_W, height: MAP_H, num_land_tiles: full.numLandTiles },
@@ -462,6 +488,115 @@ describe("Impassable Terrain", () => {
       // No nukes should have been launched.
       const nukes = nukePlayer.units(UnitType.AtomBomb, UnitType.HydrogenBomb);
       expect(nukes.length).toBe(0);
+    });
+  });
+
+  // ── Nukes: silo selection & curve direction ───────────────────────────
+
+  describe("silo selection and curve direction around impassable terrain", () => {
+    async function setupSiloGame(opts?: {
+      wallYMin?: number;
+      wallYMax?: number;
+    }): Promise<{ g: Game; p: Player; o: Player }> {
+      const g = await setupImpassableGame(
+        [
+          new PlayerInfo("player", PlayerType.Human, "c1", "player_id"),
+          new PlayerInfo("other", PlayerType.Human, "c2", "other_id"),
+        ],
+        opts,
+      );
+      (g.config() as TestConfig).nukeMagnitudes = vi.fn(() => ({
+        inner: 5,
+        outer: 5,
+      }));
+      (g.config() as TestConfig).nukeAllianceBreakThreshold = vi.fn(() => 999);
+      (g.config() as TestConfig).setDefaultNukeSpeed(50);
+      return { g, p: g.player("player_id"), o: g.player("other_id") };
+    }
+
+    function buildSilo(g: Game, p: Player, x: number, y: number) {
+      p.conquer(g.ref(x, y));
+      p.buildUnit(UnitType.MissileSilo, g.ref(x, y), {});
+    }
+
+    test("closest silo with blocked trajectory is skipped for a farther clear silo", async () => {
+      const { g, p } = await setupSiloGame();
+      // 60 tiles from the target but on the other side of the wall —
+      // both curves are blocked.
+      buildSilo(g, p, 90, 100);
+      // 70 tiles from the target, same side — clear.
+      buildSilo(g, p, 150, 30);
+
+      const target = g.ref(150, 100);
+      expect(p.canBuild(UnitType.AtomBomb, target)).toBe(g.ref(150, 30));
+
+      const nuke = new NukeExecution(UnitType.AtomBomb, p, target);
+      g.addExecution(nuke);
+      executeTicks(g, 30);
+      expect(nuke.getNuke()).not.toBeNull();
+      expect(nuke.getNuke()!.reachedTarget()).toBe(true);
+    });
+
+    test("up curve blocked by impassable terrain flips to the down curve", async () => {
+      // Wall only spans y < 150: the up curve (arcing toward y=0) crosses
+      // it, the down curve passes underneath.
+      const { g, p } = await setupSiloGame({ wallYMax: 150 });
+      buildSilo(g, p, 50, 150);
+      const target = g.ref(150, 150);
+      expect(p.canBuild(UnitType.AtomBomb, target)).toBe(g.ref(50, 150));
+
+      // Requests the up curve (default).
+      const nuke = new NukeExecution(UnitType.AtomBomb, p, target);
+      g.addExecution(nuke);
+      executeTicks(g, 30);
+      expect(nuke.getNuke()).not.toBeNull();
+      expect(nuke.getNuke()!.reachedTarget()).toBe(true);
+    });
+
+    test("down curve blocked by impassable terrain flips to the up curve", async () => {
+      // Wall only spans y >= 50: the down curve (arcing toward y=199)
+      // crosses it, the up curve passes above.
+      const { g, p } = await setupSiloGame({ wallYMin: 50 });
+      buildSilo(g, p, 50, 30);
+      const target = g.ref(150, 30);
+      expect(p.canBuild(UnitType.AtomBomb, target)).toBe(g.ref(50, 30));
+
+      // Requests the down curve.
+      const nuke = new NukeExecution(
+        UnitType.AtomBomb,
+        p,
+        target,
+        null,
+        -1,
+        0,
+        false,
+      );
+      g.addExecution(nuke);
+      executeTicks(g, 30);
+      expect(nuke.getNuke()).not.toBeNull();
+      expect(nuke.getNuke()!.reachedTarget()).toBe(true);
+    });
+
+    test("canBuild returns false when both curves from every silo are blocked", async () => {
+      const { g, p } = await setupSiloGame();
+      buildSilo(g, p, 20, 100);
+      const target = g.ref(150, 100);
+      expect(p.canBuild(UnitType.AtomBomb, target)).toBe(false);
+
+      const nuke = new NukeExecution(UnitType.AtomBomb, p, target);
+      g.addExecution(nuke);
+      executeTicks(g, 5);
+      expect(nuke.isActive()).toBe(false);
+      expect(nuke.getNuke()).toBeNull();
+    });
+
+    test("MIRV silo selection ignores impassable trajectories", async () => {
+      const { g, p, o } = await setupSiloGame();
+      buildSilo(g, p, 20, 100);
+      // MIRV targets must be owned; the warheads are exempt from
+      // impassable checks, so the blocked silo is still chosen.
+      o.conquer(g.ref(150, 100));
+      expect(p.canBuild(UnitType.MIRV, g.ref(150, 100))).toBe(g.ref(20, 100));
     });
   });
 });


### PR DESCRIPTION
## Problem

Silo selection for nuke launches picked the closest silo by Manhattan distance with no path awareness. When that silo's parabola crossed impassable terrain, the launch was accepted (`canBuild` succeeded) and then silently aborted in `NukeExecution` — even when a slightly farther silo had a clear shot, or when the *other* curve direction (up vs down) from the same silo was clear.

## Changes

**Silo selection** (`PlayerImpl.nukeSpawn`)
- Ready silos are walked in Manhattan-distance order; the first one whose trajectory avoids impassable terrain on the up **or** down curve is chosen.
- If no silo has a clear curve, `canBuild` returns `false`, so the UI shows the target as unbuildable up front instead of accepting a launch that would abort.
- MIRVs keep plain closest-silo selection: they fly to a separation point high above the map and their warheads are exempt from impassable checks.

**Curve direction** (`NukeExecution`)
- The nuke flies the requested curve direction if it is clear, automatically flips to the opposite curve if not, and aborts only when both cross impassable terrain. The recorded trajectory (used by SAMs) and the client motion plan both use the resolved direction.

**Speed-independent blocked checks** (`PathFinder.Parabola`)
- New shared `isParabolaBlocked` / `clearParabolaDirection` helpers sample the curve at a fixed fine increment instead of the nuke's speed. Previously a fast nuke could "tunnel" through a thin impassable strip between samples that a slow nuke would hit.

**Consumers kept in sync**
- Nation AI: `isTrajectoryBlockedByImpassable` now means "blocked on both curves" (matching the sim's flip behavior); the per-target check in `maybeSendNuke` was removed since `canBuild` now guarantees it.
- Build preview: the trajectory arc originates from the silo the sim would actually pick and draws the curve direction that will actually fly, falling back to the nearest silo + requested direction (red X) when everything is blocked.

## Tests

Five new tests in `ImpassableTerrain.test.ts` (terrain builder now supports partial-height walls so the two curves can be blocked independently):
- a closer blocked silo is skipped for a farther clear one (verified through full flight to `reachedTarget()`)
- up curve blocked → flips to down curve; down curve blocked → flips to up curve
- both curves blocked from every silo → `canBuild` returns `false` and the execution never builds a unit
- MIRV silo selection ignores impassable trajectories

Full suite passes (2842 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)