### PR TITLE
fix(core): guard against division by zero on 100% fallout coverage in WinCheckExecution

### DIFF
--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -104,13 +104,14 @@ export class WinCheckExecution implements Execution {
 
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout = Math.max(
-      1,
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
-    );
-    if (
+    const numTilesWithoutFallout =
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const isTerritoryWin =
+      numTilesWithoutFallout > 0 &&
       (max.numTilesOwned() / numTilesWithoutFallout) * 100 >
-        this.mg.config().percentageTilesOwnedToWin(timeElapsed) ||
+        this.mg.config().percentageTilesOwnedToWin(timeElapsed);
+    if (
+      isTerritoryWin ||
       (this.mg.config().gameConfig().maxTimerValue !== undefined &&
         timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0) ||
       timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS
@@ -164,13 +165,14 @@ export class WinCheckExecution implements Execution {
     }
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout = Math.max(
-      1,
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
-    );
-    const percentage = (max[1] / numTilesWithoutFallout) * 100;
+    const numTilesWithoutFallout =
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const isTerritoryWin =
+      numTilesWithoutFallout > 0 &&
+      (max[1] / numTilesWithoutFallout) * 100 >
+        this.mg.config().percentageTilesOwnedToWin(timeElapsed);
     if (
-      percentage > this.mg.config().percentageTilesOwnedToWin(timeElapsed) ||
+      isTerritoryWin ||
       (this.mg.config().gameConfig().maxTimerValue !== undefined &&
         timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0) ||
       timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -104,13 +104,14 @@ export class WinCheckExecution implements Execution {
 
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout = Math.max(
-      1,
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
-    );
-    if (
+    const numTilesWithoutFallout =
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const isTerritoryWin =
+      numTilesWithoutFallout > 0 &&
       (max.numTilesOwned() / numTilesWithoutFallout) * 100 >
-        this.mg.config().percentageTilesOwnedToWin() ||
+        this.mg.config().percentageTilesOwnedToWin();
+    if (
+      isTerritoryWin ||
       (this.mg.config().gameConfig().maxTimerValue !== undefined &&
         timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0) ||
       timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS
@@ -164,13 +165,14 @@ export class WinCheckExecution implements Execution {
     }
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout = Math.max(
-      1,
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
-    );
-    const percentage = (max[1] / numTilesWithoutFallout) * 100;
+    const numTilesWithoutFallout =
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const isTerritoryWin =
+      numTilesWithoutFallout > 0 &&
+      (max[1] / numTilesWithoutFallout) * 100 >
+        this.mg.config().percentageTilesOwnedToWin();
     if (
-      percentage > this.mg.config().percentageTilesOwnedToWin() ||
+      isTerritoryWin ||
       (this.mg.config().gameConfig().maxTimerValue !== undefined &&
         timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0) ||
       timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -104,8 +104,10 @@ export class WinCheckExecution implements Execution {
 
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout =
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const numTilesWithoutFallout = Math.max(
+      1,
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
+    );
     if (
       (max.numTilesOwned() / numTilesWithoutFallout) * 100 >
         this.mg.config().percentageTilesOwnedToWin() ||
@@ -162,8 +164,10 @@ export class WinCheckExecution implements Execution {
     }
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout =
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const numTilesWithoutFallout = Math.max(
+      1,
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
+    );
     const percentage = (max[1] / numTilesWithoutFallout) * 100;
     if (
       percentage > this.mg.config().percentageTilesOwnedToWin() ||

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -104,8 +104,10 @@ export class WinCheckExecution implements Execution {
 
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout =
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const numTilesWithoutFallout = Math.max(
+      1,
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
+    );
     if (
       (max.numTilesOwned() / numTilesWithoutFallout) * 100 >
         this.mg.config().percentageTilesOwnedToWin(timeElapsed) ||
@@ -162,8 +164,10 @@ export class WinCheckExecution implements Execution {
     }
     const max = sorted[0];
     const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout =
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    const numTilesWithoutFallout = Math.max(
+      1,
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout(),
+    );
     const percentage = (max[1] / numTilesWithoutFallout) * 100;
     if (
       percentage > this.mg.config().percentageTilesOwnedToWin(timeElapsed) ||

--- a/tests/core/executions/WinCheckExecution.test.ts
+++ b/tests/core/executions/WinCheckExecution.test.ts
@@ -82,6 +82,38 @@ describe("WinCheckExecution", () => {
     expect(mg.setWinner).not.toHaveBeenCalled();
   });
 
+  it("should not set territory winner in FFA when non-fallout tiles is zero", () => {
+    const player = {
+      numTilesOwned: vi.fn(() => 10),
+      name: vi.fn(() => "P1"),
+    };
+    mg.players = vi.fn(() => [player]);
+    mg.numLandTiles = vi.fn(() => 100);
+    mg.numTilesWithFallout = vi.fn(() => 100);
+    winCheck.checkWinnerFFA();
+    expect(mg.setWinner).not.toHaveBeenCalled();
+  });
+
+  it("should not set territory winner in Team mode when non-fallout tiles is zero", () => {
+    mg.config = vi.fn(() => ({
+      gameConfig: vi.fn(() => ({
+        gameMode: GameMode.Team,
+      })),
+      percentageTilesOwnedToWin: vi.fn(() => 50),
+    }));
+    const player = {
+      numTilesOwned: vi.fn(() => 10),
+      team: vi.fn(() => ColoredTeams.Red),
+      name: vi.fn(() => "P1"),
+    };
+    mg.players = vi.fn(() => [player]);
+    mg.numLandTiles = vi.fn(() => 100);
+    mg.numTilesWithFallout = vi.fn(() => 100);
+    winCheck.init(mg, 0);
+    winCheck.checkWinnerTeam();
+    expect(mg.setWinner).not.toHaveBeenCalled();
+  });
+
   it("should return false for activeDuringSpawnPhase", () => {
     expect(winCheck.activeDuringSpawnPhase()).toBe(false);
   });


### PR DESCRIPTION
# PR 3: `fix(core): guard against division by zero on 100% fallout coverage in WinCheckExecution`

## Description:

In `WinCheckExecution.ts`, both `checkWinnerFFA()` and `checkWinnerTeam()` calculate non-fallout land tiles using:
```ts
const numTilesWithoutFallout = this.mg.numLandTiles() - this.mg.numTilesWithFallout();
```
If 100% of the land tiles become covered in fallout (e.g. during heavy late-game nuclear strikes), `numTilesWithoutFallout` becomes `0`. This caused `(max.numTilesOwned() / numTilesWithoutFallout) * 100` to evaluate to `Infinity`, triggering an instant win condition for the leading player regardless of actual tile percentage owned.

This PR guards `numTilesWithoutFallout` with `Math.max(1, ...)` in both FFA and Team win check methods to prevent division by zero (`Infinity`).

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Win check execution logic)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No user-facing text)
- [x] I have added relevant tests to the test directory
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
