### PR TITLE
Doomsday Clock: territory rot, so a doomed side actually dies

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -439,6 +439,7 @@
   "doomsday_clock": {
     "collapsing": "Collapsing -{rate}/s",
     "decay_in": "Decay in {secs}s",
+    "decaying": "Decaying",
     "final": "Final zone, hold {pct}%",
     "growing": "Will reach {pct}% in {time}",
     "hold": "Hold ≥ {pct}%",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -439,7 +439,7 @@
   "doomsday_clock": {
     "collapsing": "Collapsing -{rate}/s",
     "decay_in": "Decay in {secs}s",
-    "decaying": "Decaying",
+    "decaying": "Decaying -{rate} tiles/s",
     "final": "Final zone, hold {pct}%",
     "growing": "Will reach {pct}% in {time}",
     "hold": "Hold ≥ {pct}%",

--- a/src/client/components/DoomsdayClockPanel.ts
+++ b/src/client/components/DoomsdayClockPanel.ts
@@ -4,6 +4,7 @@ import { assetUrl } from "../../core/AssetUrls";
 import {
   doomsdayClockDrain,
   doomsdayClockRequiredTiles,
+  doomsdayClockRotQuota,
   doomsdayClockTroopFloor,
   doomsdayClockWaveState,
 } from "../../core/game/DoomsdayClock";
@@ -130,7 +131,12 @@ export class DoomsdayClockPanel extends LitElement {
     let statusClass = "";
     let detail = zoneDetail;
     if (live && draining && me && decaying) {
-      status = translateText("doomsday_clock.decaying");
+      // Rot is a deadline, not a rate, so the per-second loss climbs as the
+      // deadline nears. Same shared quota the sim applies, keyed on this player's
+      // own tiles (rot is per player, unlike the team share shown above).
+      status = translateText("doomsday_clock.decaying", {
+        rate: doomsdayClockRotQuota(me.numTilesOwned(), secondsUnder, sd),
+      });
       statusClass = "text-red-500 font-bold";
     } else if (live && draining && me) {
       // Drain is a % of max-troop capacity that stops at the floor; show the

--- a/src/client/components/DoomsdayClockPanel.ts
+++ b/src/client/components/DoomsdayClockPanel.ts
@@ -4,6 +4,7 @@ import { assetUrl } from "../../core/AssetUrls";
 import {
   doomsdayClockDrain,
   doomsdayClockRequiredTiles,
+  doomsdayClockTroopFloor,
   doomsdayClockWaveState,
 } from "../../core/game/DoomsdayClock";
 import { GameMode, PlayerType, Team } from "../../core/game/Game";
@@ -15,7 +16,8 @@ const doomsdayClockIcon = assetUrl("images/DoomsdayClockSkull.svg");
 
 /**
  * The Doomsday Clock readout: a self-contained panel showing the rising bar, the
- * side's share vs the threshold, the stage (Stable/Unstable/Collapsing) and the
+ * side's share vs the threshold, the stage (Stable/Unstable/Collapsing/Decaying)
+ * and the
  * wave countdown. Embedded by game-right-sidebar so it stacks (centered) under
  * the game timer; it hides only when the mode is off or after a winner. A
  * spectator, replay viewer, or eliminated / not-spawned player still sees the
@@ -96,6 +98,8 @@ export class DoomsdayClockPanel extends LitElement {
     const flagged = me?.inDoomsdayClock() ?? false;
     const secondsUnder = Math.floor((me?.doomsdayClockTicks() ?? 0) / 10);
     const draining = flagged && secondsUnder >= sd.warnSeconds;
+    // From the sim, not re-derived here — see PlayerImpl.isDecaying.
+    const decaying = draining && (me?.isDecaying() ?? false);
     // Safe but within 10% (relative) of the bar: e.g. at 9% when the bar is 10%,
     // or 0.9% when it's 1%. About to be caught, so it blinks red too.
     const nearDanger =
@@ -125,17 +129,19 @@ export class DoomsdayClockPanel extends LitElement {
     let status = "";
     let statusClass = "";
     let detail = zoneDetail;
-    if (live && draining && me) {
-      // Drain is a % of max-troop capacity that stops at the floor
-      // (drainFloorPercent of max); show the actual per-second loss, i.e. only
-      // what sits above the floor (renderTroops handles the /10 display unit).
+    if (live && draining && me && decaying) {
+      status = translateText("doomsday_clock.decaying");
+      statusClass = "text-red-500 font-bold";
+    } else if (live && draining && me) {
+      // Drain is a % of max-troop capacity that stops at the floor; show the
+      // actual per-second loss, i.e. only what sits above the floor (renderTroops
+      // handles the /10 display unit). The floor comes from the shared helper, not
+      // a local formula, because it decays — the readout would otherwise overstate
+      // the loss for the whole comeback window.
       const maxTroops = this.game.config().maxTroops(me);
-      const floor = Math.floor((maxTroops * sd.drainFloorPercent) / 100);
-      const chunk = doomsdayClockDrain(
-        maxTroops,
-        secondsUnder - sd.warnSeconds,
-        sd,
-      );
+      const secondsPastWarn = secondsUnder - sd.warnSeconds;
+      const floor = doomsdayClockTroopFloor(maxTroops, secondsPastWarn, sd);
+      const chunk = doomsdayClockDrain(maxTroops, secondsPastWarn, sd);
       status = translateText("doomsday_clock.collapsing", {
         rate: renderTroops(Math.max(0, Math.min(me.troops() - floor, chunk))),
       });

--- a/src/client/render/frame/derive/PlayerStatus.ts
+++ b/src/client/render/frame/derive/PlayerStatus.ts
@@ -112,6 +112,8 @@ export function computePlayerStatus(
     const doomsdayClockWarnTicks = opts.doomsdayClockWarnTicks ?? 0;
     const doomsdayClockDraining =
       inDoomsdayClock && doomsdayClockUnderTicks >= doomsdayClockWarnTicks;
+    // Red, static skull. From the sim — see PlayerImpl.isDecaying.
+    const doomsdayClockDecaying = inDoomsdayClock && ps.isDecaying;
     // How far through the warn countdown (0->1); the danger skull blinks faster
     // as this nears 1, i.e. as the side approaches draining.
     const doomsdayClockWarnProgress =
@@ -189,6 +191,7 @@ export function computePlayerStatus(
         disconnected,
         inDoomsdayClock,
         doomsdayClockDraining,
+        doomsdayClockDecaying,
         doomsdayClockWarnProgress,
         alliance,
         allianceReq,

--- a/src/client/render/gl/passes/name-pass/Types.ts
+++ b/src/client/render/gl/passes/name-pass/Types.ts
@@ -81,6 +81,7 @@ export interface PlayerSlot {
   nukeTargetsMe: boolean;
   inDoomsdayClock: boolean;
   doomsdayClockDraining: boolean;
+  doomsdayClockDecaying: boolean;
   doomsdayClockWarnProgress: number;
   traitorRemainingTicks: number;
   allianceFraction: number;

--- a/src/client/render/gl/passes/name-pass/index.ts
+++ b/src/client/render/gl/passes/name-pass/index.ts
@@ -382,6 +382,7 @@ export class NamePass {
             nukeTargetsMe: false,
             inDoomsdayClock: false,
             doomsdayClockDraining: false,
+            doomsdayClockDecaying: false,
             doomsdayClockWarnProgress: 0,
             traitorRemainingTicks: 0,
             allianceFraction: 0,
@@ -516,6 +517,7 @@ export class NamePass {
       const disconnected = sd?.disconnected ?? false;
       const inDoomsdayClock = sd?.inDoomsdayClock ?? false;
       const doomsdayClockDraining = sd?.doomsdayClockDraining ?? false;
+      const doomsdayClockDecaying = sd?.doomsdayClockDecaying ?? false;
       const doomsdayClockWarnProgress = sd?.doomsdayClockWarnProgress ?? 0;
       const alliance = sd?.alliance ?? false;
       const allianceReq = sd?.allianceReq ?? false;
@@ -533,6 +535,7 @@ export class NamePass {
         disconnected !== slot.disconnected ||
         inDoomsdayClock !== slot.inDoomsdayClock ||
         doomsdayClockDraining !== slot.doomsdayClockDraining ||
+        doomsdayClockDecaying !== slot.doomsdayClockDecaying ||
         doomsdayClockWarnProgress !== slot.doomsdayClockWarnProgress ||
         alliance !== slot.alliance ||
         allianceReq !== slot.allianceReq ||
@@ -549,6 +552,7 @@ export class NamePass {
         slot.disconnected = disconnected;
         slot.inDoomsdayClock = inDoomsdayClock;
         slot.doomsdayClockDraining = doomsdayClockDraining;
+        slot.doomsdayClockDecaying = doomsdayClockDecaying;
         slot.doomsdayClockWarnProgress = doomsdayClockWarnProgress;
         slot.alliance = alliance;
         slot.allianceReq = allianceReq;
@@ -636,18 +640,21 @@ export class NamePass {
     d[off + 15] = slot.nameHalfWidth;
 
     // Column 4: flagLayerIdx, emojiAtlasIdx, smallID, doomsdayClock state
-    // (0 none, 1.0-1.49 danger -> blinking skull, 2 draining -> steady skull).
+    // (0 none, 1.0-1.49 danger -> blinking skull, 2 draining -> steady skull,
+    // 3 decaying -> steady RED skull, i.e. territory is rotting away).
     // The warn-countdown progress (0->1) is packed into the danger value's
     // fraction so the shader can blink faster as drain nears; it stays < 1.5 so
     // the draining threshold is untouched.
     d[off + 16] = slot.flagLayerIdx;
     d[off + 17] = slot.emojiAtlasIdx;
     d[off + 18] = slot.static.smallID;
-    d[off + 19] = slot.doomsdayClockDraining
-      ? 2.0
-      : slot.inDoomsdayClock
-        ? 1.0 + slot.doomsdayClockWarnProgress * 0.49
-        : 0.0;
+    d[off + 19] = slot.doomsdayClockDecaying
+      ? 3.0
+      : slot.doomsdayClockDraining
+        ? 2.0
+        : slot.inDoomsdayClock
+          ? 1.0 + slot.doomsdayClockWarnProgress * 0.49
+          : 0.0;
 
     // Column 5: crown, traitor, disconnected, alliance
     d[off + 20] = slot.crown ? 1.0 : 0.0;

--- a/src/client/render/gl/shaders/name/status-icon.frag.glsl
+++ b/src/client/render/gl/shaders/name/status-icon.frag.glsl
@@ -16,6 +16,7 @@ flat in vec2 vFadedUV0;
 flat in vec2 vFadedUV1;
 flat in float vFlashAlpha;
 flat in float vOutline;          // 1.0 = draw a dark outline behind this icon
+flat in float vDecay;            // 1.0 = tint this icon red (decaying skull)
 in float vHoverAlpha;
 
 out vec4 fragColor;
@@ -49,6 +50,12 @@ void main() {
 
     // Above the cut line → show faded; below → show colored
     texel = vLocalUV.y < topCut ? fadedTexel : texel;
+  }
+
+  // Decaying skull: tint red, keeping some luminance so its shading still reads.
+  if (vDecay > 0.5) {
+    float lum = dot(texel.rgb, vec3(0.299, 0.587, 0.114));
+    texel.rgb = vec3(0.90, 0.10, 0.10) * (0.55 + 0.45 * lum);
   }
 
   // Traitor flash + hover fade: modulate alpha

--- a/src/client/render/gl/shaders/name/status-icon.vert.glsl
+++ b/src/client/render/gl/shaders/name/status-icon.vert.glsl
@@ -42,6 +42,7 @@ flat out vec2 vFadedUV0;         // top-left UV of faded alliance cell
 flat out vec2 vFadedUV1;         // bottom-right UV of faded alliance cell
 flat out float vFlashAlpha;      // traitor flash opacity (1.0 = fully visible)
 flat out float vOutline;         // 1.0 = alliance icon, draw a dark outline
+flat out float vDecay;           // 1.0 = doomsday skull is DECAYING -> tint red
 out float vHoverAlpha;
 
 // Status flag float array — indexed by icon slot.
@@ -104,6 +105,8 @@ void main() {
 
   // A crown cosmetic skins the first-place crown (slot 0).
   vCrownLayer = (iconSlot == 0 && pd8.x >= 0.0) ? int(pd8.x) : -1;
+
+  vDecay = 0.0; // only the decaying doomsday skull raises this
 
   // Early out: dead player only (emoji no longer hides status icons)
   if (pd1.w <= 0.0) {
@@ -306,6 +309,8 @@ void main() {
     } else {
       vFlashAlpha = 1.0;
     }
+    // 3.0 = decaying: steady like draining, but tinted red.
+    if (statusFlag[8] > 2.5) vDecay = 1.0;
   }
 
   vDiscard = 0;

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -70,6 +70,7 @@ export interface PlayerState {
   isTraitor: boolean;
   traitorRemainingTicks: number;
   inDoomsdayClock: boolean;
+  isDecaying: boolean;
   markedDoomsdayClockTick: number;
   betrayals: number;
   hasSpawned: boolean;
@@ -200,6 +201,7 @@ export interface PlayerStatusData {
   nukeTargetsMe: boolean;
   inDoomsdayClock: boolean;
   doomsdayClockDraining: boolean;
+  doomsdayClockDecaying: boolean;
   doomsdayClockWarnProgress: number;
   traitorRemainingTicks: number;
   allianceFraction: number;

--- a/src/client/view/PlayerView.ts
+++ b/src/client/view/PlayerView.ts
@@ -85,6 +85,7 @@ function stateFromUpdate(pu: PlayerUpdate): PlayerState {
     isTraitor: pu.isTraitor!,
     traitorRemainingTicks: Math.max(0, pu.traitorRemainingTicks ?? 0),
     inDoomsdayClock: pu.inDoomsdayClock ?? false,
+    isDecaying: pu.isDecaying ?? false,
     markedDoomsdayClockTick: pu.markedDoomsdayClockTick ?? -1,
     betrayals: pu.betrayals!,
     hasSpawned: pu.hasSpawned!,
@@ -616,6 +617,9 @@ export class PlayerView {
   }
   inDoomsdayClock(): boolean {
     return this.state.inDoomsdayClock;
+  }
+  isDecaying(): boolean {
+    return this.state.isDecaying;
   }
   doomsdayClockTicks(): number {
     return this.inDoomsdayClock()

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -101,7 +101,25 @@ const DOOMSDAY_CLOCK_DEFAULTS = {
   drainStartPercent: 2, // starts bleeding at once (already beats troop income)
   drainMaxPercent: 5,
   drainRampSeconds: 90, // ramps LINEARLY to the max over this long
-  drainFloorPercent: 5, // drain stops here: crippled to 5% of max, never wiped
+  drainFloorPercent: 5, // drain settles here: crippled to 5% of max, never wiped
+  // The floor decays start -> drainFloorPercent over floorDecaySeconds, leaving
+  // one comeback window with a usable army. It must not be permanent: maxTroops is
+  // sublinear (~100k at one tile), so a fixed 40% is ~40k troops on a single tile.
+  floorStartPercent: 40,
+  floorDecaySeconds: 90,
+  // TERRITORY ROT — the finisher, since the drain never kills. rotDeathSeconds is
+  // a DEADLINE, not a rate: the territory is gone this long after the skull
+  // appeared, whatever it holds. 0 disables rot. Timeline:
+  //
+  //   0s    skull blinks, warn countdown
+  //   30s   skull steady, troops draining              (warnSeconds)
+  //   120s  floor at 5%, territory rotting, skull RED  (warn + floorDecay)
+  //   180s  nothing left, eliminated                   (rotDeathSeconds)
+  rotDeathSeconds: 180,
+  // Grainy opening: pinholes across this share of the territory before the holes
+  // grow together.
+  rotGrainSeconds: 20,
+  rotSpecklePercent: 15,
   // Warships bleed on their OWN gentler start + a STEEP (convex) ramp to a much
   // higher ceiling. A ship caught when its side is first doomed lasts about as
   // long as troops (the low start + no income ≈ the troop net rate), but the rate
@@ -149,6 +167,11 @@ export class Config {
       drainMaxPercent: d.drainMaxPercent,
       drainRampSeconds: d.drainRampSeconds,
       drainFloorPercent: d.drainFloorPercent,
+      floorStartPercent: d.floorStartPercent,
+      floorDecaySeconds: d.floorDecaySeconds,
+      rotDeathSeconds: d.rotDeathSeconds,
+      rotGrainSeconds: d.rotGrainSeconds,
+      rotSpecklePercent: d.rotSpecklePercent,
       warshipDrainStartPercent: d.warshipDrainStartPercent,
       warshipDrainMaxPercent: d.warshipDrainMaxPercent,
       warshipDrainCurveExponent: d.warshipDrainCurveExponent,

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -114,11 +114,12 @@ const DOOMSDAY_CLOCK_DEFAULTS = {
   //   0s    skull blinks, warn countdown
   //   30s   skull steady, troops draining              (warnSeconds)
   //   120s  floor at 5%, territory rotting, skull RED  (warn + floorDecay)
-  //   180s  nothing left, eliminated                   (rotDeathSeconds)
-  rotDeathSeconds: 180,
+  //   150s  nothing left, eliminated                   (rotDeathSeconds)
+  rotDeathSeconds: 150,
   // Grainy opening: pinholes across this share of the territory before the holes
-  // grow together.
-  rotGrainSeconds: 20,
+  // grow together. Held to a third of the rot window, so shortening the window
+  // shortens this too: at 20s the speckle WAS the death rather than its opening.
+  rotGrainSeconds: 10,
   rotSpecklePercent: 15,
   // Warships bleed on their OWN gentler start + a STEEP (convex) ramp to a much
   // higher ceiling. A ship caught when its side is first doomed lasts about as

--- a/src/core/execution/DoomsdayClockExecution.ts
+++ b/src/core/execution/DoomsdayClockExecution.ts
@@ -1,6 +1,10 @@
 import {
   doomsdayClockDrain,
   doomsdayClockRequiredTiles,
+  doomsdayClockTroopFloor,
+  ROT_NOISE_SCALE,
+  rotFrontNoise,
+  rotSpeckleNoise,
 } from "../game/DoomsdayClock";
 import {
   Execution,
@@ -11,6 +15,7 @@ import {
   Team,
   UnitType,
 } from "../game/Game";
+import { TileRef } from "../game/GameMap";
 
 /**
  * Doomsday Clock (anti-stall). Once armed, every side must hold a rising
@@ -26,22 +31,60 @@ import {
  * wave's level (chosen by the speed preset, see DoomsdayClock.ts) and holding. As
  * it rises the bottom is cut, which forces consolidation and guarantees a finish.
  *
- * A side below the bar is marked (inDoomsdayClock -> blinking skull on the client)
- * and, after the warn window, every member bleeds an escalating percentage of
- * their troops (and warship health) until the side recovers or reaches the floor
- * (drainFloorPercent of each max). The drain cripples, it does not wipe: a doomed
- * side settles at 5% of max, not zero, so a brief dip below the bar is
- * recoverable. Climbing back above the bar clears the mark and stops the drain;
- * the rising bar still forces a finish by squeezing territory.
+ * A side below the bar is marked (inDoomsdayClock -> blinking skull) and, after
+ * the warn window, bleeds troops (and warship health) down to a decaying floor.
+ * Climbing back above the bar clears the mark and stops everything below.
  *
- * Deterministic: integer-only. The threshold is one floored integer ratio (see
- * DoomsdayClock.ts) and the drain a floored percentage, no floating-point. Off
+ * Once the floor bottoms out, TERRITORY ROT takes land until the side dies. The
+ * drain alone never kills, so without rot a stalemate outlives the final wave
+ * with every challenger crippled but unkillable. Timings in Config.ts.
+ *
+ * Deterministic: every value the sim stores is an integer — the threshold is one
+ * floored ratio (see DoomsdayClock.ts), the drain and floor are floored
+ * percentages, and quotas are exact ceilings over integers. Tile choices come from
+ * integer hashes of the tile, salted per player — no PRNG state and no floats. Off
  * unless enabled in the GameConfig. Runs once per second (every 10 ticks), like
  * WinCheckExecution.
  */
+/** Keeps the `n` lowest-keyed tiles seen, in one pass and in key order. */
+class LowestN {
+  private tiles: TileRef[] = [];
+  private keys: number[] = [];
+  constructor(private readonly n: number) {}
+  get size(): number {
+    return this.tiles.length;
+  }
+  offer(tile: TileRef, key: number): void {
+    if (
+      this.tiles.length === this.n &&
+      key >= this.keys[this.tiles.length - 1]
+    ) {
+      return;
+    }
+    let i = this.keys.length;
+    while (i > 0 && this.keys[i - 1] > key) i--;
+    this.tiles.splice(i, 0, tile);
+    this.keys.splice(i, 0, key);
+    if (this.tiles.length > this.n) {
+      this.tiles.pop();
+      this.keys.pop();
+    }
+  }
+  take(): TileRef[] {
+    return this.tiles;
+  }
+}
+
 export class DoomsdayClockExecution implements Execution {
   private active = true;
   private mg: Game | null = null;
+  /** Per doomed player: when rot began, and the tiles it eats next mapped to how
+   *  many of their neighbours have already rotted. Kept between ticks so rot
+   *  spreads from where it started. Sim-derived, so replay-safe. */
+  private rotState = new Map<
+    number,
+    { since: number; held: number; front: Map<TileRef, number> }
+  >();
 
   init(mg: Game, ticks: number): void {
     this.mg = mg;
@@ -108,18 +151,27 @@ export class DoomsdayClockExecution implements Execution {
           const secondsUnder = Math.floor(m.doomsdayClockTicks() / 10);
           if (secondsUnder >= cfg.warnSeconds) {
             const secondsPastWarn = secondsUnder - cfg.warnSeconds;
-            // The drain floors at drainFloorPercent of each max: a doomed side is
-            // crippled to 5%, not wiped to zero, so recovery is possible if it
-            // climbs back above the bar. Clamp the removal to what sits above the
-            // floor (integer-only, so the lockstep sim stays deterministic).
+            // Crippled, not wiped: clamp the removal to what sits above the
+            // floor. The floor itself decays, leaving one comeback window.
             const maxTroops = mg.config().maxTroops(m);
-            const troopFloor = Math.floor(
-              (maxTroops * cfg.drainFloorPercent) / 100,
+            const troopFloor = doomsdayClockTroopFloor(
+              maxTroops,
+              secondsPastWarn,
+              cfg,
             );
             const chunk = doomsdayClockDrain(maxTroops, secondsPastWarn, cfg);
             m.removeTroops(
               Math.min(chunk, Math.max(0, m.troops() - troopFloor)),
             );
+            // Paced on secondsUnder: the deadline covers the whole doomed
+            // spell, warn and comeback window included.
+            if (
+              cfg.rotDeathSeconds > 0 &&
+              secondsPastWarn >= cfg.floorDecaySeconds &&
+              m.troops() <= troopFloor
+            ) {
+              this.rot(mg, m, secondsUnder, cfg);
+            }
             // The navy bleeds on the same ramp but toward warshipDrainCfg's far
             // higher ceiling (see above), so a doomed side's fleet is battered
             // fast at full attrition, down to the SAME floor (drainFloorPercent of
@@ -144,9 +196,161 @@ export class DoomsdayClockExecution implements Execution {
           }
         }
       } else {
-        for (const m of members) m.clearDoomsdayClock();
+        for (const m of members) {
+          m.clearDoomsdayClock();
+          this.rotState.delete(m.smallID()); // recovered: any rot starts over
+        }
       }
     }
+  }
+
+  /**
+   * Take territory so the player holds none by rotDeathSeconds after their skull
+   * appeared. The per-second quota ceil(tilesLeft / secondsLeft) self-corrects, so
+   * the deadline holds whatever the size and however late rot started.
+   */
+  private rot(
+    mg: Game,
+    player: Player,
+    secondsUnder: number,
+    cfg: {
+      rotDeathSeconds: number;
+      rotGrainSeconds: number;
+      rotSpecklePercent: number;
+    },
+  ): void {
+    const owned = player.numTilesOwned();
+    if (owned <= 0) return;
+
+    const id = player.smallID();
+    const state = this.rotState.get(id) ?? {
+      since: mg.ticks(),
+      held: owned, // territory at the start, which sets the speckle density
+      front: new Map<TileRef, number>(),
+    };
+
+    const secondsLeft = Math.max(1, cfg.rotDeathSeconds - secondsUnder);
+    const evenQuota = Math.ceil(owned / secondsLeft);
+
+    // Grainy opening, sized off the TERRITORY: a share of the quota would be one
+    // or two holes a second on all but a huge empire. Runs ahead; quota absorbs it.
+    const grainy = mg.ticks() - state.since < cfg.rotGrainSeconds * 10;
+    const specks = grainy
+      ? Math.max(
+          1,
+          Math.ceil(
+            (state.held * cfg.rotSpecklePercent) / 100 / cfg.rotGrainSeconds,
+          ),
+        )
+      : 0;
+    let budget = Math.min(owned, Math.max(evenQuota, specks));
+
+    const tiles = player.tiles();
+    const front = new Map<TileRef, number>();
+    for (const [tile, rotted] of state.front) {
+      if (tiles.has(tile)) front.set(tile, rotted);
+    }
+
+    budget -= this.speckle(mg, player, Math.min(specks, budget), front);
+    budget -= this.spread(mg, player, budget, front);
+    // Front exhausted (no holes yet, or blobs walled in on an island).
+    if (budget > 0) this.speckle(mg, player, budget, front);
+
+    this.rotState.set(id, { since: state.since, held: state.held, front });
+  }
+
+  /** Open `count` holes, preferring the INTERIOR so decay starts inside rather
+   *  than eroding the frontier. Reservoir sampling: TileSet has no indexing. */
+  private speckle(
+    mg: Game,
+    player: Player,
+    count: number,
+    front: Map<TileRef, number>,
+  ): number {
+    if (count <= 0) return 0;
+    const salt = player.smallID();
+    const border = player.borderTiles();
+    // Lowest noise first. The field is near-evenly spaced (see rotNoise), so holes
+    // land spread out instead of clotting the way uniform random picks do.
+    const interior = new LowestN(count);
+    const edge = new LowestN(count);
+    player.tiles().forEach((tile) => {
+      const key = rotSpeckleNoise(mg.x(tile), mg.y(tile), salt);
+      (border.has(tile) ? edge : interior).offer(tile, key);
+    });
+    const picked =
+      interior.size >= count
+        ? interior.take()
+        : [...interior.take(), ...edge.take()];
+    let opened = 0;
+    for (const tile of picked) {
+      if (opened === count) break;
+      if (this.consume(mg, player, tile, front)) opened++;
+    }
+    return opened;
+  }
+
+  /**
+   * Grow the holes outward by up to `count` tiles, favouring TIPS: a front tile
+   * with one rotted neighbour goes before one with three. That is a cheap local
+   * stand-in for the dielectric-breakdown growth exponent — growth concentrates
+   * where the field is steepest — and it is the difference between dendritic
+   * fingers and the compact round blobs of plain perimeter growth (Eden), which is
+   * provably what uniform selection produces. Noise breaks ties so equal-rank
+   * tiles do not fill in as tidy diamonds.
+   */
+  private spread(
+    mg: Game,
+    player: Player,
+    count: number,
+    front: Map<TileRef, number>,
+  ): number {
+    if (count <= 0 || front.size === 0) return 0;
+    const salt = player.smallID();
+    const pick = new LowestN(count);
+    for (const [tile, rotted] of front) {
+      const key = rotted * ROT_NOISE_SCALE + rotFrontNoise(tile, salt);
+      pick.offer(tile, key);
+    }
+    let taken = 0;
+    for (const tile of pick.take()) {
+      if (taken === count) break;
+      if (this.consume(mg, player, tile, front)) taken++;
+    }
+    return taken;
+  }
+
+  /**
+   * Rot one tile: hand the land to nobody and queue its neighbours. No conqueror
+   * is passed, so this is environmental — never a credited kill or captured gold.
+   * Anything built on it is deleted by PlayerExecution, which already removes
+   * structures standing on unowned land.
+   *
+   * False if the player no longer holds the tile. relinquish THROWS on unowned
+   * land, and a tile can sit on the front twice (reached from two rotted
+   * neighbours in one second) or be conquered away between seconds.
+   */
+  private consume(
+    mg: Game,
+    player: Player,
+    tile: TileRef,
+    front: Map<TileRef, number>,
+  ): boolean {
+    const tiles = player.tiles();
+    if (!tiles.has(tile)) return false;
+    player.relinquish(tile);
+    // Stamp it so the client can paint the red "Decaying" skull off authoritative
+    // state instead of re-deriving the (knife-edge) troops-vs-floor test.
+    player.markRotted();
+    front.delete(tile);
+    // Tallying here keeps every front tile's rotted-neighbour count current for
+    // free, which is what spread() ranks tips by.
+    for (const neighbour of mg.neighbors(tile)) {
+      if (tiles.has(neighbour)) {
+        front.set(neighbour, (front.get(neighbour) ?? 0) + 1);
+      }
+    }
+    return true;
   }
 
   /** Group contenders into sides: singletons in FFA, by team otherwise. */

--- a/src/core/execution/DoomsdayClockExecution.ts
+++ b/src/core/execution/DoomsdayClockExecution.ts
@@ -1,6 +1,7 @@
 import {
   doomsdayClockDrain,
   doomsdayClockRequiredTiles,
+  doomsdayClockRotQuota,
   doomsdayClockTroopFloor,
   ROT_NOISE_SCALE,
   rotFrontNoise,
@@ -229,8 +230,9 @@ export class DoomsdayClockExecution implements Execution {
       front: new Map<TileRef, number>(),
     };
 
-    const secondsLeft = Math.max(1, cfg.rotDeathSeconds - secondsUnder);
-    const evenQuota = Math.ceil(owned / secondsLeft);
+    // Shared with the HUD readout so the number on screen is the number the sim
+    // applies.
+    const evenQuota = doomsdayClockRotQuota(owned, secondsUnder, cfg);
 
     // Grainy opening, sized off the TERRITORY: a share of the quota would be one
     // or two holes a second on all but a huge empire. Runs ahead; quota absorbs it.

--- a/src/core/game/DoomsdayClock.ts
+++ b/src/core/game/DoomsdayClock.ts
@@ -341,3 +341,22 @@ export function doomsdayClockDrain(
   }
   return Math.max(1, Math.floor((maxTroops * pct) / 100));
 }
+
+/**
+ * Tiles rot takes per second: the deadline quota ceil(tilesLeft / secondsLeft).
+ * Self-correcting, so it holds the rotDeathSeconds deadline whatever the size and
+ * however late rot started. Shared so the HUD readout and the sim cannot drift.
+ *
+ * This is the steady quota. The grainy opening can briefly exceed it (it runs
+ * ahead and the quota absorbs it), so the readout understates the first few
+ * seconds rather than overstating the rest.
+ */
+export function doomsdayClockRotQuota(
+  tilesLeft: number,
+  secondsUnder: number,
+  cfg: { rotDeathSeconds: number },
+): number {
+  if (tilesLeft <= 0 || cfg.rotDeathSeconds <= 0) return 0;
+  const secondsLeft = Math.max(1, cfg.rotDeathSeconds - secondsUnder);
+  return Math.ceil(tilesLeft / secondsLeft);
+}

--- a/src/core/game/DoomsdayClock.ts
+++ b/src/core/game/DoomsdayClock.ts
@@ -38,41 +38,44 @@ interface WaveSchedule {
 // share rises linearly during each ramp and is flat during the grace and pauses.
 //
 // Design: the clock is a STALEMATE-BREAKER, not an early-game culler. It stays at
-// 0% for the first 10 minutes (combat decides the early game), then a 6-wave
-// squeeze climbs to 55% by the preset's cap. Levels accelerate (4/9/16/26/40/55%)
-// so the endgame tightens; the 6th wave (55%) only one side can hold, so — with
-// the crown exemption — it forces out everyone but the leader for a single winner.
-// Grace is a flat 10:00 on every preset; presets differ only in how long the
-// squeeze takes: 55% at 45/35/25/15 min for slow/normal/fast/veryfast.
-const LEVELS = [400, 900, 1600, 2600, 4000, 5500]; // 4, 9, 16, 26, 40, 55%
+// 0% for the first 10 minutes (combat decides the early game), then climbs to 35%
+// by the preset's cap.
+//
+// Ceiling and steps come from 85 tournament games: the runner-up's share at game
+// end has never exceeded 21.6%, so a bar above ~16% catches the same players while
+// a higher one climbs past the leader's own share. Steps stay small because half
+// the players alive at the end hold under 0.4% of the map.
+const LEVELS = [200, 400, 700, 1100, 1700, 2500, 3500]; // 2/4/7/11/17/25/35%
 const SCHEDULES: Record<DoomsdayClockSpeed, WaveSchedule> = {
-  // grace 10:00, then six ~208s ramps + 50s pauses -> 55% at 35:00.
+  // grace 10:00, then seven 168s ramps + 54s pauses -> 35% at 35:00.
   normal: {
     graceSeconds: 600,
-    rampSeconds: [208, 208, 208, 208, 208, 210],
-    pauseSeconds: [50, 50, 50, 50, 50, 0],
+    rampSeconds: [168, 168, 168, 168, 168, 168, 168],
+    pauseSeconds: [54, 54, 54, 54, 54, 54, 0],
     levels: LEVELS,
   },
-  // grace 10:00, then six ~292s ramps + 70s pauses -> 55% at 45:00.
+  // grace 10:00, then seven 240s ramps + 70s pauses -> 35% at 45:00.
   slow: {
     graceSeconds: 600,
-    rampSeconds: [292, 292, 292, 292, 292, 290],
-    pauseSeconds: [70, 70, 70, 70, 70, 0],
+    rampSeconds: [240, 240, 240, 240, 240, 240, 240],
+    pauseSeconds: [70, 70, 70, 70, 70, 70, 0],
     levels: LEVELS,
   },
-  // grace 10:00, then six 125s ramps + 30s pauses -> 4/9/16/26/40/55% at
-  // 12:05/14:40/17:15/19:50/22:25/25:00.
+  // grace 10:00, then seven 102s ramps + 31s pauses -> 2/4/7/11/17/25/35% at
+  // 11:42/13:55/16:08/18:21/20:34/22:47/25:00 — the final bar lands exactly on a
+  // 25-minute cap, so it has the whole endgame to act rather than arriving at the
+  // buzzer, which is what a ceiling reached only at the cap amounts to.
   fast: {
     graceSeconds: 600,
-    rampSeconds: [125, 125, 125, 125, 125, 125],
-    pauseSeconds: [30, 30, 30, 30, 30, 0],
+    rampSeconds: [102, 102, 102, 102, 102, 102, 102],
+    pauseSeconds: [31, 31, 31, 31, 31, 31, 0],
     levels: LEVELS,
   },
-  // grace 10:00, then six 40s ramps + 12s pauses -> 55% at 15:00 (tight squeeze).
+  // grace 10:00, then seven 36s ramps + 8s pauses -> 35% at 15:00.
   veryfast: {
     graceSeconds: 600,
-    rampSeconds: [40, 40, 40, 40, 40, 40],
-    pauseSeconds: [12, 12, 12, 12, 12, 0],
+    rampSeconds: [36, 36, 36, 36, 36, 36, 36],
+    pauseSeconds: [8, 8, 8, 8, 8, 8, 0],
     levels: LEVELS,
   },
 };
@@ -110,8 +113,10 @@ function requiredBasisPoints(
  * Minimum tiles one SIDE must hold at `elapsed` game seconds — a solo player in
  * FFA, a whole team's combined territory in team modes. The bar is identical
  * for every side regardless of headcount: the clock's job is to shrink the
- * number of viable sides (floor(100 / wave%) can be above the bar at once,
- * down to 1 at the final 55% wave), and elimination happens at side
+ * number of viable sides (floor(100 / wave%) can be above the bar at once — two
+ * at the final 35% wave, so the bar narrows the field but no longer forces a
+ * single winner by arithmetic alone; territory rot is what closes out the last
+ * pair), and elimination happens at side
  * granularity, so scaling by member count only distorts it — a headcount-
  * scaled bar saturated at "hold the whole map" for big teams the moment the
  * grace ended, and dropped whenever a teammate died. One floored integer
@@ -215,6 +220,71 @@ export interface DoomsdayClockDrainConfig {
   drainStartPercent: number;
   drainMaxPercent: number;
   drainRampSeconds: number;
+}
+
+/** Upper bound (exclusive) of both rot noise fields, so callers share a scale. */
+export const ROT_NOISE_SCALE = 1 << 16;
+
+// R2 low-discrepancy lattice constants (inverse plastic-number powers) at 2^32.
+const R2_X = 3242174889;
+const R2_Y = 2447445413;
+
+/**
+ * Even, blue-noise-like per-tile value in [0, ROT_NOISE_SCALE): used to place
+ * scattered pinholes. Taking the lowest values gives points that are near-evenly
+ * spaced, where a plain hash clumps — measured on a 60x60 grid, 0% of picks touch
+ * a neighbour here against 32% for white noise.
+ *
+ * Deliberately NOT avalanched: the evenness is the lattice being linear in x and
+ * y, and hashing the result measures worse than white noise (36% touching).
+ */
+export function rotSpeckleNoise(x: number, y: number, salt: number): number {
+  const h =
+    (Math.imul(x, R2_X) + Math.imul(y, R2_Y) + Math.imul(salt, 0x9e3779b9)) >>>
+    0;
+  return (h >>> 16) % ROT_NOISE_SCALE;
+}
+
+/**
+ * Unstructured per-tile value in [0, ROT_NOISE_SCALE): used to order the rot
+ * front. This one MUST be hashed. The lattice above is striped, and ranking an
+ * advancing front by it walks along a stripe and grows a straight 80x21 filament
+ * instead of a shape.
+ */
+export function rotFrontNoise(tile: number, salt: number): number {
+  let h = (Math.imul(tile, 0x27d4eb2d) ^ Math.imul(salt, 0x9e3779b9)) | 0;
+  h ^= h >>> 15;
+  h = Math.imul(h, 0x2545f491);
+  h ^= h >>> 13;
+  return (h >>> 16) % ROT_NOISE_SCALE;
+}
+
+export interface DoomsdayClockFloorConfig {
+  /** Where the troop floor settles, as a percent of max (the long-run floor). */
+  drainFloorPercent: number;
+  /** Where the troop floor STARTS, as a percent of max, before it decays. */
+  floorStartPercent: number;
+  /** How long the floor takes to decay from the start down to drainFloorPercent. */
+  floorDecaySeconds: number;
+}
+
+/**
+ * Troop floor `secondsPastWarn` into the decay: linear from floorStartPercent down
+ * to drainFloorPercent over floorDecaySeconds, flat after. Integer-only.
+ */
+export function doomsdayClockTroopFloor(
+  maxTroops: number,
+  secondsPastWarn: number,
+  cfg: DoomsdayClockFloorConfig,
+): number {
+  const end = cfg.drainFloorPercent;
+  const span = cfg.floorStartPercent - end;
+  const t = Math.max(0, secondsPastWarn);
+  const pct =
+    span > 0 && cfg.floorDecaySeconds > 0 && t < cfg.floorDecaySeconds
+      ? cfg.floorStartPercent - Math.floor((span * t) / cfg.floorDecaySeconds)
+      : end;
+  return Math.floor((maxTroops * pct) / 100);
 }
 
 // Fixed-point scale for the convex drain curve. (t/r)^exponent is evaluated as a

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -565,6 +565,9 @@ export interface Player {
   markTraitor(): void;
   // Doomsday Clock (anti-stall): marked when below the rising territory bar.
   inDoomsdayClock(): boolean;
+  /** Territory is actively rotting away (the final doomsday phase). */
+  isDecaying(): boolean;
+  markRotted(): void;
   doomsdayClockTicks(): number;
   enterDoomsdayClock(): void;
   clearDoomsdayClock(): void;

--- a/src/core/game/GameUpdateUtils.ts
+++ b/src/core/game/GameUpdateUtils.ts
@@ -51,6 +51,7 @@ export function diffPlayerUpdate(
     prev.traitorRemainingTicks === next.traitorRemainingTicks &&
     prev.inDoomsdayClock === next.inDoomsdayClock &&
     prev.markedDoomsdayClockTick === next.markedDoomsdayClockTick &&
+    prev.isDecaying === next.isDecaying &&
     prev.hasSpawned === next.hasSpawned &&
     prev.spawnTile === next.spawnTile &&
     prev.betrayals === next.betrayals &&
@@ -109,6 +110,7 @@ export function diffPlayerUpdate(
     "markedDoomsdayClockTick",
     prev.markedDoomsdayClockTick === next.markedDoomsdayClockTick,
   );
+  setIfDifferent("isDecaying", prev.isDecaying === next.isDecaying);
   setIfDifferent("hasSpawned", prev.hasSpawned === next.hasSpawned);
   setIfDifferent("spawnTile", prev.spawnTile === next.spawnTile);
   setIfDifferent("betrayals", prev.betrayals === next.betrayals);
@@ -177,6 +179,7 @@ export function applyStateUpdate(target: PlayerState, pu: PlayerUpdate): void {
   if (pu.markedDoomsdayClockTick !== undefined) {
     target.markedDoomsdayClockTick = pu.markedDoomsdayClockTick;
   }
+  if (pu.isDecaying !== undefined) target.isDecaying = pu.isDecaying;
   if (pu.betrayals !== undefined) target.betrayals = pu.betrayals;
   if (pu.hasSpawned !== undefined) target.hasSpawned = pu.hasSpawned;
   if (pu.spawnTile !== undefined) target.spawnTile = pu.spawnTile;

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -243,6 +243,7 @@ export interface PlayerUpdate {
   isTraitor?: boolean;
   traitorRemainingTicks?: number;
   inDoomsdayClock?: boolean;
+  isDecaying?: boolean;
   markedDoomsdayClockTick?: number;
   targets?: number[];
   outgoingEmojis?: EmojiMessage[];

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -60,6 +60,9 @@ import {
 } from "./TransportShipUtils";
 import { UnitImpl } from "./UnitImpl";
 
+// Rot re-stamps every second, so a little slack keeps the cue from strobing.
+const DECAY_CUE_GRACE_TICKS = 30;
+
 interface Target {
   tick: Tick;
   target: Player;
@@ -108,6 +111,8 @@ export class PlayerImpl implements Player {
 
   markedTraitorTick = -1;
   markedDoomsdayClockTick = -1;
+  /** Tick territory rot last took land from this player (-1 = never). */
+  private rottedAtTick = -1;
   private _betrayalCount: number = 0;
 
   private embargoes = new Map<PlayerID, Embargo>();
@@ -334,6 +339,7 @@ export class PlayerImpl implements Player {
       isTraitor: this.isTraitor(),
       traitorRemainingTicks: this.getTraitorRemainingTicks(),
       inDoomsdayClock: this.inDoomsdayClock(),
+      isDecaying: this.isDecaying(),
       markedDoomsdayClockTick: this.markedDoomsdayClockTick,
       targets: targets,
       outgoingEmojis: outgoingEmojis,
@@ -779,6 +785,20 @@ export class PlayerImpl implements Player {
 
   clearDoomsdayClock(): void {
     this.markedDoomsdayClockTick = -1;
+    this.rottedAtTick = -1;
+  }
+
+  markRotted(): void {
+    this.rottedAtTick = this.mg.ticks();
+  }
+
+  // Territory actively rotting. Stamped by the execution rather than derived from
+  // troops vs the floor: that is a knife-edge equality (the drain lands exactly ON
+  // the floor) and the floor moves as rot shrinks the cap, so a client-side copy
+  // flickers.
+  isDecaying(): boolean {
+    if (!this.inDoomsdayClock() || this.rottedAtTick < 0) return false;
+    return this.mg.ticks() - this.rottedAtTick <= DECAY_CUE_GRACE_TICKS;
   }
 
   betrayals(): number {

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -1306,7 +1306,7 @@ describe("DoomsdayClockExecution (territory rot, real simulation)", () => {
 // ---------------------------------------------------------------------------
 
 describe("doomsday clock: the shipped timeline", () => {
-  it("blinks for 30s, rots at 120s, and is gone at 180s", async () => {
+  it("blinks for 30s, rots at 120s, and is gone at 150s", async () => {
     const game = await setup(
       "plains",
       {
@@ -1333,13 +1333,14 @@ describe("doomsday clock: the shipped timeline", () => {
       doomsdayClockTroopFloor(1000, cfg.floorDecaySeconds - 1, cfg),
     ).toBeGreaterThan(Math.floor((1000 * cfg.drainFloorPercent) / 100));
 
-    // Everything is gone at the deadline, leaving 60s of visible rotting.
-    expect(cfg.rotDeathSeconds).toBe(180);
-    expect(
-      cfg.rotDeathSeconds - (cfg.warnSeconds + cfg.floorDecaySeconds),
-    ).toBe(60);
-    // The grainy opening has to fit inside that window with room to spread after.
-    expect(cfg.rotGrainSeconds).toBeLessThan(60);
+    // Everything is gone at the deadline, leaving 30s of visible rotting.
+    expect(cfg.rotDeathSeconds).toBe(150);
+    const rotWindow =
+      cfg.rotDeathSeconds - (cfg.warnSeconds + cfg.floorDecaySeconds);
+    expect(rotWindow).toBe(30);
+    // The grainy opening has to fit inside that window with room to spread after,
+    // so it stays a minority of it rather than merely shorter than it.
+    expect(cfg.rotGrainSeconds).toBeLessThan(rotWindow / 2);
   });
 });
 

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -4,6 +4,7 @@ import { PlayerExecution } from "../src/core/execution/PlayerExecution";
 import {
   doomsdayClockDrain,
   doomsdayClockRequiredTiles,
+  doomsdayClockRotQuota,
   doomsdayClockTroopFloor,
   doomsdayClockWaveState,
   ROT_NOISE_SCALE,
@@ -1429,5 +1430,43 @@ describe("rot noise fields", () => {
     const p1 = lowest((x, y) => rotSpeckleNoise(x, y, 1));
     const p2 = lowest((x, y) => rotSpeckleNoise(x, y, 2));
     expect(p1).not.toEqual(p2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The rot quota is shared between the sim and the HUD readout, so the number a
+// player sees is the number being applied to them. Pinned here because a drift
+// between the two would be invisible until someone counted tiles on screen.
+// ---------------------------------------------------------------------------
+
+describe("doomsdayClockRotQuota", () => {
+  const cfg = { rotDeathSeconds: 150 };
+
+  it("is off when there is nothing to rot, or rot is disabled", () => {
+    expect(doomsdayClockRotQuota(0, 130, cfg)).toBe(0);
+    expect(doomsdayClockRotQuota(100, 130, { rotDeathSeconds: 0 })).toBe(0);
+  });
+
+  it("spreads the territory evenly over the time left, rounding up", () => {
+    // 30s of rot window left at the moment rot starts (150 - 120).
+    expect(doomsdayClockRotQuota(300, 120, cfg)).toBe(10);
+    expect(doomsdayClockRotQuota(301, 120, cfg)).toBe(11); // never rounds down
+  });
+
+  it("climbs as the deadline nears, so a stalled rot still finishes on time", () => {
+    const early = doomsdayClockRotQuota(300, 120, cfg);
+    const late = doomsdayClockRotQuota(300, 145, cfg);
+    expect(late).toBeGreaterThan(early);
+    // At and past the deadline the whole remainder goes in one second.
+    expect(doomsdayClockRotQuota(300, 150, cfg)).toBe(300);
+    expect(doomsdayClockRotQuota(300, 999, cfg)).toBe(300);
+  });
+
+  it("actually clears the territory by the deadline", () => {
+    let tiles = 1000;
+    for (let s = 120; s < cfg.rotDeathSeconds && tiles > 0; s++) {
+      tiles -= doomsdayClockRotQuota(tiles, s, cfg);
+    }
+    expect(tiles).toBeLessThanOrEqual(0);
   });
 });

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -1,9 +1,14 @@
+import { vi } from "vitest";
 import { DoomsdayClockExecution } from "../src/core/execution/DoomsdayClockExecution";
 import { PlayerExecution } from "../src/core/execution/PlayerExecution";
 import {
   doomsdayClockDrain,
   doomsdayClockRequiredTiles,
+  doomsdayClockTroopFloor,
   doomsdayClockWaveState,
+  ROT_NOISE_SCALE,
+  rotFrontNoise,
+  rotSpeckleNoise,
 } from "../src/core/game/DoomsdayClock";
 import {
   Game,
@@ -11,6 +16,7 @@ import {
   Player,
   PlayerType,
   Team,
+  UnitType,
 } from "../src/core/game/Game";
 import { TileRef } from "../src/core/game/GameMap";
 import { playerInfo, setup } from "./util/Setup";
@@ -22,14 +28,14 @@ import { playerInfo, setup } from "./util/Setup";
 // the pure-function tests further down; the end-to-end integration against the
 // real simulation is the final test.
 //
-// The exec reads the real "veryfast" waves. WAVE_TICK sits in the 26% hold
-// window (elapsed 796-808), so the bar is a stable 26% of the map (land 1000 ->
-// bar 260) while the drain/flag logic is exercised. b(100) stays below it and
+// The exec reads the real "veryfast" waves. WAVE_TICK sits in the 25% hold
+// window (elapsed 856-864), so the bar is a stable 25% of the map (land 1000 ->
+// bar 250) while the drain/flag logic is exercised. b(100) stays below it and
 // a(400) above, so the flag/drain assertions (which depend on the drain config,
 // not the exact bar) are unchanged.
 // ---------------------------------------------------------------------------
 
-const WAVE_TICK = 8000; // elapsed 800s -> veryfast 26% hold (bar 260 @ land 1000)
+const WAVE_TICK = 8600; // elapsed 860s -> veryfast 25% hold (bar 250 @ land 1000)
 
 type SDConfig = ReturnType<ReturnType<Game["config"]>["doomsdayClockConfig"]>;
 
@@ -41,7 +47,12 @@ function sdConfig(over: Partial<SDConfig> = {}): SDConfig {
     drainStartPercent: 10,
     drainMaxPercent: 80,
     drainRampSeconds: 3,
-    drainFloorPercent: 5, // drain stops at 5% of max (matches production default)
+    drainFloorPercent: 5, // drain settles at 5% of max (matches production default)
+    floorStartPercent: 5, // == drainFloorPercent -> flat floor, no comeback window
+    floorDecaySeconds: 0,
+    rotDeathSeconds: 0, // rot off unless a test asks for it (prod default)
+    rotGrainSeconds: 20,
+    rotSpecklePercent: 15,
     warshipDrainStartPercent: 10, // fixture: same start as troops (linear curve below)
     warshipDrainMaxPercent: 100, // ships ramp to a higher ceiling than troops
     warshipDrainCurveExponent: 1, // fixture uses a linear ramp for exact numbers
@@ -78,7 +89,7 @@ class FakePlayer {
   readonly troopMax: number;
   constructor(
     private game: FakeGame,
-    public tiles: number,
+    public tileCount: number,
     public troopCount: number,
     private kind: PlayerType = PlayerType.Human,
     private alive: boolean = true,
@@ -102,7 +113,7 @@ class FakePlayer {
     this.alive = false;
   }
   numTilesOwned(): number {
-    return this.tiles;
+    return this.tileCount;
   }
   troops(): number {
     return this.troopCount;
@@ -125,11 +136,57 @@ class FakePlayer {
   }
   clearDoomsdayClock(): void {
     this.markedTick = -1;
+    this.rottedAtTick = -1;
   }
-  // The exec calls units(UnitType.Warship); we ignore the filter and hand back
-  // this side's warships.
+  // Stamped by rot so the client can paint the red "Decaying" skull.
+  rottedAtTick = -1;
+  markRotted(): void {
+    this.rottedAtTick = this.game.now;
+  }
+  // The exec only ever asks for warships (the navy drain).
   units(..._types: unknown[]): FakeWarship[] {
     return this.warships;
+  }
+
+  // --- Territory, for the rot tests -----------------------------------------
+  // The number-only tests above just set tileCount; giveTiles() additionally
+  // hands over real tile refs so rot has something to pick from.
+  id = 0;
+  private tileSet = new Set<TileRef>();
+  private borderSet = new Set<TileRef>();
+  relinquished: TileRef[] = [];
+
+  giveTiles(interior: TileRef[], border: TileRef[] = []): void {
+    this.tileSet = new Set([...interior, ...border]);
+    this.borderSet = new Set(border);
+    this.tileCount = this.tileSet.size;
+  }
+  smallID(): number {
+    return this.id;
+  }
+  tiles(): {
+    has: (t: TileRef) => boolean;
+    forEach: (fn: (t: TileRef) => void) => void;
+  } {
+    return {
+      has: (t) => this.tileSet.has(t),
+      forEach: (fn) => this.tileSet.forEach(fn),
+    };
+  }
+  borderTiles(): { has: (t: TileRef) => boolean } {
+    return { has: (t) => this.borderSet.has(t) };
+  }
+  relinquish(tile: TileRef): void {
+    // GameImpl.relinquish throws on an unowned tile, so mirror that: it turns a
+    // double-relinquish (e.g. the same tile landing in two reservoirs) into a
+    // failure here rather than a silent no-op.
+    if (!this.tileSet.delete(tile)) {
+      throw new Error(`relinquish of an unowned tile: ${tile}`);
+    }
+    this.borderSet.delete(tile);
+    this.relinquished.push(tile);
+    this.tileCount = this.tileSet.size;
+    if (this.tileCount === 0) this.alive = false; // PlayerImpl: isAlive() = tiles > 0
   }
 }
 
@@ -152,6 +209,23 @@ class FakeGame {
   }
   numLandTiles(): number {
     return this.land;
+  }
+  // Rot spreads to cardinal neighbours and reads a per-tile noise field, so the
+  // fake lays its tiles out on a GRID x GRID board: ref = y * GRID + x.
+  x(t: TileRef): number {
+    return t % GRID;
+  }
+  y(t: TileRef): number {
+    return Math.floor(t / GRID);
+  }
+  neighbors(t: TileRef): TileRef[] {
+    const x = t % GRID;
+    const out: TileRef[] = [];
+    if (x > 0) out.push((t - 1) as TileRef);
+    if (x < GRID - 1) out.push((t + 1) as TileRef);
+    if (t - GRID >= 0) out.push((t - GRID) as TileRef);
+    if (t + GRID < GRID * GRID) out.push((t + GRID) as TileRef);
+    return out;
   }
   numTilesWithFallout(): number {
     return 0;
@@ -182,7 +256,7 @@ function makeExec(game: FakeGame): DoomsdayClockExecution {
 }
 
 describe("DoomsdayClockExecution (logic)", () => {
-  // land 1000, veryfast 20% wave -> bar = 200 at WAVE_TICK.
+  // land 1000, veryfast 25% wave -> bar = 250 at WAVE_TICK.
   function twoPlayerGame(
     aTiles: number,
     bTiles: number,
@@ -256,7 +330,7 @@ describe("DoomsdayClockExecution (logic)", () => {
     const afterDrain = b.troops();
     expect(b.inDoomsdayClock()).toBe(true);
 
-    b.tiles = 400; // recovered above the bar
+    b.tileCount = 400; // recovered above the bar
     runAt(exec, game, WAVE_TICK + 20);
     expect(b.inDoomsdayClock()).toBe(false);
     expect(b.troops()).toBe(afterDrain); // drain stopped
@@ -416,8 +490,8 @@ describe("DoomsdayClockExecution (warship decay)", () => {
 
 describe("DoomsdayClockExecution (teams)", () => {
   function teamGame(teams: { team: string; tiles: number[] }[]) {
-    // WAVE_TICK sits in the veryfast 26% hold @ land 1000 -> every side's bar
-    // is 260, team or solo.
+    // WAVE_TICK sits in the veryfast 25% hold @ land 1000 -> every side's bar
+    // is 250, team or solo.
     const game = new FakeGame(1000, sdConfig(), []);
     game.gameMode = GameMode.Team;
     const players: FakePlayer[] = [];
@@ -433,7 +507,7 @@ describe("DoomsdayClockExecution (teams)", () => {
   }
 
   it("judges a team on combined territory and skulls every member when below", () => {
-    // Bar 260. Red 250+250=500 above (and the leader); Blue 50+50=100 below
+    // Bar 250. Red 250+250=500 above (and the leader); Blue 50+50=100 below
     // -> both Blue members skulled together.
     const { game, players } = teamGame([
       { team: "Red", tiles: [250, 250] },
@@ -453,7 +527,7 @@ describe("DoomsdayClockExecution (teams)", () => {
   });
 
   it("spares a tiny member whose team is collectively above the bar", () => {
-    // Bar 260. Red 400+40=440 above -> safe, so the 40-tile member is NOT
+    // Bar 250. Red 400+40=440 above -> safe, so the 40-tile member is NOT
     // skulled even though 40 is far below the bar on its own.
     const { game, players } = teamGame([
       { team: "Red", tiles: [400, 40] },
@@ -467,14 +541,14 @@ describe("DoomsdayClockExecution (teams)", () => {
   });
 
   it("does NOT scale the bar by headcount (a team faces the same bar as a solo)", () => {
-    // Bar 260 for every side. Red (2 members, 300 combined) is safe — the old
-    // headcount-scaled rule would have demanded 260x2=520 and skulled them.
+    // Bar 250 for every side. Red (2 members, 300 combined) is safe — the old
+    // headcount-scaled rule would have demanded 250x2=500 and skulled them.
     // Green (3 members, 240 combined) is below the SOLO bar -> skulled: being
     // three players earns no leniency either.
     const { game, players } = teamGame([
       { team: "Blue", tiles: [700] }, // leader
-      { team: "Red", tiles: [150, 150] }, // 300 >= 260 -> safe
-      { team: "Green", tiles: [100, 80, 60] }, // 240 < 260 -> skulled
+      { team: "Red", tiles: [150, 150] }, // 300 >= 250 -> safe
+      { team: "Green", tiles: [100, 80, 60] }, // 240 < 250 -> skulled
     ]);
     const [blue1, red1, red2, green1, green2, green3] = players;
     const exec = makeExec(game);
@@ -488,7 +562,7 @@ describe("DoomsdayClockExecution (teams)", () => {
   });
 
   it("keeps the bar unchanged when a teammate dies", () => {
-    // Bar 260. Red holds 300+5: safe before AND after losing the 5-tile member
+    // Bar 250. Red holds 300+5: safe before AND after losing the 5-tile member
     // (still 300 >= 260). The old rule moved the bar with the alive headcount:
     // 520 while both lived (skulled), 260 after the death (saved by dying) —
     // deaths must never move the bar.
@@ -524,23 +598,42 @@ describe("doomsdayClockRequiredTiles (ramping waves)", () => {
   const land = 10000;
 
   it("is 0 through the grace, ramps linearly, then holds during the pause", () => {
-    // normal: grace 600s, then a 208s ramp 0->4%, then a 50s hold, ...
+    // normal: grace 600s, then a 168s ramp 0->2%, then a 54s hold, ...
     expect(doomsdayClockRequiredTiles("normal", land, 300)).toBe(0); // in the grace
     expect(doomsdayClockRequiredTiles("normal", land, 600)).toBe(0); // grace ends
-    expect(doomsdayClockRequiredTiles("normal", land, 704)).toBe(200); // halfway up -> 2%
-    expect(doomsdayClockRequiredTiles("normal", land, 808)).toBe(400); // ramp done -> 4%
-    expect(doomsdayClockRequiredTiles("normal", land, 830)).toBe(400); // pause holds 4%
-    expect(doomsdayClockRequiredTiles("normal", land, 858)).toBe(400); // next ramp starts at 4%
-    expect(doomsdayClockRequiredTiles("normal", land, 9999)).toBe(5500); // final 55%
+    expect(doomsdayClockRequiredTiles("normal", land, 684)).toBe(100); // halfway up -> 1%
+    expect(doomsdayClockRequiredTiles("normal", land, 768)).toBe(200); // ramp done -> 2%
+    expect(doomsdayClockRequiredTiles("normal", land, 800)).toBe(200); // pause holds 2%
+    expect(doomsdayClockRequiredTiles("normal", land, 822)).toBe(200); // next ramp starts at 2%
+    expect(doomsdayClockRequiredTiles("normal", land, 9999)).toBe(3500); // final 35%
   });
 
-  it("reaches the 40% wave then the final 55% squeeze per preset", () => {
-    // 40% waypoint (5th wave), then the 6th wave to 55% at the preset cap.
-    expect(doomsdayClockRequiredTiles("normal", land, 1850)).toBe(4000); // 40% wave
-    expect(doomsdayClockRequiredTiles("normal", land, 2110)).toBe(5500); // 55% @ 35:00
-    expect(doomsdayClockRequiredTiles("fast", land, 1510)).toBe(5500); // 55% @ 25:00
-    expect(doomsdayClockRequiredTiles("veryfast", land, 910)).toBe(5500); // 55% @ 15:00
-    expect(doomsdayClockRequiredTiles("slow", land, 2710)).toBe(5500); // 55% @ 45:00
+  it("tops out at 35% exactly on each preset's cap", () => {
+    // Seven waves (2/4/7/11/17/25/35%); the last lands ON the cap so it has the
+    // endgame to act. 35% -- not the old 55% -- because no runner-up in 85
+    // tournament games ever held more than 21.6%, so a higher ceiling only ever
+    // climbed past the leader's own share.
+    expect(doomsdayClockRequiredTiles("normal", land, 1878)).toBe(2500); // 25% wave
+    expect(doomsdayClockRequiredTiles("normal", land, 2100)).toBe(3500); // 35% @ 35:00
+    expect(doomsdayClockRequiredTiles("fast", land, 1500)).toBe(3500); // 35% @ 25:00
+    expect(doomsdayClockRequiredTiles("veryfast", land, 900)).toBe(3500); // 35% @ 15:00
+    expect(doomsdayClockRequiredTiles("slow", land, 2700)).toBe(3500); // 35% @ 45:00
+    // And never beyond it, however long the game runs.
+    expect(doomsdayClockRequiredTiles("fast", land, 5000)).toBe(3500);
+  });
+
+  it("steps gently and never jumps more than 10 points at once", () => {
+    // The field is bottom-heavy (half of end-survivors hold under 0.4% of the
+    // map), so a big step sweeps the whole cluster into the debuff at once --
+    // which is how games ended up with 8 of 10 survivors crippled together.
+    const levels = [200, 400, 700, 1100, 1700, 2500, 3500];
+    let prev = 0;
+    for (const l of levels) {
+      expect(l - prev).toBeLessThanOrEqual(1000); // <= 10 percentage points
+      prev = l;
+    }
+    // Dense at the bottom: the first four steps are all <= 4 points.
+    expect(levels[3] - levels[2]).toBeLessThanOrEqual(400);
   });
 
   it("never decreases, and is zero for no land", () => {
@@ -556,28 +649,28 @@ describe("doomsdayClockRequiredTiles (ramping waves)", () => {
 
 describe("doomsdayClockWaveState", () => {
   it("reports the live share and target while ramping", () => {
-    const s = doomsdayClockWaveState("normal", 704); // mid the first ramp (0->4%)
-    expect(s.currentPercent).toBe(2);
-    expect(s.targetPercent).toBe(4);
+    const s = doomsdayClockWaveState("normal", 684); // mid the first ramp (0->2%)
+    expect(s.currentPercent).toBe(1);
+    expect(s.targetPercent).toBe(2);
     expect(s.growing).toBe(true);
     expect(s.secondsToNextGrowth).toBe(0);
-    expect(s.secondsToTarget).toBe(104); // 208s ramp, 104s elapsed into it
+    expect(s.secondsToTarget).toBe(84); // 168s ramp, 84s elapsed into it
     expect(s.done).toBe(false);
   });
 
   it("counts down to the next ramp during a pause", () => {
-    const s = doomsdayClockWaveState("normal", 830); // in the first pause (808-858)
+    const s = doomsdayClockWaveState("normal", 800); // in the first pause (768-822)
     expect(s.growing).toBe(false);
-    expect(s.currentPercent).toBe(4); // held at the level just reached
-    expect(s.targetPercent).toBe(9); // next ramp climbs to 9%
-    expect(s.secondsToNextGrowth).toBe(28); // next ramp starts at 858
+    expect(s.currentPercent).toBe(2); // held at the level just reached
+    expect(s.targetPercent).toBe(4); // next ramp climbs to 4%
+    expect(s.secondsToNextGrowth).toBe(22); // next ramp starts at 822
     expect(s.secondsToTarget).toBe(0); // not rising, so no rise countdown
   });
 
   it("counts down through the grace", () => {
     const s = doomsdayClockWaveState("normal", 200);
     expect(s.currentPercent).toBe(0);
-    expect(s.targetPercent).toBe(4);
+    expect(s.targetPercent).toBe(2);
     expect(s.secondsToNextGrowth).toBe(400); // first ramp at 600
   });
 
@@ -589,9 +682,9 @@ describe("doomsdayClockWaveState", () => {
   });
 
   it("marks done after the last ramp", () => {
-    const s = doomsdayClockWaveState("veryfast", 1100); // past the final ramp (@900) = 55%
+    const s = doomsdayClockWaveState("veryfast", 1100); // past the final ramp (@900) = 35%
     expect(s.done).toBe(true);
-    expect(s.currentPercent).toBe(55);
+    expect(s.currentPercent).toBe(35);
     expect(s.secondsToNextGrowth).toBe(0);
   });
 });
@@ -753,6 +846,16 @@ describe("DoomsdayClockExecution (default drain, with income)", () => {
     const small = game.player("small");
     giveLandTiles(game, big, 4000); // safely above the bar
     giveLandTiles(game, small, 3); // a sliver, caught once the bar rises
+    // This test is about the DRAIN floor, so pin rot off and the floor flat. Left
+    // to the defaults it would break the day rot ships switched on -- the sliver
+    // would rot away before there was anything to measure.
+    const dcfg = game.config();
+    vi.spyOn(dcfg, "doomsdayClockConfig").mockReturnValue({
+      ...dcfg.doomsdayClockConfig(),
+      floorStartPercent: 5,
+      floorDecaySeconds: 0,
+      rotDeathSeconds: 0,
+    });
     game.addExecution(new PlayerExecution(big));
     game.addExecution(new PlayerExecution(small)); // income every tick
     game.addExecution(new DoomsdayClockExecution());
@@ -781,5 +884,549 @@ describe("DoomsdayClockExecution (default drain, with income)", () => {
     expect(small.troops()).toBeGreaterThanOrEqual(floor - 1); // never below the 5% floor
     // Settles at the floor (income keeps it a little above, within one drain step).
     expect(small.troops()).toBeLessThan(floor + Math.floor(maxTroops * 0.05));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The DECAYING troop floor. Pure integer math, so assert exact numbers: the
+// floor starts at floorStartPercent of max and decays linearly to
+// drainFloorPercent over floorDecaySeconds, then holds. Defaults must be inert.
+// ---------------------------------------------------------------------------
+
+describe("doomsdayClockTroopFloor", () => {
+  const decaying = {
+    drainFloorPercent: 5,
+    floorStartPercent: 40,
+    floorDecaySeconds: 100,
+  };
+
+  it("starts at floorStartPercent and lands exactly on drainFloorPercent", () => {
+    expect(doomsdayClockTroopFloor(1000, 0, decaying)).toBe(400); // 40%
+    expect(doomsdayClockTroopFloor(1000, 100, decaying)).toBe(50); // 5%
+  });
+
+  it("decays linearly in between", () => {
+    // 50s in: 40 - floor(35 * 50/100) = 40 - 17 = 23% of 1000.
+    expect(doomsdayClockTroopFloor(1000, 50, decaying)).toBe(230);
+    // 20s in: 40 - floor(35 * 20/100) = 40 - 7 = 33%.
+    expect(doomsdayClockTroopFloor(1000, 20, decaying)).toBe(330);
+  });
+
+  it("holds at the settled floor forever after the window", () => {
+    expect(doomsdayClockTroopFloor(1000, 101, decaying)).toBe(50);
+    expect(doomsdayClockTroopFloor(1000, 100_000, decaying)).toBe(50);
+  });
+
+  it("never rises: the comeback window only ever closes", () => {
+    let prev = Infinity;
+    for (let t = 0; t <= 120; t++) {
+      const floor = doomsdayClockTroopFloor(1000, t, decaying);
+      expect(floor).toBeLessThanOrEqual(prev);
+      expect(Number.isInteger(floor)).toBe(true); // integer-only: lockstep-safe
+      prev = floor;
+    }
+  });
+
+  it("clamps a negative elapsed to the start of the window", () => {
+    expect(doomsdayClockTroopFloor(1000, -5, decaying)).toBe(400);
+  });
+
+  it("is flat when the window is zero, or the start equals the settled floor", () => {
+    // Either degenerate case gives a plain Math.floor(max * floor% / 100).
+    const noWindow = { ...decaying, floorDecaySeconds: 0 };
+    const noSpan = {
+      ...decaying,
+      floorStartPercent: 5,
+      floorDecaySeconds: 100,
+    };
+    for (const t of [0, 1, 50, 100, 999]) {
+      expect(doomsdayClockTroopFloor(1000, t, noWindow)).toBe(50);
+      expect(doomsdayClockTroopFloor(1000, t, noSpan)).toBe(50);
+    }
+  });
+
+  it("floors the percentage against max, not the other way round", () => {
+    // 5% of 999 = 49.95 -> 49. Truncation, never a rounded-up floor.
+    expect(doomsdayClockTroopFloor(999, 100, decaying)).toBe(49);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// TERRITORY ROT. A doomed side whose army has bottomed out starts losing LAND,
+// which is what actually ends a stalemate — the drain alone stops at the floor.
+//
+// Rot SPREADS: a few seeds deep inside the territory, then outward through their
+// neighbours, so the fakes lay tiles out on a real GRID x GRID board (ref =
+// y * GRID + x) and FakeGame.neighbors walks it. Note the fake's relinquish(tile)
+// takes no conqueror, exactly like GameImpl's: rot cannot credit a kill or
+// transfer gold even by accident.
+// ---------------------------------------------------------------------------
+
+const GRID = 32;
+
+/** A solid w x h block of tiles at (x0, y0), split into interior and border. */
+function gridBlock(x0: number, y0: number, w: number, h: number) {
+  const interior: TileRef[] = [];
+  const border: TileRef[] = [];
+  for (let y = y0; y < y0 + h; y++) {
+    for (let x = x0; x < x0 + w; x++) {
+      const tile = (y * GRID + x) as TileRef;
+      const edge = x === x0 || y === y0 || x === x0 + w - 1 || y === y0 + h - 1;
+      (edge ? border : interior).push(tile);
+    }
+  }
+  return { interior, border, all: [...interior, ...border] };
+}
+
+describe("DoomsdayClockExecution (territory rot)", () => {
+  const BLOCK = gridBlock(4, 4, 10, 10); // 100 tiles: 64 interior, 36 border
+  const DEADLINE = 60; // seconds from skull to gone, for these fixtures
+
+  // A leader safely above the bar plus a doomed side already sitting at its troop
+  // floor (maxTroops 100 -> 5% floor = 5, and we start it at 0), so the very first
+  // post-warn tick both drains (a no-op) and rots.
+  function rotGame(
+    over: Partial<SDConfig> = {},
+    doomedId = 7,
+    world = { land: 1000, leaderTiles: 400 },
+  ) {
+    const game = new FakeGame(
+      world.land,
+      sdConfig({ rotDeathSeconds: DEADLINE, rotGrainSeconds: 20, ...over }),
+      [],
+    );
+    const leader = new FakePlayer(game, world.leaderTiles, 1000);
+    const doomed = new FakePlayer(game, 0, 100);
+    doomed.troopCount = 0; // bottomed out
+    doomed.id = doomedId;
+    doomed.giveTiles(BLOCK.interior, BLOCK.border); // 100 tiles, below the 250 bar
+    game.ps = [leader, doomed];
+    return { game, leader, doomed, exec: makeExec(game) };
+  }
+
+  /** Run the warn tick plus `seconds` rotting seconds. */
+  function rotFor(
+    g: ReturnType<typeof rotGame>,
+    seconds: number,
+    from = WAVE_TICK,
+  ): void {
+    for (let s = 0; s <= seconds; s++) runAt(g.exec, g.game, from + s * 10);
+  }
+
+  it("does nothing when rotDeathSeconds is 0", () => {
+    const g = rotGame({ rotDeathSeconds: 0 });
+    rotFor(g, 200);
+    expect(g.doomed.relinquished).toHaveLength(0);
+    expect(g.doomed.numTilesOwned()).toBe(100);
+    expect(g.doomed.isAlive()).toBe(true); // the drain alone can never finish it
+  });
+
+  it("holds off during the warn window", () => {
+    const g = rotGame();
+    runAt(g.exec, g.game, WAVE_TICK); // flagged, 0s under -> still warning
+    expect(g.doomed.relinquished).toHaveLength(0);
+  });
+
+  it("spares a side that still has an army above the floor", () => {
+    const g = rotGame();
+    g.doomed.troopCount = 100; // full stack: draining, but not bottomed out
+    rotFor(g, 1); // the fixture drain is steep; one second still leaves an army
+    expect(g.doomed.troops()).toBeLessThan(100); // the drain is biting...
+    expect(g.doomed.troops()).toBeGreaterThan(5); // ...but it is above the floor
+    expect(g.doomed.relinquished).toHaveLength(0); // ...so the land is safe
+  });
+
+  it("waits for the comeback window to close before rotting", () => {
+    const g = rotGame({ floorStartPercent: 40, floorDecaySeconds: 30 });
+    rotFor(g, 30); // window runs from the END of the warn (warnSeconds is 1 here)
+    expect(g.doomed.relinquished).toHaveLength(0);
+
+    runAt(g.exec, g.game, WAVE_TICK + 31 * 10);
+    expect(g.doomed.relinquished.length).toBeGreaterThan(0);
+  });
+
+  // --- the deadline, which is the whole point -------------------------------
+
+  it("kills the side COMPLETELY and on time, whatever its size", () => {
+    // The quota is ceil(tilesLeft / secondsLeft), so size changes the rate, never
+    // the finish time. This is what stops big players outliving the round.
+    for (const w of [4, 8, 10]) {
+      const g = rotGame();
+      const block = gridBlock(2, 2, w, 3);
+      g.doomed.giveTiles(block.interior, block.border);
+      const held = g.doomed.numTilesOwned();
+      rotFor(g, DEADLINE);
+      expect(g.doomed.numTilesOwned()).toBe(0);
+      expect(g.doomed.isAlive()).toBe(false); // PlayerImpl: isAlive() = tiles > 0
+      // The fake throws on a double relinquish, so this also proves each tile went
+      // exactly once -- none double-counted against the quota.
+      expect(g.doomed.relinquished).toHaveLength(held);
+      expect(new Set(g.doomed.relinquished).size).toBe(held);
+    }
+  });
+
+  it("finishes on time even when rot starts late in the budget", () => {
+    // A long warn + comeback window eats most of the deadline. The quota inflates
+    // to compensate: a slow start means a faster finish, never a missed deadline.
+    const g = rotGame({ warnSeconds: 20, floorDecaySeconds: 25 });
+    rotFor(g, DEADLINE);
+    expect(g.doomed.numTilesOwned()).toBe(0);
+    expect(g.doomed.isAlive()).toBe(false);
+  });
+
+  it("does not dump the whole territory in one second", () => {
+    // The deadline must not read as a mass deletion: with room to work, no single
+    // second may take more than a modest slice.
+    const g = rotGame();
+    let last = 0;
+    const perSecond: number[] = [];
+    for (let s = 0; s <= DEADLINE; s++) {
+      runAt(g.exec, g.game, WAVE_TICK + s * 10);
+      perSecond.push(g.doomed.relinquished.length - last);
+      last = g.doomed.relinquished.length;
+    }
+    expect(Math.max(...perSecond)).toBeLessThan(20); // of 100 tiles
+  });
+
+  // --- how it looks ---------------------------------------------------------
+
+  it("opens MANY holes in the grainy phase, scattered across the territory", () => {
+    // Graininess is a share of the TERRITORY, so it only means anything at scale:
+    // 15% of 900 tiles over 20s is ~7 new specks every second.
+    // A 10x larger world so a 900-tile territory is still below the bar (25% of
+    // 10000 = 2500) and its holder is not the leader.
+    const g = rotGame({ rotGrainSeconds: 20, rotSpecklePercent: 15 }, 7, {
+      land: 10000,
+      leaderTiles: 5000,
+    });
+    const big = gridBlock(1, 1, 30, 30); // 900 tiles
+    g.doomed.giveTiles(big.interior, big.border);
+    rotFor(g, 5);
+
+    const rotted = g.doomed.relinquished;
+    expect(rotted.length).toBeGreaterThan(25); // dozens of holes, not one or two
+
+    // Scattered, not clustered: they span most of the block in both axes.
+    const xs = rotted.map((t) => t % GRID);
+    const ys = rotted.map((t) => Math.floor(t / GRID));
+    expect(Math.max(...xs) - Math.min(...xs)).toBeGreaterThan(15);
+    expect(Math.max(...ys) - Math.min(...ys)).toBeGreaterThan(15);
+
+    // And it is still only a nibble of the whole — grainy, not gone.
+    expect(g.doomed.numTilesOwned()).toBeGreaterThan(800);
+  });
+
+  it("starts INSIDE the territory, not on the frontier", () => {
+    const g = rotGame();
+    rotFor(g, 1);
+    expect(g.doomed.relinquished.length).toBeGreaterThan(0);
+    // The SEED is what sets the tone: it must open inside the territory. Tiles
+    // taken after it come from spreading, which can legitimately reach the edge.
+    expect(BLOCK.interior).toContain(g.doomed.relinquished[0]);
+  });
+
+  it("SPREADS from the holes as well as speckling new ones", () => {
+    // Past the grainy phase the whole quota grows existing holes, so every tile
+    // taken then must touch something already rotted.
+    const g = rotGame({ rotGrainSeconds: 3 });
+    rotFor(g, 3); // grainy phase over
+    const afterGrain = g.doomed.relinquished.length;
+    const seen = new Set(g.doomed.relinquished);
+    rotFor(g, 8, WAVE_TICK + 4 * 10);
+
+    const grown = g.doomed.relinquished.slice(afterGrain);
+    expect(grown.length).toBeGreaterThan(0);
+    for (const tile of grown) {
+      const touching = g.game
+        .neighbors(tile)
+        .some((n) => seen.has(n as TileRef));
+      expect(touching).toBe(true);
+      seen.add(tile);
+    }
+  });
+
+  it("stamps every rotting second, which is what drives the red skull", () => {
+    // PlayerImpl.isDecaying() is a short window after this stamp, so a gap here
+    // would make the on-map cue strobe.
+    const g = rotGame();
+    expect(g.doomed.rottedAtTick).toBe(-1); // nothing yet
+    rotFor(g, 1);
+    expect(g.doomed.rottedAtTick).toBe(WAVE_TICK + 10); // first rotting second
+    rotFor(g, 3, WAVE_TICK + 20);
+    expect(g.doomed.rottedAtTick).toBe(WAVE_TICK + 50); // re-stamped, not stale
+  });
+
+  it("kills islands too, by speckling when a blob is walled in", () => {
+    const g = rotGame();
+    const far = gridBlock(20, 20, 4, 4);
+    g.doomed.giveTiles(
+      [...BLOCK.interior, ...far.interior],
+      [...BLOCK.border, ...far.border],
+    );
+    rotFor(g, DEADLINE);
+    expect(g.doomed.numTilesOwned()).toBe(0);
+    expect(g.doomed.relinquished).toHaveLength(116);
+  });
+
+  // --- recovery and determinism --------------------------------------------
+
+  it("stops the moment the side climbs back above the bar", () => {
+    const g = rotGame();
+    rotFor(g, 2);
+    const taken = g.doomed.relinquished.length;
+    expect(taken).toBeGreaterThan(0);
+
+    g.doomed.tileCount = 400; // recovered
+    runAt(g.exec, g.game, WAVE_TICK + 30);
+    expect(g.doomed.inDoomsdayClock()).toBe(false);
+    expect(g.doomed.relinquished).toHaveLength(taken); // no further rot
+  });
+
+  it("gives a recovered side its full deadline again, from scratch", () => {
+    // Surviving a scare must reset the clock: the doom mark is cleared, so the
+    // next spell starts a fresh budget rather than resuming a nearly-expired one.
+    const g = rotGame();
+    rotFor(g, 5);
+    const held = g.doomed.numTilesOwned();
+    g.doomed.tileCount = 400; // recovered
+    runAt(g.exec, g.game, WAVE_TICK + 60);
+    g.doomed.tileCount = held; // doomed again
+    runAt(g.exec, g.game, WAVE_TICK + 70); // re-flagged: back inside the warn
+    expect(g.doomed.numTilesOwned()).toBe(held); // nothing taken yet
+    runAt(g.exec, g.game, WAVE_TICK + 80); // first second of the new spell
+    // A fresh budget, so the first bite is small, not a catch-up wipe.
+    expect(g.doomed.numTilesOwned()).toBeGreaterThan(held - 10);
+    expect(g.doomed.numTilesOwned()).toBeLessThan(held);
+  });
+
+  it("picks the same tiles from the same seed — the lockstep sim requires it", () => {
+    const a = rotGame();
+    const b = rotGame();
+    for (let s = 0; s <= 8; s++) {
+      runAt(a.exec, a.game, WAVE_TICK + s * 10);
+      runAt(b.exec, b.game, WAVE_TICK + s * 10);
+    }
+    expect(a.doomed.relinquished.length).toBeGreaterThan(5);
+    expect(a.doomed.relinquished).toEqual(b.doomed.relinquished);
+  });
+
+  it("seeds per player, so two doomed sides don't rot in lockstep", () => {
+    const a = rotGame({}, 1);
+    const b = rotGame({}, 2);
+    for (const g of [a, b]) rotFor(g, 4);
+    expect(a.doomed.relinquished).not.toEqual(b.doomed.relinquished);
+  });
+
+  it("never rots the leader, whatever its territory looks like", () => {
+    const g = rotGame();
+    g.leader.giveTiles(BLOCK.interior, BLOCK.border); // real tiles for the leader too
+    g.leader.tileCount = 400; // still the biggest side
+    g.leader.troopCount = 0; // and bottomed out, which must not matter
+    rotFor(g, DEADLINE);
+    expect(g.leader.relinquished).toHaveLength(0);
+    expect(g.leader.isAlive()).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Territory rot against the REAL simulation. The fakes above pin the selection
+// rules; this pins the thing that actually matters — that relinquishing tiles
+// out of a live player kills them, hands the land to nobody, and credits no one
+// with the kill.
+// ---------------------------------------------------------------------------
+
+describe("DoomsdayClockExecution (territory rot, real simulation)", () => {
+  it("rots a doomed player off the map, leaving the land unowned", async () => {
+    const game = await setup(
+      "plains",
+      {
+        instantBuild: true,
+        doomsdayClock: { enabled: true, speed: "veryfast" },
+      },
+      [
+        playerInfo("big", PlayerType.Human),
+        playerInfo("small", PlayerType.Human),
+      ],
+    );
+    const big = game.player("big");
+    const small = game.player("small");
+    giveLandTiles(game, big, 4000); // safely above the bar: the leader, exempt
+    giveLandTiles(game, small, 60); // caught once the bar rises
+    game.addExecution(new PlayerExecution(big));
+    game.addExecution(new PlayerExecution(small)); // real income every tick
+    game.addExecution(new DoomsdayClockExecution());
+
+    // Rot is internal tuning, not wire-configurable, so switch it on directly.
+    const cfg = game.config();
+    vi.spyOn(cfg, "doomsdayClockConfig").mockReturnValue({
+      ...cfg.doomsdayClockConfig(),
+      rotDeathSeconds: 200, // the target: gone within ~3.5 minutes of the skull
+    });
+
+    const held = [...small.tiles()];
+    expect(held).toHaveLength(60);
+    // Cities on rotted ground must not be left standing. Rot does not delete them
+    // itself -- PlayerExecution already removes structures on unowned land.
+    for (const t of [held[0], held[20], held[40]]) {
+      small.buildUnit(UnitType.City, t, {});
+    }
+    expect(small.units(UnitType.City)).toHaveLength(3);
+    const bigTilesBefore = big.numTilesOwned();
+
+    // Past the 600s grace, into the waves, and on until the sliver is gone.
+    let sawDecaying = false;
+    let lostCityWhileAlive = false;
+    for (let i = 0; i < 20_000 && small.isAlive(); i++) {
+      game.executeNextTick();
+      if (small.isDecaying()) sawDecaying = true;
+      if (small.units(UnitType.City).length < 3) lostCityWhileAlive = true;
+    }
+
+    expect(small.isAlive()).toBe(false);
+    expect(small.numTilesOwned()).toBe(0);
+    // The client paints the red "Decaying" skull off this flag, so it has to have
+    // been true while the rotting was happening — and false once there is nothing
+    // left to rot.
+    expect(sawDecaying).toBe(true);
+    expect(small.isDecaying()).toBe(false);
+    // Gone with their ground, not merely swept up by death cleanup.
+    expect(lostCityWhileAlive).toBe(true);
+    expect(small.units(UnitType.City)).toHaveLength(0);
+    // The land fell off the map — it was not conquered, so nobody owns it and the
+    // leader gained nothing (relinquish takes no conqueror: no kill, no gold).
+    for (const tile of held) expect(game.owner(tile).isPlayer()).toBe(false);
+    expect(big.numTilesOwned()).toBe(bigTilesBefore);
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// The shipped timeline. These are the numbers the feature was tuned to and
+// verified against in-game, so they are pinned: changing them should be a
+// deliberate edit here, not a side effect of touching the drain or the floor.
+// ---------------------------------------------------------------------------
+
+describe("doomsday clock: the shipped timeline", () => {
+  it("blinks for 30s, rots at 120s, and is gone at 180s", async () => {
+    const game = await setup(
+      "plains",
+      {
+        instantBuild: true,
+        doomsdayClock: { enabled: true, speed: "veryfast" },
+      },
+      [playerInfo("a", PlayerType.Human)],
+    );
+    const cfg = game.config().doomsdayClockConfig();
+
+    // Skull blinks until the warn ends, then holds steady (PlayerStatus.ts keys
+    // the blink off exactly this).
+    expect(cfg.warnSeconds).toBe(30);
+
+    // Rot is gated on the floor's decay window closing, so the red "Decaying"
+    // phase begins warnSeconds + floorDecaySeconds after the skull appears.
+    expect(cfg.warnSeconds + cfg.floorDecaySeconds).toBe(120);
+
+    // ...and by then the floor has reached its 5% low, not a moment before.
+    expect(doomsdayClockTroopFloor(1000, cfg.floorDecaySeconds, cfg)).toBe(
+      Math.floor((1000 * cfg.drainFloorPercent) / 100),
+    );
+    expect(
+      doomsdayClockTroopFloor(1000, cfg.floorDecaySeconds - 1, cfg),
+    ).toBeGreaterThan(Math.floor((1000 * cfg.drainFloorPercent) / 100));
+
+    // Everything is gone at the deadline, leaving 60s of visible rotting.
+    expect(cfg.rotDeathSeconds).toBe(180);
+    expect(
+      cfg.rotDeathSeconds - (cfg.warnSeconds + cfg.floorDecaySeconds),
+    ).toBe(60);
+    // The grainy opening has to fit inside that window with room to spread after.
+    expect(cfg.rotGrainSeconds).toBeLessThan(60);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The two rot noise fields. They look interchangeable and are not: each one is
+// wrong for the other's job, in a way that only shows up on screen. Both
+// properties below were broken during development, so they are pinned here.
+// ---------------------------------------------------------------------------
+
+describe("rot noise fields", () => {
+  const GRID = 60;
+  const lowest = (fn: (x: number, y: number) => number) => {
+    const p: [number, number][] = [];
+    for (let y = 0; y < GRID; y++) {
+      for (let x = 0; x < GRID; x++) {
+        if (fn(x, y) < ROT_NOISE_SCALE / 10) p.push([x, y]);
+      }
+    }
+    return p;
+  };
+  /** Share of picks that touch another pick — clumping, which reads as static. */
+  const touching = (p: [number, number][]) => {
+    const set = new Set(p.map(([x, y]) => `${x},${y}`));
+    const near = p.filter(([x, y]) =>
+      [
+        [1, 0],
+        [-1, 0],
+        [0, 1],
+        [0, -1],
+      ].some(([dx, dy]) => set.has(`${x + dx},${y + dy}`)),
+    );
+    return near.length / p.length;
+  };
+
+  it("speckle noise scatters evenly — it must NOT be a plain hash", () => {
+    const even = lowest((x, y) => rotSpeckleNoise(x, y, 7));
+    const hashed = lowest((x, y) => rotFrontNoise(y * GRID + x, 7));
+    expect(even.length).toBeGreaterThan(200); // a real sample, not a few points
+    // The lattice leaves picks non-adjacent; a hash clumps a third of them.
+    expect(touching(even)).toBeLessThan(0.05);
+    expect(touching(hashed)).toBeGreaterThan(0.2);
+  });
+
+  it("front noise is isotropic — it must NOT be the lattice", () => {
+    // The lattice's low values form a CRYSTAL: every pick's nearest neighbour sits
+    // at one of a handful of fixed offsets. That is what makes it space things
+    // evenly, and also what makes it useless for growth -- a front that always eats
+    // its lowest-valued tile marches along those offsets and grows a straight
+    // filament (measured 80x20) instead of a shape. The hash has no such axes.
+    const nnOffsets = (p: [number, number][]) => {
+      const seen = new Set<string>();
+      for (const [x, y] of p) {
+        let best = Infinity;
+        let off = "";
+        for (const [a, b] of p) {
+          if (a === x && b === y) continue;
+          const d = (a - x) ** 2 + (b - y) ** 2;
+          if (d < best) {
+            best = d;
+            off = `${a - x},${b - y}`;
+          }
+        }
+        seen.add(off);
+      }
+      return seen.size;
+    };
+    const lattice = nnOffsets(lowest((x, y) => rotSpeckleNoise(x, y, 7)));
+    const hash = nnOffsets(lowest((x, y) => rotFrontNoise(y * GRID + x, 7)));
+    expect(lattice).toBeLessThan(12); // crystalline: a few fixed axes
+    expect(hash).toBeGreaterThan(25); // isotropic: no preferred direction
+  });
+
+  it("both are deterministic and in range, and vary per salt", () => {
+    for (let i = 0; i < 50; i++) {
+      const a = rotSpeckleNoise(i, i * 3, 1);
+      const b = rotFrontNoise(i, 1);
+      expect(a).toBe(rotSpeckleNoise(i, i * 3, 1));
+      expect(b).toBe(rotFrontNoise(i, 1));
+      for (const v of [a, b]) {
+        expect(Number.isInteger(v)).toBe(true);
+        expect(v).toBeGreaterThanOrEqual(0);
+        expect(v).toBeLessThan(ROT_NOISE_SCALE);
+      }
+    }
+    // Two doomed sides must not rot in the same pattern.
+    const p1 = lowest((x, y) => rotSpeckleNoise(x, y, 1));
+    const p2 = lowest((x, y) => rotSpeckleNoise(x, y, 2));
+    expect(p1).not.toEqual(p2);
   });
 });

--- a/tests/GameUpdateUtils.test.ts
+++ b/tests/GameUpdateUtils.test.ts
@@ -26,6 +26,7 @@ function makePlayerState(overrides: Partial<PlayerState> = {}): PlayerState {
     isTraitor: false,
     traitorRemainingTicks: 0,
     inDoomsdayClock: false,
+    isDecaying: false,
     markedDoomsdayClockTick: -1,
     betrayals: 0,
     hasSpawned: true,
@@ -421,5 +422,73 @@ describe("diff + apply round-trip", () => {
     const v0 = makePlayerUpdate({ gold: 100n, playerType: PlayerType.Human });
     const v1 = makePlayerUpdate({ gold: 100n, playerType: PlayerType.Human });
     expect(diffPlayerUpdate(v0, v1)).toBeNull();
+  });
+});
+
+describe("diffPlayerUpdate — every scalar field must be wired up", () => {
+  // diffPlayerUpdate sends ONLY changed fields, so a field added to PlayerUpdate
+  // without a matching setIfDifferent() line is silently never transmitted: the
+  // client keeps its initial value forever. That is not a hypothetical -- it is
+  // exactly how `isDecaying` shipped broken (the red doomsday skull never lit,
+  // because the flag flipped in the sim and no update ever carried it).
+  //
+  // This walks every scalar field on a PlayerUpdate, flips it, and asserts the
+  // diff carries it and applyStateUpdate merges it. Non-scalars (arrays, nested
+  // objects) have bespoke comparators and are covered by the tests above.
+  const SKIP = new Set([
+    // Identity: never changes for a given player.
+    "type",
+    "id",
+    "smallID",
+    "clientID",
+    // Deliberately NOT diffed: these ride the packed transferable channel
+    // (GameUpdateViewData.packedPlayerUpdates) every tick instead. See the
+    // diffPlayerUpdate doc comment.
+    "tilesOwned",
+    "gold",
+    "troops",
+  ]);
+
+  function flip(value: unknown): unknown {
+    if (typeof value === "boolean") return !value;
+    if (typeof value === "number") return value + 7;
+    if (typeof value === "bigint") return value + 7n;
+    if (typeof value === "string") return value + "-changed";
+    return undefined; // not a scalar
+  }
+
+  const base = makePlayerUpdate({ id: "p1" });
+  const asRecord = base as unknown as Record<string, unknown>;
+  const scalars = Object.keys(base).filter(
+    (k) =>
+      !SKIP.has(k) && asRecord[k] !== null && flip(asRecord[k]) !== undefined,
+  );
+
+  it("covers a meaningful number of fields (guards the walk itself)", () => {
+    expect(scalars.length).toBeGreaterThan(8);
+  });
+
+  for (const key of scalars) {
+    it(`transmits a change to ${key}`, () => {
+      const next = { ...base, [key]: flip(asRecord[key]) } as PlayerUpdate;
+      const diff = diffPlayerUpdate(base, next);
+      expect(diff, `${key} produced no diff at all`).not.toBeNull();
+      expect(
+        Object.prototype.hasOwnProperty.call(diff, key),
+        `${key} is missing a setIfDifferent() line in diffPlayerUpdate`,
+      ).toBe(true);
+    });
+  }
+
+  it("merges isDecaying through to the client state", () => {
+    const state = makePlayerState({ isDecaying: false });
+    applyStateUpdate(state, { ...base, isDecaying: true } as PlayerUpdate);
+    expect(state.isDecaying).toBe(true);
+    // ...and a later update that omits it must not clobber it.
+    applyStateUpdate(state, {
+      type: GameUpdateType.Player,
+      id: "p1",
+    } as PlayerUpdate);
+    expect(state.isDecaying).toBe(true);
   });
 });

--- a/tests/client/render/frame/derive/nuke-telegraphs.test.ts
+++ b/tests/client/render/frame/derive/nuke-telegraphs.test.ts
@@ -39,6 +39,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     isTraitor: false,
     traitorRemainingTicks: 0,
     inDoomsdayClock: false,
+    isDecaying: false,
     markedDoomsdayClockTick: -1,
     betrayals: 0,
     hasSpawned: true,

--- a/tests/client/render/frame/derive/player-status.test.ts
+++ b/tests/client/render/frame/derive/player-status.test.ts
@@ -35,6 +35,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     isTraitor: false,
     traitorRemainingTicks: 0,
     inDoomsdayClock: false,
+    isDecaying: false,
     markedDoomsdayClockTick: -1,
     betrayals: 0,
     hasSpawned: true,
@@ -363,5 +364,65 @@ describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
     });
     expect(status.get(2)?.allianceFraction).toBe(0.5);
     expect(status.get(2)?.allianceRemainingTicks).toBe(300);
+  });
+});
+
+describe("computePlayerStatus — doomsday clock phases", () => {
+  // Three phases drive three different skulls: blinking (warn), steady white
+  // (draining), steady RED (decaying). The last one comes straight from the sim.
+  const WARN = 300; // 30s
+
+  function phase(over: Partial<PlayerState>) {
+    const out = computePlayerStatus(
+      new Map([[1, ps({ smallID: 1, ...over })]]),
+      new Map(),
+      {
+        tick: 1000,
+        doomsdayClockWarnTicks: WARN,
+      },
+    );
+    return out.get(1)!;
+  }
+
+  it("is neither draining nor decaying while merely warning", () => {
+    const s = phase({
+      inDoomsdayClock: true,
+      markedDoomsdayClockTick: 1000 - 100,
+    });
+    expect(s.doomsdayClockDraining).toBe(false);
+    expect(s.doomsdayClockDecaying).toBe(false);
+  });
+
+  it("drains but does not decay once past the warn", () => {
+    const s = phase({
+      inDoomsdayClock: true,
+      markedDoomsdayClockTick: 1000 - 400,
+    });
+    expect(s.doomsdayClockDraining).toBe(true);
+    expect(s.doomsdayClockDecaying).toBe(false);
+  });
+
+  it("decays when the sim says territory is rotting", () => {
+    const s = phase({
+      inDoomsdayClock: true,
+      markedDoomsdayClockTick: 1000 - 400,
+      isDecaying: true,
+    });
+    expect(s.doomsdayClockDraining).toBe(true);
+    expect(s.doomsdayClockDecaying).toBe(true);
+  });
+
+  it("never decays a side that is not flagged at all", () => {
+    // Defensive: a stale isDecaying must not paint a skull on a recovered side.
+    // An unflagged player may get no status entry at all, which is equally fine —
+    // what matters is that nothing reports a decaying skull.
+    const out = computePlayerStatus(
+      new Map([
+        [1, ps({ smallID: 1, inDoomsdayClock: false, isDecaying: true })],
+      ]),
+      new Map(),
+      { tick: 1000, doomsdayClockWarnTicks: WARN },
+    );
+    expect(out.get(1)?.doomsdayClockDecaying ?? false).toBe(false);
   });
 });

--- a/tests/util/viewStubs.ts
+++ b/tests/util/viewStubs.ts
@@ -130,6 +130,12 @@ export function makePlayerUpdate(
     allies: [],
     embargoes: new Set(),
     isTraitor: false,
+    // Doomsday-clock state. Present here so the diffPlayerUpdate field-coverage
+    // walk in GameUpdateUtils.test.ts reaches these: a field missing from this
+    // stub is a field that walk cannot check.
+    inDoomsdayClock: false,
+    markedDoomsdayClockTick: -1,
+    isDecaying: false,
     targets: [],
     outgoingEmojis: [],
     outgoingAttacks: [],


### PR DESCRIPTION
## Problem

The Doomsday Clock can't end a game. The drain stops at the troop floor, so a doomed side is crippled but never eliminated, and nothing ever removes territory. R4 of the last Major ended on the clock with 16 players alive, three of them holding 4, 22 and 64 tiles.

## Change

**Territory rot.** A doomed side loses land until it holds none. Paced to a deadline (`rotDeathSeconds` from the skull appearing), each second taking `ceil(tilesLeft / secondsLeft)` — self-correcting, so the finish time is the same for a sliver and an empire. Rot spreads from interior seeds rather than picking scattered tiles, and takes any structure with the ground. Nothing is credited: no conqueror is passed, so no kill and no captured gold.

**Decaying troop floor.** The floor starts high and decays to `drainFloorPercent`, giving one window with a usable army to climb back above the bar. A permanently high floor would make a doomed side unconquerable (`maxTroops` is sublinear, ~100k at a single tile).

**Wave schedule** re-cut from 85 tournament games: seven small steps to 35% (`2/4/7/11/17/25/35`) instead of six accelerating ones to 55%. The runner-up's share at game end has never exceeded 21.6%, so any bar above ~16% catches the same players — a higher ceiling only climbed past the *leader's* own share (median 41%) and handed the game to the crown exemption. Small steps matter because half the players alive at the end hold under 0.4% of the map, so a big jump debuffed most of the field at once.

## Timings

| from skull | | skull |
|---|---|---|
| 0s | warn countdown | blinking white |
| 30s | troops draining | steady white |
| 120s | territory rotting | **steady red**, "Decaying" |
| 180s | eliminated | — |

Verified in-sim at 150 / 1,200 / 2,000 tiles: dead at 179s with zero tiles in every case.

## Notes

- Opt-in per lobby — `doomsdayClock.enabled` still defaults to `false`. `rotDeathSeconds: 0` disables rot alone.
- Deterministic: integer-only, rot's choices via `PseudoRandom` seeded per `(tick, player)`.
- The red skull is a shader tint of the existing asset, no new image. `isDecaying` comes from the sim rather than being re-derived client-side, because the phase test is a knife-edge equality that flickers when recomputed.
- Spreading is `O(quota)` per second, not a per-tick territory scan — 10k ticks of a 3,000-tile player in 48ms.
- `tests/GameUpdateUtils.test.ts` now asserts every scalar `PlayerUpdate` field survives `diffPlayerUpdate`, which transmits only changed fields and is easy to half-wire.

2642 tests pass (291 server), `tsc`/`oxlint`/`eslint` clean.

**Caveat:** on a 25-minute `fast` round the 35% bar lands at the buzzer, so a player caught in the last two minutes won't finish dying before the cap. Fix is pulling the schedule earlier, not shortening the 180s.



---

Moved from #4874 (same commits, same head SHA `1be7633`). The branch lived on the main repo, which auto-deploys every branch to staging, so it now sits on the fork instead. Review history is on #4874.
