### PR TITLE
fix(core): gate spawn intents on when they were issued, not when they land

### DIFF
--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -72,7 +72,14 @@ export class Executor {
       case "move_warship":
         return new MoveWarshipExecution(player, intent.unitIds, intent.tile);
       case "spawn":
-        return new SpawnExecution(this.gameID, player.info(), intent.tile);
+        // fromIntent: this one came off the wire, so it is subject to the
+        // spawn-phase gate that internal spawns are not.
+        return new SpawnExecution(
+          this.gameID,
+          player.info(),
+          intent.tile,
+          true,
+        );
       case "boat":
         return new TransportShipExecution(player, intent.dst, intent.troops);
       case "allianceRequest":

--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -21,12 +21,17 @@ export class SpawnExecution implements Execution {
   private random: PseudoRandom;
   active: boolean = true;
   private mg: Game;
+  private queuedDuringSpawnPhase = false;
   private static readonly MAX_SPAWN_TRIES = 1_000;
 
   constructor(
     gameID: GameID,
     private playerInfo: PlayerInfo,
     public tile?: TileRef,
+    // True only for spawns built from a client's spawn intent. Internal
+    // callers (PlayerSpawner, NationExecution) are trusted and place players
+    // deliberately, including at the end of the spawn phase; a client may not.
+    private fromIntent: boolean = false,
   ) {
     this.random = new PseudoRandom(
       simpleHash(playerInfo.id) + simpleHash(gameID),
@@ -35,6 +40,7 @@ export class SpawnExecution implements Execution {
 
   init(mg: Game, ticks: number) {
     this.mg = mg;
+    this.queuedDuringSpawnPhase = mg.inSpawnPhase();
   }
 
   tick(ticks: number) {
@@ -56,12 +62,15 @@ export class SpawnExecution implements Execution {
       player = this.mg.addPlayer(this.playerInfo);
     }
 
-    // Security: a spawn intent may only place or relocate a player's starting
-    // territory during the spawn phase. Once the game is underway, an
-    // already-spawned player who sends a spawn intent is attempting to
-    // teleport — relinquishing their territory and re-conquering it elsewhere.
-    // Ignore it so the intent is a deterministic no-op on every client.
-    if (!this.mg.inSpawnPhase() && player.hasSpawned()) {
+    // Security: a client's spawn intent is only honoured if it was *issued*
+    // during the spawn phase. Gating on the phase at tick time is wrong in
+    // both directions — an intent sent on the final spawn-phase tick runs a
+    // tick later and would be rejected, while checking hasSpawned() instead
+    // lets a player who never picked drop into a live game at a tile of their
+    // choosing. init() still sees the phase for a last-tick pick but not for
+    // anything sent afterwards, and runs identically on every client, so a
+    // rejected intent is a deterministic no-op rather than a desync.
+    if (this.fromIntent && !this.queuedDuringSpawnPhase) {
       return;
     }
 

--- a/tests/core/execution/SpawnExecution.test.ts
+++ b/tests/core/execution/SpawnExecution.test.ts
@@ -1,4 +1,6 @@
+import { Executor } from "../../../src/core/execution/ExecutionManager";
 import { SpawnExecution } from "../../../src/core/execution/SpawnExecution";
+import { SpawnTimerExecution } from "../../../src/core/execution/SpawnTimerExecution";
 import { PlayerInfo, PlayerType } from "../../../src/core/game/Game";
 import { setup } from "../../util/Setup";
 
@@ -127,12 +129,131 @@ describe("Spawn execution", () => {
     // Malicious "teleport": a spawn intent to a new tile after the game has
     // started must be a deterministic no-op — the player keeps their original
     // spawn location and territory rather than relinquishing and re-conquering.
-    game.addExecution(new SpawnExecution("game_id", playerInfo, 10));
+    game.addExecution(new SpawnExecution("game_id", playerInfo, 10, true));
     game.executeNextTick();
     game.executeNextTick();
 
     expect(player.spawnTile()).toBe(20);
     expect(player.numTilesOwned()).toBe(tilesBefore);
+  });
+
+  // Reported against #4657: that fix gated on `!inSpawnPhase() &&
+  // hasSpawned()`, so a player who never picked a spawn failed the second
+  // condition and was exempt — free to drop into a live game wherever they
+  // liked, with full knowledge of the map.
+  test("Spawn intent after the spawn phase is ignored for a player who never spawned", async () => {
+    const playerInfo = new PlayerInfo(
+      `player`,
+      PlayerType.Human,
+      `client_id`,
+      `player_id`,
+    );
+
+    // setup() ends the spawn phase, so this intent is issued into a live game.
+    const game = await setup("half_land_half_ocean", {}, [playerInfo]);
+    expect(game.inSpawnPhase()).toBe(false);
+
+    game.addExecution(new SpawnExecution("game_id", playerInfo, 20, true));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    const player = game.playerByClientID("client_id")!;
+    expect(player.hasSpawned()).toBe(false);
+    expect(player.numTilesOwned()).toBe(0);
+  });
+
+  test("Repeated spawn intents after the spawn phase all stay no-ops", async () => {
+    const playerInfo = new PlayerInfo(
+      `player`,
+      PlayerType.Human,
+      `client_id`,
+      `player_id`,
+    );
+
+    const game = await setup("half_land_half_ocean", {}, [playerInfo]);
+
+    // A burst in one turn, then more across later turns.
+    game.addExecution(
+      new SpawnExecution("game_id", playerInfo, 20, true),
+      new SpawnExecution("game_id", playerInfo, 10, true),
+      new SpawnExecution("game_id", playerInfo, 30, true),
+    );
+    game.executeNextTick();
+    game.executeNextTick();
+    game.addExecution(new SpawnExecution("game_id", playerInfo, 40, true));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    const player = game.playerByClientID("client_id")!;
+    expect(player.hasSpawned()).toBe(false);
+    expect(player.numTilesOwned()).toBe(0);
+  });
+
+  // The gate must not punish a legitimate last-moment pick: that intent is
+  // issued in-phase but its execution runs a tick later, once the phase has
+  // already ended.
+  test("Spawn intent issued on the final spawn-phase tick still lands on the chosen tile", async () => {
+    const playerInfo = new PlayerInfo(
+      `player`,
+      PlayerType.Human,
+      `client_id`,
+      `player_id`,
+    );
+
+    const game = await setup(
+      "half_land_half_ocean",
+      {},
+      [playerInfo],
+      undefined,
+      undefined,
+      false,
+    );
+    expect(game.inSpawnPhase()).toBe(true);
+    game.addExecution(new SpawnTimerExecution());
+
+    const lastPhaseTick = game.config().numSpawnPhaseTurns();
+    let queued = false;
+    for (let i = 0; i < lastPhaseTick + 5; i++) {
+      if (!queued && game.ticks() >= lastPhaseTick) {
+        game.addExecution(new SpawnExecution("game_id", playerInfo, 20, true));
+        queued = true;
+      }
+      game.executeNextTick();
+    }
+
+    // The phase ended before the execution ticked, yet the pick is honoured
+    // at the tile the player actually chose.
+    expect(game.inSpawnPhase()).toBe(false);
+    const player = game.playerByClientID("client_id")!;
+    expect(player.spawnTile()).toBe(20);
+    expect(player.numTilesOwned()).toBeGreaterThan(0);
+  });
+
+  // Locks the wiring: the gate is only meaningful if the intent path actually
+  // marks its executions as client-sourced.
+  test("Executor marks spawn intents as client-sourced", async () => {
+    const playerInfo = new PlayerInfo(
+      `player`,
+      PlayerType.Human,
+      `client_id`,
+      `player_id`,
+    );
+
+    const game = await setup("half_land_half_ocean", {}, [playerInfo]);
+    const executor = new Executor(game, "game_id", "client_id");
+
+    const exec = executor.createExec({
+      type: "spawn",
+      tile: 20,
+      clientID: "client_id",
+    } as never);
+
+    game.addExecution(exec);
+    game.executeNextTick();
+    game.executeNextTick();
+
+    const player = game.playerByClientID("client_id")!;
+    expect(player.hasSpawned()).toBe(false);
   });
 
   test("Random spawn ignores client-specified tile", async () => {


### PR DESCRIPTION
Follow-up to #4657, which a player reported was still exploitable. They were right about the hole, though not about the impact.

## The hole

```ts
if (!this.mg.inSpawnPhase() && player.hasSpawned()) return;   // #4657
```

A player who **never spawned** fails the second condition, so the guard never fires for them. They can sit out the spawn phase, then send a spawn intent at any later point and land on any unowned tile, with the whole map visible.

I confirmed the chain rather than just the execution:

- `GameImpl`'s constructor calls `addPlayers()`, so every lobby human is in game state from tick 0 — `playerByClientID` resolves and a real `SpawnExecution` is built.
- `ExecutionManager.createExec` gates only on the player existing.
- **`spawnPlayers()` runs only under `isRandomSpawn()`, and at `init`** — so in a normal game nothing ever auto-spawns someone who didn't pick. They stay unspawned indefinitely.

Random-spawn games were unaffected: everyone spawns at init, so `hasSpawned()` is true and the old guard held.

**The "multiple times" part of the report does not reproduce.** Firing four intents in a single tick lands only the first — `setSpawnTile()` runs at the end of `tick()`, so the rest hit the guard. It's one late drop, not repeated teleporting. Severity is lower than reported, but the hole is real. Also worth noting `getSpawnTiles` filters out owned tiles, so a late spawner claims only unowned land — no territory theft.

## Why not just gate on the phase

Checking `inSpawnPhase()` at tick time breaks legitimate spawns. New executions are initialised at the end of the tick they're queued in and first tick on the **next** one. I probed the boundary:

```
LAST-TICK  -> atInit=true   atTick=false
POST-PHASE -> atInit=false  atTick=false
```

So an intent sent on the final spawn-phase tick executes once the phase has ended. A blanket gate would silently drop it and the player would never spawn — which is exactly the state that enables this exploit. It would also break `NationExecution`, which queues in-phase and explicitly waits for a spawn that lands after the boundary (`NationExecution.ts:165`).

## The fix

Capture the phase in `init()`, which still sees it for a last-tick pick but not for anything sent afterwards, and apply the gate only to executions built from a **client intent**:

```ts
if (this.fromIntent && !this.queuedDuringSpawnPhase) return;
```

Internal callers (`PlayerSpawner`, `NationExecution`) place players deliberately and legitimately land a queued spawn just past the boundary; a client may not. `init()` runs identically in every client's simulation, so a rejected intent stays a deterministic no-op rather than a desync — the same property #4657 relied on.

This **subsumes** the `hasSpawned()` check, which is removed: an already-spawned player's mid-game intent is now rejected because it was issued out of phase, not because of what they own. The random-spawn re-roll guard is unchanged.

### Why intent-scoped rather than all human spawns

Gating every human `SpawnExecution` on init-time phase also works, but breaks 11 test files / 35 tests that use `SpawnExecution` simply to place a player after `setup()` has ended the phase. The vulnerability is specifically untrusted client input, and `createExec` is the only place an intent becomes a `SpawnExecution`, so scoping the gate to that trust boundary is both tighter and non-destructive. The trade-off is that a future call site forwarding an intent must set the flag — there's a test locking the current wiring.

## Tests

Four added:

- spawn intent after the phase, from a player who never spawned → ignored
- repeated intents (same-tick burst + across turns) → all no-ops
- intent issued on the **final spawn-phase tick** → still lands on the chosen tile
- `Executor` marks spawn intents as client-sourced (locks the wiring)

The existing anti-teleport test now goes through the intent path, which is what it always meant to model.

I verified the tests aren't vacuous by stashing the source fix: three of the four fail against unfixed `main`. The last-tick test passes either way by design — it's a regression guard for the new gate, not a bug-catcher.

Full suite: 225 files, 2598 tests, all passing. `tsc --noEmit`, eslint and prettier clean.

To be cherry-picked into `v33`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)