### PR TITLE
test: cover Humans Vs Nations buckets in the profile stats tree schema

### DIFF
--- a/tests/ApiSchemas.test.ts
+++ b/tests/ApiSchemas.test.ts
@@ -137,6 +137,43 @@ describe("PlayerProfileSchema", () => {
   });
 });
 
+describe("PlayerProfileSchema stats tree modes", () => {
+  const base = {
+    createdAt: "2024-01-15T12:00:00.000Z",
+  };
+  const leaf = { wins: "3", losses: "1", total: "4", stats: {} };
+
+  // Regression: the API buckets HvN games under a "Humans Vs Nations" key,
+  // which a z.enum(GameMode) record key rejected — failing the whole profile
+  // parse in production.
+  it("accepts Humans Vs Nations stat buckets", () => {
+    const result = PlayerProfileSchema.safeParse({
+      ...base,
+      stats: {
+        Public: {
+          "Free For All": { Medium: leaf },
+          "Humans Vs Nations": { Medium: leaf },
+        },
+        Private: { "Humans Vs Nations": { Medium: leaf } },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.stats.Public?.["Humans Vs Nations"]?.Medium?.wins).toBe(
+      3n,
+    );
+  });
+
+  it("rejects an unknown mode bucket", () => {
+    expect(
+      PlayerProfileSchema.safeParse({
+        ...base,
+        stats: { Public: { "Battle Royale": { Medium: leaf } } },
+      }).success,
+    ).toBe(false);
+  });
+});
+
 describe("PlayerProfileSchema clans", () => {
   const base = {
     createdAt: "2024-01-15T12:00:00.000Z",


### PR DESCRIPTION
## Summary

Regression tests for the production parse failure where `fetchPlayerById` rejected any profile carrying Humans vs Nations games:

```
fetchPlayerById: Zod validation failed ... path: ["stats", "Public", "Humans Vs Nations"] "Invalid input"
```

The API buckets HvN games under a `"Humans Vs Nations"` key in the profile stats tree, but `GameModeStatsSchema` used to key the record with `z.enum(GameMode)` (only `Free For All` / `Team`), so the whole profile parse failed and the profile came up empty. #4873 already fixed the schema by introducing `PlayerStatsGameModes`; this PR pins that behavior so it can't regress:

- a profile with `"Humans Vs Nations"` buckets under `Public` and `Private` (the exact failing prod payload shape) parses, and the leaf bigints come through
- a genuinely unknown mode bucket (`"Battle Royale"`) is still rejected

## Test plan

- [x] `npx vitest tests/ApiSchemas.test.ts --run` — 131 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)