### PR TITLE
feat(store): show plutonium signup bonus on subscription tiles

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -417,6 +417,7 @@
     "public_lobbies_info": "Host custom lobbies that are publicly listed for anyone to join.",
     "rare": "Rare",
     "search": "Search...",
+    "signup_bonus": "Signup bonus",
     "soft": "Caps",
     "title": "Cosmetics",
     "uncommon": "Uncommon",

--- a/src/client/components/CosmeticButton.ts
+++ b/src/client/components/CosmeticButton.ts
@@ -274,19 +274,19 @@ export class CosmeticButton extends LitElement {
         class="flex flex-col items-center justify-center h-full w-full text-center gap-2 p-1"
       >
         <div class="flex flex-col items-center gap-1 w-full">
-          <div class="flex items-center gap-1.5">
+          <div class="self-start flex items-center gap-1.5">
+            <plutonium-icon .size=${24}></plutonium-icon>
+            <span class="text-sm font-bold text-green-400"
+              >${sub.hardCurrencySignupBonus.toLocaleString()}</span
+            >
+            <span class="text-[10px] text-white/50 uppercase"
+              >${translateText("cosmetics.signup_bonus")}</span
+            >
+          </div>
+          <div class="self-start flex items-center gap-1.5">
             <plutonium-icon .size=${24}></plutonium-icon>
             <span class="text-sm font-bold text-green-400"
               >${sub.dailyHardCurrency.toLocaleString()}</span
-            >
-            <span class="text-[10px] text-white/50 uppercase"
-              >${translateText("cosmetics.per_day")}</span
-            >
-          </div>
-          <div class="flex items-center gap-1.5">
-            <cap-icon .size=${24}></cap-icon>
-            <span class="text-sm font-bold text-amber-700"
-              >${sub.dailySoftCurrency.toLocaleString()}</span
             >
             <span class="text-[10px] text-white/50 uppercase"
               >${translateText("cosmetics.per_day")}</span

--- a/src/client/components/SubscriptionPanel.ts
+++ b/src/client/components/SubscriptionPanel.ts
@@ -11,7 +11,6 @@ import { translateCosmetic } from "../Cosmetics";
 import { showInGameAlert, showInGameConfirm } from "../InGameModal";
 import { translateText } from "../Utils";
 import "./baseComponents/Button";
-import "./CapIcon";
 import "./PlutoniumIcon";
 
 @customElement("subscription-panel")
@@ -143,16 +142,16 @@ export class SubscriptionPanel extends LitElement {
                   <div class="flex items-center gap-1.5">
                     <plutonium-icon .size=${20}></plutonium-icon>
                     <span class="text-sm font-bold text-green-400"
-                      >${cosmetic.dailyHardCurrency.toLocaleString()}</span
+                      >${cosmetic.hardCurrencySignupBonus.toLocaleString()}</span
                     >
                     <span class="text-[10px] text-white/50 uppercase"
-                      >${translateText("cosmetics.per_day")}</span
+                      >${translateText("cosmetics.signup_bonus")}</span
                     >
                   </div>
                   <div class="flex items-center gap-1.5">
-                    <cap-icon .size=${20}></cap-icon>
-                    <span class="text-sm font-bold text-amber-700"
-                      >${cosmetic.dailySoftCurrency.toLocaleString()}</span
+                    <plutonium-icon .size=${20}></plutonium-icon>
+                    <span class="text-sm font-bold text-green-400"
+                      >${cosmetic.dailyHardCurrency.toLocaleString()}</span
                     >
                     <span class="text-[10px] text-white/50 uppercase"
                       >${translateText("cosmetics.per_day")}</span

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -398,6 +398,8 @@ export const SubscriptionSchema = CosmeticSchema.extend({
   priceMonthly: z.number(),
   dailySoftCurrency: z.number(),
   dailyHardCurrency: z.number(),
+  // One-time plutonium grant on subscribing (advertised on the store tile).
+  hardCurrencySignupBonus: z.number(),
   // Whether this tier exempts subscribers from the free-ranked-play limits
   // (advertised on the store tile).
   unlimitedRanked: z.boolean(),

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -992,6 +992,7 @@ describe("SubscriptionSchema unlimitedRanked", () => {
     priceMonthly: 5,
     dailySoftCurrency: 100,
     dailyHardCurrency: 10,
+    hardCurrencySignupBonus: 100,
     canCreatePublicLobbies: false,
   };
 
@@ -1026,6 +1027,7 @@ describe("SubscriptionSchema canCreatePublicLobbies", () => {
     priceMonthly: 5,
     dailySoftCurrency: 100,
     dailyHardCurrency: 10,
+    hardCurrencySignupBonus: 100,
     unlimitedRanked: false,
   };
 
@@ -1047,6 +1049,42 @@ describe("SubscriptionSchema canCreatePublicLobbies", () => {
   it("rejects a non-boolean canCreatePublicLobbies", () => {
     expect(
       SubscriptionSchema.safeParse({ ...base, canCreatePublicLobbies: "yes" })
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe("SubscriptionSchema hardCurrencySignupBonus", () => {
+  const base = {
+    name: "gold",
+    product: null,
+    rarity: "epic",
+    description: "Gold tier",
+    priceMonthly: 5,
+    dailySoftCurrency: 100,
+    dailyHardCurrency: 10,
+    unlimitedRanked: false,
+    canCreatePublicLobbies: false,
+  };
+
+  it("rejects a tier without hardCurrencySignupBonus", () => {
+    expect(SubscriptionSchema.safeParse(base).success).toBe(false);
+  });
+
+  it("accepts a tier with hardCurrencySignupBonus", () => {
+    const result = SubscriptionSchema.safeParse({
+      ...base,
+      hardCurrencySignupBonus: 250,
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.hardCurrencySignupBonus).toBe(250);
+    }
+  });
+
+  it("rejects a non-number hardCurrencySignupBonus", () => {
+    expect(
+      SubscriptionSchema.safeParse({ ...base, hardCurrencySignupBonus: "250" })
         .success,
     ).toBe(false);
   });


### PR DESCRIPTION
## Summary

Subscription tiers now grant a one-time plutonium signup bonus, and the API's `cosmetics.json` already serves `hardCurrencySignupBonus` per tier. This PR advertises it in the client:

- **Store subscription tiles** (`CosmeticButton.ts`): the daily-caps (soft currency) row is replaced with a "Signup bonus" row; daily plutonium stays. Both rows are left-aligned with the perk checkmarks below.
- **Account "Your subscription" panel** (`SubscriptionPanel.ts`): same replacement, and the now-unused `CapIcon` import is removed.
- **Schema** (`CosmeticSchemas.ts`): `SubscriptionSchema` gains required `hardCurrencySignupBonus: z.number()`. No deploy-ordering hazard — the live API already serves the field on all tiers.
- **i18n**: adds `cosmetics.signup_bonus` to `en.json`.

`dailySoftCurrency` stays in the schema (still served by the API) but is no longer displayed.

## Test plan

- `tests/CosmeticSchemas.test.ts`: subscription fixtures updated for the new required field, plus a new `hardCurrencySignupBonus` describe block (rejects missing / accepts number / rejects non-number) matching the existing `unlimitedRanked` pattern.
- `npx vitest tests/CosmeticSchemas.test.ts --run` — 64 passed.
- `tsc --noEmit`, ESLint, and Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)