### PR TITLE
Fix: Effects out of view and unscrollable on mobile screens

### DIFF
--- a/src/client/components/EffectsGrid.ts
+++ b/src/client/components/EffectsGrid.ts
@@ -184,12 +184,12 @@ export class EffectsGrid extends LitElement {
   private renderTabBar(): TemplateResult {
     return html`
       <div
-        class="flex items-center justify-center gap-6 border-b border-white/10 px-4"
+        class="flex flex-wrap items-center justify-center gap-x-6 gap-y-2 border-b border-white/10 px-4 sm:flex-nowrap"
       >
         ${EFFECT_TYPES.map((type) => {
           const active = this.activeType === type;
           return html`<button
-            class="-mb-px border-b-2 px-2 py-3 text-sm font-black uppercase tracking-wider transition-colors ${active
+            class="-mb-px min-w-0 border-b-2 px-2 py-3 text-sm font-black uppercase tracking-wider transition-colors ${active
               ? "border-blue-500 text-blue-400"
               : "border-transparent text-white/50 hover:text-white/80"}"
             @click=${() => (this.activeType = type)}


### PR DESCRIPTION
In Store and Cosmetics modals, fix horizontal display of Effects on mobile screens. 

Left-most Effect effectively wasn't shown on screen and couldn't be scrolled to, so you would not know what Effect you were looking at. The right-most Effect was partly shown and was scrollable, but still you'd have to discover this and you want to make it easy for users. 

**BEFORE:**
https://github.com/user-attachments/assets/4d1defb2-7bec-44bb-b013-b4311d6fed5d

**AFTER:**
https://github.com/user-attachments/assets/d8cdebc1-ec56-48dd-aee7-9f0e9749ea31


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33