### PR TITLE
fix(tribes): carry custom tribe names into the archived game record

### DIFF
--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -9,6 +9,7 @@ import {
   GameRecord,
   PartialGameRecord,
   PlayerRecord,
+  Tribe,
   Turn,
   Winner,
 } from "./Schemas";
@@ -264,6 +265,10 @@ export function createPartialGameRecord(
   lobbyCreatedAt?: number,
   // Time the lobby became visible to players (ms).
   visibleAt?: number,
+  // Purchased bot tribe names in use this game (public games only). Infra
+  // ingest reads them from the record for owner appearance stats, and
+  // replays rebuild GameStartInfo from the record so the same names spawn.
+  tribes?: Tribe[],
 ): PartialGameRecord {
   const duration = Math.floor((end - start) / 1000);
   const num_turns = allTurns.length;
@@ -291,6 +296,7 @@ export function createPartialGameRecord(
       duration,
       num_turns,
       winner,
+      tribes,
     },
     version: "v0.0.2",
     turns,

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1804,6 +1804,7 @@ export class GameServer {
           this.winner?.winner,
           this.createdAt,
           this.visibleAt,
+          this.gameStartInfo.tribes,
         ),
       ),
     );

--- a/tests/server/ArchivePlayerRecord.test.ts
+++ b/tests/server/ArchivePlayerRecord.test.ts
@@ -77,4 +77,45 @@ describe("archiveGame player records", () => {
       isLobbyCreator: false,
     });
   });
+
+  it("carries custom tribe names into the archived record for infra ingest and replays", () => {
+    const game = new GameServer("test-game", mockLogger, Date.now(), {
+      gameType: GameType.Public,
+    } as any);
+
+    (game as any).gameStartInfo = {
+      gameID: "test-game",
+      lobbyCreatedAt: 0,
+      config: { gameType: GameType.Public },
+      players: [],
+      tribes: [{ name: "Dragon Riders" }, { name: "Night Wolves" }],
+    };
+
+    (game as any).archiveGame();
+
+    expect(archive).toHaveBeenCalledTimes(1);
+    const record = vi.mocked(archive).mock.calls[0][0] as any;
+    expect(record.info.tribes).toEqual([
+      { name: "Dragon Riders" },
+      { name: "Night Wolves" },
+    ]);
+  });
+
+  it("omits tribes from the archived record when none were fetched", () => {
+    const game = new GameServer("test-game", mockLogger, Date.now(), {
+      gameType: GameType.Public,
+    } as any);
+
+    (game as any).gameStartInfo = {
+      gameID: "test-game",
+      lobbyCreatedAt: 0,
+      config: { gameType: GameType.Public },
+      players: [],
+    };
+
+    (game as any).archiveGame();
+
+    const record = vi.mocked(archive).mock.calls[0][0] as any;
+    expect(record.info.tribes).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Problem

The tribes leaderboard (`GET /leaderboard/tribes`) is empty. The original diagnosis was that prod servers predated the custom-tribes integration (#4727) — but after today's v0.33.0 deploy, fresh game records stamped with the v0.33.0 commit (`7a7ca5be`) **still** have no `info.tribes` key (checked `3DM5jo9P`, `TKDVms7Y`, `6e6gvscX` via the public game API).

## Root cause

`GameServer.fetchTribes()` fetches the purchased-name pool at prestart and `start()` embeds it in the game start info sent to clients — but `archiveGame()` never passed it to `createPartialGameRecord`, which builds the record `info` from an explicit field list. So the tribes were dropped from the analytics record, and infra's ingest (`maybeSaveTribeNameStats`) silently no-ops on the missing field. `custom_tribe_name_stats_daily` has never been written.

This also affects replays: they rebuild `GameStartInfo` from `record.info` (`GameEndInfoSchema` extends `GameStartInfoSchema`, so `tribes` is already part of the record schema), meaning replays currently spawn organic bot names instead of the purchased ones the live game showed.

## Fix

- `createPartialGameRecord` takes an optional `tribes` param and includes it in `info`.
- `archiveGame()` passes `this.gameStartInfo.tribes`.
- Client callers (singleplayer/local archive paths) are unchanged — those games never have tribes and are skipped by ingest anyway.

## Tests

- New regression tests in `ArchivePlayerRecord.test.ts`: tribes survive archiving; absent tribes stay absent.
- Full suite passes (31 files, 291 tests), `tsc --noEmit` clean.

## Post-deploy verification

- `curl -s "https://api.openfront.io/public/game/<id>?turns=false" | jq '.info.tribes'` on a finished public game with bots should return the name array.
- `custom_tribe_name_stats_daily` should start accruing rows; `/leaderboard/tribes` populates within the 1-hour cache window.

Note: this needs to ride a v0.33.x hotfix release to reach prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)