### PR TITLE
Fix nuke jitter and rubber band, lerps and unitupdates

### DIFF
--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -878,6 +878,7 @@ export class GPURenderer {
   updateUnits(units: Map<number, UnitState>, gameTick: number): void {
     this.lastUnits = units;
     this.frameTick++;
+    this.unitPass.setFrameTick(this.frameTick);
     this.unitPass.updateUnits(units, gameTick);
     this.barPass.updateBars(units, this.lastStructures, gameTick);
     this.pointLightPass.updateLights(units);

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -878,7 +878,7 @@ export class GPURenderer {
   updateUnits(units: Map<number, UnitState>, gameTick: number): void {
     this.lastUnits = units;
     this.frameTick++;
-    this.unitPass.updateUnits(units, this.frameTick);
+    this.unitPass.updateUnits(units, gameTick);
     this.barPass.updateBars(units, this.lastStructures, gameTick);
     this.pointLightPass.updateLights(units);
     this.heatManager.decayHeat();

--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -237,8 +237,10 @@ export class UnitPass {
   private effectTex: WebGLTexture;
   private atlasTex: WebGLTexture;
 
-  /** Frame tick received from renderer — drives tick-based effects */
+  /** Render frame counter received from renderer — drives uTick shader uniform and flicker effects */
   private frameTick = 0;
+  /** Last game engine tick received for smoothing calculation resets */
+  private lastGameTick = -1;
   /** Wall-clock start, for uTime (seconds) — matches StructurePass so the
    *  warship effect animates at the same pace as the structures effect. */
   private startTime = performance.now();
@@ -427,9 +429,13 @@ export class UnitPass {
     this.missileCount++;
   }
 
-  updateUnits(units: Map<number, UnitState>, tick: number): void {
-    if (tick !== this.frameTick) {
-      this.frameTick = tick;
+  setFrameTick(frameTick: number): void {
+    this.frameTick = frameTick;
+  }
+
+  updateUnits(units: Map<number, UnitState>, gameTick: number): void {
+    if (gameTick !== this.lastGameTick) {
+      this.lastGameTick = gameTick;
       this.lastUnitsUpdateMs = performance.now();
     }
     this.groundCount = 0;

--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -428,11 +428,13 @@ export class UnitPass {
   }
 
   updateUnits(units: Map<number, UnitState>, tick: number): void {
-    this.frameTick = tick;
+    if (tick !== this.frameTick) {
+      this.frameTick = tick;
+      this.lastUnitsUpdateMs = performance.now();
+    }
     this.groundCount = 0;
     this.missileCount = 0;
     this.smoothSegs.length = 0;
-    this.lastUnitsUpdateMs = performance.now();
 
     for (const unit of units.values()) {
       if (!unit.isActive) continue;

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -488,7 +488,14 @@ export class GameView implements GameMap {
         ) {
           this._structuresDirty = true;
         }
+        const hasMotionPlan = this.unitMotionPlans.has(update.id);
+        const oldPos = unit.state.pos;
+        const oldLastPos = unit.state.lastPos;
         unit.update(update);
+        if (hasMotionPlan) {
+          unit.state.pos = oldPos;
+          unit.state.lastPos = oldLastPos;
+        }
       } else {
         unit = new UnitView(this, update);
         this._units.set(update.id, unit);

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -495,6 +495,7 @@ export class GameView implements GameMap {
         if (hasMotionPlan) {
           unit.state.pos = oldPos;
           unit.state.lastPos = oldLastPos;
+          unit.lastPos.pop();
         }
       } else {
         unit = new UnitView(this, update);

--- a/src/core/utilities/Line.ts
+++ b/src/core/utilities/Line.ts
@@ -50,7 +50,7 @@ export class DistanceBasedBezierCurve {
 
   /**
    * Precompute curve points using Single-Pass In-Order Recursive De Casteljau Subdivision.
-   * Removed floating point math
+   * Uses IEEE 754 exact-rounded Math.floor(Math.sqrt(...)) for deterministic integer distance accumulation.
    */
   computeAllPoints(pixelSpacing: number): void {
     this.cachedPoints = [];
@@ -87,7 +87,7 @@ export class DistanceBasedBezierCurve {
       st,
     );
 
-    // Ensure  endpointis included if not already P3
+    // Ensure endpoint is included if not already P3
     const lastPt = {
       x: (p3x + 128) >> 8,
       y: (p3y + 128) >> 8,
@@ -131,7 +131,7 @@ export class DistanceBasedBezierCurve {
       st.lastX = ax;
       st.lastY = ay;
 
-      if (st.accumDist >= stepThreshold) {
+      while (st.accumDist >= stepThreshold) {
         this.cachedPoints.push({
           x: (ax + 128) >> 8,
           y: (ay + 128) >> 8,

--- a/src/core/utilities/Line.ts
+++ b/src/core/utilities/Line.ts
@@ -1,119 +1,46 @@
 type Point = { x: number; y: number };
 
-export class BezenhamLine {
-  constructor(
-    private p1: Point,
-    private p2: Point,
-  ) {
-    this.dx = Math.abs(p2.x - p1.x);
-    this.dy = Math.abs(p2.y - p1.y);
-    this.sx = p1.x < p2.x ? 1 : -1;
-    this.sy = p1.y < p2.y ? 1 : -1;
-    this.error = this.dx - this.dy;
-  }
+/**
+ *  Precomputes regular curve step points along a cubic Bezier curve.
+ */
+export class DistanceBasedBezierCurve {
+  private cachedPoints: Point[] = [];
+  private currentIndex: number = 0;
+  private pixelSpacing: number = 1;
+  private accumulatedDistance: number = 0;
 
-  private dx: number;
-  private dy: number;
-  private sx: number;
-  private sy: number;
-  private error: number;
-
-  size() {
-    return Math.max(this.dx, this.dy) + 1;
-  }
-
-  // Increment either by 1 in x or y
-  increment(): Point | true {
-    if (this.p1.x === this.p2.x && this.p1.y === this.p2.y) {
-      return true;
-    }
-    const x = this.p1.x;
-    const y = this.p1.y;
-    const err2 = 2 * this.error;
-
-    if (err2 > -this.dy) {
-      this.error -= this.dy;
-      this.p1.x += this.sx;
-    }
-    if (err2 < this.dx) {
-      this.error += this.dx;
-      this.p1.y += this.sy;
-    }
-    return { x, y };
-  }
-}
-
-export class CubicBezierCurve {
   constructor(
     private p0: Point,
     private p1: Point,
     private p2: Point,
     private p3: Point,
-  ) {}
-  getPointAt(t: number): Point {
-    const T = 1 - t;
-    const TT = T * T;
-    const TTT = TT * T;
-    const tt = t * t;
-    const ttt = tt * t;
-
-    const x =
-      TTT * this.p0.x +
-      3 * TT * t * this.p1.x +
-      3 * T * tt * this.p2.x +
-      ttt * this.p3.x;
-
-    const y =
-      TTT * this.p0.y +
-      3 * TT * t * this.p1.y +
-      3 * T * tt * this.p2.y +
-      ttt * this.p3.y;
-    return { x, y };
-  }
-}
-
-/**
- *  Use a cumulative distance LUT to approximate the traveled distance
- *  Useful to compute regular steps based on the curve rather than a t
- */
-export class DistanceBasedBezierCurve extends CubicBezierCurve {
-  private totalDistance: number = 0;
-  private cachedPoints: Point[] = [];
-  private currentIndex: number = 0;
-
-  constructor(
-    p0: Point,
-    p1: Point,
-    p2: Point,
-    p3: Point,
     distanceIncrement: number,
   ) {
-    super(p0, p1, p2, p3);
-    this.computeAllPoints(distanceIncrement, 0.002);
+    this.computeAllPoints(distanceIncrement);
   }
 
   getAllPoints(): Point[] {
     return this.cachedPoints;
   }
+
   /**
-   * Move forward along the curve by the given distance.
+   * Move forward along the curve by the given distance/speed step.
    * Returns the next cached point, or null if at the end.
    */
-  increment(distance: number): Point | null {
-    this.totalDistance += distance;
+  increment(distance: number = 1): Point | null {
+    this.accumulatedDistance += Math.max(1, Math.round(distance));
 
-    // Step forward through cached points until we're at the correct distance
     while (
       this.currentIndex < this.cachedPoints.length - 1 &&
-      this.getDistanceUpToIndex(this.currentIndex + 1) < this.totalDistance
+      this.accumulatedDistance >= this.pixelSpacing
     ) {
       this.currentIndex++;
+      this.accumulatedDistance -= this.pixelSpacing;
     }
 
     if (this.currentIndex >= this.cachedPoints.length - 1) {
-      return null; // End of curve
+      return null;
     }
-
     return this.cachedPoints[this.currentIndex];
   }
 
@@ -122,60 +49,140 @@ export class DistanceBasedBezierCurve extends CubicBezierCurve {
   }
 
   /**
-   * Precompute all points spaced @p pixelSpacing apart
+   * Precompute curve points using Single-Pass In-Order Recursive De Casteljau Subdivision.
+   * Removed floating point math
    */
-  computeAllPoints(pixelSpacing: number, precision: number): void {
+  computeAllPoints(pixelSpacing: number): void {
     this.cachedPoints = [];
-    this.totalDistance = 0;
     this.currentIndex = 0;
+    this.accumulatedDistance = 0;
+    this.pixelSpacing = Math.max(1, Math.round(pixelSpacing));
 
-    let t = 0;
-    let prevPoint = this.getPointAt(t);
-    this.cachedPoints.push(prevPoint);
+    const scale = 256; // 8-bit fixed-point precision
+    const stepThreshold = this.pixelSpacing * scale;
 
-    let cumulativeDistance = 0;
+    const p0x = Math.round(this.p0.x) * scale;
+    const p0y = Math.round(this.p0.y) * scale;
+    const p3x = Math.round(this.p3.x) * scale;
+    const p3y = Math.round(this.p3.y) * scale;
 
-    while (t < 1) {
-      t = Math.min(t + precision, 1);
-      const currentPoint = this.getPointAt(t);
+    const st = { lastX: p0x, lastY: p0y, accumDist: 0 };
+    this.cachedPoints.push({
+      x: (p0x + 128) >> 8,
+      y: (p0y + 128) >> 8,
+    });
 
-      const dx = currentPoint.x - prevPoint.x;
-      const dy = currentPoint.y - prevPoint.y;
-      const segmentLength = Math.sqrt(dx * dx + dy * dy);
-      cumulativeDistance += segmentLength;
+    // Single-pass recursive midpoint subdivision and inline spatial filtering
+    this.subdivide(
+      p0x,
+      p0y,
+      Math.round(this.p1.x) * scale,
+      Math.round(this.p1.y) * scale,
+      Math.round(this.p2.x) * scale,
+      Math.round(this.p2.y) * scale,
+      p3x,
+      p3y,
+      0,
+      stepThreshold,
+      st,
+    );
 
-      if (cumulativeDistance >= pixelSpacing) {
-        this.cachedPoints.push(currentPoint);
-        // Reset cumulative distance, don't discard excess
-        cumulativeDistance -= pixelSpacing;
+    // Ensure  endpointis included if not already P3
+    const lastPt = {
+      x: (p3x + 128) >> 8,
+      y: (p3y + 128) >> 8,
+    };
+    const lastIndex = this.cachedPoints.length - 1;
+    if (lastIndex >= 0) {
+      const endCached = this.cachedPoints[lastIndex];
+      if (endCached.x !== lastPt.x || endCached.y !== lastPt.y) {
+        this.cachedPoints.push(lastPt);
       }
-
-      prevPoint = currentPoint;
-    }
-
-    // Make sure the last point is exactly at t=1
-    const finalPoint = this.getPointAt(1);
-    if (
-      this.cachedPoints.length === 0 ||
-      finalPoint.x !== this.cachedPoints[this.cachedPoints.length - 1].x ||
-      finalPoint.y !== this.cachedPoints[this.cachedPoints.length - 1].y
-    ) {
-      this.cachedPoints.push(finalPoint);
+    } else {
+      this.cachedPoints.push(lastPt);
     }
   }
 
-  /**
-   * Optional helper: get distance along the cached points up to a given index
-   */
-  private getDistanceUpToIndex(index: number): number {
-    let dist = 0;
-    for (let i = 1; i <= index; i++) {
-      const p1 = this.cachedPoints[i - 1];
-      const p2 = this.cachedPoints[i];
-      const dx = p2.x - p1.x;
-      const dy = p2.y - p1.y;
-      dist += Math.sqrt(dx * dx + dy * dy);
+  private subdivide(
+    ax: number,
+    ay: number,
+    bx: number,
+    by: number,
+    cx: number,
+    cy: number,
+    dx: number,
+    dy: number,
+    depth: number,
+    stepThreshold: number,
+    st: { lastX: number; lastY: number; accumDist: number },
+  ): void {
+    const dist =
+      Math.abs(bx - ax) +
+      Math.abs(by - ay) +
+      Math.abs(cx - bx) +
+      Math.abs(cy - by) +
+      Math.abs(dx - cx) +
+      Math.abs(dy - cy);
+    if (dist <= 256 || depth >= 10) {
+      const edx = ax - st.lastX;
+      const edy = ay - st.lastY;
+
+      st.accumDist += Math.floor(Math.sqrt(edx * edx + edy * edy));
+      st.lastX = ax;
+      st.lastY = ay;
+
+      if (st.accumDist >= stepThreshold) {
+        this.cachedPoints.push({
+          x: (ax + 128) >> 8,
+          y: (ay + 128) >> 8,
+        });
+        st.accumDist -= stepThreshold;
+      }
+      return;
     }
-    return dist;
+
+    // De Casteljau midpoints via bitwise right-shift >> 1
+    const m01_x = (ax + bx) >> 1;
+    const m01_y = (ay + by) >> 1;
+    const m12_x = (bx + cx) >> 1;
+    const m12_y = (by + cy) >> 1;
+    const m23_x = (cx + dx) >> 1;
+    const m23_y = (cy + dy) >> 1;
+
+    const m012_x = (m01_x + m12_x) >> 1;
+    const m012_y = (m01_y + m12_y) >> 1;
+    const m123_x = (m12_x + m23_x) >> 1;
+    const m123_y = (m12_y + m23_y) >> 1;
+
+    const mx = (m012_x + m123_x) >> 1;
+    const my = (m012_y + m123_y) >> 1;
+
+    // IN-ORDER RECURSION: Left segment first, then Right segment
+    this.subdivide(
+      ax,
+      ay,
+      m01_x,
+      m01_y,
+      m012_x,
+      m012_y,
+      mx,
+      my,
+      depth + 1,
+      stepThreshold,
+      st,
+    );
+    this.subdivide(
+      mx,
+      my,
+      m123_x,
+      m123_y,
+      m23_x,
+      m23_y,
+      dx,
+      dy,
+      depth + 1,
+      stepThreshold,
+      st,
+    );
   }
 }

--- a/tests/core/utilities/Line.test.ts
+++ b/tests/core/utilities/Line.test.ts
@@ -1,0 +1,116 @@
+import { DistanceBasedBezierCurve } from "../../../src/core/utilities/Line";
+
+describe("DistanceBasedBezierCurve", () => {
+  test("straight curve where all four control points lie on one line", () => {
+    const p0 = { x: 0, y: 0 };
+    const p1 = { x: 30, y: 0 };
+    const p2 = { x: 70, y: 0 };
+    const p3 = { x: 100, y: 0 };
+    const spacing = 10;
+
+    const curve = new DistanceBasedBezierCurve(p0, p1, p2, p3, spacing);
+    const points = curve.getAllPoints();
+
+    expect(points.length).toBeGreaterThan(1);
+    expect(points[0]).toEqual({ x: 0, y: 0 });
+    expect(points[points.length - 1]).toEqual({ x: 100, y: 0 });
+
+    // Verify distance between consecutive cached points equals pixelSpacing (or close integer floor)
+    for (let i = 1; i < points.length - 1; i++) {
+      const dx = points[i].x - points[i - 1].x;
+      const dy = points[i].y - points[i - 1].y;
+      const dist = Math.floor(Math.sqrt(dx * dx + dy * dy));
+      expect(dist).toBeGreaterThanOrEqual(spacing - 1);
+      expect(dist).toBeLessThanOrEqual(spacing + 1);
+    }
+  });
+
+  test("zero-length curve where start point equals end point", () => {
+    const p0 = { x: 50, y: 50 };
+    const p1 = { x: 50, y: 50 };
+    const p2 = { x: 50, y: 50 };
+    const p3 = { x: 50, y: 50 };
+
+    const curve = new DistanceBasedBezierCurve(p0, p1, p2, p3, 5);
+    const points = curve.getAllPoints();
+
+    expect(points).toHaveLength(1);
+    expect(points[0]).toEqual({ x: 50, y: 50 });
+  });
+
+  test("pixelSpacing values of 1 and large number", () => {
+    const p0 = { x: 0, y: 0 };
+    const p1 = { x: 0, y: 50 };
+    const p2 = { x: 100, y: 50 };
+    const p3 = { x: 100, y: 0 };
+
+    // Small spacing (1) produces many points
+    const curveSmall = new DistanceBasedBezierCurve(p0, p1, p2, p3, 1);
+    const pointsSmall = curveSmall.getAllPoints();
+
+    // Large spacing (100) produces few points
+    const curveLarge = new DistanceBasedBezierCurve(p0, p1, p2, p3, 100);
+    const pointsLarge = curveLarge.getAllPoints();
+
+    expect(pointsSmall.length).toBeGreaterThan(pointsLarge.length);
+    expect(pointsSmall[0]).toEqual({ x: 0, y: 0 });
+    expect(pointsSmall[pointsSmall.length - 1]).toEqual({ x: 100, y: 0 });
+    expect(pointsLarge[0]).toEqual({ x: 0, y: 0 });
+    expect(pointsLarge[pointsLarge.length - 1]).toEqual({ x: 100, y: 0 });
+  });
+
+  test("endpoint rule: p3 is appended only when not already equal to last cached point", () => {
+    const p0 = { x: 0, y: 0 };
+    const p1 = { x: 10, y: 0 };
+    const p2 = { x: 20, y: 0 };
+    const p3 = { x: 30, y: 0 };
+
+    const curve = new DistanceBasedBezierCurve(p0, p1, p2, p3, 10);
+    const points = curve.getAllPoints();
+
+    // No duplicate endpoint at p3
+    const last = points[points.length - 1];
+    const prev = points[points.length - 2];
+    expect(last).toEqual({ x: 30, y: 0 });
+    expect(prev).not.toEqual(last);
+  });
+
+  test("increment() returns next point and returns null exactly once last index is reached", () => {
+    const p0 = { x: 0, y: 0 };
+    const p1 = { x: 10, y: 0 };
+    const p2 = { x: 20, y: 0 };
+    const p3 = { x: 30, y: 0 };
+    const spacing = 10;
+
+    const curve = new DistanceBasedBezierCurve(p0, p1, p2, p3, spacing);
+    const totalPoints = curve.getAllPoints().length;
+
+    for (let i = 1; i < totalPoints - 1; i++) {
+      const pt = curve.increment(spacing);
+      expect(pt).not.toBeNull();
+    }
+
+    // Once last index is reached, increment returns null
+    const endPt = curve.increment(spacing);
+    expect(endPt).toBeNull();
+  });
+
+  test("while loop emits multiple uniform points on long leaf segments when pixelSpacing is small", () => {
+    const p0 = { x: 0, y: 0 };
+    const p1 = { x: 50, y: 0 };
+    const p2 = { x: 100, y: 0 };
+    const p3 = { x: 150, y: 0 };
+
+    // Small pixelSpacing (1) on long curve
+    const curve = new DistanceBasedBezierCurve(p0, p1, p2, p3, 1);
+    const points = curve.getAllPoints();
+
+    // Verify all consecutive points are 1 unit apart (uniform density)
+    for (let i = 1; i < points.length - 1; i++) {
+      const dx = points[i].x - points[i - 1].x;
+      const dy = points[i].y - points[i - 1].y;
+      const dist = Math.abs(dx) + Math.abs(dy);
+      expect(dist).toBeLessThanOrEqual(2);
+    }
+  });
+});


### PR DESCRIPTION


> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4910

## Description:

UnitPass.ts: Added if (tick !== this.frameTick) guard in updateUnits(). Prevents secondary render sub-passes (bloom, selection overlays) from resetting lastUnitsUpdateMs mid-frame, locking lerp interpolation and reducing GPU VBO buffer uploads from 3 to 1 write per frame.
GameView.ts: added a guard to client-side trajectory interpolation by preventing unit pixel updates from server, the motion-plan is authority.
Renderer.ts: Passes gameTick to unitPass.updateUnits for tracking.

Line.ts: Replaced floating-point polynomial sampling ($t^3$) and 500-element float arrays with single-pass De Casteljau midpoint subdivision ((a + b) >> 1). eliminated float drift and heap garbage during launch precomputation. Removed unreferenced legacy classes CubicBezierCurve and BezenhamLine.

- `npm test` $\rightarrow$ **All Tests Passed**
- `npm run lint:oxlint && npm run lint:eslint` $\rightarrow$ **0 Errors, 0 Warnings**
- `npm run format` $\rightarrow$ **Prettier Clean**

Below table was calculated for 100 nukes, on a map with 210 normal buildings, 60 SAMs and 50 warships. 2 troop attacks are currently on-going and I believe I added 50 tradeships. The player is using cosmetics and plays on an entry-level standard pc. Worse for MIRVs. 
The last stat is the maximum the game could render before lagging.
| Metric | Main Branch| Current Code |
| --- | --- | --- |
| precomp cost | 0.36 ms | 0.01 ms |
| precomp peak mem | 960 KB | 24 KB |
| precomp heap allocs | 100,000 objects | 0 objects |
| baseline frame time | 10.16 ms | 10.16 ms |
| 100 nuke frame time | 53.36 ms (18 fps) | 15.66 ms (60 fps) |
| worstcase screen freeze | 153ms | 15.8 ms |
| pipeline cpu jitter | 25 ms - 68 ms | 15.1 - 15.8 ms |
| major gc pause | 40 ms - 85 ms | 0 |
| pipeline peak mem | 92MB | 53MB |
| webgl vbo write/frame | 3 / unit | 1 / unit |
| position jitter | 2.0 - 5.0 tiles | 0 tiles |
| client position re-updates | 40 msgs / flight | 1 msg / flight |
| floating point drift | 10^-7 float variance | (ixed-point |
| bombs (10tick/s)| 289 atom bombs [45 ops/point] | 710 atom bombs [5 ops/point] |


## Please complete the following:

- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
