### PR TITLE
fix(ai): prevent defense post placement failures from blocking bot economic construction

### DIFF
--- a/src/core/execution/nation/NationStructureBehavior.ts
+++ b/src/core/execution/nation/NationStructureBehavior.ts
@@ -161,11 +161,6 @@ export class NationStructureBehavior {
       if (this.tryBuildDefensePost()) {
         return true;
       }
-      // If the attack threshold is met, block other structures even when
-      // placement failed (no tile found / can't afford).
-      if (this.defensePostNeeded()) {
-        return false;
-      }
     }
 
     if (this.isOnStructureCooldown()) {

--- a/tests/NationStructureBehavior.test.ts
+++ b/tests/NationStructureBehavior.test.ts
@@ -519,6 +519,33 @@ describe("NationStructureBehavior.tryBuildDefensePost", () => {
   });
 });
 
+describe("NationStructureBehavior.handleStructures", () => {
+  it("does not block economic structures when defense post placement fails", () => {
+    const game = {
+      config: () => ({
+        gameConfig: () => ({ difficulty: Difficulty.Hard }),
+        isUnitDisabled: () => false,
+        startingGold: () => 0n,
+      }),
+      unitInfo: () => ({ cost: () => 0n }),
+      ticks: () => 100,
+    };
+    const player = {
+      gold: () => 0n,
+      troops: () => 1000,
+      incomingAttacks: () => [{ troops: () => 1000, sourceTile: () => null, attacker: () => ({ id: () => "a" }) }],
+    };
+    const behavior = makeBehavior(game, player);
+    (behavior as any).placementsCount = 1;
+    vi.spyOn(behavior as any, "tryBuildDefensePost").mockReturnValue(false);
+    const doHandleSpy = vi.spyOn(behavior as any, "doHandleStructures").mockReturnValue(true);
+
+    const result = behavior.handleStructures();
+    expect(result).toBe(true);
+    expect(doHandleSpy).toHaveBeenCalled();
+  });
+});
+
 // ── defensePostNeeded ────────────────────────────────────────────────────────
 
 describe("NationStructureBehavior.defensePostNeeded", () => {


### PR DESCRIPTION
# PR 5: `fix(ai): prevent defense post placement failures from blocking bot economic construction`

## Description:

In `NationStructureBehavior.ts`, when a bot nation is under land attack (`defensePostNeeded() === true`), `handleStructures()` attempts to build a defense post via `tryBuildDefensePost()`.

Previously, if `tryBuildDefensePost()` failed (e.g. because the nation could not afford a defense post or no valid tile was found near the front), the method executed `if (this.defensePostNeeded()) return false;`. This early exit blocked all subsequent economic structure building (cities, factories, ports, SAM launchers) for as long as the attack persisted, completely paralyzing the bot's economy during sustained sieges.

This PR removes the early return on defense post placement failure so that when a defense post cannot be placed, the bot AI gracefully falls through to handle regular structure construction and upgrades instead of stalling.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Bot AI structure construction logic)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No user-facing text additions)
- [x] I have added relevant tests to the test directory (`tests/NationStructureBehavior.test.ts`)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
