### PR TITLE
feat(cosmetics): render "embers" nuke-explosion effect style

### DIFF
--- a/src/client/WebGLFrameBuilder.ts
+++ b/src/client/WebGLFrameBuilder.ts
@@ -89,7 +89,7 @@ function toRgb01(s: string): [number, number, number] | null {
 }
 
 /** Resolve a nuke-explosion cosmetic's catalog attributes into render params. */
-function attributesToExplosionParams(
+export function attributesToExplosionParams(
   attrs: NukeExplosionAttributes,
 ): NukeExplosionRenderParams {
   // The shader cycles through the whole palette; the instance layout carries
@@ -107,7 +107,9 @@ function attributesToExplosionParams(
   };
   return attrs.type === "sparkles"
     ? { ...base, type: "sparkles", density: attrs.density }
-    : { ...base, type: "shockwave" };
+    : attrs.type === "embers"
+      ? { ...base, type: "embers", density: attrs.density }
+      : { ...base, type: "shockwave" };
 }
 
 /**

--- a/src/client/render/gl/passes/fx-pass/FxShockwavePass.ts
+++ b/src/client/render/gl/passes/fx-pass/FxShockwavePass.ts
@@ -32,12 +32,12 @@ interface ActiveShockwave {
   startMs: number;
   durationMs: number;
   maxRadius: number;
-  style: number; // 0 = classic ring (SAM + no-cosmetic nuke), 1 = EMP, 2 = sparkles
+  style: number; // 0 = classic ring (SAM + no-cosmetic nuke), 1 = EMP, 2 = sparkles, 3 = embers
   colors: readonly RGB[]; // 1..MAX_NUKE_EXPLOSION_COLORS palette, never empty
   speed: number; // crackle-animation multiplier (effect pace vs the default)
   transitionSpeed: number; // palette step rate (colors/s); 0 = static, <0 = reverse
   thickness: number; // ring band / avg sparkle size (world tiles); unused by classic
-  cell: number; // sparkles grid pitch (front-normalized); 0 for other styles
+  cell: number; // sparkles grid pitch; embers keep-fraction; 0 for other styles
 }
 
 // ---------------------------------------------------------------------------
@@ -180,6 +180,11 @@ export class FxShockwavePass {
     if (params?.type === "sparkles") {
       const density = Math.min(Math.max(params.density, 2), 5000);
       cell = Math.sqrt((2 * Math.PI) / 3 / density);
+    } else if (params?.type === "embers") {
+      const density = Math.min(Math.max(params.density, 2), 5000);
+      // Embers reuse `cell` as the keep-fraction: the shader lights up that
+      // share of grid cells, so a higher density gives a denser scatter.
+      cell = Math.min(Math.max(density / 500, 0.04), 0.6);
     }
     this.active.push({
       x,
@@ -191,7 +196,13 @@ export class FxShockwavePass {
       maxRadius: params?.maxRadius ?? nukeRadius * fx.nukeShockwaveRadiusFactor,
       // Cosmetic type → its style; no cosmetic → classic ring (the original
       // nuke look).
-      style: params ? (params.type === "sparkles" ? 2 : 1) : 0,
+      style: params
+        ? params.type === "sparkles"
+          ? 2
+          : params.type === "embers"
+            ? 3
+            : 1
+        : 0,
       colors: params?.colors ?? [DEFAULT_NUKE_EXPLOSION_COLOR],
       speed,
       transitionSpeed: params?.transitionSpeed ?? 0,

--- a/src/client/render/gl/shaders/fx/shockwave.frag.glsl
+++ b/src/client/render/gl/shaders/fx/shockwave.frag.glsl
@@ -6,7 +6,7 @@ uniform float uTime;      // seconds — animates procedural styles
 
 in vec2  vLocalPos;
 flat in float vAlpha;   // 1 - lifetime progress (fades out over the effect)
-flat in float vStyle;   // 0 = classic ring, 1 = EMP pulse, 2 = sparkles
+flat in float vStyle;   // 0 = classic ring, 1 = EMP pulse, 2 = sparkles, 3 = embers
 flat in vec3  vColor0;  // cosmetic: palette color 0
 flat in vec3  vColor1;  // cosmetic: palette color 1
 flat in vec3  vColor2;  // cosmetic: palette color 2 (pads repeat the last color)
@@ -15,7 +15,7 @@ flat in float vColorCount; // active palette size (1..4)
 flat in float vSpeed;   // cosmetic: animation-speed multiplier
 flat in float vTransSpeed; // cosmetic: palette step rate (colors/s)
 flat in float vThickness; // ring band thickness / avg sparkle size (world tiles)
-flat in float vCell;    // sparkles: grid pitch (front-normalized units)
+flat in float vCell;    // sparkles: grid pitch (front-normalized); embers: keep-fraction
 flat in float vRadius;  // current front radius (world tiles)
 
 // Palette lookup by (already-wrapped) index.
@@ -171,9 +171,51 @@ void sparkles() {
   fragColor = vec4(col, clamp(glow, 0.0, 1.0));
 }
 
+// Pixel ember splash (style 3). Top-down: chunky embers scattered on a stable
+// world-space grid, thrown outward as the blast expands and cooling through the
+// palette over the effect. A 2D grid (not angular sectors) — reads as a field
+// of pixels, never radial rays. vThickness = ember block size (world tiles);
+// vCell = keep-fraction (density-derived: the share of grid cells that light up).
+void emberScatter() {
+  float R = max(vRadius, 0.001);
+  vec2 worldPos = vLocalPos * R; // tiles from the blast centre (grid is stable)
+  float block = max(vThickness, 0.5); // chunky pixel size, world tiles
+  // Rotate the grid off the world axes so it never reads as a lattice.
+  const mat2 ROT = mat2(0.8253, -0.5646, 0.5646, 0.8253);
+  vec2 cid = floor((ROT * worldPos) / block);
+  float h1 = hash11(dot(cid, vec2(157.0, 113.0)) + 41.7);
+  float h2 = hash11(h1 * 251.0 + 7.3);
+  // Sparse: keep only a fraction of cells as embers (vCell = keep-fraction).
+  if (h1 > clamp(vCell, 0.02, 1.0)) discard;
+
+  // This cell's distance from the centre, front-normalised (0 = centre, 1 = rim).
+  vec2 blockCentre = (cid + 0.5) * block;
+  float distN = length(blockCentre) / R;
+  if (distN > 1.0) discard;
+
+  // Thrown outward as the blast expands: a cell only appears once the eased
+  // front has reached its hashed range, so embers spread over the effect.
+  float lifeT = 1.0 - vAlpha;
+  float ease = 1.0 - (1.0 - lifeT) * (1.0 - lifeT);
+  float reach = (0.15 + 0.85 * h2) * ease;
+  if (distN > reach) discard;
+
+  float a = smoothstep(0.0, 0.22, vAlpha); // fade over the last fifth of life
+  if (a < 0.01) discard;
+
+  // Cooling: hot (color 0) at birth -> cool (last color) as the blast ages,
+  // posterised (one palette entry, no blend), with transitionSpeed cycling.
+  float coolStep = lifeT * (vColorCount - 1.0);
+  float idx = floor(coolStep + uTime * vTransSpeed);
+  vec3 col = colorAt(mod(idx, vColorCount));
+  fragColor = vec4(col, a);
+}
+
 void main() {
   float dist = length(vLocalPos);
-  if (vStyle > 1.5) {
+  if (vStyle > 2.5) {
+    emberScatter();
+  } else if (vStyle > 1.5) {
     sparkles();
   } else if (vStyle > 0.5) {
     empPulse(dist);

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -164,7 +164,8 @@ interface NukeExplosionRenderParamsBase {
 
 export type NukeExplosionRenderParams =
   | (NukeExplosionRenderParamsBase & { type: "shockwave" })
-  | (NukeExplosionRenderParamsBase & { type: "sparkles"; density: number });
+  | (NukeExplosionRenderParamsBase & { type: "sparkles"; density: number })
+  | (NukeExplosionRenderParamsBase & { type: "embers"; density: number });
 
 /** Default nuke-explosion color (purple) when a cosmetic has no usable color. */
 export const DEFAULT_NUKE_EXPLOSION_COLOR: readonly [number, number, number] = [

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -183,16 +183,18 @@ export const NUKE_EXPLOSION_TYPES = ["atom", "hydro", "mirvWarhead"] as const;
 export type NukeExplosionType = (typeof NUKE_EXPLOSION_TYPES)[number];
 
 // A nuke-explosion effect — a detonation FX, not a trail. `type` picks the
-// visual (an expanding "shockwave" ring, or a firework burst of twinkling
-// "sparkles") and `nukeType` the bomb; a value this client can't render is
+// visual (an expanding "shockwave" ring, a firework burst of twinkling
+// "sparkles", or "embers", a top-down pixel ember splash sharing the sparkles
+// fields) and `nukeType` the bomb; a value this client can't render is
 // dropped by lenientRecord instead of rendering wrong. Shared knobs:
 // `colors` is the palette; size (final effect width in tiles), speed (tiles/s
-// the width grows), thickness (ring band thickness — or average sparkle size,
-// glints vary ±50% around it — in tiles), and transitionSpeed (palette
-// colors/s) drive the animation. Sparkles also take density — roughly how
-// many sparkles the burst contains. size, thickness, and density must be
-// positive — a non-positive value hits undefined shader behavior, so the
-// entry is dropped like the enums; the renderer clamps speed and density.
+// the width grows), thickness (ring band thickness — or average sparkle/ember
+// size, glints vary ±50% around it — in tiles), and transitionSpeed (palette
+// colors/s) drive the animation. Sparkles and embers also take density —
+// roughly how many sparkles/embers the burst contains. size, thickness, and
+// density must be positive — a non-positive value hits undefined shader
+// behavior, so the entry is dropped like the enums; the renderer clamps speed
+// and density.
 export const NukeExplosionAttributesSchema = z.discriminatedUnion("type", [
   z.object({
     type: z.literal("shockwave"),
@@ -205,6 +207,16 @@ export const NukeExplosionAttributesSchema = z.discriminatedUnion("type", [
   }),
   z.object({
     type: z.literal("sparkles"),
+    nukeType: z.enum(NUKE_EXPLOSION_TYPES),
+    colors: z.array(z.string()),
+    size: z.number().positive(),
+    speed: z.number(),
+    thickness: z.number().positive(),
+    transitionSpeed: z.number(),
+    density: z.number().positive(),
+  }),
+  z.object({
+    type: z.literal("embers"),
     nukeType: z.enum(NUKE_EXPLOSION_TYPES),
     colors: z.array(z.string()),
     size: z.number().positive(),

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -540,6 +540,44 @@ describe("NukeExplosionAttributesSchema", () => {
   });
 });
 
+describe("NukeExplosionAttributesSchema embers", () => {
+  const base = {
+    nukeType: "atom" as const,
+    colors: ["#ffffff", "#ff8a28"],
+    size: 20,
+    speed: 5,
+    thickness: 1,
+    transitionSpeed: 0,
+  };
+
+  it("accepts a valid embers style", () => {
+    expect(
+      NukeExplosionAttributesSchema.safeParse({
+        ...base,
+        type: "embers",
+        density: 100,
+      }).success,
+    ).toBe(true);
+  });
+
+  it("rejects embers with a non-positive density", () => {
+    expect(
+      NukeExplosionAttributesSchema.safeParse({
+        ...base,
+        type: "embers",
+        density: 0,
+      }).success,
+    ).toBe(false);
+  });
+
+  it("rejects embers missing density", () => {
+    expect(
+      NukeExplosionAttributesSchema.safeParse({ ...base, type: "embers" })
+        .success,
+    ).toBe(false);
+  });
+});
+
 describe("nukeExplosion in the cosmetics catalog", () => {
   it("parses the atom shockwave catalog entry", () => {
     const result = CosmeticsSchema.safeParse({

--- a/tests/WebGLFrameBuilder.explosionParams.test.ts
+++ b/tests/WebGLFrameBuilder.explosionParams.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import { attributesToExplosionParams } from "../src/client/WebGLFrameBuilder";
+
+describe("attributesToExplosionParams", () => {
+  const base = {
+    nukeType: "atom" as const,
+    colors: ["#ffffff", "#ff8a28"],
+    size: 20,
+    speed: 5,
+    thickness: 1,
+    transitionSpeed: 0,
+  };
+
+  it("maps embers to embers render params carrying density", () => {
+    const p = attributesToExplosionParams({
+      ...base,
+      type: "embers",
+      density: 100,
+    });
+    expect(p.type).toBe("embers");
+    expect((p as { type: "embers"; density: number }).density).toBe(100);
+  });
+
+  it("still maps sparkles to sparkles", () => {
+    const p = attributesToExplosionParams({
+      ...base,
+      type: "sparkles",
+      density: 7,
+    });
+    expect(p.type).toBe("sparkles");
+  });
+
+  it("maps shockwave to shockwave", () => {
+    const p = attributesToExplosionParams({ ...base, type: "shockwave" });
+    expect(p.type).toBe("shockwave");
+  });
+
+  // Colours are author-configurable per cosmetic: the catalogue's hex list is
+  // converted to rgb 0..1 and passed straight through, so changing them in the
+  // catalogue recolours the effect. Same path for every explosion style.
+  it("passes the cosmetic's colours through (hex -> rgb 0..1) for each style", () => {
+    for (const type of ["shockwave", "sparkles", "embers"] as const) {
+      const p = attributesToExplosionParams({
+        ...base,
+        type,
+        density: 100,
+        colors: ["#ff0000", "#00ff00", "#0000ff"],
+      });
+      expect(p.colors).toEqual([
+        [1, 0, 0],
+        [0, 1, 0],
+        [0, 0, 1],
+      ]);
+    }
+  });
+
+  it("scales embers by the cosmetic's size the same way as the other styles", () => {
+    // size is the final diameter in tiles; maxRadius = size / 2, identical across
+    // shockwave/sparkles/embers. Per-bomb sizing is therefore per-cosmetic.
+    const embers = attributesToExplosionParams({
+      ...base,
+      type: "embers",
+      density: 100,
+      size: 60,
+    });
+    const shockwave = attributesToExplosionParams({
+      ...base,
+      type: "shockwave",
+      size: 60,
+    });
+    expect(embers.maxRadius).toBe(30);
+    expect(embers.maxRadius).toBe(shockwave.maxRadius);
+  });
+
+  it("falls back to the default colour when the list has no valid colours", () => {
+    const p = attributesToExplosionParams({
+      ...base,
+      type: "embers",
+      density: 100,
+      colors: ["not-a-colour"],
+    });
+    expect(p.colors.length).toBe(1);
+  });
+});


### PR DESCRIPTION
Adds **embers** as a third `nukeExplosion` render style, alongside `shockwave` and `sparkles` — a top-down pixel ember splash.

Companion to **openfrontio/infra#503** (the catalogue/admin half). This PR is the renderer: it mirrors the catalogue schema and draws an embers cosmetic in-game. Additive and safe to merge independently — the client already drops an effect type it doesn't list, so nothing renders as embers until an embers cosmetic exists in the catalogue.

### What it does
An embers cosmetic scatters chunky pixel embers on a stable world-space grid, throws them outward as the blast expands, and cools them through the cosmetic's colour palette over the effect. Sized and coloured per cosmetic, exactly like shockwave/sparkles (`size` = final diameter in tiles, so per-bomb sizing is per-cosmetic).

### Changes
- `src/core/CosmeticSchemas.ts` — `embers` member of the `nukeExplosion` discriminated union (carries `density`).
- `src/client/render/types/Renderer.ts` — `embers` render-param variant.
- `src/client/WebGLFrameBuilder.ts` — attributes → embers explosion params.
- `src/client/render/gl/passes/fx-pass/FxShockwavePass.ts` — embers → shader style 3 (`density` → keep-fraction).
- `src/client/render/gl/shaders/fx/shockwave.frag.glsl` — `emberScatter()` + dispatch.
- `tests/` — schema + explosion-param coverage.

### Verification
- `tsc --noEmit`: clean
- `vitest tests/CosmeticSchemas.test.ts tests/WebGLFrameBuilder.explosionParams.test.ts`: 73 passed
- prettier: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
