### PR TITLE
fix(core): preserve null gold in DonateGoldExecution constructor (#4092)

### DIFF
--- a/src/core/execution/DonateGoldExecution.ts
+++ b/src/core/execution/DonateGoldExecution.ts
@@ -18,7 +18,7 @@ import {
 
 export class DonateGoldExecution implements Execution {
   private recipient: Player;
-  private gold: Gold;
+  private gold: Gold | null = null;
 
   private mg: Game;
   private random: PseudoRandom;
@@ -30,7 +30,7 @@ export class DonateGoldExecution implements Execution {
     private recipientID: PlayerID,
     goldNum: number | null,
   ) {
-    this.gold = toInt(goldNum ?? 0);
+    this.gold = goldNum !== null ? toInt(goldNum) : null;
   }
 
   init(mg: Game, ticks: number): void {

--- a/tests/Donate.test.ts
+++ b/tests/Donate.test.ts
@@ -124,6 +124,59 @@ describe("Donate gold to an ally", () => {
     expect(donor.gold() < donorGoldBefore).toBe(true);
     expect(recipient.gold() > recipientGoldBefore).toBe(true);
   });
+
+  it("Gold should be defaulted to 1/3 when null is passed", async () => {
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      donateGold: true,
+    });
+    const gameID: GameID = "game_id";
+
+    const donorInfo = new PlayerInfo(
+      "donor",
+      PlayerType.Human,
+      null,
+      "donor_id",
+    );
+    const recipientInfo = new PlayerInfo(
+      "recipient",
+      PlayerType.Human,
+      null,
+      "recipient_id",
+    );
+
+    game.addPlayer(donorInfo);
+    game.addPlayer(recipientInfo);
+
+    const donor = game.player(donorInfo.id);
+    const recipient = game.player(recipientInfo.id);
+
+    const spawnA = game.ref(0, 10);
+    const spawnB = game.ref(0, 15);
+
+    game.addExecution(
+      new SpawnExecution(gameID, donorInfo, spawnA),
+      new SpawnExecution(gameID, recipientInfo, spawnB),
+    );
+
+    const allianceRequest = donor.createAllianceRequest(recipient);
+    if (allianceRequest) {
+      allianceRequest.accept();
+    }
+    game.executeNextTick();
+
+    donor.addGold(9000n);
+    const donorGoldBefore = donor.gold();
+    const recipientGoldBefore = recipient.gold();
+    const expectedDonated = donorGoldBefore / 3n;
+
+    game.addExecution(new DonateGoldExecution(donor, recipientInfo.id, null));
+
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(recipient.gold() >= recipientGoldBefore + expectedDonated).toBe(true);
+  });
 });
 
 describe("Donate troops to a non ally", () => {


### PR DESCRIPTION
# PR 1: `fix(core): preserve null gold in DonateGoldExecution constructor`

Resolves #4092

## Description:

In `DonateGoldExecution.ts`, the constructor previously initialized `this.gold = toInt(goldNum ?? 0)`. When `null` was explicitly passed as `goldNum` (intended to trigger a default donation of 1/3 of the sender's gold), the nullish coalescing operator `?? 0` immediately converted `null` to `0`, setting `this.gold` to `0n`.

Consequently, in `init()`, the line `this.gold ??= this.sender.gold() / 3n;` failed to trigger because `0n` is neither `null` nor `undefined`. As a result, calling `DonateGoldExecution` with `null` caused the player to donate `0` gold instead of 1/3 of their current gold balance.

This PR fixes the constructor to preserve `null` when `goldNum` is `null`:
```ts
this.gold = goldNum !== null ? toInt(goldNum) : null;
```
This allows `init()` to correctly evaluate `this.gold ??= this.sender.gold() / 3n` and donate 1/3 of the sender's gold.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Backend execution logic fix)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No new user-facing strings)
- [x] I have added relevant tests to the test directory (`tests/Donate.test.ts`)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
