### PR TITLE
Fix TribeSpawner crash on invalid nation coordinates

### DIFF
--- a/src/core/execution/TribeSpawner.ts
+++ b/src/core/execution/TribeSpawner.ts
@@ -22,7 +22,11 @@ export class TribeSpawner {
     // to avoid tribe IDs colliding with nation/human IDs from the same PRNG sequence.
     this.random = new PseudoRandom(simpleHash(gameID) + 2);
     this.tribeNameData = resolveTribeNameData(gs.config().gameConfig().gameMap);
-    this.nationTiles = new Set(nationCells.map((c) => gs.ref(c.x, c.y)));
+    this.nationTiles = new Set(
+      nationCells
+        .filter((c) => gs.isValidCoord(c.x, c.y))
+        .map((c) => gs.ref(c.x, c.y)),
+    );
   }
 
   spawnTribes(

--- a/tests/core/execution/TribeSpawner.test.ts
+++ b/tests/core/execution/TribeSpawner.test.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import type { Game } from "../../../src/core/game/Game";
 import {
+  Cell,
   GameMapSize,
   GameMapType,
   PlayerType,
@@ -359,5 +360,48 @@ describe("TribeSpawner", () => {
       expect(tile).toBeDefined();
       expect(game.isLand(tile)).toBe(true);
     }
+  });
+
+  test("constructor ignores out-of-bounds nation cells without throwing", async () => {
+    const game = await setup("plains", { bots: 1, gameMap: GameMapType.Asia });
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Test"],
+      suffixes: ["Tribe"],
+    });
+
+    const oobCell = new Cell(99999, 99999);
+    // Must not throw despite the out-of-bounds cell.
+    const spawner = new TribeSpawner(game, GAME_ID, [oobCell]);
+    const execs = spawner.spawnTribes(1);
+
+    expect(execs).toHaveLength(1);
+    // Tribe should still spawn normally (random, no fixed tile).
+    expect(execs[0].tile).toBeUndefined();
+  });
+
+  test("valid nation cell prevents positioned tribe from occupying that tile", async () => {
+    const game = await setup("plains", { bots: 1, gameMap: GameMapType.Asia });
+    const tile = findLandTile(game);
+    const x = game.x(tile);
+    const y = game.y(tile);
+
+    mockResolveTribeNameData.mockReturnValue({
+      prefixes: ["Test"],
+      suffixes: ["Tribe"],
+      customTribes: [{ name: "Occupied", coordinates: [x, y] }],
+    });
+
+    // A nation already sits on this tile.
+    const nationCell = new Cell(x, y);
+    const spawner = new TribeSpawner(game, GAME_ID, [nationCell]);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const execs = spawner.spawnTribes(1);
+
+    expect(execs).toHaveLength(1);
+    // The positioned tribe was rejected (tile occupied by nation), so
+    // it falls back to a random spawn with no fixed tile.
+    expect(execs[0].tile).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalled();
   });
 });

--- a/tests/core/execution/TribeSpawner.test.ts
+++ b/tests/core/execution/TribeSpawner.test.ts
@@ -383,6 +383,7 @@ describe("TribeSpawner", () => {
   test("valid nation cell prevents positioned tribe from occupying that tile", async () => {
     const game = await setup("plains", { bots: 1, gameMap: GameMapType.Asia });
     const tile = findLandTile(game);
+    expect(game.hasOwner(tile)).toBe(false);
     const x = game.x(tile);
     const y = game.y(tile);
 


### PR DESCRIPTION
## Description:

The `TribeSpawner` constructor called `gs.ref(c.x, c.y)` on all nation cells without checking if coordinates are valid. If a map has nation coordinates outside its bounds (e.g. the Scandinavia map has "Tver" at x=2007 on a 2006-wide image), the game would crash with `Error: Invalid coordinates` during map load.

Added a `gs.isValidCoord()` filter before building the `nationTiles` set, matching the existing defensive pattern in `spawnPositionedTribe()`.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin