### PR TITLE
Relax minDistanceBetweenPlayers after 750 spawn retries on crowded maps 🗺️

### DIFF
--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -23,6 +23,7 @@ export class SpawnExecution implements Execution {
   private mg: Game;
   private queuedDuringSpawnPhase = false;
   private static readonly MAX_SPAWN_TRIES = 1_000;
+  private static readonly RELAX_MIN_DIST_AT = 750;
 
   constructor(
     gameID: GameID,
@@ -147,24 +148,26 @@ export class SpawnExecution implements Execution {
         continue;
       }
 
-      const isOtherPlayerSpawnedNearby = this.mg
-        .allPlayers()
-        .filter((player) => player.id() !== this.playerInfo.id)
-        .some((player) => {
-          const spawnTile = player.spawnTile();
+      if (tries < SpawnExecution.RELAX_MIN_DIST_AT) {
+        const isOtherPlayerSpawnedNearby = this.mg
+          .allPlayers()
+          .filter((player) => player.id() !== this.playerInfo.id)
+          .some((player) => {
+            const spawnTile = player.spawnTile();
 
-          if (spawnTile === undefined) {
-            return false;
-          }
+            if (spawnTile === undefined) {
+              return false;
+            }
 
-          return (
-            this.mg.manhattanDist(spawnTile, center) <
-            this.mg.config().minDistanceBetweenPlayers()
-          );
-        });
+            return (
+              this.mg.manhattanDist(spawnTile, center) <
+              this.mg.config().minDistanceBetweenPlayers()
+            );
+          });
 
-      if (isOtherPlayerSpawnedNearby) {
-        continue;
+        if (isOtherPlayerSpawnedNearby) {
+          continue;
+        }
       }
 
       const tiles = getSpawnTiles(this.mg, center, true);

--- a/src/core/execution/SpawnExecution.ts
+++ b/src/core/execution/SpawnExecution.ts
@@ -148,7 +148,7 @@ export class SpawnExecution implements Execution {
         continue;
       }
 
-      if (tries < SpawnExecution.RELAX_MIN_DIST_AT) {
+      if (tries <= SpawnExecution.RELAX_MIN_DIST_AT) {
         const isOtherPlayerSpawnedNearby = this.mg
           .allPlayers()
           .filter((player) => player.id() !== this.playerInfo.id)

--- a/tests/core/execution/SpawnExecution.test.ts
+++ b/tests/core/execution/SpawnExecution.test.ts
@@ -79,11 +79,14 @@ describe("Spawn execution", () => {
     game.executeNextTick();
     game.executeNextTick();
 
-    // Should spawn fewer than requested when map is too small
-    expect(
-      game.allPlayers().filter((player) => player.spawnTile() !== undefined)
-        .length,
-    ).toBe(1);
+    // On a very small map the relaxed-spawn fallback (allowing owned tiles)
+    // lets a second player spawn on top of the first. Not all 5 will make
+    // it — the map is still too small — but more than one can land.
+    const spawned = game
+      .allPlayers()
+      .filter((player) => player.spawnTile() !== undefined).length;
+    expect(spawned).toBeGreaterThanOrEqual(1);
+    expect(spawned).toBeLessThan(5);
   });
 
   test("Spawn on specific tile", async () => {

--- a/tests/core/execution/SpawnExecution.test.ts
+++ b/tests/core/execution/SpawnExecution.test.ts
@@ -79,14 +79,13 @@ describe("Spawn execution", () => {
     game.executeNextTick();
     game.executeNextTick();
 
-    // On a very small map the relaxed-spawn fallback (allowing owned tiles)
-    // lets a second player spawn on top of the first. Not all 5 will make
-    // it — the map is still too small — but more than one can land.
-    const spawned = game
-      .allPlayers()
-      .filter((player) => player.spawnTile() !== undefined).length;
-    expect(spawned).toBeGreaterThanOrEqual(1);
-    expect(spawned).toBeLessThan(5);
+    // Should spawn fewer than requested when map is too small.
+    // Player 1 spawns with relaxed minDistance after 750 retries,
+    // but players 2-4 still fail (no unowned land tiles left).
+    expect(
+      game.allPlayers().filter((player) => player.spawnTile() !== undefined)
+        .length,
+    ).toBe(2);
   });
 
   test("Spawn on specific tile", async () => {


### PR DESCRIPTION
## Description:

On crowded tiny maps like "Onion", the minimum-distance-between-players check in SpawnExecution.getSpawn() can prevent tribes / nations from finding a valid spawn location. See this game: https://openfront.io/w8/game/AHrrXY4L?replay After 750 of 1000 max retries, the minDistance check is now skipped so that players can still spawn even when the map is packed.

The threshold is exposed as a `private static readonly RELAX_MIN_DIST_AT` constant for easy tuning.

Before (400 tribes + 64 nations):

<img width="581" height="584" alt="Screenshot 2026-08-09 164308" src="https://github.com/user-attachments/assets/b039cbb4-0501-4dbf-a3a5-afecf25fe73e" />

With this PR (400 tribes + 64 nations):

<img width="594" height="595" alt="Screenshot 2026-08-09 164316" src="https://github.com/user-attachments/assets/e409afa2-44d5-42a3-8fc2-9f26992c7e40" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin