### PR TITLE
Document C compiler requirement for map generator 📝

### DIFF
--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -12,7 +12,7 @@ the [Official Openfront Wiki](https://openfront.wiki/Map_Making)
 
 1. Install go <https://go.dev/doc/install>
 2. Install a C compiler (required by the WebP dependency via CGO):
-   - **Windows:** Install [MSYS2](https://www.msys2.org/) and the `mingw-w64-gcc` package, or [TDM-GCC](https://jmeubank.github.io/tdm-gcc/). Make sure `gcc` is on your PATH.
+   - **Windows:** Install [MSYS2](https://www.msys2.org/), open the **UCRT64** terminal, and run `pacman -S mingw-w64-ucrt-x86_64-gcc`. Either use Go from within that terminal or add the UCRT64 `bin` directory (e.g. `C:\msys64\ucrt64\bin`) to your PATH so `gcc` is available. Alternatively, install [TDM-GCC](https://jmeubank.github.io/tdm-gcc/).
    - **macOS:** `xcode-select --install`
    - **Linux:** `sudo apt install gcc` (Debian/Ubuntu) or equivalent.
 3. Go to map-generator folder: `cd map-generator`

--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -11,9 +11,13 @@ the [Official Openfront Wiki](https://openfront.wiki/Map_Making)
 ## Installation
 
 1. Install go <https://go.dev/doc/install>
-2. Go to map-generator folder: `cd map-generator`
-3. Install dependencies: `go mod download`
-4. Run the generator for all maps: `go run .`
+2. Install a C compiler (required by the WebP dependency via CGO):
+   - **Windows:** Install [MSYS2](https://www.msys2.org/) and the `mingw-w64-gcc` package, or [TDM-GCC](https://jmeubank.github.io/tdm-gcc/). Make sure `gcc` is on your PATH.
+   - **macOS:** `xcode-select --install`
+   - **Linux:** `sudo apt install gcc` (Debian/Ubuntu) or equivalent.
+3. Go to map-generator folder: `cd map-generator`
+4. Install dependencies: `go mod download`
+5. Run the generator for all maps: `go run .`
 
 ## Creating a new map
 


### PR DESCRIPTION
## Description:

Add a C compiler installation step to the map-generator README. The `chai2010/webp` dependency bundles libwebp-1.4 and uses CGO, so a C compiler (GCC on Windows/Linux, Xcode CLI tools on macOS) is required to build the map generator.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin