### PR TITLE
Allow selecting missile launch silo

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1199,6 +1199,10 @@
     "tutorial": "TUTORIAL",
     "warning": "WARNING"
   },
+  "nuke_targeting": {
+    "silo_selected": "Missile silo selected",
+    "silo_unavailable": "That missile silo is not ready"
+  },
   "performance_overlay": {
     "avg_60s": "Avg (60s):",
     "collapse": "Collapse",

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -91,6 +91,7 @@ export class BuildUnitIntentEvent implements GameEvent {
     public readonly unit: UnitType,
     public readonly tile: TileRef,
     public readonly rocketDirectionUp?: boolean,
+    public readonly sourceSiloId?: number,
   ) {}
 }
 
@@ -583,6 +584,7 @@ export class Transport {
       unit: event.unit,
       tile: event.tile,
       rocketDirectionUp: event.rocketDirectionUp,
+      sourceSiloId: event.sourceSiloId,
     });
   }
 

--- a/src/client/controllers/BuildPreviewController.ts
+++ b/src/client/controllers/BuildPreviewController.ts
@@ -24,6 +24,7 @@ import {
   ConfirmGhostStructureEvent,
   MouseMoveEvent,
   MouseUpEvent,
+  ToggleStructureEvent,
 } from "../InputHandler";
 import { MapRenderer, buildNukeTrajectory } from "../render/gl";
 import type { SAMInfo } from "../render/gl/utils/NukeTrajectory";
@@ -34,11 +35,48 @@ import {
   SendUpgradeStructureIntentEvent,
 } from "../Transport";
 import { UIState } from "../UIState";
+import { showToast, translateText } from "../Utils";
 import { GameView } from "../view";
+import type { UnitView } from "../view/UnitView";
 
 /** True for nuke types (AtomBomb, HydrogenBomb): ghost is preserved after placement so user can place multiple or keep selection (Enter/key confirm). */
 export function shouldPreserveGhostAfterBuild(unitType: UnitType): boolean {
   return unitType === UnitType.AtomBomb || unitType === UnitType.HydrogenBomb;
+}
+
+export function isPlayerMissileType(unitType: UnitType | null): boolean {
+  return (
+    unitType === UnitType.AtomBomb ||
+    unitType === UnitType.HydrogenBomb ||
+    unitType === UnitType.MIRV
+  );
+}
+
+export function isReadyMissileSilo(
+  silo: Pick<UnitView, "isActive" | "isInCooldown" | "isUnderConstruction">,
+): boolean {
+  return silo.isActive() && !silo.isInCooldown() && !silo.isUnderConstruction();
+}
+
+export function chooseMissileSilo<T extends Pick<UnitView, "id">>(
+  silos: readonly T[],
+  sourceSiloId: number | null,
+  distance: (silo: T) => number,
+): T | undefined {
+  if (sourceSiloId !== null) {
+    return silos.find((silo) => silo.id() === sourceSiloId);
+  }
+
+  let nearest: T | undefined;
+  let nearestDistance = Infinity;
+  for (const silo of silos) {
+    const siloDistance = distance(silo);
+    if (siloDistance < nearestDistance) {
+      nearest = silo;
+      nearestDistance = siloDistance;
+    }
+  }
+  return nearest;
 }
 
 // tSamIntercept value used to flag an untargetable (impassable) destination:
