### PR TITLE
Player info name font scaling

### DIFF
--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -235,14 +235,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     return renderDuration(remainingSeconds);
   }
 
-  private renderPlayerNameIcons(player: PlayerView) {
-    const firstPlace = getFirstPlacePlayer(this.game);
-    const icons = getPlayerIcons({
-      game: this.game,
-      player,
-      firstPlace,
-    });
-
+  private renderPlayerNameIcons(icons: ReturnType<typeof getPlayerIcons>) {
     if (icons.length === 0) {
       return html``;
     }
@@ -250,7 +243,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     return html`<span class="flex items-center gap-1 shrink-0">
       ${icons.map((icon) =>
         icon.kind === EMOJI_ICON_KIND && icon.text
-          ? html`<span class="text-sm shrink-0" translate="no"
+          ? html`<span class="h-4 w-4 font-mono text-sm shrink-0" translate="no"
               >${icon.text}</span
             >`
           : icon.kind === IMAGE_ICON_KIND && icon.src
@@ -260,6 +253,59 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     </span>`;
   }
 
+  /**
+   * Returns a CSS font-size value for the player name that scales down when
+   * icon pressure + name length would overflow the available row width.
+   * Uses calc(var(--text-lg) * scale) so the result always respects the
+   * CSS variable; min is var(--text-lg)/2, max is var(--text-lg).
+   */
+  private getNameFontSize(params: {
+    nameLength: number;
+    iconCount: number;
+    hasFlag: boolean;
+    hasBetrayal: boolean;
+    hasAlliance: boolean;
+    hasTeam: boolean;
+  }): string {
+    const { nameLength, iconCount, hasFlag, hasBetrayal, hasAlliance, hasTeam } =
+      params;
+
+    // Approximate char-widths each element occupies at --text-lg. 
+    const PRESSURE = { //35 39.8 just player 41 for none, 43.3 for one, 46.7 for two, 50.9 for three
+      playerType: 6,
+      perIcon:  2.25,
+      icon:     1.25,
+      flag:     1.5,
+      betrayal: 4,
+      alliance: 5.5,
+      team:     2.5,
+    } as const;
+
+    const iconPressure =
+      PRESSURE.playerType +
+      iconCount   * PRESSURE.perIcon + 
+      (iconCount   ? PRESSURE.icon     : 0) +
+      (hasFlag     ? PRESSURE.flag     : 0) +
+      (hasBetrayal ? PRESSURE.betrayal : 0) +
+      (hasAlliance ? PRESSURE.alliance : 0) +
+      (hasTeam     ? PRESSURE.team     : 0);
+
+    
+    const isDesktop = window.innerWidth >= 1024;
+
+    // How many chars fit at --text-lg.
+    const capacity = isDesktop ? 34 : 37;
+    const mobileFactor = isDesktop ? 1 : 1.29;
+    const scale = (capacity - iconPressure * mobileFactor) / nameLength;
+    
+    //  lg breakpoint (1024px)
+    if (isDesktop) {
+      return `clamp(var(--text-lg) * .65, var(--text-lg) * ${scale.toFixed(3)}, var(--text-lg))`;
+    } else {
+      return `clamp(var(--text-sm) * .65, var(--text-sm) * ${scale.toFixed(3)}, var(--text-sm))`;
+    }
+  }
+
   private renderPlayerInfo(player: PlayerView) {
     const myPlayer = this.game.myPlayer();
     const isFriendly = myPlayer?.isFriendly(player);
@@ -267,6 +313,8 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     const traitorTicks = player.getTraitorRemainingTicks();
     let allianceHtml: TemplateResult | null = null;
     let betrayalHtml: TemplateResult | null = null;
+    const firstPlace = getFirstPlacePlayer(this.game);
+    const playerIcons = getPlayerIcons({ game: this.game, player, firstPlace });
     const maxTroops = this.game.config().maxTroops(player);
     const attackingTroops = player
       .outgoingAttacks()
@@ -280,7 +328,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
         .find((alliance) => alliance.other === player.id());
       if (alliance !== undefined) {
         allianceHtml = html` <div
-          class="flex items-center  mr-0 gap-1 text-sm font-bold leading-tight"
+          class="${traitorTicks === 0 ? "ml-auto" : ""} flex items-center  mr-0 gap-1 text-sm font-bold leading-tight min-w-[17%]"
         >
           <img src=${allianceIcon} width="20" height="20" />
           ${this.allianceExpirationText(alliance)}
@@ -289,7 +337,8 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     }
 
     if (traitorTicks > 0) {
-      betrayalHtml = html`<img
+      betrayalHtml = html`<span class="flex ml-auto items-center shrink-0 "
+              ><img
           src=${traitorIcon}
           alt=""
           class="w-4 h-4 shrink-0"
@@ -299,7 +348,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
           drop-shadow-[-.2px_-.2px_.8px_rgba(0,0,0,.7),.2px_.2px_.8px_rgba(0,0,0,.7)]"
         >
           ${renderDuration(Math.floor(traitorTicks / 10))}
-        </span>`;
+        </span><span>`;
     }
 
     let playerType = "";
@@ -355,19 +404,26 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
           </div>
         </div>
         <!-- Right: Player identity + Units below -->
-        <div class="flex flex-col justify-between self-stretch flex-grow-1">
+        <div class="flex flex-col justify-between self-stretch w-[100%] flex-grow-1">
           <div
-            class="flex items-center gap-1 gap-y-2 md:gap-2 font-bold text-sm lg:text-lg ${this.getPlayerNameColor(
+            class="flex items-center gap-1 md:gap-2 font-bold text-sm lg:text-lg ${this.getPlayerNameColor(
               isFriendly ?? false,
             )}"
           >
             ${player.cosmetics.flag
               ? html`<img
-                  class="h-6 object-contain"
+                  class="h-6 object-contain shrink-0"
                   src=${assetUrl(player.cosmetics.flag!)}
                 />`
               : html``}
