### PR TITLE
Add copy notification to game cards

### DIFF
--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -16,9 +16,9 @@ import { fetchPublicPlayerGames } from "../../../Api";
 import { ClientEnv } from "../../../ClientEnv";
 import { terrainMapFileLoader } from "../../../TerrainMapFileLoader";
 import {
-  copyToClipboard,
   getMapName,
   renderDuration,
+  showToast,
   translateText,
 } from "../../../Utils";
 import { renderLoadingSpinner } from "../../BaseModal";
@@ -264,10 +264,16 @@ export class PlayerGameHistoryView extends LitElement {
     );
   }
 
-  private copyGameLink(gameId: string) {
+  private async copyGameLink(gameId: string) {
     const encodedGameId = encodeURIComponent(gameId);
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
-    void copyToClipboard(url);
+
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast(translateText("common.copied"), "green");
+    } catch {
+      showToast(translateText("error_modal.failed_copy"), "red");
+    }
   }
 
   render() {

--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -16,6 +16,7 @@ import { fetchPublicPlayerGames } from "../../../Api";
 import { ClientEnv } from "../../../ClientEnv";
 import { terrainMapFileLoader } from "../../../TerrainMapFileLoader";
 import {
+  copyToClipboard,
   getMapName,
   renderDuration,
   showToast,
@@ -269,7 +270,7 @@ export class PlayerGameHistoryView extends LitElement {
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
 
     try {
-      await navigator.clipboard.writeText(url);
+      void copyToClipboard(url);
       showToast(translateText("common.copied"), "green");
     } catch {
       showToast(translateText("error_modal.failed_copy"), "red");

--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -265,12 +265,12 @@ export class PlayerGameHistoryView extends LitElement {
     );
   }
 
-  private copyGameLink(gameId: string) {
+  private async copyGameLink(gameId: string) {
     const encodedGameId = encodeURIComponent(gameId);
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
 
     try {
-      void copyToClipboard(url);
+      await void copyToClipboard(url);
       showToast(translateText("common.copied"), "green");
     } catch {
       showToast(translateText("error_modal.failed_copy"), "red");

--- a/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
+++ b/src/client/components/baseComponents/stats/PlayerGameHistoryView.ts
@@ -265,7 +265,7 @@ export class PlayerGameHistoryView extends LitElement {
     );
   }
 
-  private async copyGameLink(gameId: string) {
+  private copyGameLink(gameId: string) {
     const encodedGameId = encodeURIComponent(gameId);
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
 

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -10,9 +10,9 @@ import {
 import { ClientEnv } from "../../ClientEnv";
 import { terrainMapFileLoader } from "../../TerrainMapFileLoader";
 import {
-  copyToClipboard,
   getMapName,
   renderDuration,
+  showToast,
   translateText,
 } from "../../Utils";
 import "../CopyButton";
@@ -24,7 +24,7 @@ import {
 import { formatGameType, isFfa } from "../baseComponents/stats/GameTypeLabels";
 import { dispatchViewProfile } from "../ui/PlayerNameLink";
 import { verifiedBadge } from "../ui/VerifiedBadge";
-import { renderLoadingSpinner, showToast } from "./ClanShared";
+import { renderLoadingSpinner } from "./ClanShared";
 
 const statsIcon = assetUrl("images/LeaderboardIconRegularWhite.svg");
 const replayIcon = assetUrl("images/ReplayRegularIconWhite.svg");
@@ -219,10 +219,16 @@ export class ClanGameHistoryView extends LitElement {
     );
   }
 
-  private copyGameLink(gameId: string) {
+  private async copyGameLink(gameId: string) {
     const encodedGameId = encodeURIComponent(gameId);
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
-    void copyToClipboard(url);
+
+    try {
+      await navigator.clipboard.writeText(url);
+      showToast(translateText("common.copied"), "green");
+    } catch {
+      showToast(translateText("error_modal.failed_copy"), "red");
+    }
   }
 
   render() {

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -220,12 +220,12 @@ export class ClanGameHistoryView extends LitElement {
     );
   }
 
-  private copyGameLink(gameId: string) {
+  private async copyGameLink(gameId: string) {
     const encodedGameId = encodeURIComponent(gameId);
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
 
     try {
-      void copyToClipboard(url);
+      await void copyToClipboard(url);
       showToast(translateText("common.copied"), "green");
     } catch {
       showToast(translateText("error_modal.failed_copy"), "red");

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -220,7 +220,7 @@ export class ClanGameHistoryView extends LitElement {
     );
   }
 
-  private async copyGameLink(gameId: string) {
+  private copyGameLink(gameId: string) {
     const encodedGameId = encodeURIComponent(gameId);
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
 

--- a/src/client/components/clan/ClanGameHistoryView.ts
+++ b/src/client/components/clan/ClanGameHistoryView.ts
@@ -10,6 +10,7 @@ import {
 import { ClientEnv } from "../../ClientEnv";
 import { terrainMapFileLoader } from "../../TerrainMapFileLoader";
 import {
+  copyToClipboard,
   getMapName,
   renderDuration,
   showToast,
@@ -224,7 +225,7 @@ export class ClanGameHistoryView extends LitElement {
     const url = `${window.location.origin}/${ClientEnv.workerPath(gameId)}/game/${encodedGameId}`;
 
     try {
-      await navigator.clipboard.writeText(url);
+      void copyToClipboard(url);
       showToast(translateText("common.copied"), "green");
     } catch {
       showToast(translateText("error_modal.failed_copy"), "red");


### PR DESCRIPTION
## Description:

Adds a copy notification when using the copy buttons on game cards.
This provides immediate feedback to the user after copying a Game ID or game URL, making it clear that the action was successful.

after

https://github.com/user-attachments/assets/8893cfdd-4b2a-4489-9e59-0102791327f4

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri



