### PR TITLE
prevent translation keys from appearing in the Streaming Now panel

### DIFF
--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -246,6 +246,7 @@ export class LangSelector extends LitElement {
       "tribes-panel",
       "steam-wishlist",
       "steam-wishlist-button",
+      "streaming-now",
     ];
 
     document.title = this.translateText("main.title") ?? document.title;


### PR DESCRIPTION
## Description:

This PR addresses an issue reported in the translation server where the Streaming Now panel temporarily displayed translation keys when using a language other than English.

The `streaming-now` component was not refreshed after translations finished loading, so the correct strings did not appear until the next stream refresh.

before
<img width="323" height="152" alt="スクリーンショット 2026-08-05 6 58 23" src="https://github.com/user-attachments/assets/d69ec43b-fab6-44e5-bb7e-cd58ff94d735" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri
