### PR TITLE
feat(featured-stream): let everyone close the panel, not just ad-free users

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -525,6 +525,7 @@
   },
   "featured_stream": {
     "expand": "Expand",
+    "hide_today": "Hide for today",
     "live": "LIVE",
     "minimize": "Minimize",
     "open_on_twitch": "Open {channel} on Twitch"

--- a/src/client/FeaturedStream.ts
+++ b/src/client/FeaturedStream.ts
@@ -55,7 +55,7 @@ declare global {
 export type Corner = "tl" | "tr" | "bl" | "br";
 const CORNER_KEY = "featured-stream-corner";
 const MIN_KEY = "featured-stream-minimized";
-const CLOSED_KEY = "featured-stream-closed"; // ad-free close, remembered for the current day
+const CLOSED_KEY = "featured-stream-closed"; // "hide for today" (ad-free), scoped to the day
 
 // Local calendar day, used to scope the "closed" and "minimized" states to the current stream:
 // each is stored with the day it was set and ignored once the day changes, so the panel resets
@@ -138,7 +138,7 @@ export class FeaturedStream extends LitElement {
   @state() private minimized = false;
   @state() private corner: Corner = "br"; // which screen corner the panel snaps to
   @state() private dragPos: { x: number; y: number } | null = null; // free pos while dragging
-  @state() private dismissed = false; // closed; ad-free close persists for the day, flick session-only
+  @state() private dismissed = false; // closed for this visit; only ⊘ persists it
   @state() private stream: LiveStream | null = null; // broadcast the API reports live
 
   private player?: TwitchPlayer;
@@ -189,8 +189,8 @@ export class FeaturedStream extends LitElement {
     // Steam's no-in-game-ads rules (and can't satisfy Twitch's parent-domain check in the
     // shell). Matches how the rest of the app suppresses promos off the open web.
     if (crazyGamesSDK.isOnCrazyGames() || isDesktopShell()) return;
-    // An ad-free user who closed the panel stays closed for the rest of that day (only the
-    // ad-free x/flick writes this key, so it never suppresses the panel for ad-supported users).
+    // An ad-free user who chose "hide for today" stays hidden for the rest of that day
+    // (only that button writes this key, so an ordinary close never suppresses a later visit).
     // A value from an earlier day is stale: drop it so the next day's stream shows again.
     const closedDay = localStorage.getItem(CLOSED_KEY);
     if (closedDay === todayKey()) {
@@ -397,13 +397,14 @@ export class FeaturedStream extends LitElement {
       ) as HTMLElement | null;
       const cx = this.dragPos.x + (card?.offsetWidth ?? 360) / 2;
       const cy = this.dragPos.y + (card?.offsetHeight ?? 200) / 2;
-      // Touch only: flicking the panel off the edge closes it (persisted for ad-free users,
-      // session-only otherwise).
+      // Touch only: flicking the panel off the edge closes it for this page visit. A
+      // flick is a casual gesture, so it deliberately never persists — hiding for the
+      // day is only ever the explicit ⊘.
       if (
         isCoarsePointer() &&
         isOffFrame(cx, cy, window.innerWidth, window.innerHeight)
       ) {
-        this.dismiss(this.adFree);
+        this.dismiss(false);
         return;
       }
       this.corner = cornerFromCenter(
@@ -450,14 +451,18 @@ export class FeaturedStream extends LitElement {
     this.kickPlay(); // resume playback after the resize either way
   };
 
-  // Only ad-free users get a close button (any shop purchase makes a user adfree for life,
-  // which zeroes window.adsEnabled); ad-supported users can only minimize. Checked with
-  // `=== false` so the button doesn't flash before /user/me resolves the entitlement.
+  // Everyone can minimize and close; ad-free users additionally get "hide for today"
+  // (any shop purchase makes a user adfree for life, which zeroes window.adsEnabled).
+  // Checked with `=== false` so the extra button doesn't flash before /user/me resolves
+  // the entitlement — a click landing before then simply closes for the visit instead.
   private get adFree(): boolean {
     return window.adsEnabled === false;
   }
 
-  private onClose = () => this.dismiss(this.adFree);
+  // Everyone can close. ✕ is always just for this page visit; only the ad-free ⊘ makes it
+  // stick, so a close never silently outlives the visit the user expected it to.
+  private onClose = () => this.dismiss(false);
+  private onHideToday = () => this.dismiss(true);
 
   render() {
     if (this.stream === null || this.dismissed) return html``;
@@ -518,13 +523,21 @@ export class FeaturedStream extends LitElement {
             >
               ${min ? "⤢" : "–"}
             </button>
-            ${min && this.adFree
+            <button
+              class="px-1 text-lg leading-none text-white/70 hover:text-white"
+              aria-label=${translateText("common.close")}
+              @click=${this.onClose}
+            >
+              ✕
+            </button>
+            ${this.adFree
               ? html`<button
                   class="px-1 text-lg leading-none text-white/70 hover:text-white"
-                  aria-label=${translateText("common.close")}
-                  @click=${this.onClose}
+                  aria-label=${translateText("featured_stream.hide_today")}
+                  title=${translateText("featured_stream.hide_today")}
+                  @click=${this.onHideToday}
                 >
-                  ✕
+                  ⊘
                 </button>`
               : ""}
           </div>

--- a/tests/client/components/FeaturedStreamPanel.test.ts
+++ b/tests/client/components/FeaturedStreamPanel.test.ts
@@ -203,7 +203,7 @@ describe("featured-stream panel", () => {
   // Closing must stop everything: no poll left scheduled, no player rebuilt. Minimizing
   // deliberately does not, because Twitch's terms disallow an obscured embed, so the
   // minimized panel stays a visible thumbnail that keeps playing.
-  describe("after the user closes the panel", () => {
+  describe("closing", () => {
     const clickByLabel = (el: HTMLElement, label: string) => {
       const btn = el.querySelector(
         `[aria-label="${label}"]`,
@@ -212,21 +212,39 @@ describe("featured-stream panel", () => {
       btn!.click();
     };
 
-    const openThenClose = async () => {
-      // The x only exists for ad-free users, and only once minimized.
-      (window as unknown as { adsEnabled?: boolean }).adsEnabled = false;
+    const open = async (adFree: boolean) => {
+      (window as unknown as { adsEnabled?: boolean }).adsEnabled = !adFree;
       const el = await mount(stream("openfrontmasters"));
       FakePlayer.last!.fire(FakePlayer.READY);
-      await el.updateComplete;
-      clickByLabel(el, "featured_stream.minimize");
-      await el.updateComplete;
-      clickByLabel(el, "common.close");
       await el.updateComplete;
       return el;
     };
 
+    // The point of this change: closing no longer requires minimising first, and is no
+    // longer reserved for people who have paid.
+    it("offers close to an ad-supported user without minimising first", async () => {
+      const el = await open(false);
+      expect(el.querySelector('[aria-label="common.close"]')).not.toBeNull();
+      expect(
+        el.querySelector('[aria-label="featured_stream.hide_today"]'),
+      ).toBeNull(); // hide-for-today stays ad-free only
+    });
+
+    it("offers all three controls to an ad-free user", async () => {
+      const el = await open(true);
+      expect(
+        el.querySelector('[aria-label="featured_stream.minimize"]'),
+      ).not.toBeNull();
+      expect(el.querySelector('[aria-label="common.close"]')).not.toBeNull();
+      expect(
+        el.querySelector('[aria-label="featured_stream.hide_today"]'),
+      ).not.toBeNull();
+    });
+
     it("removes the panel and stops polling entirely", async () => {
-      await openThenClose();
+      const el = await open(false);
+      clickByLabel(el, "common.close");
+      await el.updateComplete;
       expect(card()).toBeNull();
       const before = getStreams.mock.calls.length;
       await vi.advanceTimersByTimeAsync(10 * 60_000);
@@ -244,12 +262,53 @@ describe("featured-stream panel", () => {
     });
 
     it("does not come back when a game ends", async () => {
-      const el = await openThenClose();
+      const el = await open(false);
+      clickByLabel(el, "common.close");
+      await el.updateComplete;
       document.dispatchEvent(new CustomEvent("leave-lobby"));
       await el.updateComplete;
       await vi.advanceTimersByTimeAsync(10 * 60_000);
       expect(card()).toBeNull();
       expect(FakePlayer.constructed).toEqual(["openfrontmasters"]);
+    });
+
+    // A plain close is for this visit only, whoever you are.
+    it("does not persist an ordinary close, even for an ad-free user", async () => {
+      const el = await open(true);
+      clickByLabel(el, "common.close");
+      await el.updateComplete;
+      expect(localStorage.getItem("featured-stream-closed")).toBeNull();
+    });
+
+    it("persists hide-for-today and suppresses the panel on the next visit", async () => {
+      const el = await open(true);
+      clickByLabel(el, "featured_stream.hide_today");
+      await el.updateComplete;
+      expect(localStorage.getItem("featured-stream-closed")).not.toBeNull();
+
+      // Remount as if the page were reloaded the same day. Built by hand rather than via
+      // mount(), which waits for a fetch this path must never make.
+      document.body.innerHTML = "";
+      streamsFeed.reset();
+      getStreams.mockClear();
+      const again = document.createElement("featured-stream") as HTMLElement & {
+        updateComplete: Promise<boolean>;
+      };
+      document.body.appendChild(again);
+      await again.updateComplete;
+      await vi.advanceTimersByTimeAsync(1000);
+      await again.updateComplete;
+      expect(card()).toBeNull();
+      expect(getStreams).not.toHaveBeenCalled(); // never even asks the API
+    });
+
+    it("shows again once the stored day is stale", async () => {
+      localStorage.setItem("featured-stream-closed", "1999-1-1");
+      const el = await mount(stream("openfrontmasters"));
+      FakePlayer.last!.fire(FakePlayer.READY);
+      await el.updateComplete;
+      expect(card()).not.toBeNull();
+      expect(localStorage.getItem("featured-stream-closed")).toBeNull(); // pruned
     });
   });
 


### PR DESCRIPTION
## What

Everyone can close the featured stream panel now. Ad-free users additionally get
"hide for today".

| Control | Who | Effect |
|---|---|---|
| `–` minimise | everyone | unchanged |
| `✕` close | **everyone** (was ad-free, and only after minimising) | gone for this page visit |
| `⊘` hide for today | ad-free | gone until local midnight, across reloads |

## Why

Closing required *both* minimising first *and* having made a purchase. An ad-supported
user had no close button at all — their only escape was flicking the panel off-screen on
a touch device, which doesn't exist on desktop. Gating a dismiss behind a paywall on a
panel that autoplays video in the corner of the homepage is a rough edge.

The two-step also wasn't discoverable: nothing signalled that minimising was what revealed
the ✕.

## Behaviour notes

- **A plain `✕` never persists, for anyone.** Previously the same button meant "for now"
  or "for the day" depending on entitlement, which is invisible to the user. Persistence
  is now only ever the explicit ⊘.
- **The touch flick no longer persists either** (it used to, for ad-free). A flick is a
  casual gesture and shouldn't outlive the visit when the button right next to it doesn't.
- `⊘` reuses the existing `featured-stream-closed` key and day-scoping, so behaviour on a
  second visit is unchanged for the people who had it before — it just isn't what `✕` does
  any more.
- The entitlement check stays `=== false`, so the extra button doesn't flash before
  `/user/me` resolves. A click landing before then closes for the visit rather than the day.

## Testing

`npx vitest run --dir tests` — full suite green. `npx tsc --noEmit` and `npm run lint` clean.

New coverage: an ad-supported user sees a close button without minimising; an ad-free user
sees all three controls; an ordinary close writes nothing to localStorage even for ad-free;
hide-for-today survives a remount and the panel then never even calls the API; a stale
stored day is pruned and the panel returns.

> Note: a bare `npm test` also sweeps stale git worktrees under `.claude/worktrees/` and
> `.worktrees/` — gitignored, unrelated branches, failing for pre-existing reasons. Scope
> with `--dir tests`.

## Not included

Minimise still only shrinks the card (720px → 400px) rather than collapsing it, because
Twitch's embed minimum is 400x300 and an obscured embed breaks their terms. At viewports
below ~1000px both states resolve to the same width, so the button appears to do nothing.
Worth addressing separately — renaming it, or hiding it where it can't do anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
