### PR TITLE
fix(lang): change missile intercepted notification to SAM intercepted

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -506,7 +506,7 @@
     "focus": "Focus",
     "hydrogen_bomb_detonated": "{name} - hydrogen bomb detonated",
     "ignore": "Ignore",
-    "missile_intercepted": "Missile intercepted {unit}",
+    "missile_intercepted": "SAM intercepted {unit}",
     "no_boats_available": "No boats available, max {max}",
     "received_gold_from_captured_ship": "Received {gold} gold from ship captured from {name}",
     "received_gold_from_conquest": "Conquered {name}, received {gold} gold",


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves n/a
## Description:

When a SAM launcher shoots down an incoming nuke, the event log currently says `"Missile intercepted [Unit]"` (e.g., *"Missile intercepted Atom Bomb"*). Since both the interceptor and the nuke are missiles, the phrasing feels a bit awkward.

I updated the `"missile_intercepted"` string to `"SAM intercepted {unit}"` (e.g., *"SAM intercepted Atom Bomb"*). This makes it immediately clear that your SAM did the intercepting and matches the rest of the in-game SAM terminology (*"SAM Launcher"*, *"SAMs Disabled"*).

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

blontd6