-            <span>${player.displayName()}</span>
+            <div class="shrink-10000 min-w-0"><span class="font-mono inline-block leading-[1.2] wrap-anywhere" style="font-size: ${this.getNameFontSize({
+              nameLength: player.displayName().length,
+              iconCount: playerIcons.length,
+              hasFlag: !!player.cosmetics.flag,
+              hasBetrayal: betrayalHtml !== null,
+              hasAlliance: allianceHtml !== null,
+              hasTeam: playerTeam !== "" && player.type() !== PlayerType.Bot,
+            })}">${player.displayName()}</span></div>
             ${this.getRelationSmiley(player, myPlayer)}
             ${playerTeam !== "" && player.type() !== PlayerType.Bot
               ? html`<div class="flex flex-col leading-tight">
@@ -387,10 +443,8 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
               : html`<span class="text-gray-400 text-xs font-normal"
                   >${playerType}</span
                 >`}
-            ${this.renderPlayerNameIcons(player)}
-            <span class="flex ml-auto items-center shrink-0 "
-              >${betrayalHtml ?? ""}</span
-            >
+            ${this.renderPlayerNameIcons(playerIcons)}
+            ${betrayalHtml ?? ""}
             ${allianceHtml ?? ""}
           </div>
           <div class="flex gap-0.5 lg:gap-1 items-center mt-0.5">

--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -267,37 +267,43 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     hasAlliance: boolean;
     hasTeam: boolean;
   }): string {
-    const { nameLength, iconCount, hasFlag, hasBetrayal, hasAlliance, hasTeam } =
-      params;
+    const {
+      nameLength,
+      iconCount,
+      hasFlag,
+      hasBetrayal,
+      hasAlliance,
+      hasTeam,
+    } = params;
 
-    // Approximate char-widths each element occupies at --text-lg. 
-    const PRESSURE = { //35 39.8 just player 41 for none, 43.3 for one, 46.7 for two, 50.9 for three
+    // Approximate char-widths each element occupies at --text-lg.
+    const PRESSURE = {
+      //35 39.8 just player 41 for none, 43.3 for one, 46.7 for two, 50.9 for three
       playerType: 6,
-      perIcon:  2.25,
-      icon:     1.25,
-      flag:     1.5,
+      perIcon: 2.25,
+      icon: 1.25,
+      flag: 1.5,
       betrayal: 4,
       alliance: 5.5,
-      team:     2.5,
+      team: 2.5,
     } as const;
 
     const iconPressure =
       PRESSURE.playerType +
-      iconCount   * PRESSURE.perIcon + 
-      (iconCount   ? PRESSURE.icon     : 0) +
-      (hasFlag     ? PRESSURE.flag     : 0) +
+      iconCount * PRESSURE.perIcon +
+      (iconCount ? PRESSURE.icon : 0) +
+      (hasFlag ? PRESSURE.flag : 0) +
       (hasBetrayal ? PRESSURE.betrayal : 0) +
       (hasAlliance ? PRESSURE.alliance : 0) +
-      (hasTeam     ? PRESSURE.team     : 0);
+      (hasTeam ? PRESSURE.team : 0);
 
-    
     const isDesktop = window.innerWidth >= 1024;
 
     // How many chars fit at --text-lg.
     const capacity = isDesktop ? 34 : 37;
     const mobileFactor = isDesktop ? 1 : 1.29;
     const scale = (capacity - iconPressure * mobileFactor) / nameLength;
-    
+
     //  lg breakpoint (1024px)
     if (isDesktop) {
       return `clamp(var(--text-lg) * .65, var(--text-lg) * ${scale.toFixed(3)}, var(--text-lg))`;
@@ -328,7 +334,9 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
         .find((alliance) => alliance.other === player.id());
       if (alliance !== undefined) {
         allianceHtml = html` <div
-          class="${traitorTicks === 0 ? "ml-auto" : ""} flex items-center  mr-0 gap-1 text-sm font-bold leading-tight min-w-[17%]"
+          class="${traitorTicks === 0
+            ? "ml-auto"
+            : ""} flex items-center  mr-0 gap-1 text-sm font-bold leading-tight min-w-[17%]"
         >
           <img src=${allianceIcon} width="20" height="20" />
           ${this.allianceExpirationText(alliance)}
