### PR TITLE
fix(core): reject spawn intents after the spawn phase

### DIFF
--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -72,6 +72,16 @@ export class Executor {
       case "move_warship":
         return new MoveWarshipExecution(player, intent.unitIds, intent.tile);
       case "spawn":
+        // Security: a spawn intent is only honored during the spawn phase. Once
+        // it ends, a client relaying a spawn intent is attempting the "late
+        // spawn" exploit — skipping the spawn phase to materialize a base on the
+        // running map, or teleporting an existing one by relinquishing and
+        // re-conquering elsewhere. Drop it to a deterministic no-op on every
+        // client. Internal spawns (nations, bots, random spawn) construct
+        // SpawnExecution directly and are unaffected.
+        if (!this.mg.inSpawnPhase()) {
+          return new NoOpExecution();
+        }
         return new SpawnExecution(this.gameID, player.info(), intent.tile);
       case "boat":
         return new TransportShipExecution(player, intent.dst, intent.troops);

--- a/tests/SpawnAfterPhase.test.ts
+++ b/tests/SpawnAfterPhase.test.ts
@@ -1,0 +1,90 @@
+import { Executor } from "../src/core/execution/ExecutionManager";
+import { NoOpExecution } from "../src/core/execution/NoOpExecution";
+import { SpawnExecution } from "../src/core/execution/SpawnExecution";
+import { PlayerInfo, PlayerType } from "../src/core/game/Game";
+import { ClientID, GameID, StampedIntent } from "../src/core/Schemas";
+import { setup } from "./util/Setup";
+
+const gameID: GameID = "game_id";
+
+function spawnIntent(clientID: ClientID, tile: number): StampedIntent {
+  return { type: "spawn", tile, clientID } as StampedIntent;
+}
+
+// Regression guard for the "late spawn" exploit: a modified client that relays a
+// { type: "spawn", tile } intent AFTER the spawn phase has ended must not place
+// any territory. A client's only untrusted input is the intent, and every honest
+// client turns that intent into an execution through Executor.createExec — so the
+// authoritative gate lives there. The client-side guard in ClientGameRunner is UX
+// only; a modified client skips it.
+describe("Spawn intent after the spawn phase", () => {
+  it("drops a spawn intent relayed after the phase ended", async () => {
+    // The default setup ends the spawn phase immediately — the exact post-phase
+    // state a late spawner exploits.
+    const game = await setup("plains", { infiniteGold: true });
+    const info = new PlayerInfo(
+      "latecomer",
+      PlayerType.Human,
+      "late_client",
+      "late_id",
+    );
+    game.addPlayer(info);
+    const latecomer = game.player(info.id);
+
+    expect(game.inSpawnPhase()).toBe(false);
+
+    const executor = new Executor(game, gameID, "late_client");
+    const exec = executor.createExec(
+      spawnIntent("late_client" as ClientID, game.ref(40, 40)),
+    );
+
+    // The intent is neutralized at creation: no SpawnExecution is produced.
+    expect(exec).toBeInstanceOf(NoOpExecution);
+    expect(exec).not.toBeInstanceOf(SpawnExecution);
+
+    // End-to-end: running it places nothing. (Before the fix this player
+    // materialized ~52 tiles on the running map.)
+    game.addExecution(exec);
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(latecomer.hasSpawned()).toBe(false);
+    expect(latecomer.numTilesOwned()).toBe(0);
+  });
+
+  it("still honors a spawn intent during the spawn phase", async () => {
+    // Keep the spawn phase ACTIVE (autoEndSpawnPhase = false) so the intent
+    // arrives in-phase — the normal path that must keep working.
+    const game = await setup(
+      "plains",
+      { infiniteGold: true },
+      [],
+      undefined,
+      undefined,
+      false,
+    );
+    const info = new PlayerInfo(
+      "spawner",
+      PlayerType.Human,
+      "spawn_client",
+      "spawn_id",
+    );
+    game.addPlayer(info);
+    const spawner = game.player(info.id);
+
+    expect(game.inSpawnPhase()).toBe(true);
+
+    const executor = new Executor(game, gameID, "spawn_client");
+    const exec = executor.createExec(
+      spawnIntent("spawn_client" as ClientID, game.ref(40, 40)),
+    );
+
+    // In-phase, the intent produces a real spawn execution.
+    expect(exec).toBeInstanceOf(SpawnExecution);
+
+    game.addExecution(exec);
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(spawner.hasSpawned()).toBe(true);
+    expect(spawner.numTilesOwned()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Problem

The spawn phase is only enforced on the client. `ClientGameRunner` shows a
`spawn_failed` modal and drops the click once the phase ends, but that guard is
UX only — a modified client skips it and relays a `{ type: "spawn", tile }`
intent after the phase. The server relays spawn intents without a phase check
(it has no `inSpawnPhase` notion), and the simulation's `SpawnExecution` only
blocks *re-spawns* by already-spawned players:

```ts
if (!this.mg.inSpawnPhase() && player.hasSpawned()) return;
```

A player who never spawned during the phase has `hasSpawned() === false`, so the
intent falls through and places starting territory on the already-running map.
The same path can relocate an existing base (relinquish + re-conquer elsewhere)
after the map has developed.

## Fix

Gate the intent at the single choke point where untrusted client input becomes
an execution — `Executor.createExec`. Once `inSpawnPhase()` is false a `spawn`
intent becomes a `NoOpExecution`:

```ts
case "spawn":
  if (!this.mg.inSpawnPhase()) {
    return new NoOpExecution();
  }
  return new SpawnExecution(this.gameID, player.info(), intent.tile);
```

This runs identically on every client, so the drop is deterministic (no desync).
Internal spawns — nations, bots, random spawn — construct `SpawnExecution`
directly and are unaffected, and a human's last-tick click still works because
its intent is created while the phase is still active.

## Tests

`tests/SpawnAfterPhase.test.ts`:
- a spawn intent relayed **after** the phase is dropped (no territory placed)
- a spawn intent **during** the phase still spawns normally

Full test suite shows no new failures vs. `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
