### PR TITLE
feat(ranked): explain clan/friend pairing on the ranked mode screen

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1172,6 +1172,7 @@
     "coming_soon": "Coming Soon",
     "ranked_1v1_title": "1v1",
     "ranked_2v2_title": "2v2",
+    "ranked_pairing_note": "In team modes, clanmates and friends in the queue are placed on the same team where possible. Friends are paired first, then clanmates. If your ratings differ by more than {maxEloDiff} ELO you'll be matched separately to keep games fair.",
     "ranked_title": "Ranked",
     "teams_count": "{teamCount} teams",
     "teams_of": "{teamCount} teams of {playersPerTeam}",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1172,7 +1172,7 @@
     "coming_soon": "Coming Soon",
     "ranked_1v1_title": "1v1",
     "ranked_2v2_title": "2v2",
-    "ranked_pairing_note": "In team modes, clanmates and friends in the queue are placed on the same team where possible. Friends are paired first, then clanmates. If your ratings differ by more than {maxEloDiff} ELO you'll be matched separately to keep games fair.",
+    "ranked_pairing_note": "In team modes, clanmates and friends in the queue are placed on the same team where possible. Friends are paired first, then clanmates. If your ratings are too far apart you'll be matched separately to keep games fair.",
     "ranked_title": "Ranked",
     "teams_count": "{teamCount} teams",
     "teams_of": "{teamCount} teams of {playersPerTeam}",

--- a/src/client/components/RankedModal.ts
+++ b/src/client/components/RankedModal.ts
@@ -8,6 +8,11 @@ import { translateText } from "../Utils";
 import { BaseModal } from "./BaseModal";
 import { modalHeader } from "./ui/ModalHeader";
 
+// Mirrors MAX_GROUPED_ELO_DIFF in the matchmaking API: past this rating gap a
+// queued clan/friend pair is split and both players are matched on their own.
+// The API owns the real value — keep the two in step when tuning it.
+const MAX_GROUPED_ELO_DIFF = 500;
+
 @customElement("ranked-modal")
 export class RankedModal extends BaseModal {
   protected routerName = "ranked";
@@ -134,6 +139,11 @@ export class RankedModal extends BaseModal {
             "",
           )}
         </div>
+        <p class="mt-6 text-xs text-white/60 leading-relaxed text-center">
+          ${translateText("mode_selector.ranked_pairing_note", {
+            maxEloDiff: MAX_GROUPED_ELO_DIFF,
+          })}
+        </p>
       </div>
     `;
   }

--- a/src/client/components/RankedModal.ts
+++ b/src/client/components/RankedModal.ts
@@ -8,11 +8,6 @@ import { translateText } from "../Utils";
 import { BaseModal } from "./BaseModal";
 import { modalHeader } from "./ui/ModalHeader";
 
-// Mirrors MAX_GROUPED_ELO_DIFF in the matchmaking API: past this rating gap a
-// queued clan/friend pair is split and both players are matched on their own.
-// The API owns the real value — keep the two in step when tuning it.
-const MAX_GROUPED_ELO_DIFF = 500;
-
 @customElement("ranked-modal")
 export class RankedModal extends BaseModal {
   protected routerName = "ranked";
@@ -140,9 +135,7 @@ export class RankedModal extends BaseModal {
           )}
         </div>
         <p class="mt-6 text-xs text-white/60 leading-relaxed text-center">
-          ${translateText("mode_selector.ranked_pairing_note", {
-            maxEloDiff: MAX_GROUPED_ELO_DIFF,
-          })}
+          ${translateText("mode_selector.ranked_pairing_note")}
         </p>
       </div>
     `;


### PR DESCRIPTION
## What

Adds a note under the cards on the ranked mode select screen:

> In team modes, clanmates and friends in the queue are placed on the same team where possible. Friends are paired first, then clanmates. If your ratings are too far apart you'll be matched separately to keep games fair.

## Why

Players had no way to know that queuing with a clanmate or friend is *meant* to put them on the same team, or why it sometimes doesn't. The matchmaking side of this is openfrontio/infra#495, which makes clan/friend pairs a first-class grouping key ahead of ELO selection — this explains the resulting behaviour, including the rating gap past which a pair is deliberately split.

Worded for **team modes generally** rather than 2v2 specifically, so it still reads correctly as more team gamemodes are added.

## Notes

- New `mode_selector.ranked_pairing_note` key in `en.json` only — Crowdin owns the other locales.
- The note deliberately does not quote the ELO threshold. That value lives in the matchmaking API, a separate repo the client cannot import from, so any client-side literal would silently go stale when the matchmaker is retuned — and the repo has a standing convention against hardcoding API-owned values (`TribesPanel.ts:363`). Describing the rule qualitatively keeps the threshold in one place.
- `translateText` uses `IntlMessageFormat`, where apostrophes are escape characters and the string contains "you'll" — verified the message renders and interpolates correctly rather than assuming.

## Testing

- `tsc --noEmit` clean, eslint clean, prettier clean.
- Client suite: 225 files, 2594 tests, all passing.

Targets `v33` rather than `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
