### PR TITLE
make more things use the player name not copy button

### DIFF
--- a/src/client/ClanModal.ts
+++ b/src/client/ClanModal.ts
@@ -356,6 +356,8 @@ export class ClanModal extends BaseModal {
           @navigate-detail=${() => (this.view = "detail")}
           @navigate-bans=${() => (this.view = "bans")}
           @navigate-transfer=${() => (this.view = "transfer")}
+          @view-profile=${(e: CustomEvent<{ publicId: string }>) =>
+            this.openPlayerProfile(e.detail.publicId)}
           @clan-updated=${(e: CustomEvent<Partial<ClanInfo>>) => {
             if (this.selectedClan) {
               this.selectedClan = { ...this.selectedClan, ...e.detail };
@@ -383,6 +385,8 @@ export class ClanModal extends BaseModal {
           .clanTag=${this.selectedClanTag}
           .selectedClan=${this.selectedClan}
           @navigate-back=${() => (this.view = "manage")}
+          @view-profile=${(e: CustomEvent<{ publicId: string }>) =>
+            this.openPlayerProfile(e.detail.publicId)}
           @leadership-transferred=${() => {
             this.loadMyClans().then(() =>
               this.openDetail(this.selectedClanTag),
@@ -395,6 +399,8 @@ export class ClanModal extends BaseModal {
           .clanTag=${this.selectedClanTag}
           .selectedClan=${this.selectedClan}
           @navigate-back=${() => (this.view = "detail")}
+          @view-profile=${(e: CustomEvent<{ publicId: string }>) =>
+            this.openPlayerProfile(e.detail.publicId)}
           @request-approved=${() => {
             if (this.selectedClan) {
               this.selectedClan = {
@@ -410,6 +416,8 @@ export class ClanModal extends BaseModal {
         return html`<clan-bans-view
           .clanTag=${this.selectedClanTag}
           @navigate-back=${() => (this.view = "manage")}
+          @view-profile=${(e: CustomEvent<{ publicId: string }>) =>
+            this.openPlayerProfile(e.detail.publicId)}
         ></clan-bans-view>`;
       }
       // Default: detail view — dispatched by the active detail tab
@@ -609,6 +617,13 @@ export class ClanModal extends BaseModal {
     // rather than leave the user on an empty page.
     if (!this.selectedClanTag) {
       this.open({});
+      return;
+    }
+    // A sub-view (manage / transfer / requests / bans) survived the handoff in
+    // `view`, so reopening without a tab lands the user back on it.
+    if (this.view !== "detail") {
+      this.returningFromModalHandoff = true;
+      this.open({ clan: this.selectedClanTag });
       return;
     }
     if (this.profileOpenedFromGameHistory) {

--- a/src/client/components/FriendsList.ts
+++ b/src/client/components/FriendsList.ts
@@ -10,7 +10,7 @@ import {
   sendFriendRequest,
 } from "../FriendsApi";
 import { showToast, translateText } from "../Utils";
-import "./PlayerName";
+import { playerNameLink } from "./ui/PlayerNameLink";
 
 const PAGE_LIMIT = 20;
 
@@ -221,18 +221,6 @@ export class FriendsList extends LitElement {
     return new Date(iso).toLocaleDateString();
   }
 
-  // Bubble up to the account modal, which opens the player profile modal
-  // (and its back button returns here). Same handoff as clan/leaderboard rows.
-  private viewProfile(publicId: string): void {
-    this.dispatchEvent(
-      new CustomEvent<{ publicId: string }>("view-profile", {
-        detail: { publicId },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-  }
-
   render(): TemplateResult {
     if (this.loading) {
       return html`
@@ -347,12 +335,7 @@ export class FriendsList extends LitElement {
         class="flex items-center gap-3 bg-white/5 rounded-lg border border-white/10 p-3"
       >
         <div class="flex-1 min-w-0">
-          <player-name
-            .username=${entry.username}
-            .publicId=${entry.publicId}
-            .nameClass=${"font-bold text-blue-300 truncate hover:underline"}
-            .onNameClick=${() => this.viewProfile(entry.publicId)}
-          ></player-name>
+          ${playerNameLink(this, entry.username, entry.publicId)}
           <div class="text-white/30 text-[10px] mt-0.5">
             ${this.formatDate(entry.createdAt)}
           </div>
@@ -421,12 +404,7 @@ export class FriendsList extends LitElement {
                 class="flex items-center gap-3 bg-white/5 rounded-lg border border-white/10 p-3"
               >
                 <div class="flex-1 min-w-0">
-                  <player-name
-                    .username=${f.username}
-                    .publicId=${f.publicId}
-                    .nameClass=${"font-bold text-blue-300 truncate hover:underline"}
-                    .onNameClick=${() => this.viewProfile(f.publicId)}
-                  ></player-name>
+                  ${playerNameLink(this, f.username, f.publicId)}
                   <div class="text-white/30 text-[10px] mt-0.5">
                     ${translateText("friends.friends_since", {
                       date: this.formatDate(f.createdAt),

--- a/src/client/components/clan/ClanBansView.ts
+++ b/src/client/components/clan/ClanBansView.ts
@@ -2,7 +2,7 @@ import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { type ClanBan, fetchClanBans, unbanClanMember } from "../../ClanApi";
 import { translateText } from "../../Utils";
-import "../PlayerName";
+import { playerNameLink } from "../ui/PlayerNameLink";
 import {
   formatClanDate,
   renderLoadingSpinner,
@@ -150,17 +150,15 @@ export class ClanBansView extends LitElement {
                             />
                           </svg>
                         </div>
-                        <player-name
-                          .username=${ban.username}
-                          .publicId=${ban.publicId}
-                        ></player-name>
+                        ${playerNameLink(this, ban.username, ban.publicId)}
                         <span class="text-white/30 text-xs shrink-0"
                           >${translateText("clan_modal.banned_by_label")}</span
                         >
-                        <player-name
-                          .username=${ban.bannedByUsername}
-                          .publicId=${ban.bannedBy}
-                        ></player-name>
+                        ${playerNameLink(
+                          this,
+                          ban.bannedByUsername,
+                          ban.bannedBy,
+                        )}
                         <span class="text-white/30 text-xs shrink-0"
                           >${formatClanDate(ban.createdAt)}</span
                         >

--- a/src/client/components/clan/ClanDetailView.ts
+++ b/src/client/components/clan/ClanDetailView.ts
@@ -548,17 +548,7 @@ export class ClanDetailView extends LitElement {
           ),
         )}
         <div class="space-y-2">
-          ${filtered.map((m) =>
-            renderMemberRow(m, this.myPublicId, (publicId) =>
-              this.dispatchEvent(
-                new CustomEvent("view-profile", {
-                  detail: { publicId },
-                  bubbles: true,
-                  composed: true,
-                }),
-              ),
-            ),
-          )}
+          ${filtered.map((m) => renderMemberRow(m, this.myPublicId, this))}
         </div>
         ${renderMemberPagination(
           this.memberPage,

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -16,6 +16,7 @@ import {
   groupByDay,
 } from "../baseComponents/stats/GameHistoryDates";
 import { formatGameType, isFfa } from "../baseComponents/stats/GameTypeLabels";
+import { dispatchViewProfile } from "../ui/PlayerNameLink";
 import { verifiedBadge } from "../ui/VerifiedBadge";
 import { renderLoadingSpinner, showToast } from "./ClanShared";
 
@@ -205,16 +206,6 @@ export class ClanGameHistoryView extends LitElement {
     this.dispatchEvent(
       new CustomEvent<{ gameId: string }>("view-stats", {
         detail: { gameId },
-        bubbles: true,
-        composed: true,
-      }),
-    );
-  }
-
-  private viewProfile(publicId: string) {
-    this.dispatchEvent(
-      new CustomEvent<{ publicId: string }>("view-profile", {
-        detail: { publicId },
         bubbles: true,
         composed: true,
       }),
@@ -632,7 +623,7 @@ export class ClanGameHistoryView extends LitElement {
           type="button"
           class="font-bold text-blue-300 truncate hover:underline"
           title=${translateText("player_profile.view")}
-          @click=${() => this.viewProfile(p.publicId)}
+          @click=${() => dispatchViewProfile(this, p.publicId)}
         >
           ${p.username}
         </button>

--- a/src/client/components/clan/ClanManageView.ts
+++ b/src/client/components/clan/ClanManageView.ts
@@ -16,7 +16,7 @@ import {
 } from "../../ClanApi";
 import { translateText } from "../../Utils";
 import "../ConfirmDialog";
-import "../PlayerName";
+import { playerNameLink } from "../ui/PlayerNameLink";
 import {
   type ClanRole,
   defaultOrderForSort,
@@ -554,10 +554,7 @@ export class ClanManageView extends LitElement {
           >
             ${renderRoleIcon(member.role)}
           </div>
-          <player-name
-            .username=${member.username}
-            .publicId=${member.publicId}
-          ></player-name>
+          ${playerNameLink(this, member.username, member.publicId)}
           <span class="text-white/30 text-[10px] whitespace-nowrap">
             ${translateText("clan_modal.joined_date", {
               date: formatClanDate(member.joinedAt),

--- a/src/client/components/clan/ClanRequestsView.ts
+++ b/src/client/components/clan/ClanRequestsView.ts
@@ -8,7 +8,7 @@ import {
   fetchClanRequests,
 } from "../../ClanApi";
 import { translateText } from "../../Utils";
-import "../PlayerName";
+import { playerNameLink } from "../ui/PlayerNameLink";
 import {
   filterRequestsBySearch,
   formatClanDate,
@@ -153,10 +153,7 @@ export class ClanRequestsView extends LitElement {
                       class="flex items-center gap-3 bg-white/5 rounded-xl border border-white/10 p-4"
                     >
                       <div class="flex-1 min-w-0">
-                        <player-name
-                          .username=${req.username}
-                          .publicId=${req.publicId}
-                        ></player-name>
+                        ${playerNameLink(this, req.username, req.publicId)}
                         <span class="text-white/30 text-[10px]">
                           ${translateText("clan_modal.requested_on", {
                             tag: this.selectedClan?.tag ?? this.clanTag,

--- a/src/client/components/clan/ClanShared.ts
+++ b/src/client/components/clan/ClanShared.ts
@@ -7,7 +7,7 @@ import type {
   ClanMemberStats,
 } from "../../ClanApi";
 import { showToast, translateText } from "../../Utils";
-import "../PlayerName";
+import { playerNameLink } from "../ui/PlayerNameLink";
 import "./ClanStatsBreakdown";
 export { renderLoadingSpinner } from "../BaseModal";
 export { showToast };
@@ -376,10 +376,11 @@ export function renderMemberStats(
   `;
 }
 
+// `host` raises the `view-profile` event that opens the profile modal.
 export function renderMemberRow(
   member: ClanMember,
   myPublicId: string | null,
-  onViewProfile?: (publicId: string) => void,
+  host: HTMLElement,
 ): TemplateResult {
   const isMe = member.publicId === myPublicId;
   return html`
@@ -401,14 +402,7 @@ export function renderMemberRow(
         <div class="flex-1 min-w-0 flex flex-col">
           <div class="flex items-center justify-between gap-2">
             <div class="min-w-0">
-              <player-name
-                .username=${member.username}
-                .publicId=${member.publicId}
-                .nameClass=${"font-bold text-blue-300 truncate text-base hover:underline"}
-                .onNameClick=${onViewProfile
-                  ? () => onViewProfile(member.publicId)
-                  : null}
-              ></player-name>
+              ${playerNameLink(host, member.username, member.publicId)}
             </div>
             <div class="flex items-center gap-2 shrink-0">
               <span

--- a/src/client/components/clan/ClanTransferView.ts
+++ b/src/client/components/clan/ClanTransferView.ts
@@ -9,7 +9,7 @@ import {
 } from "../../ClanApi";
 import { translateText } from "../../Utils";
 import "../ConfirmDialog";
-import "../PlayerName";
+import { playerNameLink } from "../ui/PlayerNameLink";
 import {
   filterMembersBySearch,
   renderLoadingSpinner,
@@ -155,27 +155,36 @@ export class ClanTransferView extends LitElement {
         <div class="space-y-2">
           ${filterMembersBySearch(nonLeaders, this.memberSearch).map(
             (m) => html`
-              <button
-                @click=${() => (this.transferTarget = m.publicId)}
-                class="w-full flex items-center gap-3 py-2.5 px-3 rounded-xl border cursor-pointer transition-all text-left focus:outline-none focus:ring-2 focus:ring-amber-500/50
+              <div
+                class="relative w-full flex items-center gap-3 py-2.5 px-3 rounded-xl border transition-all text-left
                       ${this.transferTarget === m.publicId
                   ? "bg-amber-500/10 border-amber-500/20"
                   : "bg-white/5 border-white/10 hover:bg-white/10"}"
-                aria-selected=${this.transferTarget === m.publicId}
               >
+                <button
+                  type="button"
+                  @click=${() => (this.transferTarget = m.publicId)}
+                  aria-pressed=${this.transferTarget === m.publicId}
+                  aria-labelledby=${`transfer-target-${m.publicId}`}
+                  class="absolute inset-0 w-full h-full rounded-xl cursor-pointer focus:outline-none focus:ring-2 focus:ring-amber-500/50"
+                ></button>
                 <div
-                  class="w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-white/50 text-xs font-bold shrink-0"
+                  class="relative pointer-events-none w-8 h-8 rounded-full bg-white/10 flex items-center justify-center text-white/50 text-xs font-bold shrink-0"
                 >
                   ${renderRoleIcon(m.role)}
                 </div>
-                <div class="flex-1 min-w-0">
-                  <player-name
-                    .username=${m.username}
-                    .publicId=${m.publicId}
-                  ></player-name>
+                <div
+                  id=${`transfer-target-${m.publicId}`}
+                  class="relative pointer-events-none flex-1 min-w-0"
+                >
+                  <span
+                    class="pointer-events-auto inline-flex max-w-full min-w-0"
+                  >
+                    ${playerNameLink(this, m.username, m.publicId)}
+                  </span>
                 </div>
                 <span
-                  class="text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full shrink-0
+                  class="relative pointer-events-none text-[10px] font-bold uppercase tracking-wider px-2 py-0.5 rounded-full shrink-0
                         ${m.role === "officer"
                     ? "bg-purple-500/20 text-purple-400 border border-purple-500/30"
                     : "bg-white/10 text-white/40 border border-white/10"}"
@@ -185,7 +194,7 @@ export class ClanTransferView extends LitElement {
                 ${this.transferTarget === m.publicId
                   ? html`<svg
                       xmlns="http://www.w3.org/2000/svg"
-                      class="w-5 h-5 text-amber-400 shrink-0"
+                      class="relative pointer-events-none w-5 h-5 text-amber-400 shrink-0"
                       fill="none"
                       viewBox="0 0 24 24"
                       stroke="currentColor"
@@ -198,7 +207,7 @@ export class ClanTransferView extends LitElement {
                       />
                     </svg>`
                   : ""}
-              </button>
+              </div>
             `,
           )}
         </div>

--- a/src/client/components/ui/PlayerNameLink.ts
+++ b/src/client/components/ui/PlayerNameLink.ts
@@ -1,0 +1,38 @@
+import { html, TemplateResult } from "lit";
+import "../PlayerName";
+
+// Shared look for a clickable player name in a list row. No size class — every
+// row that uses it sits at the ambient 16px.
+const NAME_CLASS = "font-bold text-blue-300 truncate hover:underline";
+
+/**
+ * Raises the `view-profile` request from a list row. The row's owning modal
+ * (account, clan, …) listens for it and opens the player profile modal, so the
+ * profile's Back button can return to whichever surface asked for it.
+ */
+export function dispatchViewProfile(host: HTMLElement, publicId: string): void {
+  host.dispatchEvent(
+    new CustomEvent<{ publicId: string }>("view-profile", {
+      detail: { publicId },
+      bubbles: true,
+      composed: true,
+    }),
+  );
+}
+
+/**
+ * Player identity that opens their profile on click — `<player-name>` wired to
+ * dispatchViewProfile from `host`.
+ */
+export function playerNameLink(
+  host: HTMLElement,
+  username: string | null | undefined,
+  publicId: string,
+): TemplateResult {
+  return html`<player-name
+    .username=${username}
+    .publicId=${publicId}
+    .nameClass=${NAME_CLASS}
+    .onNameClick=${() => dispatchViewProfile(host, publicId)}
+  ></player-name>`;
+}

--- a/tests/client/clan/ClanModalProfileHandoff.test.ts
+++ b/tests/client/clan/ClanModalProfileHandoff.test.ts
@@ -208,6 +208,25 @@ describe("ClanModal — player-profile handoff", () => {
     expect(getElState(modal, "activeTab")).toBe("members");
   });
 
+  it("returns a profile opened from a sub-view to that sub-view", async () => {
+    // Manage/transfer/requests/bans have no tab of their own, so the Members
+    // tab fallback would drop the user a level up from where they clicked.
+    modal.open({ clan: "AAA" });
+    await waitForSubComponent(modal, "clan-detail-view");
+    setState(modal, "myRole" as keyof ClanModal, "leader" as never);
+    setState(modal, "view" as keyof ClanModal, "manage" as never);
+    await waitForSubComponent(modal, "clan-manage-view");
+
+    dispatchViewProfile("player-P", "clan-manage-view");
+    await flushAsync(modal);
+
+    modal.returnFromPlayerProfile();
+    await flushAsync(modal);
+
+    expect(getElState(modal, "selectedClanTag")).toBe("AAA");
+    expect(getElState(modal, "view")).toBe("manage");
+  });
+
   it("returns a member's profile to the clan's Game History tab", async () => {
     modal.open({ clan: "AAA" });
     await waitForSubComponent(modal, "clan-detail-view");


### PR DESCRIPTION
## Description:

switches everything else i can think of to the player info instead of the old copy button:

<img width="968" height="768" alt="image" src="https://github.com/user-attachments/assets/f3fa274e-dd4d-4112-8462-409e82270438" />
<img width="1025" height="774" alt="image" src="https://github.com/user-attachments/assets/84c0198f-b333-40b8-a695-90f245a1b55f" />
<img width="997" height="398" alt="image" src="https://github.com/user-attachments/assets/3e3b1626-5320-463d-9cb2-c6d1d4d57112" />
<img width="1038" height="330" alt="image" src="https://github.com/user-attachments/assets/86c4ea2e-0fac-45ec-9ac1-48bd6179d982" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
