### PR TITLE
fix: always show your own structures effect (mobile never hovers)

### DIFF
--- a/src/client/render/gl/shaders/structure/structure.frag.glsl
+++ b/src/client/render/gl/shaders/structure/structure.frag.glsl
@@ -171,14 +171,16 @@ void main() {
     borderColor.a = 1.0;
   }
 
-  // structures cosmetic: while the owner's territory is hovered, recolor the
-  // fill with their effect (raw catalog colors, like trails — no darken). The
-  // border keeps the player color so ownership stays readable. Skipped for
-  // alt view and construction gray.
+  // structures cosmetic: recolor the fill with the owner's effect (raw catalog
+  // colors, like trails — no darken) while their territory is hovered. The
+  // local player's own effect always shows — touch devices never hover, and
+  // buyers should see what they paid for. The border keeps the player color
+  // so ownership stays readable. Skipped for alt view and construction gray.
   bool effectActive = false;
   if (uAltView == 0 && vUnderConstruction < 0.5) {
     int effOwner = int(vOwnerID + 0.5);
-    if (effOwner == int(uHoverOwner + 0.5) && effOwner > 0) {
+    if ((effOwner == int(uHoverOwner + 0.5) ||
+         effOwner == int(uLocalPlayerID)) && effOwner > 0) {
       vec3 effectRGB;
       if (structuresEffectColor(effOwner, effectRGB)) {
         fillColor.rgb = effectRGB;


### PR DESCRIPTION
## Description:

The structures cosmetic effect (#4492) is only rendered while the owner's territory is hovered. Touch devices never produce hover, so a mobile player who buys the effect never sees it in game — and desktop buyers only see their own purchase when they happen to hover themselves.

This changes the shader gate so the **local player's own effect is always visible**; other players' effects remain hover-gated, keeping the readability tradeoff from #4492 intact. `uLocalPlayerID` was already a uniform in `structure.frag.glsl`, and the existing `effOwner > 0` guard keeps spectators (local ID 0) unaffected.

```glsl
if ((effOwner == int(uHoverOwner + 0.5) ||
     effOwner == int(uLocalPlayerID)) && effOwner > 0) {
```

Known gap, deliberately out of scope: mobile players still can't see *other* players' structure effects, since the whole hover-highlight family (territory/border/name/effect) has no touch trigger. That needs an input-design decision (tap already attacks, long-press opens the radial menu) and can be a follow-up.

## Verification

Drove a real headless game (dev server + Chromium) with a dev-only patch injecting a neon gradient structures effect for all players, then reverted it:

- Own city, mouse parked on neutral land → **gradient shown** (the fix; previously plain)
- Bot city, hovered → **gradient shown** (hover path unchanged)
- Bot city, not hovered → **plain player color** (others are still hover-gated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)