### PR TITLE
Chore(DevOps): app-id is deprecated for actions/create-github-app-token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
         id: generate-token
         if: ${{ github.repository == 'openfrontio/OpenFrontIO' }}
         with:
-          app-id: ${{ vars.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Export the token
         if: ${{ github.repository == 'openfrontio/OpenFrontIO' }}


### PR DESCRIPTION
## Description:

app-id is deprecated for actions/create-github-app-token@v3. Before it's deleted one day, let's move to the use of client-id.

1. Please check if we already have a variable called APP_CLIENT_ID and if not, please create it see below
2. This PR only has the one small change needed in `deploy.yml`, when APP_CLIENT_ID exists as a variable

**Background info:**
See the warnings at every [run](https://github.com/openfrontio/OpenFrontIO/actions/runs/31042067417/job/92428568196):
<img width="672" height="148" alt="image" src="https://github.com/user-attachments/assets/4eb318f3-93b5-4c13-8d34-2a7a16603c55" />

This stems from https://github.com/actions/create-github-app-token/pull/353 and https://github.com/actions/create-github-app-token/pull/363.

Their current README reads:
<img width="778" height="165" alt="image" src="https://github.com/user-attachments/assets/5ba8d865-4a78-42ae-b2e1-d2b5b35497a1" />

How to get the [client_id](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app):
<img width="865" height="261" alt="image" src="https://github.com/user-attachments/assets/f79b6c2b-b25e-485a-86ea-ed29ad6445db" />
https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#navigating-to-your-github-app-settings

How to store the client_id in variable APP_CLIENT_ID:
https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/use-variables#defining-configuration-variables-for-multiple-workflows

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

tryout33