### PR TITLE
feat(ranked): explain clan/friend pairing on the ranked mode screen (port of #4861 to main)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1172,6 +1172,7 @@
     "coming_soon": "Coming Soon",
     "ranked_1v1_title": "1v1",
     "ranked_2v2_title": "2v2",
+    "ranked_pairing_note": "In team modes, clanmates and friends in the queue are placed on the same team where possible. Friends are paired first, then clanmates. If your ratings are too far apart you'll be matched separately to keep games fair.",
     "ranked_title": "Ranked",
     "teams_count": "{teamCount} teams",
     "teams_of": "{teamCount} teams of {playersPerTeam}",

--- a/src/client/components/RankedModal.ts
+++ b/src/client/components/RankedModal.ts
@@ -134,6 +134,9 @@ export class RankedModal extends BaseModal {
             "",
           )}
         </div>
+        <p class="mt-6 text-xs text-white/60 leading-relaxed text-center">
+          ${translateText("mode_selector.ranked_pairing_note")}
+        </p>
       </div>
     `;
   }


### PR DESCRIPTION
Port of #4861, which merged into `v33`, so the change isn't lost on the next release cut.

Straight `git cherry-pick -x` of `72b1861ec` — no conflicts, and the resulting `RankedModal.ts` and `en.json` are byte-identical to the `v33` versions.

## What

Adds a note under the cards on the ranked mode select screen:

> In team modes, clanmates and friends in the queue are placed on the same team where possible. Friends are paired first, then clanmates. If your ratings are too far apart you'll be matched separately to keep games fair.

Worded for team modes generally rather than 2v2 specifically, so it still reads correctly as more team gamemodes are added. It deliberately doesn't quote the ELO threshold — that value lives in the matchmaking API, a separate repo the client can't import from, so any client-side literal would silently go stale when the matchmaker is retuned.

New `mode_selector.ranked_pairing_note` key in `en.json` only; Crowdin owns the other locales.

## Testing

- `tsc --noEmit` clean, prettier clean, against `main`'s tree rather than just assuming the `v33` result carries over.
- Client suite: 225 files, 2594 tests, all passing.

## Note

The matchmaking change this describes is openfrontio/infra#495, which is **still open**. Until it merges and deploys, this note describes pairing behaviour the API doesn't implement yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)