### PR TITLE
feat(adminbot): optional public listing at create_game

### DIFF
--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -76,12 +76,47 @@ export function registerAdminBotRoutes(opts: {
       return res.status(400).json({ error: z.prettifyError(parsed.error) });
     }
     const config = parsed.data;
+    // Optional public listing (#4480). Read alongside the config, not from it:
+    // `listed` lives on GameServer precisely so it can't be smuggled through
+    // GameConfig, and the schema parse above strips it from `config` for us.
+    //
+    // Set at CREATE time rather than via a follow-up toggle because a bot never
+    // needs to withdraw a listing by hand — a lobby delists itself the moment it
+    // starts, fills or dies. The human toggle (POST /api/game/:id/listing) can't
+    // serve a bot: it authorizes via isCreator + subscription, and an admin-bot
+    // lobby is deliberately created with NO creatorPersistentID (below), so it has
+    // no owner to match and no account to bill.
+    const listedParsed = z
+      .object({ listed: z.boolean().optional() })
+      .safeParse(req.body ?? {});
+    if (!listedParsed.success) {
+      return res
+        .status(400)
+        .json({ error: z.prettifyError(listedParsed.error) });
+    }
+    const listed = listedParsed.data.listed === true;
     // Private only: reject Public and Singleplayer. An omitted gameType defaults
     // to Private in createGame, so it's allowed through.
     if (config.gameType !== undefined && config.gameType !== GameType.Private) {
       return res
         .status(400)
         .json({ error: "admin bot can only create private games" });
+    }
+
+    // Guard BEFORE minting a lobby, so an ineligible request doesn't leave an
+    // orphan behind. Both mirror the human endpoint's refusals: a whitelisted
+    // lobby would be advertised to everyone yet reject every joiner (and the
+    // whitelist is stripped from the broadcast, so browsers couldn't tell why),
+    // and host cheats give the host an edge over players recruited from the
+    // browser. The cluster-wide MAX_HOSTED_LOBBIES cap is left to the master,
+    // which already delists overflow as the authoritative backstop.
+    if (listed) {
+      if ((config.allowedPublicIds?.length ?? 0) > 0) {
+        return res.status(409).json({ error: "listing_whitelist_enabled" });
+      }
+      if (config.hostCheats !== undefined) {
+        return res.status(409).json({ error: "listing_host_cheats_enabled" });
+      }
     }
 
     const id = ServerEnv.generateGameIdForWorker(workerId);
@@ -94,7 +129,10 @@ export function registerAdminBotRoutes(opts: {
     if (game === null) {
       return res.status(409).json({ error: "Game ID already exists" });
     }
-    log.info(`admin bot created game ${id}`);
+    if (listed) {
+      game.setListed(true);
+    }
+    log.info(`admin bot created game ${id}`, { listed });
     res.json({
       ...game.gameInfo(),
       workerIndex: workerId,

--- a/tests/server/AdminBotCreateListed.test.ts
+++ b/tests/server/AdminBotCreateListed.test.ts
@@ -1,0 +1,116 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerAdminBotRoutes } from "../../src/server/AdminBotRoutes";
+import { ServerEnv } from "../../src/server/ServerEnv";
+
+// Capture the create_game handler off a fake Express app. requireAdminBotKey is
+// the preceding middleware (tested separately), so this exercises the listing
+// behaviour: the pre-create guards, and that `listed` never reaches GameConfig.
+function captureCreateHandler(game: { setListed: (v: boolean) => void }) {
+  const routes: Record<string, (req: any, res: any) => void> = {};
+  const app: any = {
+    post(path: string, ...handlers: ((req: any, res: any) => void)[]) {
+      routes[path] = handlers[handlers.length - 1];
+    },
+    get() {},
+  };
+  const created: { config?: Record<string, unknown> } = {};
+  const gm: any = {
+    createGame(_id: string, config: Record<string, unknown>) {
+      created.config = config;
+      return { ...game, gameInfo: () => ({ gameID: "x" }) };
+    },
+  };
+  const log: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  registerAdminBotRoutes({ app, gm, workerId: 0, log });
+  return { handler: routes["/api/adminbot/create_game"], created };
+}
+
+function mockRes() {
+  const res: any = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+const BASE = { gameMap: "World", gameMode: "Free For All" };
+
+beforeEach(() => {
+  // Minting an id derives the worker count from the environment; the other
+  // admin-bot route tests stub ServerEnv the same way.
+  vi.spyOn(ServerEnv, "generateGameIdForWorker").mockReturnValue("aaaaaaaa");
+  vi.spyOn(ServerEnv, "workerPath").mockReturnValue("w0");
+});
+
+describe("admin bot create_game public listing", () => {
+  it("lists the lobby when asked", () => {
+    const setListed = vi.fn();
+    const { handler } = captureCreateHandler({ setListed });
+    const res = mockRes();
+    handler({ body: { ...BASE, listed: true } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(setListed).toHaveBeenCalledWith(true);
+  });
+
+  it("does not list by default", () => {
+    const setListed = vi.fn();
+    const { handler } = captureCreateHandler({ setListed });
+    handler({ body: BASE }, mockRes());
+    expect(setListed).not.toHaveBeenCalled();
+  });
+
+  it("never leaks `listed` into GameConfig", () => {
+    // It belongs to GameServer, not the config — otherwise it could be smuggled
+    // in through update_game_config and would reach the sim/records.
+    const { handler, created } = captureCreateHandler({ setListed: vi.fn() });
+    handler({ body: { ...BASE, listed: true } }, mockRes());
+    expect(created.config).toBeDefined();
+    expect("listed" in created.config!).toBe(false);
+  });
+
+  it("refuses to list an allowlisted lobby, and mints nothing", () => {
+    // Advertising a lobby that rejects every joiner; the whitelist is stripped
+    // from the broadcast so browsers could not tell why.
+    const setListed = vi.fn();
+    const { handler, created } = captureCreateHandler({ setListed });
+    const res = mockRes();
+    handler(
+      { body: { ...BASE, listed: true, allowedPublicIds: ["abc"] } },
+      res,
+    );
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: "listing_whitelist_enabled" });
+    expect(created.config).toBeUndefined(); // guarded before createGame
+    expect(setListed).not.toHaveBeenCalled();
+  });
+
+  it("still allows an allowlist when NOT listing", () => {
+    const { handler } = captureCreateHandler({ setListed: vi.fn() });
+    const res = mockRes();
+    handler({ body: { ...BASE, allowedPublicIds: ["abc"] } }, res);
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("refuses to list a lobby with host cheats", () => {
+    const { handler } = captureCreateHandler({ setListed: vi.fn() });
+    const res = mockRes();
+    handler({ body: { ...BASE, listed: true, hostCheats: {} } }, res);
+    expect(res.statusCode).toBe(409);
+    expect(res.body).toEqual({ error: "listing_host_cheats_enabled" });
+  });
+
+  it("400s a non-boolean listed", () => {
+    const { handler } = captureCreateHandler({ setListed: vi.fn() });
+    const res = mockRes();
+    handler({ body: { ...BASE, listed: "yes" } }, res);
+    expect(res.statusCode).toBe(400);
+  });
+});


### PR DESCRIPTION

## Description

Lets a bot-hosted lobby be published in the "Open Lobbies" browser by passing `listed: true` to `POST /api/adminbot/create_game`.

**Motivation:** OpenFront Masters runs daily regional scrims through the admin-bot API. Those only fill from players already in the OFM Discord today — listing them lets the lobby browser recruit from the whole player base, which is the funnel into the league's Minors.

## Why the human toggle can't serve a bot

`POST /api/game/:id/listing` authorizes a **human host**:

```
verifyClientToken(token) → game.isCreator(auth.persistentId) → hasActiveSubscription(userMe)
```

An admin-bot lobby is created with **no `creatorPersistentID`**, so it has no owner to match and no account to bill — it fails at **ownership**, before billing is even consulted. Verified against the deployed build (dev + prod):

| Call | Result |
|---|---|
| `POST /api/adminbot/create_game` | 200, response already carries `listed: false` |
| `POST /{worker}/api/game/:id/listing` with the admin-bot key | 400 `Authorization header required` |
| Same with a bare persistentId as the token | 401 — only allowed when env is Dev |

## Why create-time instead of a second endpoint

A bot never needs to withdraw a listing by hand: **a lobby delists itself when it starts, fills or dies**. So the whole use case fits one flag on an existing route, and there's no delist path or extra dependency to reason about.

`listed` is read **alongside** the config, never from it — it lives on `GameServer` precisely so it can't be smuggled through `GameConfig`, and the existing schema parse strips it from `config` for free. There's a test asserting it never appears in what reaches `createGame`.

## Guards

Both mirror the human endpoint's refusals and run **before the lobby is minted**, so an ineligible request leaves no orphan:

- `allowedPublicIds` set → **409 `listing_whitelist_enabled`** — a listed whitelisted lobby would be advertised to everyone yet reject every joiner, and the whitelist is stripped from the broadcast so browsers couldn't tell why
- `hostCheats` set → **409 `listing_host_cheats_enabled`**

The cluster-wide `MAX_HOSTED_LOBBIES` cap is left to the master, which already delists overflow as the authoritative backstop — so this adds no new worker-side dependency.

## Deliberately unchanged

**Admin-bot lobbies still have no `creatorPersistentID`.** Attaching a synthetic one would have let the existing endpoint work untouched, but it would mean the admin-bot key could claim ownership on behalf of an arbitrary `persistentId` — against the explicit *"Never accept persistentID directly"* rule on `/api/create_game`.

**The auto-start fuse is untouched.** A bot arms its own countdown (`toggle_game_start_timer`) well inside `HOSTED_LOBBY_AUTO_START_MS`, so the fuse only fires if the bot goes away — exactly the case it exists for.

## Testing

- `tsc --noEmit` clean · `oxlint` + `eslint` clean
- `tests/server` — **298 passing (32 files)**, including 7 new

New tests: lists when asked · off by default · never leaks into `GameConfig` · both guards refuse **and mint nothing** · an allowlist still works when not listing · a non-boolean `listed` 400s.

Diff is two files, +155/−1.
