### PR TITLE
Move game history action buttons onto map previews

### DIFF
--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -430,7 +430,9 @@ export class PlayerGameHistoryView extends LitElement {
     const mapDisplayName = game.map ? (getMapName(game.map) ?? game.map) : null;
 
     return html`
-      <div class="bg-white/5 border border-white/10 rounded-xl overflow-hidden">
+      <div
+        class="relative bg-white/5 border border-white/10 rounded-xl overflow-hidden"
+      >
         ${mapWebpPath
           ? html`<div
               class="relative w-full aspect-[3/1] overflow-hidden bg-surface"
@@ -464,7 +466,9 @@ export class PlayerGameHistoryView extends LitElement {
             </div>`
           : ""}
         <div
-          class="flex items-center justify-end px-4 py-3 border-b border-white/5"
+          class=${mapWebpPath
+            ? "absolute top-2 left-2 z-[1]"
+            : "flex items-center justify-end px-4 py-3 border-b border-white/5"}
         >
           <div class="flex items-center gap-2 shrink-0">
             <button
@@ -472,7 +476,7 @@ export class PlayerGameHistoryView extends LitElement {
               title=${translateText("game_list.stats")}
               aria-label=${translateText("game_list.stats")}
               @click=${() => this.showStats(game.gameId)}
-              class="inline-flex w-8 h-8 items-center justify-center text-white/80 bg-white/10 hover:bg-white/20 border border-white/10 rounded-lg transition-colors"
+              class="inline-flex w-8 h-8 items-center justify-center text-white/80 bg-black/60 hover:bg-black/80 backdrop-blur-sm border border-white/10 rounded-lg transition-colors"
             >
               <img
                 src=${statsIcon}

--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -435,7 +435,7 @@ export class PlayerGameHistoryView extends LitElement {
       >
         ${mapWebpPath
           ? html`<div
-              class="relative w-full aspect-[3/1] overflow-hidden bg-surface"
+              class="relative w-full aspect-[30/15] overflow-hidden bg-surface"
             >
               <img
                 src=${mapWebpPath}
@@ -455,7 +455,7 @@ export class PlayerGameHistoryView extends LitElement {
                     ${mapDisplayName}
                   </div>`
                 : ""}
-              <div class="absolute top-2 right-2">
+              <div class="absolute top-2 left-2">
                 ${this.renderResultBadge(game)}
               </div>
               <div
@@ -467,7 +467,7 @@ export class PlayerGameHistoryView extends LitElement {
           : ""}
         <div
           class=${mapWebpPath
-            ? "absolute top-2 left-2 z-[1]"
+            ? "absolute top-2 right-2 z-[1]"
             : "flex items-center justify-end px-4 py-3 border-b border-white/5"}
         >
           <div class="flex items-center gap-2 shrink-0">
@@ -476,7 +476,7 @@ export class PlayerGameHistoryView extends LitElement {
               title=${translateText("game_list.stats")}
               aria-label=${translateText("game_list.stats")}
               @click=${() => this.showStats(game.gameId)}
-              class="inline-flex w-8 h-8 items-center justify-center text-white/80 bg-black/60 hover:bg-black/80 backdrop-blur-sm border border-white/10 rounded-lg transition-colors"
+              class="inline-flex w-8 h-8 items-center justify-center text-white bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 rounded-lg transition-all"
             >
               <img
                 src=${statsIcon}

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -399,7 +399,9 @@ export class ClanGameHistoryView extends LitElement {
     }
 
     return html`
-      <div class="bg-white/5 border border-white/10 rounded-xl overflow-hidden">
+      <div
+        class="relative bg-white/5 border border-white/10 rounded-xl overflow-hidden"
+      >
         ${mapWebpPath
           ? html`<div
               class="relative w-full aspect-[3/1] overflow-hidden bg-surface"
@@ -433,7 +435,9 @@ export class ClanGameHistoryView extends LitElement {
             </div>`
           : ""}
         <div
-          class="flex items-center justify-end px-4 py-3 border-b border-white/5"
+          class=${mapWebpPath
+            ? "absolute top-2 left-2 z-[1]"
+            : "flex items-center justify-end px-4 py-3 border-b border-white/5"}
         >
           <div class="flex items-center gap-2 shrink-0">
             <button
@@ -441,7 +445,7 @@ export class ClanGameHistoryView extends LitElement {
               title=${translateText("game_list.stats")}
               aria-label=${translateText("game_list.stats")}
               @click=${() => this.showStats(game.gameId)}
-              class="inline-flex w-8 h-8 items-center justify-center text-white/80 bg-white/10 hover:bg-white/20 border border-white/10 rounded-lg transition-colors"
+              class="inline-flex w-8 h-8 items-center justify-center text-white/80 bg-black/60 hover:bg-black/80 backdrop-blur-sm border border-white/10 rounded-lg transition-colors"
             >
               <img
                 src=${statsIcon}

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -404,7 +404,7 @@ export class ClanGameHistoryView extends LitElement {
       >
         ${mapWebpPath
           ? html`<div
-              class="relative w-full aspect-[3/1] overflow-hidden bg-surface"
+              class="relative w-full aspect-[30/11] overflow-hidden bg-surface"
             >
               <img
                 src=${mapWebpPath}
@@ -424,7 +424,7 @@ export class ClanGameHistoryView extends LitElement {
                     ${mapDisplayName}
                   </div>`
                 : ""}
-              <div class="absolute top-2 right-2">
+              <div class="absolute top-2 left-2">
                 ${this.renderResultBadge(game, winners)}
               </div>
               <div
@@ -436,7 +436,7 @@ export class ClanGameHistoryView extends LitElement {
           : ""}
         <div
           class=${mapWebpPath
-            ? "absolute top-2 left-2 z-[1]"
+            ? "absolute top-2 right-2 z-[1]"
             : "flex items-center justify-end px-4 py-3 border-b border-white/5"}
         >
           <div class="flex items-center gap-2 shrink-0">
@@ -445,7 +445,7 @@ export class ClanGameHistoryView extends LitElement {
               title=${translateText("game_list.stats")}
               aria-label=${translateText("game_list.stats")}
               @click=${() => this.showStats(game.gameId)}
-              class="inline-flex w-8 h-8 items-center justify-center text-white/80 bg-black/60 hover:bg-black/80 backdrop-blur-sm border border-white/10 rounded-lg transition-colors"
+              class="inline-flex w-8 h-8 items-center justify-center text-white bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 rounded-lg transition-all"
             >
               <img
                 src=${statsIcon}


### PR DESCRIPTION
## Description:

This is a follow-up to #4824 based on this post-merge review comment:

https://github.com/openfrontio/OpenFrontIO/pull/4824#issuecomment-5160949025

This is a separate follow-up PR because the feedback was posted after #4824 had already been merged. Sorry for the additional PR.

---
Moves the Stats and Replay action buttons onto the top-left corner of the map preview in both player and clan game history cards.
This removes the mostly empty action row and reduces dead space.

before
<img width="889" height="769" alt="スクリーンショット 2026-08-03 16 57 59" src="https://github.com/user-attachments/assets/f5cb5b67-6f7b-4542-b298-eedd4c232798" />

after
<img width="1410" height="622" alt="スクリーンショット 2026-08-03 17 18 22" src="https://github.com/user-attachments/assets/52562bf7-8b7c-451b-b010-421329e463f3" />




## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
