### PR TITLE
perf(store): fix packs tab stutter (animated drop-shadow filters + per-tile backdrop blur)

### DIFF
--- a/src/client/components/CosmeticContainer.ts
+++ b/src/client/components/CosmeticContainer.ts
@@ -221,7 +221,9 @@ export class CosmeticContainer extends LitElement {
     this.style.position = "relative";
     this.style.background = `linear-gradient(to top, ${cfg.gradient} 0%, rgba(15,15,20,0.85) 100%)`;
     this.style.border = `1px solid ${this.selected ? cfg.glow : cfg.border}`;
-    this.style.backdropFilter = "blur(8px)";
+    // No per-tile backdrop-filter: the tile gradient is ~85% opaque over the
+    // modal's already-blurred shell, so the blur is invisible — but dozens of
+    // blur surfaces made every animated frame in the store expensive.
     this.style.borderRadius = "0.75rem";
     this.style.transition =
       "border-color 0.2s, background 0.2s, transform 0.2s cubic-bezier(0.34, 1.56, 0.64, 1), box-shadow 0.2s";

--- a/src/client/components/PlutoniumIcon.ts
+++ b/src/client/components/PlutoniumIcon.ts
@@ -6,21 +6,18 @@ const STYLE_ID = "plutonium-icon-styles";
 if (!document.getElementById(STYLE_ID)) {
   const style = document.createElement("style");
   style.id = STYLE_ID;
+  // Only compositor-animatable properties (transform/opacity) may appear in
+  // these keyframes: animating filter/drop-shadow here re-rasterizes every
+  // icon each frame and forces the store's backdrop-blur surfaces to redraw,
+  // which stutters the whole packs menu (see #4816 follow-up).
   style.textContent = `
     @keyframes plutonium-pulse {
-      0%   { filter: drop-shadow(0 0 4px rgba(34,197,94,0.6)) drop-shadow(0 0 8px rgba(34,197,94,0.3)); scale: 1; }
-      50%  { filter: drop-shadow(0 0 10px rgba(34,197,94,0.9)) drop-shadow(0 0 20px rgba(34,197,94,0.5)) drop-shadow(0 0 30px rgba(34,197,94,0.2)); scale: 1.04; }
-      100% { filter: drop-shadow(0 0 4px rgba(34,197,94,0.6)) drop-shadow(0 0 8px rgba(34,197,94,0.3)); scale: 1; }
+      0%, 100% { opacity: 0.45; transform: scale(1); }
+      50%      { opacity: 1;    transform: scale(1.12); }
     }
     @keyframes plutonium-rotate {
       0%   { transform: rotate(0deg); }
       100% { transform: rotate(360deg); }
-    }
-    @keyframes plutonium-jiggle {
-      0%, 100% { translate: 0 0; }
-      25%  { translate: -0.4px 0.3px; }
-      50%  { translate: 0.3px -0.4px; }
-      75%  { translate: -0.3px -0.3px; }
     }
   `;
   document.head.appendChild(style);
@@ -38,15 +35,17 @@ export class PlutoniumIcon extends LitElement {
   render() {
     return html`
       <div
-        class="inline-flex items-center justify-center"
-        style="width:${this.size}px; height:${this
-          .size}px; animation: plutonium-pulse 2s ease-in-out infinite, plutonium-jiggle 0.15s linear infinite;"
+        class="relative inline-flex items-center justify-center"
+        style="width:${this.size}px; height:${this.size}px;"
       >
+        <div
+          style="position:absolute; inset:-25%; pointer-events:none; background:radial-gradient(circle, rgba(34,197,94,0.5) 0%, rgba(34,197,94,0.22) 40%, transparent 68%); animation: plutonium-pulse 2s ease-in-out infinite; will-change: transform, opacity;"
+        ></div>
         <img
           src=${assetUrl("images/PlutoniumIcon.svg")}
           alt="Plutonium"
-          style="width:${this.size}px; height:${this
-            .size}px; animation: plutonium-rotate 7s linear infinite;"
+          style="position:relative; width:${this.size}px; height:${this
+            .size}px; filter: drop-shadow(0 0 4px rgba(34,197,94,0.6)); animation: plutonium-rotate 7s linear infinite; will-change: transform;"
           draggable="false"
         />
       </div>


### PR DESCRIPTION
## Problem

The store's packs tab on openfront.io is slow and stuttery, while local dev feels fine. Local dev has no API, so no packs render — the regression only appears when pack tiles are present.

## Diagnosis

Reproduced production locally by intercepting `cosmetics.json` with the real prod catalog (7 plutonium packs) and measuring the store in a headless-Chromium harness:

| Condition | FPS | Median frame |
|---|---|---|
| Packs tab as shipped | **17.7** | 50ms (104/106 frames > 33ms) |
| Plutonium icon animations paused | **60.0** | 16.7ms |

Each `plutonium-icon` runs three infinite CSS animations, and **any one of them alone** tanks the tab to ~16fps:

- `plutonium-pulse` animates `filter: drop-shadow(...)` (2–3 stacked shadows) — not compositor-animatable, re-rasterizes the icon every frame
- `plutonium-jiggle` — a 0.15s infinite ±0.4px jitter, visually imperceptible but keeps the compositor permanently busy
- `plutonium-rotate` — fine by itself in principle, but every animated frame re-renders a scene containing **867 elements with `backdrop-filter: blur(8px)`** (every cosmetic tile + modal shell)

A devtools trace confirmed the main thread is nearly idle — the cost is all compositor/raster work, which is exactly what stutters iGPU/mid-range machines. `plutonium-icon` is also used in the header `currency-display`, so logged-in users paid this cost outside the packs grid too.

## Fix

- **PlutoniumIcon**: the pulse is now a pre-blurred radial-gradient glow layer animating only `opacity`/`transform` (compositor-only), with a static drop-shadow on the icon; the jiggle is removed; the 7s rotation stays. `will-change` hints added.
- **CosmeticContainer**: drop the per-tile `backdrop-filter: blur(8px)`. Tile backgrounds are ~85%-opaque gradients over the already-blurred modal shell, so the per-tile blur is visually invisible — but it multiplied blur surfaces 867 → 21.

## Results

Same harness after the change: **~39fps with all animations running** (up from 17.7), and the median frame reaches 16.7ms (60fps) once the modal-shell blur — trivial for real GPUs, slow only under the harness's software rasterizer — is excluded. Before/after screenshots are visually identical (glow pulse look preserved).

Caveat: absolute numbers come from software-rendered headless Chromium, which exaggerates raster cost; the eliminated work (per-frame filter rasterization × dozens of blur surfaces) is what matters on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
