### PR TITLE
Restore game ID copying and add game link button to history cards

### DIFF
--- a/resources/images/LinkIconWhite.svg
+++ b/resources/images/LinkIconWhite.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24"><g fill="none" stroke="#fefffe" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></g></svg>

--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -13,9 +13,16 @@ import {
 import { assetUrl } from "../../../../core/AssetUrls";
 import { GameMapType } from "../../../../core/game/Game";
 import { fetchPublicPlayerGames } from "../../../Api";
+import { ClientEnv } from "../../../ClientEnv";
 import { terrainMapFileLoader } from "../../../TerrainMapFileLoader";
-import { getMapName, renderDuration, translateText } from "../../../Utils";
+import {
+  copyToClipboard,
+  getMapName,
+  renderDuration,
+  translateText,
+} from "../../../Utils";
 import { renderLoadingSpinner } from "../../BaseModal";
+import "../../CopyButton";
 import {
   formatAbsoluteTime,
   formatDayHeader,
@@ -25,6 +32,7 @@ import { formatGameType } from "./GameTypeLabels";
 
 const statsIcon = assetUrl("images/LeaderboardIconRegularWhite.svg");
 const replayIcon = assetUrl("images/ReplayRegularIconWhite.svg");
+const linkIcon = assetUrl("images/LinkIconWhite.svg");
 
 type TypeKey = PlayerGameTypeFilter | "all";
 type ModeKey = PlayerGameModeFilter | "all";
@@ -254,6 +262,12 @@ export class PlayerGameHistoryView extends LitElement {
         composed: true,
       }),
     );
+  }
+
+  private copyGameLink(gameId: string) {
+    const encodedGameId = encodeURIComponent(gameId);
+    const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
+    void copyToClipboard(url);
   }
 
   render() {
@@ -486,6 +500,24 @@ export class PlayerGameHistoryView extends LitElement {
                 height="18"
               />
               <span class="sr-only">${translateText("game_list.stats")}</span>
+            </button>
+            <button
+              type="button"
+              title=${translateText("common.click_to_copy")}
+              aria-label=${translateText("common.click_to_copy")}
+              @click=${() => this.copyGameLink(game.gameId)}
+              class="inline-flex w-8 h-8 items-center justify-center text-white bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 rounded-lg transition-all"
+            >
+              <img
+                src=${linkIcon}
+                alt=""
+                aria-hidden="true"
+                width="18"
+                height="18"
+              />
+              <span class="sr-only"
+                >${translateText("common.click_to_copy")}</span
+              >
             </button>
             <button
               type="button"

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -9,7 +9,13 @@ import {
 } from "../../ClanApi";
 import { ClientEnv } from "../../ClientEnv";
 import { terrainMapFileLoader } from "../../TerrainMapFileLoader";
-import { getMapName, renderDuration, translateText } from "../../Utils";
+import {
+  copyToClipboard,
+  getMapName,
+  renderDuration,
+  translateText,
+} from "../../Utils";
+import "../CopyButton";
 import {
   formatAbsoluteTime,
   formatDayHeader,
@@ -22,6 +28,7 @@ import { renderLoadingSpinner, showToast } from "./ClanShared";
 
 const statsIcon = assetUrl("images/LeaderboardIconRegularWhite.svg");
 const replayIcon = assetUrl("images/ReplayRegularIconWhite.svg");
+const linkIcon = assetUrl("images/LinkIconWhite.svg");
 
 type FilterKey = ClanGameFilter | "all";
 
@@ -210,6 +217,12 @@ export class ClanGameHistoryView extends LitElement {
         composed: true,
       }),
     );
+  }
+
+  private copyGameLink(gameId: string) {
+    const encodedGameId = encodeURIComponent(gameId);
+    const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
+    void copyToClipboard(url);
   }
 
   render() {
@@ -446,6 +459,24 @@ export class ClanGameHistoryView extends LitElement {
                 height="18"
               />
               <span class="sr-only">${translateText("game_list.stats")}</span>
+            </button>
+            <button
+              type="button"
+              title=${translateText("common.click_to_copy")}
+              aria-label=${translateText("common.click_to_copy")}
+              @click=${() => this.copyGameLink(game.gameId)}
+              class="inline-flex w-8 h-8 items-center justify-center text-white bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 rounded-lg transition-all"
+            >
+              <img
+                src=${linkIcon}
+                alt=""
+                aria-hidden="true"
+                width="18"
+                height="18"
+              />
+              <span class="sr-only"
+                >${translateText("common.click_to_copy")}</span
+              >
             </button>
             <button
               type="button"


### PR DESCRIPTION
## Description:

Following feedback from the main Discord server’s game-feedback channel, this PR restores direct access to the Game ID from game history cards.

“Turn back ‘Copy game ID’ button to game tile, that’s even more annoying that you can’t get Game ID from history directly, now you need to click even more to get Game ID. Not to mention that we have no way to copy the whole game link without opening game by clicking on something like simple link button on game tile.”

before
<img width="417" height="329" alt="スクリーンショット 2026-08-06 17 40 57" src="https://github.com/user-attachments/assets/1a74e11e-2531-48f5-8b34-b94eeb2e01d6" />

after
<img width="426" height="332" alt="スクリーンショット 2026-08-06 17 40 43" src="https://github.com/user-attachments/assets/9b0a70e5-1070-4488-b36c-527e4dc48515" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri