### PR TITLE
capture transport stats

### DIFF
--- a/src/core/game/Stats.ts
+++ b/src/core/game/Stats.ts
@@ -65,6 +65,11 @@ export interface Stats {
     troops: number | bigint,
   ): void;
 
+  // Player takes ownership of target's transport ship, by conquering them or
+  // by inheriting from a disconnected teammate. Unlike a trade ship, which is
+  // captured by hunting it down, this one changes hands with its owner.
+  boatCapturedTroops(player: Player, target: Player): void;
+
   // Player launches bomb at target
   bombLaunch(
     player: Player,

--- a/src/core/game/StatsImpl.ts
+++ b/src/core/game/StatsImpl.ts
@@ -227,6 +227,10 @@ export class StatsImpl implements Stats {
     this._addBoat(player, "trans", BOAT_INDEX_DESTROY, 1);
   }
 
+  boatCapturedTroops(player: Player, target: Player): void {
+    this._addBoat(player, "trans", BOAT_INDEX_CAPTURE, 1);
+  }
+
   bombLaunch(
     player: Player,
     target: Player | TerraNullius,

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -215,6 +215,16 @@ export class UnitImpl implements Unit {
         this.mg.stats().unitCapture(newOwner, this._type);
         this.mg.stats().unitLose(this._owner, this._type);
         break;
+      // Transports change hands when their owner is conquered, or when a
+      // disconnected teammate's fleet is inherited. Boats have no "lost"
+      // slot, so only the captor is credited.
+      //
+      // Trade ships are deliberately absent: they reach here too, but the
+      // warship that hunts one down records the capture itself, and counting
+      // it again would double every act of piracy.
+      case UnitType.TransportShip:
+        this.mg.stats().boatCapturedTroops(newOwner, this._owner);
+        break;
     }
     this._lastOwner = this._owner;
     this._lastOwner._units = this._lastOwner._units.filter((u) => u !== this);

--- a/tests/TransportCaptureStats.test.ts
+++ b/tests/TransportCaptureStats.test.ts
@@ -1,0 +1,79 @@
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../src/core/game/Game";
+import {
+  BOAT_INDEX_CAPTURE,
+  BOAT_INDEX_DESTROY,
+} from "../src/core/StatsSchemas";
+import { setup } from "./util/Setup";
+
+let game: Game;
+let captor: Player;
+let victim: Player;
+
+const captorInfo = new PlayerInfo(
+  "captor",
+  PlayerType.Human,
+  "captor",
+  "captor",
+);
+const victimInfo = new PlayerInfo(
+  "victim",
+  PlayerType.Human,
+  "victim",
+  "victim",
+);
+
+function transBoats(player: Player): readonly bigint[] | undefined {
+  return game.stats().getPlayerStats(player)?.boats?.trans;
+}
+
+describe("TransportCaptureStats", () => {
+  beforeEach(async () => {
+    game = await setup("plains", { infiniteTroops: true }, [
+      captorInfo,
+      victimInfo,
+    ]);
+    captor = game.player("captor");
+    victim = game.player("victim");
+    captor.conquer(game.ref(50, 50));
+    victim.conquer(game.ref(50, 51));
+  });
+
+  test("credits the captor when a transport ship changes hands", () => {
+    const transport = victim.buildUnit(
+      UnitType.TransportShip,
+      game.ref(60, 60),
+      { troops: 100 },
+    );
+
+    captor.captureUnit(transport);
+
+    expect(transBoats(captor)?.[BOAT_INDEX_CAPTURE]).toBe(1n);
+    expect(transport.owner()).toBe(captor);
+    // Boats have no "lost" slot, so the previous owner records nothing — and
+    // in particular this is not a destruction.
+    expect(transBoats(victim)?.[BOAT_INDEX_DESTROY] ?? 0n).toBe(0n);
+  });
+
+  test("does not count a captured trade ship as a transport", () => {
+    // The warship that hunts a trade ship down records the capture itself, so
+    // routing trade ships through the same path would double-count piracy.
+    const destinationPort = captor.buildUnit(
+      UnitType.Port,
+      game.ref(50, 50),
+      {},
+    );
+    const tradeShip = victim.buildUnit(UnitType.TradeShip, game.ref(60, 60), {
+      targetUnit: destinationPort,
+    });
+
+    captor.captureUnit(tradeShip);
+
+    expect(transBoats(captor)?.[BOAT_INDEX_CAPTURE] ?? 0n).toBe(0n);
+  });
+});


### PR DESCRIPTION
## Description:

adds missing capture stats for transport ships of annexed teammate

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

w.o.n