@@ -338,17 +346,14 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
 
     if (traitorTicks > 0) {
       betrayalHtml = html`<span class="flex ml-auto items-center shrink-0 "
-              ><img
-          src=${traitorIcon}
-          alt=""
-          class="w-4 h-4 shrink-0"
-        />
+        ><img src=${traitorIcon} alt="" class="w-4 h-4 shrink-0" />
         <span
           class="text-sm text-red-900 
           drop-shadow-[-.2px_-.2px_.8px_rgba(0,0,0,.7),.2px_.2px_.8px_rgba(0,0,0,.7)]"
         >
-          ${renderDuration(Math.floor(traitorTicks / 10))}
-        </span><span>`;
+          ${renderDuration(Math.floor(traitorTicks / 10))} </span
+        ><span></span
+      ></span>`;
     }
 
     let playerType = "";
@@ -404,7 +409,9 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
           </div>
         </div>
         <!-- Right: Player identity + Units below -->
-        <div class="flex flex-col justify-between self-stretch w-[100%] flex-grow-1">
+        <div
+          class="flex flex-col justify-between self-stretch w-[100%] flex-grow-1"
+        >
           <div
             class="flex items-center gap-1 md:gap-2 font-bold text-sm lg:text-lg ${this.getPlayerNameColor(
               isFriendly ?? false,
@@ -416,14 +423,21 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
                   src=${assetUrl(player.cosmetics.flag!)}
                 />`
               : html``}
-            <div class="shrink-10000 min-w-0"><span class="font-mono inline-block leading-[1.2] wrap-anywhere" style="font-size: ${this.getNameFontSize({
-              nameLength: player.displayName().length,
-              iconCount: playerIcons.length,
-              hasFlag: !!player.cosmetics.flag,
-              hasBetrayal: betrayalHtml !== null,
-              hasAlliance: allianceHtml !== null,
-              hasTeam: playerTeam !== "" && player.type() !== PlayerType.Bot,
-            })}">${player.displayName()}</span></div>
+            <div class="shrink-10000 min-w-0">
+              <span
+                class="font-mono inline-block leading-[1.2] wrap-anywhere"
+                style="font-size: ${this.getNameFontSize({
+                  nameLength: player.displayName().length,
+                  iconCount: playerIcons.length,
+                  hasFlag: !!player.cosmetics.flag,
+                  hasBetrayal: betrayalHtml !== null,
+                  hasAlliance: allianceHtml !== null,
+                  hasTeam:
+                    playerTeam !== "" && player.type() !== PlayerType.Bot,
+                })}"
+                >${player.displayName()}</span
+              >
+            </div>
             ${this.getRelationSmiley(player, myPlayer)}
             ${playerTeam !== "" && player.type() !== PlayerType.Bot
               ? html`<div class="flex flex-col leading-tight">
@@ -443,8 +457,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
               : html`<span class="text-gray-400 text-xs font-normal"
                   >${playerType}</span
                 >`}
-            ${this.renderPlayerNameIcons(playerIcons)}
-            ${betrayalHtml ?? ""}
+            ${this.renderPlayerNameIcons(playerIcons)} ${betrayalHtml ?? ""}
             ${allianceHtml ?? ""}
           </div>
           <div class="flex gap-0.5 lg:gap-1 items-center mt-0.5">

--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -266,7 +266,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     hasBetrayal: boolean;
     hasAlliance: boolean;
     hasTeam: boolean;
-  }): string {
+  }): { fontSize: string; isAllianceWrapped: boolean } {
     const {
       nameLength,
       iconCount,
@@ -277,39 +277,77 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     } = params;
 
     // Approximate char-widths each element occupies at --text-lg.
-    const PRESSURE = {
-      //35 39.8 just player 41 for none, 43.3 for one, 46.7 for two, 50.9 for three
-      playerType: 6,
-      perIcon: 2.25,
-      icon: 1.25,
-      flag: 1.5,
-      betrayal: 4,
-      alliance: 5.5,
-      team: 2.5,
+    const DESKTOP_PRESSURE = {
+      playerType: 3.5,
+      perIcon: 2.0,
+      icon: 0.5,
+      flag: 3.5,
+      betrayal: 4.2,
+      alliance: 6.7,
+      allianceWrapped: 3.9,
+      team: 1.0,
     } as const;
 
-    const iconPressure =
+    const MOBILE_PRESSURE = {
+      playerType: 3.5,
+      perIcon: 2.2,
+      icon: 0.5,
+      flag: 4.2,
+      betrayal: 4.6,
+      alliance: 8.6,
+      allianceWrapped: 4.8,
+      team: 1.0,
+    } as const;
+
+    const width = window.innerWidth;
+    const isDesktop = width >= 1024;
+
+    const PRESSURE = isDesktop ? DESKTOP_PRESSURE : MOBILE_PRESSURE;
+
+    const basePressure =
       PRESSURE.playerType +
       iconCount * PRESSURE.perIcon +
       (iconCount ? PRESSURE.icon : 0) +
       (hasFlag ? PRESSURE.flag : 0) +
       (hasBetrayal ? PRESSURE.betrayal : 0) +
-      (hasAlliance ? PRESSURE.alliance : 0) +
       (hasTeam ? PRESSURE.team : 0);
 
-    const isDesktop = window.innerWidth >= 1024;
+    let capacity: number;
 
-    // How many chars fit at --text-lg.
-    const capacity = isDesktop ? 34 : 37;
-    const mobileFactor = isDesktop ? 1 : 1.29;
-    const scale = (capacity - iconPressure * mobileFactor) / nameLength;
-
-    //  lg breakpoint (1024px)
-    if (isDesktop) {
-      return `clamp(var(--text-lg) * .65, var(--text-lg) * ${scale.toFixed(3)}, var(--text-lg))`;
+    if (width < 640) {
+      // Below 640px, overlay 100% viewport width.
+      // space grows dynamically with width
+      capacity = 28.1 + (Math.max(360, width) - 360) * 0.119;
+    } else if (width < 768) {
+      // 640px - 767px: sm:w-[500px], troop col w-28
+      // space = 376px / 8.4px = 44.8 chars.
+      capacity = 44.8;
+    } else if (width < 1024) {
+      // 768px - 1023px: sm:w-[500px],  troop col md:w-36
+      // space = 344px / 8.4px = 41.0 chars.
+      capacity = 41.0;
     } else {
-      return `clamp(var(--text-sm) * .65, var(--text-sm) * ${scale.toFixed(3)}, var(--text-sm))`;
+      // >= 1024px: sm:w-[500px], font-size text-lg (18px, 10.8px/char).
+      // space = 336px / 10.8px = 31.1 chars.
+      capacity = 31.1;
     }
+
+    let isAllianceWrapped = false;
+    let alliancePressure = hasAlliance ? PRESSURE.alliance : 0;
+    let scale = (capacity - (basePressure + alliancePressure)) / nameLength;
+
+    // If alliance active and font scale < 0.85
+    // word-wrap alliance (icon & duration) to reduce width.
+    if (hasAlliance && scale < 0.85) {
+      isAllianceWrapped = true;
+      alliancePressure = PRESSURE.allianceWrapped;
+      scale = (capacity - (basePressure + alliancePressure)) / nameLength;
+    }
+
+    const textSize = isDesktop ? "lg" : "sm";
+    const fontSize = `clamp(var(--text-${textSize}) * .65, var(--text-${textSize}) * ${scale.toFixed(3)}, var(--text-${textSize}))`;
+
+    return { fontSize, isAllianceWrapped };
   }
 
   private renderPlayerInfo(player: PlayerView) {
@@ -328,19 +366,63 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
       .reduce((a, b) => a + b, 0);
     const totalTroops = player.troops();
 
+    let playerType = "";
+    switch (player.type()) {
+      case PlayerType.Bot:
+        playerType = translateText("player_type.bot");
+        break;
+      case PlayerType.Nation:
+        playerType = translateText("player_type.nation");
+        break;
+      case PlayerType.Human:
+        playerType = translateText("player_type.player");
+        break;
+    }
+    const playerTeam = getTranslatedPlayerTeamLabel(player.team());
+
+    const { fontSize, isAllianceWrapped } = this.getNameFontSize({
+      nameLength: player.displayName().length,
+      iconCount: playerIcons.length,
+      hasFlag: !!player.cosmetics.flag,
+      hasBetrayal: traitorTicks > 0,
+      hasAlliance: isAllied ?? false,
+      hasTeam: playerTeam !== "" && player.type() !== PlayerType.Bot,
+    });
+
     if (isAllied) {
       const alliance = myPlayer
         ?.alliances()
         .find((alliance) => alliance.other === player.id());
       if (alliance !== undefined) {
-        allianceHtml = html` <div
-          class="${traitorTicks === 0
-            ? "ml-auto"
-            : ""} flex items-center  mr-0 gap-1 text-sm font-bold leading-tight min-w-[17%]"
-        >
-          <img src=${allianceIcon} width="20" height="20" />
-          ${this.allianceExpirationText(alliance)}
-        </div>`;
+        allianceHtml = isAllianceWrapped
+          ? html`<div
+              class="${traitorTicks === 0
+                ? "ml-auto"
+                : ""} flex flex-col items-center gap-0 text-xs font-bold leading-none shrink-0"
+            >
+              <img
+                src=${allianceIcon}
+                width="14"
+                height="14"
+                class="shrink-0"
+              />
+              <span class="text-[10px] leading-tight"
+                >${this.allianceExpirationText(alliance)}</span
+              >
+            </div>`
+          : html`<div
+              class="${traitorTicks === 0
+                ? "ml-auto"
+                : ""} flex items-center mr-0 gap-1 text-xs font-bold leading-tight shrink-0"
+            >
+              <img
+                src=${allianceIcon}
+                width="18"
+                height="18"
+                class="shrink-0"
+              />
+              <span>${this.allianceExpirationText(alliance)}</span>
+            </div>`;
       }
     }
 
@@ -355,20 +437,6 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
         ><span></span
       ></span>`;
     }
