### PR TITLE
fix(i18n): add missing multi_tab translation keys to en.json

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1180,6 +1180,13 @@
     "teams_of": "{teamCount} teams of {playersPerTeam}",
     "teams_title": "Teams"
   },
+  "multi_tab": {
+    "detected": "Multiple open game tabs detected.",
+    "explanation": "To ensure fair play, only one active game tab is permitted at a time.",
+    "please_wait": "Please wait",
+    "seconds": "seconds",
+    "warning": "Vigilant Mode Warning"
+  },
   "new_lobby_prompt": {
     "confirm": "Start a new lobby? All players will be invited to join.",
     "dismiss": "Dismiss",

--- a/tests/client/MultiTabModal.test.ts
+++ b/tests/client/MultiTabModal.test.ts
@@ -2,7 +2,14 @@ import fs from "fs";
 import path from "path";
 import { describe, expect, it } from "vitest";
 
-const EN_JSON = path.join(__dirname, "..", "..", "resources", "lang", "en.json");
+const EN_JSON = path.join(
+  __dirname,
+  "..",
+  "..",
+  "resources",
+  "lang",
+  "en.json",
+);
 
 describe("multi_tab translations", () => {
   it("includes all multi_tab modal translation keys in en.json", () => {

--- a/tests/client/MultiTabModal.test.ts
+++ b/tests/client/MultiTabModal.test.ts
@@ -1,0 +1,19 @@
+import fs from "fs";
+import path from "path";
+import { describe, expect, it } from "vitest";
+
+const EN_JSON = path.join(__dirname, "..", "..", "resources", "lang", "en.json");
+
+describe("multi_tab translations", () => {
+  it("includes all multi_tab modal translation keys in en.json", () => {
+    const en = JSON.parse(fs.readFileSync(EN_JSON, "utf8"));
+    expect(en.multi_tab).toBeDefined();
+    expect(en.multi_tab.warning).toBe("Vigilant Mode Warning");
+    expect(en.multi_tab.detected).toBe("Multiple open game tabs detected.");
+    expect(en.multi_tab.please_wait).toBe("Please wait");
+    expect(en.multi_tab.seconds).toBe("seconds");
+    expect(en.multi_tab.explanation).toBe(
+      "To ensure fair play, only one active game tab is permitted at a time.",
+    );
+  });
+});


### PR DESCRIPTION
# PR 4: `fix(i18n): add missing multi_tab translation keys to en.json`

## Description:

The multi-tab warning modal (`MultiTabModal.ts`) renders copy using `translateText()` calls for the `multi_tab.*` namespace (`multi_tab.warning`, `multi_tab.detected`, `multi_tab.please_wait`, `multi_tab.seconds`, `multi_tab.explanation`).

However, the `multi_tab` key section was missing from `resources/lang/en.json`, causing the modal to render raw translation keys on-screen instead of localized text.

This PR adds the missing `multi_tab` translation key object to `resources/lang/en.json` in alphabetical order, resolving the modal's copy and satisfying `EnJsonSorted.test.ts`.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — i18n text resolution)
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory (`tests/client/MultiTabModal.test.ts`)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
