### PR TITLE
refactor(core): converge-until-stable loop in handleDeadDefender (#4091)

### DIFF
--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -388,7 +388,9 @@ export class AttackExecution implements Execution {
 
     this.mg.conquerPlayer(this._owner, target);
 
-    for (let i = 0; i < 10; i++) {
+    const MAX_PASSES = 100;
+    for (let pass = 0; pass < MAX_PASSES; pass++) {
+      let progressed = false;
       for (const tile of target.tiles()) {
         let borders = false;
         this.mg.forEachNeighbor(tile, (t) => {
@@ -398,6 +400,7 @@ export class AttackExecution implements Execution {
         });
         if (borders) {
           this._owner.conquer(tile);
+          progressed = true;
         } else {
           let captured = false;
           this.mg.forEachNeighbor(tile, (neighbor) => {
@@ -408,8 +411,10 @@ export class AttackExecution implements Execution {
               captured = true;
             }
           });
+          if (captured) progressed = true;
         }
       }
+      if (!progressed) break;
     }
   }
 


### PR DESCRIPTION
# PR 2: `refactor(core): converge-until-stable loop in handleDeadDefender`

Resolves #4091

## Description:

In `AttackExecution.ts`, `handleDeadDefender()` previously used a fixed 10-iteration loop (`for (let i = 0; i < 10; i++)`) to reclaim tiles from a defeated player.

For small territories, a fixed 10-pass loop wastes CPU cycles running redundant passes after all tiles have already been reassigned. Conversely, for large or oddly-shaped territories, 10 passes could theoretically be insufficient to conquer all remaining tiles.

This PR replaces the hardcoded 10-iteration loop with a converge-until-stable approach:
- Tracks `progressed` per pass and exits early (`break`) on the first pass that makes no further tile assignment progress.
- Adds a generous `MAX_PASSES = 100` safety backstop to prevent infinite loops in edge cases.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Core attack execution logic)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No user-facing text additions)
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
