### PR TITLE
fix(core): preserve null gold in DonateGoldExecution constructor (#4092)

### DIFF
--- a/src/core/execution/DonateGoldExecution.ts
+++ b/src/core/execution/DonateGoldExecution.ts
@@ -18,7 +18,7 @@ import {
 
 export class DonateGoldExecution implements Execution {
   private recipient: Player;
-  private gold: Gold;
+  private gold: Gold | null = null;
 
   private mg: Game;
   private random: PseudoRandom;
@@ -30,7 +30,7 @@ export class DonateGoldExecution implements Execution {
     private recipientID: PlayerID,
     goldNum: number | null,
   ) {
-    this.gold = toInt(goldNum ?? 0);
+    this.gold = goldNum !== null ? toInt(goldNum) : null;
   }
 
   init(mg: Game, ticks: number): void {

--- a/tests/Donate.test.ts
+++ b/tests/Donate.test.ts
@@ -126,21 +126,27 @@ describe("Donate gold to an ally", () => {
   });
 
   it("Gold should default to 1/3 when null is passed", async () => {
-    const game = await setup("ocean_and_land", { infiniteGold: false, donateGold: true });
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      donateGold: true,
+    });
     const dInfo = new PlayerInfo("d", PlayerType.Human, null, "d_id");
     const rInfo = new PlayerInfo("r", PlayerType.Human, null, "r_id");
     game.addPlayer(dInfo);
     game.addPlayer(rInfo);
-    const donor = game.player(dInfo.id), recipient = game.player(rInfo.id);
+    const donor = game.player(dInfo.id),
+      recipient = game.player(rInfo.id);
     game.addExecution(
       new SpawnExecution("g", dInfo, game.ref(0, 10)),
       new SpawnExecution("g", rInfo, game.ref(0, 15)),
     );
     donor.createAllianceRequest(recipient)?.accept();
     game.executeNextTick();
+    const donation = new DonateGoldExecution(donor, rInfo.id, null);
     donor.addGold(9000n);
-    const goldBefore = donor.gold(), recBefore = recipient.gold();
-    game.addExecution(new DonateGoldExecution(donor, rInfo.id, null));
+    const goldBefore = donor.gold(),
+      recBefore = recipient.gold();
+    game.addExecution(donation);
     game.executeNextTick();
     game.executeNextTick();
     expect(recipient.gold() >= recBefore + goldBefore / 3n).toBe(true);

--- a/tests/Donate.test.ts
+++ b/tests/Donate.test.ts
@@ -117,12 +117,13 @@ describe("Donate gold to an ally", () => {
     const recipientGoldBefore = recipient.gold();
     game.addExecution(new DonateGoldExecution(donor, recipientInfo.id, 5000));
 
-    for (let i = 0; i < 5; i++) {
-      game.executeNextTick();
-    }
+    game.executeNextTick();
+    game.executeNextTick();
 
-    expect(donor.gold() < donorGoldBefore).toBe(true);
-    expect(recipient.gold() > recipientGoldBefore).toBe(true);
+    // 1 tick elapsed; PlayerExecution adds 100n passive income from workers
+    const passiveIncome = 100n;
+    expect(donor.gold()).toBe(donorGoldBefore - 5000n + passiveIncome);
+    expect(recipient.gold()).toBe(recipientGoldBefore + 5000n + passiveIncome);
   });
 
   it("Gold should default to 1/3 when null is passed", async () => {
@@ -149,7 +150,11 @@ describe("Donate gold to an ally", () => {
     game.addExecution(donation);
     game.executeNextTick();
     game.executeNextTick();
-    expect(recipient.gold() >= recBefore + goldBefore / 3n).toBe(true);
+    // 1 tick elapsed for donation transfer; PlayerExecution adds 100n passive income from workers
+    const passiveIncome = 100n;
+    const expectedDonation = goldBefore / 3n;
+    expect(donor.gold()).toBe(goldBefore - expectedDonation + passiveIncome);
+    expect(recipient.gold()).toBe(recBefore + expectedDonation + passiveIncome);
   });
 });
 

--- a/tests/Donate.test.ts
+++ b/tests/Donate.test.ts
@@ -124,6 +124,27 @@ describe("Donate gold to an ally", () => {
     expect(donor.gold() < donorGoldBefore).toBe(true);
     expect(recipient.gold() > recipientGoldBefore).toBe(true);
   });
+
+  it("Gold should default to 1/3 when null is passed", async () => {
+    const game = await setup("ocean_and_land", { infiniteGold: false, donateGold: true });
+    const dInfo = new PlayerInfo("d", PlayerType.Human, null, "d_id");
+    const rInfo = new PlayerInfo("r", PlayerType.Human, null, "r_id");
+    game.addPlayer(dInfo);
+    game.addPlayer(rInfo);
+    const donor = game.player(dInfo.id), recipient = game.player(rInfo.id);
+    game.addExecution(
+      new SpawnExecution("g", dInfo, game.ref(0, 10)),
+      new SpawnExecution("g", rInfo, game.ref(0, 15)),
+    );
+    donor.createAllianceRequest(recipient)?.accept();
+    game.executeNextTick();
+    donor.addGold(9000n);
+    const goldBefore = donor.gold(), recBefore = recipient.gold();
+    game.addExecution(new DonateGoldExecution(donor, rInfo.id, null));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(recipient.gold() >= recBefore + goldBefore / 3n).toBe(true);
+  });
 });
 
 describe("Donate troops to a non ally", () => {


### PR DESCRIPTION
# PR 1: `fix(core): preserve null gold in DonateGoldExecution constructor`

Resolves #4092

## Description:

In `DonateGoldExecution.ts`, the constructor previously initialized `this.gold = toInt(goldNum ?? 0)`. When `null` was explicitly passed as `goldNum` (intended to trigger a default donation of 1/3 of the sender's gold), the nullish coalescing operator `?? 0` immediately converted `null` to `0`, setting `this.gold` to `0n`.

Consequently, in `init()`, the line `this.gold ??= this.sender.gold() / 3n;` failed to trigger because `0n` is neither `null` nor `undefined`. As a result, calling `DonateGoldExecution` with `null` caused the player to donate `0` gold instead of 1/3 of their current gold balance.

This PR fixes the constructor to preserve `null` when `goldNum` is `null`:
```ts
this.gold = goldNum !== null ? toInt(goldNum) : null;
```
This allows `init()` to correctly evaluate `this.gold ??= this.sender.gold() / 3n` and donate 1/3 of the sender's gold.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Backend execution logic fix)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No new user-facing strings)
- [x] I have added relevant tests to the test directory (`tests/Donate.test.ts`)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
