### PR TITLE
fix: SAMs unable to target warheads due to close spawns

### DIFF
--- a/src/client/render/frame/derive/NukeTelegraphs.ts
+++ b/src/client/render/frame/derive/NukeTelegraphs.ts
@@ -52,7 +52,7 @@ export function extractNukeTelegraphs(
 ): NukeTelegraphData[] {
   const telegraphs: NukeTelegraphData[] = [];
   for (const u of units.values()) {
-    if (u.targetTile === null || !u.isActive) continue;
+    if (u.targetTile === null || !u.isActive || u.waitTicks > 0) continue;
 
     const plan = motionPlans?.get(u.id);
     if (plan && plan.startTick > currentTick) continue;
@@ -92,7 +92,7 @@ export function extractNukeTelegraphsFromIds(
   const telegraphs: NukeTelegraphData[] = [];
   for (const id of nukeIds) {
     const u = units.get(id);
-    if (!u || u.targetTile === null || !u.isActive) continue;
+    if (!u || u.targetTile === null || !u.isActive || u.waitTicks > 0) continue;
 
     const plan = motionPlans?.get(u.id);
     if (plan && plan.startTick > currentTick) continue;

--- a/src/client/render/frame/derive/NukeTelegraphs.ts
+++ b/src/client/render/frame/derive/NukeTelegraphs.ts
@@ -47,10 +47,16 @@ export function extractNukeTelegraphs(
   localPlayerID = 0,
   relationMatrix?: Uint8Array,
   relationSize = 0,
+  motionPlans?: ReadonlyMap<number, { startTick: number }>,
+  currentTick = 0,
 ): NukeTelegraphData[] {
   const telegraphs: NukeTelegraphData[] = [];
   for (const u of units.values()) {
     if (u.targetTile === null || !u.isActive) continue;
+
+    const plan = motionPlans?.get(u.id);
+    if (plan && plan.startTick > currentTick) continue;
+
     const mag = NUKE_MAGNITUDES[u.unitType];
     if (!mag) continue;
     telegraphs.push({
@@ -80,11 +86,17 @@ export function extractNukeTelegraphsFromIds(
   localPlayerID = 0,
   relationMatrix?: Uint8Array,
   relationSize = 0,
+  motionPlans?: ReadonlyMap<number, { startTick: number }>,
+  currentTick = 0,
 ): NukeTelegraphData[] {
   const telegraphs: NukeTelegraphData[] = [];
   for (const id of nukeIds) {
     const u = units.get(id);
     if (!u || u.targetTile === null || !u.isActive) continue;
+
+    const plan = motionPlans?.get(u.id);
+    if (plan && plan.startTick > currentTick) continue;
+
     const mag = NUKE_MAGNITUDES[u.unitType];
     if (!mag) continue;
     telegraphs.push({

--- a/src/client/render/gl/passes/PointLightPass.ts
+++ b/src/client/render/gl/passes/PointLightPass.ts
@@ -187,7 +187,7 @@ export class PointLightPass {
     this.lastUnitsUpdateMs = performance.now();
 
     for (const unit of units.values()) {
-      if (!unit.isActive) continue;
+      if (!unit.isActive || unit.waitTicks > 0) continue;
       const typeIdx = this.typeToIdx.get(unit.unitType);
       if (typeIdx === undefined) continue;
       const cfg = this.typeConfigs[typeIdx];

--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -435,7 +435,7 @@ export class UnitPass {
     this.lastUnitsUpdateMs = performance.now();
 
     for (const unit of units.values()) {
-      if (!unit.isActive) continue;
+      if (!unit.isActive || unit.waitTicks > 0) continue;
 
       let atlasIdx = this.typeToAtlasCol.get(unit.unitType);
 

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -98,6 +98,7 @@ export interface UnitState {
   reachedTarget: boolean;
   retreating: boolean;
   targetable: boolean;
+  waitTicks: number;
   markedForDeletion: number | false; // -1 -> false, else tick
   health: number | null;
   underConstruction: boolean;

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -622,6 +622,8 @@ export class GameView implements GameMap {
       // carried over on the frame from the last rebuild.
       f.relationMatrix,
       f.relationSize,
+      this.unitMotionPlans,
+      gu.tick,
     );
     f.attackRings = this._myPlayer
       ? extractAttackRings(

--- a/src/client/view/UnitView.ts
+++ b/src/client/view/UnitView.ts
@@ -1,4 +1,5 @@
 import {
+  NukeState,
   Tick,
   TrainType,
   TransportShipState,
@@ -57,6 +58,7 @@ function unitStateFromUpdate(u: UnitUpdate): UnitState {
       (u.transportShipState?.isRetreating ?? false) ||
       u.warshipState?.state === "retreating",
     targetable: u.targetable,
+    waitTicks: u.nukeState?.waitTicks ?? 0,
     markedForDeletion: u.markedForDeletion,
     health: u.health ?? null,
     underConstruction: u.underConstruction ?? false,
@@ -86,6 +88,7 @@ function applyUpdateInPlace(target: UnitState, u: UnitUpdate): void {
     (u.transportShipState?.isRetreating ?? false) ||
     u.warshipState?.state === "retreating";
   target.targetable = u.targetable;
+  target.waitTicks = u.nukeState?.waitTicks ?? 0;
   target.markedForDeletion = u.markedForDeletion;
   target.health = u.health ?? null;
   target.underConstruction = u.underConstruction ?? false;
@@ -108,6 +111,7 @@ export class UnitView {
   /** Engine-only fields not in UnitState. Use warshipState() / transportShipState() to read. */
   private _warshipState?: WarshipState;
   private _transportShipState?: TransportShipState;
+  private _nukeState?: NukeState;
   private _createdAt: Tick;
 
   constructor(
@@ -117,6 +121,7 @@ export class UnitView {
     this.state = unitStateFromUpdate(data);
     this._warshipState = data.warshipState;
     this._transportShipState = data.transportShipState;
+    this._nukeState = data.nukeState;
     this.lastPos.push(data.pos);
     this._createdAt = this.gameView.ticks();
     if (this.state.underConstruction) {
@@ -150,6 +155,7 @@ export class UnitView {
     applyUpdateInPlace(this.state, data);
     this._warshipState = data.warshipState;
     this._transportShipState = data.transportShipState;
+    this._nukeState = data.nukeState;
     // constructionStartTick: set on transition into underConstruction.
     if (this.state.underConstruction && !wasUnderConstruction) {
       this.state.constructionStartTick = this.gameView.ticks();
@@ -213,6 +219,15 @@ export class UnitView {
     _update: Pick<TransportShipState, "isRetreating">,
   ): void {
     throw new Error("updateTransportShipState is not supported on UnitView");
+  }
+  nukeState(): NukeState {
+    if (this._nukeState === undefined) {
+      throw new Error("nukeState called on non-nuke unit");
+    }
+    return this._nukeState;
+  }
+  updateNukeState(_update: NukeState): void {
+    throw new Error("updateNukeState is not supported on UnitView");
   }
   tile(): TileRef {
     return this.state.pos;

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -186,7 +186,8 @@ export class MirvExecution implements Execution {
           this.player,
           dst,
           this.separateDst,
-          warheadSpeed + Math.floor((i / this.warheadCount) * 5),
+          // order of extra speed assign does not matter, they all spawn at once.
+          warheadSpeed + (i % 5),
           10 + this.random.nextInt(0, 15),
         ),
       );

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -180,6 +180,11 @@ export class MirvExecution implements Execution {
 
     const warheadSpeed = this.mg.config().nukeSpeed(UnitType.MIRVWarhead);
     for (const [i, dst] of this.stagedTargets.entries()) {
+      let speedOffset = 4;
+      if (i < 70) speedOffset = 0;
+      else if (i < 140) speedOffset = 1;
+      else if (i < 210) speedOffset = 2;
+      else if (i < 280) speedOffset = 3;
       this.mg.addExecution(
         new NukeExecution(
           UnitType.MIRVWarhead,
@@ -187,7 +192,7 @@ export class MirvExecution implements Execution {
           dst,
           this.separateDst,
           // order of extra speed assign does not matter, they all spawn at once.
-          warheadSpeed + (i % 5),
+          warheadSpeed + speedOffset,
           10 + this.random.nextInt(0, 15),
         ),
       );

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -33,6 +33,8 @@ export class MirvExecution implements Execution {
   private random: PseudoRandom;
 
   private pathFinder: ParabolaUniversalPathFinder;
+  private fullPath: TileRef[] = [];
+  private pathIndex = 0;
 
   private targetPlayer: Player | TerraNullius;
 
@@ -40,6 +42,9 @@ export class MirvExecution implements Execution {
   private spawnTile: TileRef;
 
   private speed: number = -1;
+
+  private stagedTargets: TileRef[] = [];
+  private warheadsSpawned = false;
 
   constructor(
     private player: Player,
@@ -54,6 +59,9 @@ export class MirvExecution implements Execution {
     this.pathFinder = UniversalPathFinding.Parabola(mg, {
       increment: this.speed,
     });
+    this.baseX = this.mg.x(this.dst);
+    this.baseY = this.mg.y(this.dst);
+    this.stagedTargets = [this.dst];
 
     // Betrayal on launch
     if (this.targetPlayer.isPlayer()) {
@@ -81,11 +89,23 @@ export class MirvExecution implements Execution {
         targetTile: this.dst,
       });
       this.mg.stats().bombLaunch(this.player, this.targetPlayer, UnitType.MIRV);
-      const x = Math.floor(
-        (this.mg.x(this.dst) + this.mg.x(this.nuke.tile())) / 2,
-      );
-      const y = Math.max(0, this.mg.y(this.dst) - 500) + 50;
+      const x = Math.floor((this.baseX + this.mg.x(this.nuke.tile())) / 2);
+      const y = Math.max(0, this.baseY - 500) + 50;
       this.separateDst = this.mg.ref(x, y);
+
+      let result = this.pathFinder.next(
+        this.spawnTile,
+        this.separateDst,
+        this.speed,
+      );
+      while (result.status === PathStatus.NEXT) {
+        this.fullPath.push(result.node);
+        result = this.pathFinder.next(
+          this.spawnTile,
+          this.separateDst,
+          this.speed,
+        );
+      }
 
       this.mg.displayIncomingUnit(
         this.nuke.id(),
@@ -104,19 +124,72 @@ export class MirvExecution implements Execution {
       }
     }
 
-    const result = this.pathFinder.next(
-      this.spawnTile,
-      this.separateDst,
-      this.speed,
-    );
-    if (result.status === PathStatus.COMPLETE) {
+    const remainingTicks = this.fullPath.length - this.pathIndex;
+
+    // Stagger destination finding across ticks 20 down to 11 before separation
+    if (remainingTicks <= 20 && remainingTicks > 10) {
+      for (let attempt = 0; attempt < 100; attempt++) {
+        if (this.stagedTargets.length >= this.warheadCount) break;
+
+        const target = this.tryGenerateTarget(this.stagedTargets);
+        if (target) this.stagedTargets.push(target);
+      }
+    }
+
+    // At <= 10 ticks before separation, re-validate tile ownership, finalize targets, sort, and instantiate NukeExecutions for SAM detection
+    if (remainingTicks <= 10 && !this.warheadsSpawned) {
+      this.warheadsSpawned = true;
+      // Compensate missed precomputing targets if remainingTicks started <15
+      const extraAttempts = (10 - remainingTicks) * 50;
+      this.finalizeDestinations(500 + extraAttempts);
+      this.spawnWarheadsWithWait();
+    }
+
+    if (this.pathIndex < this.fullPath.length) {
+      this.nuke.move(this.fullPath[this.pathIndex++]);
+    } else {
       this.separate();
       this.active = false;
       // Record stats
       this.mg.stats().bombLand(this.player, this.targetPlayer, UnitType.MIRV);
-      return;
-    } else if (result.status === PathStatus.NEXT) {
-      this.nuke.move(result.node);
+    }
+  }
+
+  private finalizeDestinations(additionalAttempts = 500): void {
+    // Re-check target tile ownership at tick 10
+    this.stagedTargets = this.stagedTargets.filter(
+      (tile) => tile === this.dst || this.mg.owner(tile) === this.targetPlayer,
+    );
+
+    // Top-up loop using specified attempt budget if targets were lost or not yet filled
+    for (let attempt = 0; attempt < additionalAttempts; attempt++) {
+      if (this.stagedTargets.length >= this.warheadCount) break;
+      const target = this.tryGenerateTarget(this.stagedTargets);
+      if (target) this.stagedTargets.push(target);
+    }
+
+    // Sort in place
+    this.stagedTargets.sort(
+      (a, b) =>
+        this.mg.manhattanDist(b, this.dst) - this.mg.manhattanDist(a, this.dst),
+    );
+  }
+
+  private spawnWarheadsWithWait(): void {
+    if (this.nuke === null) return;
+
+    const warheadSpeed = this.mg.config().nukeSpeed(UnitType.MIRVWarhead);
+    for (const [i, dst] of this.stagedTargets.entries()) {
+      this.mg.addExecution(
+        new NukeExecution(
+          UnitType.MIRVWarhead,
+          this.player,
+          dst,
+          this.separateDst,
+          warheadSpeed + Math.floor((i / this.warheadCount) * 5),
+          10 + this.random.nextInt(0, 15),
+        ),
+      );
     }
   }
 
@@ -125,40 +198,7 @@ export class MirvExecution implements Execution {
       throw new Error("uninitialized");
     }
 
-    this.baseX = this.mg.x(this.dst);
-    this.baseY = this.mg.y(this.dst);
-
-    const destinations = this.selectDestinations();
-    const warheadSpeed = this.mg.config().nukeSpeed(UnitType.MIRVWarhead);
-    for (const [i, dst] of destinations.entries()) {
-      this.mg.addExecution(
-        new NukeExecution(
-          UnitType.MIRVWarhead,
-          this.player,
-          dst,
-          this.nuke.tile(),
-          warheadSpeed + Math.floor((i / this.warheadCount) * 5),
-          //   this.random.nextInt(5, 9),
-          this.random.nextInt(0, 15),
-        ),
-      );
-    }
     this.nuke.delete(false);
-  }
-
-  private selectDestinations(): TileRef[] {
-    const targets: TileRef[] = [this.dst];
-
-    for (let attempt = 0; attempt < 1000; attempt++) {
-      const target = this.tryGenerateTarget(targets);
-      if (target) targets.push(target);
-      if (targets.length >= this.warheadCount) break;
-    }
-
-    return targets.sort(
-      (a, b) =>
-        this.mg.manhattanDist(b, this.dst) - this.mg.manhattanDist(a, this.dst),
-    );
   }
 
   private tryGenerateTarget(taken: TileRef[]): TileRef | undefined {

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -142,7 +142,7 @@ export class MirvExecution implements Execution {
       // Compensate missed precomputing targets if remainingTicks started <15
       const extraAttempts = (10 - remainingTicks) * 50;
       this.finalizeDestinations(500 + extraAttempts);
-      this.spawnWarheadsWithWait();
+      this.spawnWarheadsWithWait(remainingTicks);
     }
 
     if (this.pathIndex < this.fullPath.length) {
@@ -175,9 +175,10 @@ export class MirvExecution implements Execution {
     );
   }
 
-  private spawnWarheadsWithWait(): void {
+  private spawnWarheadsWithWait(remainingTicks: number): void {
     if (this.nuke === null) return;
 
+    const waitBase = Math.max(0, remainingTicks);
     const warheadSpeed = this.mg.config().nukeSpeed(UnitType.MIRVWarhead);
     for (const [i, dst] of this.stagedTargets.entries()) {
       let speedOffset = 4;
@@ -193,7 +194,7 @@ export class MirvExecution implements Execution {
           this.separateDst,
           // order of extra speed assign does not matter, they all spawn at once.
           warheadSpeed + speedOffset,
-          10 + this.random.nextInt(0, 15),
+          waitBase + this.random.nextInt(0, 15),
         ),
       );
     }

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -208,6 +208,7 @@ export class NukeExecution implements Execution {
         targetTile: this.dst,
         trajectory: this.getTrajectory(this.dst),
       });
+      this.nuke.updateNukeState({ waitTicks: this.waitTicks });
       this.recordMotionPlan(ticks);
       if (this.nuke.type() !== UnitType.MIRVWarhead) {
         this.maybeBreakAlliances();
@@ -252,7 +253,7 @@ export class NukeExecution implements Execution {
     }
 
     if (this.waitTicks > 0) {
-      this.waitTicks--;
+      this.nuke.updateNukeState({ waitTicks: --this.waitTicks });
       return;
     }
 

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -77,7 +77,7 @@ class SAMTargetingSystem {
   ): InterceptionTile | undefined {
     const trajectory = unit.trajectory();
     const currentIndex = unit.trajectoryIndex();
-
+    const waitTicks = unit.nukeState().waitTicks ?? 0;
     // NukeExecution happens before SAMMissileExecution. It cannot intercept the final tick.
     const maxInterceptionIndex = trajectory.length - 2;
     for (let i = currentIndex; i <= maxInterceptionIndex; i++) {
@@ -87,7 +87,7 @@ class SAMTargetingSystem {
         this.mg.euclideanDistSquared(samTile, trajectoryTile.tile) <=
           rangeSquared
       ) {
-        const nukeTickToReach = i - currentIndex;
+        const nukeTickToReach = i - currentIndex + waitTicks;
         const samTickToReach = this.tickToReach(samTile, trajectoryTile.tile);
         const tickBeforeShooting = nukeTickToReach - samTickToReach;
         if (tickBeforeShooting >= 0) {
@@ -106,7 +106,7 @@ class SAMTargetingSystem {
     ) {
       const targetInFlightTile = trajectory[maxInterceptionIndex];
       if (targetInFlightTile && targetInFlightTile.targetable) {
-        const nukeTickToReach = maxInterceptionIndex - currentIndex;
+        const nukeTickToReach = maxInterceptionIndex - currentIndex + waitTicks;
         const samTickToReach = this.tickToReach(
           samTile,
           targetInFlightTile.tile,
@@ -306,14 +306,15 @@ export class SAMLauncherExecution implements Execution {
       this.player = this.sam.owner();
     }
 
-    const frontTime = this.sam.missileTimerQueue()[0];
-    if (frontTime !== undefined) {
+    while (this.sam.missileTimerQueue().length > 0) {
+      const frontTime = this.sam.missileTimerQueue()[0];
       const cooldown =
         this.mg.config().SAMCooldown() - (this.mg.ticks() - frontTime);
 
-      if (cooldown <= 0) {
-        this.sam.reloadMissile();
+      if (cooldown > 0) {
+        break;
       }
+      this.sam.reloadMissile();
     }
     if (this.sam.isInCooldown()) {
       return;

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -44,6 +44,13 @@ export type TransportShipState = {
   troops: number;
 };
 
+export type NukeState = {
+  trajectory: TrajectoryTile[];
+  trajectoryIndex: number;
+  targetedBySam: boolean;
+  waitTicks: number;
+};
+
 export const AllPlayers = "AllPlayers" as const;
 
 // export type GameUpdates = Record<GameUpdateType, GameUpdate[]>;
@@ -272,6 +279,15 @@ export interface UnitParamsMap {
     trajectory: TrajectoryTile[];
   };
 
+  [UnitType.MIRV]: {
+    targetTile?: number;
+  };
+
+  [UnitType.MIRVWarhead]: {
+    targetTile?: number;
+    trajectory: TrajectoryTile[];
+  };
+
   [UnitType.TradeShip]: {
     targetUnit: Unit;
     lastSetSafeFromPirates?: number;
@@ -292,15 +308,6 @@ export interface UnitParamsMap {
   [UnitType.SAMLauncher]: Record<string, never>;
 
   [UnitType.City]: Record<string, never>;
-
-  [UnitType.MIRV]: {
-    targetTile?: number;
-  };
-
-  [UnitType.MIRVWarhead]: {
-    targetTile?: number;
-    trajectory: TrajectoryTile[];
-  };
 }
 
 // Type helper to get params type for a specific unit type
@@ -499,6 +506,9 @@ export interface Unit {
   updateWarshipState(update: Partial<WarshipState>): void;
   transportShipState(): TransportShipState;
   updateTransportShipState(update: Partial<TransportShipState>): void;
+  nukeState(): NukeState;
+  updateNukeState(update: Partial<NukeState>): void;
+
   health(): number;
   /** Effective max health, including any warship veterancy bonus. */
   maxHealth(): number;

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -5,6 +5,7 @@ import {
   Gold,
   MessageType,
   NameViewData,
+  NukeState,
   PlayerID,
   PlayerType,
   Team,
@@ -187,6 +188,7 @@ export interface UnitUpdate {
   reachedTarget: boolean;
   warshipState?: WarshipState;
   transportShipState?: TransportShipState;
+  nukeState?: NukeState;
   targetable: boolean;
   markedForDeletion: number | false;
   targetUnitId?: number; // Only for trade ships

--- a/src/core/game/UnitImpl.ts
+++ b/src/core/game/UnitImpl.ts
@@ -2,6 +2,7 @@ import { simpleHash, toInt, withinInt } from "../Util";
 import {
   AllUnitParams,
   MessageType,
+  NukeState,
   Player,
   Tick,
   TrainType,
@@ -26,7 +27,7 @@ export class UnitImpl implements Unit {
   private _lastTile: TileRef;
   private _transportShipState: TransportShipState | undefined = undefined;
   private _warshipState: WarshipState | undefined = undefined;
-  private _targetedBySAM = false;
+  private _nukeState: NukeState | undefined = undefined;
   private _reachedTarget = false;
   private _wasDestroyedByEnemy: boolean = false;
   private _destroyer: Player | undefined = undefined;
@@ -42,8 +43,6 @@ export class UnitImpl implements Unit {
   private _loaded: boolean | undefined;
   private _trainType: TrainType | undefined;
   // Nuke only
-  private _trajectoryIndex: number = 0;
-  private _trajectory: TrajectoryTile[];
   private _deletionAt: number | null = null;
 
   constructor(
@@ -58,7 +57,14 @@ export class UnitImpl implements Unit {
     this._health = toInt(this.mg.unitInfo(_type).maxHealth ?? 1);
     this._targetTile =
       "targetTile" in params ? (params.targetTile ?? undefined) : undefined;
-    this._trajectory = "trajectory" in params ? (params.trajectory ?? []) : [];
+    if ("trajectory" in params || "waitTicks" in params) {
+      this._nukeState = {
+        trajectory: params.trajectory ?? [],
+        waitTicks: 0,
+        trajectoryIndex: 0,
+        targetedBySam: false,
+      };
+    }
     this._troops = "troops" in params ? (params.troops ?? 0) : 0;
     this._lastSetSafeFromPirates =
       "lastSetSafeFromPirates" in params
@@ -141,6 +147,8 @@ export class UnitImpl implements Unit {
         this._transportShipState !== undefined
           ? this.transportShipState()
           : undefined,
+      nukeState:
+        this._nukeState !== undefined ? { ...this._nukeState } : undefined,
       pos: this._tile,
       markedForDeletion: this._deletionAt ?? false,
       targetable: this._targetable,
@@ -444,6 +452,33 @@ export class UnitImpl implements Unit {
     }
   }
 
+  nukeState(): NukeState {
+    if (this._nukeState === undefined) {
+      throw new Error("nukeState called on non-nuke unit");
+    }
+    return this._nukeState;
+  }
+
+  updateNukeState(update: Partial<NukeState>): void {
+    if (this._nukeState === undefined) {
+      throw new Error("updateNukeState called on non-nuke unit");
+    }
+    const merged = { ...this._nukeState, ...update };
+    if (
+      merged.targetedBySam === this._nukeState.targetedBySam &&
+      merged.trajectoryIndex === this._nukeState.trajectoryIndex &&
+      merged.waitTicks === this._nukeState.waitTicks
+    )
+      return;
+    this._nukeState = {
+      targetedBySam: merged.targetedBySam,
+      trajectoryIndex: merged.trajectoryIndex,
+      waitTicks: merged.waitTicks,
+      trajectory: this._nukeState.trajectory,
+    };
+    this.mg.addUpdate(this.toUpdate());
+  }
+
   isUnderConstruction(): boolean {
     return this._underConstruction;
   }
@@ -494,16 +529,19 @@ export class UnitImpl implements Unit {
   }
 
   setTrajectoryIndex(i: number): void {
-    const max = this._trajectory.length - 1;
-    this._trajectoryIndex = i < 0 ? 0 : i > max ? max : i;
+    if (this._nukeState === undefined) {
+      throw new Error("setTrajectoryIndex called on non-nuke unit");
+    }
+    const max = this.trajectory().length - 1;
+    this._nukeState.trajectoryIndex = i < 0 ? 0 : i > max ? max : i;
   }
 
   trajectoryIndex(): number {
-    return this._trajectoryIndex;
+    return this._nukeState?.trajectoryIndex ?? 0;
   }
 
   trajectory(): TrajectoryTile[] {
-    return this._trajectory;
+    return this._nukeState?.trajectory ?? [];
   }
 
   setTargetUnit(target: Unit | undefined): void {
@@ -515,11 +553,11 @@ export class UnitImpl implements Unit {
   }
 
   setTargetedBySAM(targeted: boolean): void {
-    this._targetedBySAM = targeted;
+    this._nukeState!.targetedBySam = targeted;
   }
 
   targetedBySAM(): boolean {
-    return this._targetedBySAM;
+    return this._nukeState!.targetedBySam;
   }
 
   setReachedTarget(): void {

--- a/tests/SpiralTrails.test.ts
+++ b/tests/SpiralTrails.test.ts
@@ -37,6 +37,7 @@ function makeUnit(
     reachedTarget: false,
     retreating: false,
     targetable: true,
+    waitTicks: 0,
     markedForDeletion: false,
     health: null,
     underConstruction: false,

--- a/tests/TrailManager.test.ts
+++ b/tests/TrailManager.test.ts
@@ -31,6 +31,7 @@ function makeUnit(
     reachedTarget: false,
     retreating: false,
     targetable: true,
+    waitTicks: 0,
     markedForDeletion: false,
     health: null,
     underConstruction: false,

--- a/tests/client/render/frame/TrailManager.test.ts
+++ b/tests/client/render/frame/TrailManager.test.ts
@@ -32,6 +32,7 @@ function unit(overrides: Partial<UnitState> = {}): UnitState {
     reachedTarget: false,
     retreating: false,
     targetable: true,
+    waitTicks: 0,
     markedForDeletion: false,
     health: null,
     underConstruction: false,

--- a/tests/client/render/frame/derive/nuke-telegraphs.test.ts
+++ b/tests/client/render/frame/derive/nuke-telegraphs.test.ts
@@ -68,6 +68,7 @@ function nuke(overrides: Partial<UnitState> = {}): UnitState {
     reachedTarget: false,
     retreating: false,
     targetable: true,
+    waitTicks: 0,
     markedForDeletion: false,
     health: null,
     underConstruction: false,

--- a/tests/client/render/frame/derive/player-status.test.ts
+++ b/tests/client/render/frame/derive/player-status.test.ts
@@ -64,6 +64,7 @@ function unit(overrides: Partial<UnitState> = {}): UnitState {
     reachedTarget: false,
     retreating: false,
     targetable: true,
+    waitTicks: 0,
     markedForDeletion: false,
     health: null,
     underConstruction: false,

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -492,15 +492,21 @@ describe("SAM", () => {
     );
     game.addExecution(warheadExec);
 
+    //init + first tick of NukeExec
+    game.executeNextTick();
+    game.executeNextTick();
+
+    const warhead = warheadExec.getNuke()!;
+    expect(warhead).toBeTruthy();
+
     // Advance through the entire wait period.
     for (let i = 0; i < waitTicks; i++) {
       game.executeNextTick();
-      const warheads = attacker.units(UnitType.MIRVWarhead);
-      if (warheads.length === 0) break; // already intercepted/detonated — test inconclusive
-      if (warheads[0].nukeState().waitTicks > 0) {
+      if (warhead.nukeState().waitTicks > 0) {
         // SAM must not have consumed a missile slot while the warhead is still waiting.
         expect(sam.missileTimerQueue()).toHaveLength(0);
       }
     }
+    expect(warhead.nukeState().targetedBySam).toBe(true);
   });
 });

--- a/tests/core/executions/SAMLauncherExecution.test.ts
+++ b/tests/core/executions/SAMLauncherExecution.test.ts
@@ -444,4 +444,63 @@ describe("SAM", () => {
     expect(nuke.reachedTarget()).toBeFalsy();
     expect(nuke.wasDestroyedByEnemy()).toBeTruthy();
   });
+
+  test("SAM reloads all expired missile slots in a single tick when fully in cooldown", async () => {
+    // Verifies the while-loop fix: previously only one slot reloaded per tick,
+    // leaving the SAM stuck in cooldown for extra ticks if multiple slots expired simultaneously.
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    sam.increaseLevel();
+    sam.increaseLevel();
+    sam.reloadMissile();
+    sam.reloadMissile();
+    expect(sam.level()).toBe(3);
+    expect(sam.isInCooldown()).toBeFalsy();
+
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Fill all 3 slots at the same game tick so all cooldowns expire simultaneously.
+    sam.launch();
+    sam.launch();
+    sam.launch();
+    expect(sam.isInCooldown()).toBeTruthy();
+    expect(sam.missileTimerQueue()).toHaveLength(3);
+
+    // Advance past the cooldown duration. All three timers share the same start tick
+    // so they all expire on the same tick — the while-loop must drain all of them.
+    executeTicks(game, game.config().SAMCooldown() + 1);
+
+    expect(sam.missileTimerQueue()).toHaveLength(0);
+    expect(sam.isInCooldown()).toBeFalsy();
+  });
+
+  test("SAM does not fire at a MIRV warhead while its waitTicks are still counting down", async () => {
+    // Verifies the waitTicks fix: SAM interception timing now accounts for the
+    // warhead's wait period, so it doesn't schedule a shot before the warhead moves.
+    const sam = defender.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+    game.addExecution(new SAMLauncherExecution(defender, null, sam));
+
+    // Spawn a warhead directly on top of the SAM tile with a long wait before it flies.
+    // Without the waitTicks fix the SAM would try to fire immediately (tick 0).
+    const waitTicks = 20;
+    const warheadExec = new NukeExecution(
+      UnitType.MIRVWarhead,
+      attacker,
+      game.ref(3, 1), // target outside SAM range
+      game.ref(1, 1), // separateDst: right on the SAM
+      game.config().nukeSpeed(UnitType.MIRVWarhead),
+      waitTicks,
+    );
+    game.addExecution(warheadExec);
+
+    // Advance through the entire wait period.
+    for (let i = 0; i < waitTicks; i++) {
+      game.executeNextTick();
+      const warheads = attacker.units(UnitType.MIRVWarhead);
+      if (warheads.length === 0) break; // already intercepted/detonated — test inconclusive
+      if (warheads[0].nukeState().waitTicks > 0) {
+        // SAM must not have consumed a missile slot while the warhead is still waiting.
+        expect(sam.missileTimerQueue()).toHaveLength(0);
+      }
+    }
+  });
 });

--- a/tests/nukes/HydrogenAndMirv.test.ts
+++ b/tests/nukes/HydrogenAndMirv.test.ts
@@ -188,4 +188,34 @@ describe("Hydrogen Bomb and MIRV flows", () => {
     const warheads = player.units(UnitType.MIRVWarhead).length;
     expect(mirvs > 0 || warheads > 0).toBe(true);
   });
+
+  test("MIRV warheads are pre-spawned with waitTicks > 0 while MIRV is still in flight", async () => {
+    // Verifies the pre-staging refactor: warheads are instantiated 10 ticks before
+    // separation and start with waitTicks > 0 so they don't visually glow at separateDst.
+    game.addExecution(
+      new ConstructionExecution(player, UnitType.MissileSilo, game.ref(1, 1)),
+    );
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(player.units(UnitType.MissileSilo)).toHaveLength(1);
+
+    const target = game.ref(1, 1);
+    game.addExecution(new ConstructionExecution(player, UnitType.MIRV, target));
+
+    let foundWaiting = false;
+    for (let i = 0; i < 300; i++) {
+      game.executeNextTick();
+      const warheads = player.units(UnitType.MIRVWarhead);
+      const mirvs = player.units(UnitType.MIRV);
+      // While the MIRV is still in flight AND warheads have already been created,
+      // every warhead must have waitTicks > 0 (still in its pre-flight hold).
+      if (warheads.length > 0 && mirvs.length > 0) {
+        expect(warheads.every((w) => w.nukeState().waitTicks > 0)).toBe(true);
+        foundWaiting = true;
+        break;
+      }
+    }
+    // Warheads must have appeared before the MIRV separated.
+    expect(foundWaiting).toBe(true);
+  });
 });

--- a/tests/nukes/HydrogenAndMirv.test.ts
+++ b/tests/nukes/HydrogenAndMirv.test.ts
@@ -1,3 +1,4 @@
+import { MirvExecution } from "src/core/execution/MIRVExecution";
 import { ConstructionExecution } from "../../src/core/execution/ConstructionExecution";
 import {
   Game,
@@ -7,6 +8,13 @@ import {
   UnitType,
 } from "../../src/core/game/Game";
 import { setup } from "../util/Setup";
+import { TestConfig } from "../util/TestConfig";
+
+class FastNukeTestConfig extends TestConfig {
+  nukeSpeed(_: UnitType): number {
+    return 15;
+  }
+}
 
 describe("Hydrogen Bomb and MIRV flows", () => {
   let game: Game;
@@ -217,5 +225,70 @@ describe("Hydrogen Bomb and MIRV flows", () => {
     }
     // Warheads must have appeared before the MIRV separated.
     expect(foundWaiting).toBe(true);
+  });
+
+  test("Short-distance MIRV launch (< 10 Ticks flight) dynamically adjusts warhead waitTicks below 10", async () => {
+    // Uses FastNukeTestConfig (nukeSpeed = 50) so total parabolic flight is < 5 ticks.
+    // Verifies remainingTicks dynamically scales base waitTicks down to ~3 instead of hardcoded 10.
+    const fastGame = await setup(
+      "plains",
+      { infiniteGold: true, instantBuild: true },
+      [info],
+      __dirname,
+      FastNukeTestConfig,
+    );
+    const fastPlayer = fastGame.player(info.id);
+    fastPlayer.conquer(fastGame.ref(1, 1));
+
+    fastGame.addExecution(
+      new ConstructionExecution(
+        fastPlayer,
+        UnitType.MissileSilo,
+        fastGame.ref(1, 1),
+      ),
+    );
+    fastGame.executeNextTick();
+    fastGame.executeNextTick();
+    expect(fastPlayer.units(UnitType.MissileSilo)).toHaveLength(1);
+
+    // Bypass the 55-pixel minimumSpread overlapping check so all targets within range pass
+    const spy = vi
+      .spyOn(MirvExecution.prototype as any, "isOverlapping")
+      .mockReturnValue(false);
+
+    // Conquer a surrounding area for fastPlayer so generated targets belong to fastPlayer
+    for (let x = 0; x < 100; x++) {
+      for (let y = 0; y < 100; y++) {
+        fastPlayer.conquer(fastGame.ref(x, y));
+      }
+    }
+
+    const target = fastGame.ref(1, 1);
+    fastGame.addExecution(
+      new ConstructionExecution(fastPlayer, UnitType.MIRV, target),
+    );
+    //init ConstructionExe
+    fastGame.executeNextTick();
+    //tick ConstructionExe -> create and init MIRVExe
+    fastGame.executeNextTick();
+    // Tick MirvExe -> create MIRV Unit + move -> Create/init NukeExe warhead
+    fastGame.executeNextTick();
+    // NukeExe -> create Warheads, now detectable. MIRV moves.
+    fastGame.executeNextTick();
+    const warheads = fastPlayer.units(UnitType.MIRVWarhead);
+
+    // 1 tick until separation. WaitTicks must all be between 1-16
+    const minWaitTicks = Math.min(
+      ...warheads.map((w) => w.nukeState().waitTicks),
+    );
+    const maxWaitTicks = Math.max(
+      ...warheads.map((w) => w.nukeState().waitTicks),
+    );
+
+    // Since flight time is ~3 ticks (< 10), base waitTicks is ~3 (strictly < 10)
+    expect(minWaitTicks).toBeGreaterThan(0);
+    expect(minWaitTicks).toBeLessThan(4);
+    expect(maxWaitTicks - minWaitTicks).toBeLessThanOrEqual(15);
+    spy.mockRestore();
   });
 });


### PR DESCRIPTION


> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4909

## Description:
generate warhead target locations over time. Spawn warheads 10 ticks early for SAM targeting. Fix various visual glitches related to pre-spawned nukes. Combine all nuke specific properties into NukeState. SAMs can reload multiple times during ticks if valid.

## Please complete the following:

- [x] I have added relevant tests to the test directory
- [x] I have added gifs of gameplay differences 
Before:
<img width="300" height="288" alt="Image" src="https://github.com/user-attachments/assets/a23836e9-1d1d-49c4-a4f6-7ca0df1fc837" />
After:
<img width="300" height="295" alt="Image" src="https://github.com/user-attachments/assets/cac3dfb0-aee1-4b5d-92dd-5155c17f0e54" />

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