-
-    let playerType = "";
-    switch (player.type()) {
-      case PlayerType.Bot:
-        playerType = translateText("player_type.bot");
-        break;
-      case PlayerType.Nation:
-        playerType = translateText("player_type.nation");
-        break;
-      case PlayerType.Human:
-        playerType = translateText("player_type.player");
-        break;
-    }
-    const playerTeam = getTranslatedPlayerTeamLabel(player.team());
 
     return html`
       <div class="flex items-start gap-1 lg:gap-2 p-1 lg:p-1.5">
@@ -413,7 +481,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
           class="flex flex-col justify-between self-stretch w-[100%] flex-grow-1"
         >
           <div
-            class="flex items-center gap-1 md:gap-2 font-bold text-sm lg:text-lg ${this.getPlayerNameColor(
+            class="flex items-center gap-1 lg:gap-2 font-bold text-sm lg:text-lg ${this.getPlayerNameColor(
               isFriendly ?? false,
             )}"
           >
@@ -423,18 +491,10 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
                   src=${assetUrl(player.cosmetics.flag!)}
                 />`
               : html``}
-            <div class="shrink-10000 min-w-0">
+            <div class="shrink min-w-0">
               <span
                 class="font-mono inline-block leading-[1.2] wrap-anywhere"
-                style="font-size: ${this.getNameFontSize({
-                  nameLength: player.displayName().length,
-                  iconCount: playerIcons.length,
-                  hasFlag: !!player.cosmetics.flag,
-                  hasBetrayal: betrayalHtml !== null,
-                  hasAlliance: allianceHtml !== null,
-                  hasTeam:
-                    playerTeam !== "" && player.type() !== PlayerType.Bot,
-                })}"
+                style="font-size: ${fontSize}"
                 >${player.displayName()}</span
               >
             </div>


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4863

## Description:

In player-info-overlay: Make the PlayerName monospace, this allows to scale the font-size based on pressure of the icons. All names will be text-lg (or sm for mobile) until the icons and alliance/betrayal puts spacial pressure, in which case the font-size gets reduced. If and only if the min font-size is reached through clamping, should the text start wrapping.

See album for various different device sizes, and different icons
https://imgur.com/a/20xfHFO

## Please complete the following:

- [x] I have added screenshots for all UI updates


## Please put your Discord username so you can be contacted if a bug or regression is found:

jB940