@@ -75,6 +113,7 @@ export class BuildPreviewController implements Controller {
   private readonly mousePos = { x: 0, y: 0 };
   private lastGhostQueryAt: number = 0;
   private pendingConfirm: MouseUpEvent | null = null;
+  private sourceSiloId: number | null = null;
 
   // Buildable validation runs on the snapped tile under the cursor, but the
   // rendered icon follows the cursor at sub-tile precision so motion is
@@ -315,7 +354,8 @@ export class BuildPreviewController implements Controller {
 
   /**
    * For AtomBomb / HydrogenBomb ghosts, push the Bezier trajectory preview
-   * (closest player-owned silo → target, accounting for non-allied SAMs).
+   * (selected ready silo, or closest ready silo → target, accounting for
+   * non-allied SAMs).
    * Cleared whenever the ghost isn't a nuke, has no target, or the player
    * has no silos. Unlike the ghost icon, the trajectory also renders when
    * hovering impassable terrain (cursorLoop adds the blocked X there).
@@ -343,9 +383,7 @@ export class BuildPreviewController implements Controller {
     // originating from a silo the game wouldn't use.
     const silos = myPlayer
       .units(UnitType.MissileSilo)
-      .filter(
-        (u) => u.isActive() && !u.isInCooldown() && !u.isUnderConstruction(),
-      );
+      .filter(isReadyMissileSilo);
     if (silos.length === 0) {
       this.clearNukeTrajectory();
       return;
@@ -353,15 +391,17 @@ export class BuildPreviewController implements Controller {
 
     const dstX = this.game.x(tileRef);
     const dstY = this.game.y(tileRef);
-    silos.sort(
-      (a, b) =>
-        Math.abs(this.game.x(a.tile()) - dstX) +
-        Math.abs(this.game.y(a.tile()) - dstY) -
-        (Math.abs(this.game.x(b.tile()) - dstX) +
-          Math.abs(this.game.y(b.tile()) - dstY)),
+    const bestSilo = chooseMissileSilo(
+      silos,
+      this.sourceSiloId,
+      (silo) =>
+        Math.abs(this.game.x(silo.tile()) - dstX) +
+        Math.abs(this.game.y(silo.tile()) - dstY),
     );
-
-    const bestSilo = silos[0];
+    if (bestSilo === undefined) {
+      this.clearNukeTrajectory();
+      return;
+    }
     const directionUp = this.uiState.rocketDirectionUp;
     const srcX = this.game.x(bestSilo.tile());
     const srcY = this.game.y(bestSilo.tile());
@@ -501,6 +541,7 @@ export class BuildPreviewController implements Controller {
 
   private requestConfirmStructure(e: MouseUpEvent): void {
     if (!this.ghostUnit && !this.uiState.ghostStructure) return;
+    if (this.trySelectMissileSilo(e)) return;
     if (this.isGhostReadyForConfirm()) {
       this.createStructure(e);
     } else {
@@ -537,6 +578,9 @@ export class BuildPreviewController implements Controller {
           unitType,
           this.game.ref(tile.x, tile.y),
           rocketDirectionUp,
+          isPlayerMissileType(unitType)
+            ? (this.sourceSiloId ?? undefined)
+            : undefined,
         ),
       );
       if (!shouldPreserveGhostAfterBuild(unitType)) {
@@ -565,19 +609,54 @@ export class BuildPreviewController implements Controller {
         ghostRailPaths: [],
       },
     };
+    if (isPlayerMissileType(type)) {
+      this.eventBus.emit(new ToggleStructureEvent([UnitType.MissileSilo]));
+    }
   }
 
   private clearGhostStructure() {
+    const wasPlayerMissile = isPlayerMissileType(
+      this.ghostUnit?.buildableUnit.type ?? null,
+    );
     this.pendingConfirm = null;
     this.ghostUnit = null;
+    this.sourceSiloId = null;
     this.lastGhostData = null;
     this.view.updateGhostPreview(null);
     this.clearNukeTrajectory();
+    if (wasPlayerMissile) {
+      this.eventBus.emit(new ToggleStructureEvent(null));
+    }
   }
 
   private removeGhostStructure() {
     this.clearGhostStructure();
     this.uiState.ghostStructure = null;
+  }
+
+  private trySelectMissileSilo(e: MouseUpEvent): boolean {
+    const type =
+      this.ghostUnit?.buildableUnit.type ?? this.uiState.ghostStructure;
+    if (!isPlayerMissileType(type)) return false;
+
+    const tile = this.transformHandler.screenToWorldCoordinates(e.x, e.y);
+    if (!this.game.isValidCoord(tile.x, tile.y)) return false;
+    const tileRef = this.game.ref(tile.x, tile.y);
+    const silo = this.game
+      .myPlayer()
+      ?.units(UnitType.MissileSilo)
+      .find((unit) => unit.tile() === tileRef);
+    if (silo === undefined) return false;
+
+    if (!isReadyMissileSilo(silo)) {
+      showToast(translateText("nuke_targeting.silo_unavailable"), "red", 1500);
+      return true;
+    }
+
+    this.sourceSiloId = silo.id();
+    this.lastGhostQueryAt = 0;
+    showToast(translateText("nuke_targeting.silo_selected"), "green", 1500);
+    return true;
   }
 
   private resolveGhostRangeLevel(

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -518,6 +518,7 @@ export const BuildUnitIntentSchema = z.object({
   unit: z.enum(UnitType),
   tile: z.number().int().nonnegative(),
   rocketDirectionUp: z.boolean().optional(),
+  sourceSiloId: z.number().int().nonnegative().optional(),
 });
 
 export const UpgradeStructureIntentSchema = z.object({

--- a/src/core/execution/ConstructionExecution.ts
+++ b/src/core/execution/ConstructionExecution.ts
@@ -22,6 +22,7 @@ export class ConstructionExecution implements Execution {
     private constructionType: UnitType,
     private tile: TileRef,
     private rocketDirectionUp?: boolean,
+    private sourceSiloId?: number,
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -113,11 +114,14 @@ export class ConstructionExecution implements Execution {
             -1,
             0,
             this.rocketDirectionUp,
+            this.sourceSiloId,
           ),
         );
         break;
       case UnitType.MIRV:
-        this.mg.addExecution(new MirvExecution(player, this.tile));
+        this.mg.addExecution(
+          new MirvExecution(player, this.tile, this.sourceSiloId),
+        );
         break;
       case UnitType.Warship:
         this.mg.addExecution(

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -110,6 +110,7 @@ export class Executor {
           intent.unit,
           intent.tile,
           intent.rocketDirectionUp,
+          intent.sourceSiloId,
         );
       case "allianceExtension": {
         return new AllianceExtensionExecution(player, intent.recipient);

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -44,6 +44,7 @@ export class MirvExecution implements Execution {
   constructor(
     private player: Player,
     private dst: TileRef,
+    private sourceSiloId?: number,
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -70,7 +71,12 @@ export class MirvExecution implements Execution {
 
   tick(ticks: number): void {
     if (this.nuke === null) {
-      const spawn = this.player.canBuild(UnitType.MIRV, this.dst);
+      const spawn = this.player.canBuild(
+        UnitType.MIRV,
+        this.dst,
+        null,
+        this.sourceSiloId,
+      );
       if (spawn === false) {
         console.warn(`cannot build MIRV`);
         this.active = false;

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -35,6 +35,7 @@ export class NukeExecution implements Execution {
     private speed: number = -1,
     private waitTicks = 0,
     private rocketDirectionUp: boolean = true,
+    private sourceSiloId?: number,
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -183,7 +184,12 @@ export class NukeExecution implements Execution {
 
   tick(ticks: number): void {
     if (this.nuke === null) {
-      const spawn = this.player.canBuild(this.nukeType, this.dst);
+      const spawn = this.player.canBuild(
+        this.nukeType,
+        this.dst,
+        null,
+        this.sourceSiloId,
+      );
       if (spawn === false) {
         console.warn(`cannot build Nuke`);
         this.active = false;

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -613,6 +613,7 @@ export interface Player {
     type: UnitType,
     targetTile: TileRef,
     validTiles?: TileRef[] | null,
+    sourceSiloId?: number,
   ): TileRef | false;
   buildUnit<T extends UnitType>(
     type: T,

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -1377,28 +1377,35 @@ export class PlayerImpl implements Player {
     unitType: UnitType,
     targetTile: TileRef,
     validTiles: TileRef[] | null = null,
+    sourceSiloId?: number,
   ): TileRef | false {
     if (!this.canBuildUnitType(unitType)) {
       return false;
     }
 
-    return this.canSpawnUnitType(unitType, targetTile, validTiles);
+    return this.canSpawnUnitType(
+      unitType,
+      targetTile,
+      validTiles,
+      sourceSiloId,
+    );
   }
 
   private canSpawnUnitType(
     unitType: UnitType,
     targetTile: TileRef,
     validTiles: TileRef[] | null,
+    sourceSiloId?: number,
   ): TileRef | false {
     switch (unitType) {
       case UnitType.MIRV:
         if (!this.mg.hasOwner(targetTile)) {
           return false;
         }
-        return this.nukeSpawn(targetTile, unitType);
+        return this.nukeSpawn(targetTile, unitType, sourceSiloId);
       case UnitType.AtomBomb:
       case UnitType.HydrogenBomb:
-        return this.nukeSpawn(targetTile, unitType);
+        return this.nukeSpawn(targetTile, unitType, sourceSiloId);
       case UnitType.MIRVWarhead:
         return targetTile;
       case UnitType.Port:
@@ -1425,7 +1432,11 @@ export class PlayerImpl implements Player {
     }
   }
 
-  nukeSpawn(tile: TileRef, nukeType: UnitType): TileRef | false {
+  nukeSpawn(
+    tile: TileRef,
+    nukeType: UnitType,
+    sourceSiloId?: number,
+  ): TileRef | false {
     const mg = this.mg;
     if (mg.isSpawnImmunityActive()) {
       return false;
@@ -1468,6 +1479,11 @@ export class PlayerImpl implements Player {
       (silo) =>
         silo.isActive() && !silo.isInCooldown() && !silo.isUnderConstruction(),
     );
+    if (sourceSiloId !== undefined) {
+      return (
+        readySilos.find((silo) => silo.id() === sourceSiloId)?.tile() ?? false
+      );
+    }
     readySilos.sort(
       (a, b) =>
         mg.manhattanDist(a.tile(), tile) - mg.manhattanDist(b.tile(), tile),

--- a/tests/MissileSilo.test.ts
+++ b/tests/MissileSilo.test.ts
@@ -1,3 +1,4 @@
+import { ConstructionExecution } from "../src/core/execution/ConstructionExecution";
 import { MirvExecution } from "../src/core/execution/MIRVExecution";
 import { NukeExecution } from "../src/core/execution/NukeExecution";
 import { SpawnExecution } from "../src/core/execution/SpawnExecution";
@@ -117,6 +118,76 @@ describe("MissileSilo", () => {
     // the silo is on cooldown, so it cannot launch another nuke
     attackerBuildsNuke(null, game.ref(7, 7));
     expect(attacker.units(UnitType.AtomBomb)).toHaveLength(0);
+  });
+
+  test.each([UnitType.AtomBomb, UnitType.HydrogenBomb])(
+    "selected silo launches a %s instead of the nearest silo",
+    (missileType) => {
+      attacker.buildUnit(UnitType.MissileSilo, game.ref(20, 20), {});
+      const [selectedSilo, nearestSilo] = attacker.units(UnitType.MissileSilo);
+      expect(selectedSilo.tile()).toBe(game.ref(1, 1));
+      expect(nearestSilo.tile()).toBe(game.ref(20, 20));
+
+      game.addExecution(
+        new ConstructionExecution(
+          attacker,
+          missileType,
+          game.ref(50, 50),
+          undefined,
+          selectedSilo.id(),
+        ),
+      );
+      executeTicks(game, 4);
+
+      expect(selectedSilo.isInCooldown()).toBe(true);
+      expect(nearestSilo.isInCooldown()).toBe(false);
+      expect(attacker.units(missileType)).toHaveLength(1);
+    },
+  );
+
+  test("invalid selected silo rejects the launch instead of falling back", () => {
+    const readySilo = attacker.units(UnitType.MissileSilo)[0];
+    game.addExecution(
+      new ConstructionExecution(
+        attacker,
+        UnitType.AtomBomb,
+        game.ref(50, 50),
+        undefined,
+        999_999,
+      ),
+    );
+    executeTicks(game, 4);
+
+    expect(readySilo.isInCooldown()).toBe(false);
+    expect(attacker.units(UnitType.AtomBomb)).toHaveLength(0);
+  });
+
+  test("selected silo also launches a MIRV", () => {
+    attacker.buildUnit(UnitType.MissileSilo, game.ref(20, 20), {});
+    const [selectedSilo, nearestSilo] = attacker.units(UnitType.MissileSilo);
+    const targetInfo = new PlayerInfo(
+      "mirv_target_id",
+      PlayerType.Human,
+      null,
+      "mirv_target_id",
+    );
+    game.addPlayer(targetInfo);
+    game.player(targetInfo.id).conquer(game.ref(50, 50));
+
+    game.addExecution(
+      new ConstructionExecution(
+        attacker,
+        UnitType.MIRV,
+        game.ref(50, 50),
+        undefined,
+        selectedSilo.id(),
+      ),
+    );
+    executeTicks(game, 4);
+
+    expect(selectedSilo.isInCooldown()).toBe(true);
+    expect(nearestSilo.isInCooldown()).toBe(false);
+    expect(attacker.units(UnitType.MIRV)).toHaveLength(1);
   });
 
   test("missilesilo should have increased level after upgrade", async () => {

--- a/tests/client/controllers/BuildPreviewController.test.ts
+++ b/tests/client/controllers/BuildPreviewController.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "vitest";
 import {
+  chooseMissileSilo,
+  isPlayerMissileType,
+  isReadyMissileSilo,
   samThreatensNukePreview,
   shouldPreserveGhostAfterBuild,
 } from "../../../src/client/controllers/BuildPreviewController";
@@ -31,6 +34,44 @@ describe("BuildPreviewController ghost preservation (locked nuke / Enter confirm
       expect(shouldPreserveGhostAfterBuild(UnitType.Warship)).toBe(false);
       expect(shouldPreserveGhostAfterBuild(UnitType.MIRV)).toBe(false);
     });
+  });
+});
+
+describe("missile silo source selection", () => {
+  test("recognizes every player-aimed missile type", () => {
+    expect(isPlayerMissileType(UnitType.AtomBomb)).toBe(true);
+    expect(isPlayerMissileType(UnitType.HydrogenBomb)).toBe(true);
+    expect(isPlayerMissileType(UnitType.MIRV)).toBe(true);
+    expect(isPlayerMissileType(UnitType.MIRVWarhead)).toBe(false);
+    expect(isPlayerMissileType(UnitType.MissileSilo)).toBe(false);
+  });
+
+  test("only active, completed silos with capacity are selectable", () => {
+    const silo = (
+      active: boolean,
+      cooldown: boolean,
+      underConstruction: boolean,
+    ) => ({
+      isActive: () => active,
+      isInCooldown: () => cooldown,
+      isUnderConstruction: () => underConstruction,
+    });
+
+    expect(isReadyMissileSilo(silo(true, false, false))).toBe(true);
+    expect(isReadyMissileSilo(silo(false, false, false))).toBe(false);
+    expect(isReadyMissileSilo(silo(true, true, false))).toBe(false);
+    expect(isReadyMissileSilo(silo(true, false, true))).toBe(false);
+  });
+
+  test("explicit selection overrides the nearest-silo default", () => {
+    const silos = [
+      { id: () => 11, distance: 2 },
+      { id: () => 22, distance: 20 },
+    ];
+
+    expect(chooseMissileSilo(silos, null, (s) => s.distance)?.id()).toBe(11);
+    expect(chooseMissileSilo(silos, 22, (s) => s.distance)?.id()).toBe(22);
+    expect(chooseMissileSilo(silos, 99, (s) => s.distance)).toBeUndefined();
   });
 });
 

--- a/tests/core/IntentTileRefSchemas.test.ts
+++ b/tests/core/IntentTileRefSchemas.test.ts
@@ -62,6 +62,26 @@ describe("intent schemas: tile refs are non-negative integers", () => {
 });
 
 describe("intent schemas: unit ids are non-negative integers", () => {
+  it("build_unit accepts an optional source silo id", () => {
+    const ok = {
+      type: "build_unit",
+      unit: "Atom Bomb",
+      tile: 10,
+      sourceSiloId: 3,
+    };
+    expect(BuildUnitIntentSchema.safeParse(ok).success).toBe(true);
+    expect(
+      BuildUnitIntentSchema.safeParse({ ...ok, sourceSiloId: undefined })
+        .success,
+    ).toBe(true);
+    expect(
+      BuildUnitIntentSchema.safeParse({ ...ok, sourceSiloId: 3.5 }).success,
+    ).toBe(false);
+    expect(
+      BuildUnitIntentSchema.safeParse({ ...ok, sourceSiloId: -1 }).success,
+    ).toBe(false);
+  });
+
   it("upgrade_structure", () => {
     const ok = { type: "upgrade_structure", unit: "City", unitId: 3 };
     expect(UpgradeStructureIntentSchema.safeParse(ok).success).toBe(true);


### PR DESCRIPTION
Related to #4886 (currently awaiting the required maintainer approval and assignment).

## Description

Players can now click one of their ready missile silos while aiming an Atom Bomb, Hydrogen Bomb, or MIRV to choose its launch source.

The optional source silo ID travels through the existing build intent and is validated in the deterministic simulation. If no silo is selected, the current nearest-ready-silo behavior remains unchanged. If the selected silo becomes unavailable, the launch is rejected rather than silently falling back to a different silo.

## Validation

- Focused Vitest coverage: 43 tests passed
- TypeScript compilation: passed
- Lint: passed
- Manual local two-silo game: confirmed trajectory source switch, launch, and cooldown rejection

The repository-wide suite has unrelated local-environment failures involving Node 26 localStorage configuration, unavailable assets, and the development authentication API.

## Discord username

tommysaucebonegenie