### PR TITLE
feat(usernames): allow single spaces in account usernames

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1728,7 +1728,7 @@
     "zoom_out_desc": "Zoom out the map"
   },
   "username": {
-    "account_invalid_chars": "Username can only contain letters, numbers, underscores, and hyphens.",
+    "account_invalid_chars": "Username can only contain letters, numbers, underscores, hyphens, and single spaces between words.",
     "enter_username": "Enter your username",
     "invalid_chars": "Username can only contain letters, numbers, spaces, and underscores.",
     "not_string": "Username must be a string.",

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -12,13 +12,15 @@ export const MAX_ACCOUNT_USERNAME_LENGTH = 20;
 
 // Mirrors the API's account-username rules (infra src/api/lib/Usernames.ts)
 // for instant form feedback; profanity and uniqueness stay server-side. No
-// dots (the dot separates base from suffix) and no spaces/unicode.
+// dots (the dot separates base from suffix) and no unicode. Single spaces
+// may separate words; edges are trimmed and consecutive spaces rejected so
+// no two distinct bases render alike.
 export const AccountUsernameSchema = z
   .string()
   .trim()
   .min(MIN_ACCOUNT_USERNAME_LENGTH)
   .max(MAX_ACCOUNT_USERNAME_LENGTH)
-  .regex(/^[a-zA-Z0-9_-]+$/);
+  .regex(/^[a-zA-Z0-9_-]+( [a-zA-Z0-9_-]+)*$/);
 
 export function validateUsername(username: string): {
   isValid: boolean;

--- a/tests/Censor.test.ts
+++ b/tests/Censor.test.ts
@@ -65,13 +65,21 @@ describe("username.ts functions", () => {
       expect(res.error).toBe("username.account_invalid_chars");
     });
 
-    test("rejects spaces and unicode", () => {
-      expect(validateAccountUsername("bob smith").isValid).toBe(false);
+    test("rejects unicode", () => {
       expect(validateAccountUsername("Üser").isValid).toBe(false);
     });
 
     test("accepts letters, digits, underscore, and hyphen", () => {
       expect(validateAccountUsername("Good_Name-123").isValid).toBe(true);
+    });
+
+    test("accepts single interior spaces", () => {
+      expect(validateAccountUsername("bob smith").isValid).toBe(true);
+      expect(validateAccountUsername("a b c").isValid).toBe(true);
+    });
+
+    test("rejects consecutive spaces", () => {
+      expect(validateAccountUsername("bob  smith").isValid).toBe(false);
     });
 
     test("trims before validating length", () => {


### PR DESCRIPTION
## Summary

Account (custom reserved) usernames may now contain spaces. This mirrors the API-side change (infra: "feat(api): allow spaces in account usernames") in the client's instant form validation:

- `AccountUsernameSchema` regex is now `/^[a-zA-Z0-9_-]+( [a-zA-Z0-9_-]+)*$/` — single interior spaces allowed ("Bob Smith"), edges trimmed, consecutive spaces rejected so no two distinct bases render identically.
- `username.account_invalid_chars` message updated to mention single spaces between words.
- Tests updated: spaced names accepted, consecutive spaces rejected.

## Notes

- No deploy-order constraint: if the client ships before the API, a spaced submission is rejected server-side and the form shows the server's message.
- Spaced display names are already safe downstream: every client player-ref URL wraps the ref in `encodeURIComponent` (matching the API's new percent-decoding `PlayerRefSchema`), and `splitAccountUsername` uses `.+` for the base so `bob smith.1234` splits correctly.
- The in-game `UsernameSchema` charset already includes spaces, so verified bare-name play with a spaced name passes join validation.

## Test plan

- [x] `npx vitest tests/Censor.test.ts --run` — 19 passed
- [x] eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)