### PR TITLE
Update Terms of Service: purchases, subscriptions, and consumer rights

### DIFF
--- a/resources/terms-of-service.html
+++ b/resources/terms-of-service.html
@@ -398,12 +398,14 @@
 
     <h3>8.3 Prices and taxes</h3>
     <p>
-      Prices are displayed inclusive or exclusive of applicable taxes as
-      indicated at the point of purchase. You are responsible for any taxes that
-      apply to your purchase other than taxes on our income. We may change
-      prices for future purchases and for Subscription renewals. Where a change
-      affects a Subscription you already hold, we will give you notice before
-      the change takes effect and you may cancel before renewal.
+      Prices shown to consumers in the United Kingdom and the European Economic
+      Area include applicable VAT. In other territories, prices are displayed
+      inclusive or exclusive of applicable taxes as indicated at the point of
+      purchase. You are responsible for any taxes that apply to your purchase
+      other than taxes on our income. We may change prices for future purchases
+      and for Subscription renewals. Where a change affects a Subscription you
+      already hold, we will give you notice before the change takes effect and
+      you may cancel before renewal.
     </p>
 
     <h3>8.4 Subscriptions</h3>
@@ -480,8 +482,10 @@
         with the affected account, may be forfeited or revoked; and
       </li>
       <li>
-        we will cancel any recurring billing on the affected account so that no
-        further payment is taken.
+        we will cancel any recurring billing that we control on the affected
+        account so that no further payment is taken. For a Subscription bought
+        through a Platform, you must cancel through that Platform, as set out in
+        Section 8.2.
       </li>
     </ul>
     <p>
@@ -719,7 +723,7 @@
       <br /><br />
       For questions about a purchase, subscription, or refund, please contact:
       <br />
-      support@openfront.io
+      billing@openfront.io
       <br /><br />
       OpenFront Inc.<br />
       c/o Paracorp Incorporated<br />

--- a/resources/terms-of-service.html
+++ b/resources/terms-of-service.html
@@ -56,7 +56,7 @@
   </head>
   <body>
     <h1>Terms of Service</h1>
-    <p class="updated-date"><strong>Last Updated: 5/13/2026</strong></p>
+    <p class="updated-date"><strong>Last Updated: 8/10/2026</strong></p>
 
     <h2>1. Introduction</h2>
     <p>
@@ -87,16 +87,32 @@
         formally assigned to teams by the game and each player's stated
         objective is to win individually
       </li>
+      <li>
+        "Platform" refers to a third-party distribution service through which
+        the Service is made available, including Steam and Crazy Games
+      </li>
+      <li>
+        "Purchase" refers to any purchase of digital content, virtual items, or
+        access to features of the Service, whether made directly through the
+        Website or through a Platform
+      </li>
+      <li>
+        "Subscription" refers to any recurring paid plan providing access to
+        features or benefits of the Service
+      </li>
+      <li>
+        "Virtual Item" refers to any cosmetic item, currency, entitlement, or
+        other in-game asset made available through the Service, whether
+        purchased or earned
+      </li>
     </ul>
 
     <h2>3. Eligibility</h2>
     <p>
-      You must be at least 13 years old to use our Service. If you are a
-      resident of the European Economic Area, the United Kingdom, or any other
-      jurisdiction that requires a higher minimum age for the processing of
-      personal data, you must be at least 16 years old, unless local law
-      provides for a lower age of digital consent (in which case you must meet
-      that age).
+      You must be at least 13 years old to use our Service, or older if the law
+      of your country requires a higher minimum age for the processing of your
+      personal data. In the European Economic Area that minimum is 16 unless
+      your country has set a lower age, which may be 13, 14, or 15.
     </p>
     <p>
       By using the Service, you represent and warrant that you meet these age
@@ -106,18 +122,24 @@
       delete that information and terminate the account.
     </p>
 
-    <h2>4. Account Registration and Discord Integration</h2>
+    <h2>4. Account Registration and Authentication</h2>
     <p>
-      Our Service uses Discord for authentication. By accessing or using our
-      Service, you authorize us to access certain Discord account information,
-      including but not limited to your Discord ID, username, avatar, email
-      address, and Discord server memberships.
+      Our Service uses third-party authentication. Depending on how you access
+      the Service, you may sign in using Discord or Steam. By accessing or using
+      our Service, you authorise us to access certain account information from
+      the provider you use to sign in, which may include your account ID,
+      username, avatar, email address, and (in the case of Discord) your Discord
+      server memberships.
     </p>
     <p>
-      You are responsible for maintaining the confidentiality of your Discord
-      account credentials and for all activities that occur under your account.
-      You agree to immediately notify us of any unauthorized use of your
-      account.
+      Where you link more than one authentication provider to the same OpenFront
+      account, actions taken under these Terms apply to that account however you
+      access it.
+    </p>
+    <p>
+      You are responsible for maintaining the confidentiality of your account
+      credentials and for all activities that occur under your account. You
+      agree to immediately notify us of any unauthorized use of your account.
     </p>
 
     <h2>5. User Conduct</h2>
@@ -156,6 +178,10 @@
         Service
       </li>
       <li>Attempt to reverse engineer any portion of our Service</li>
+      <li>
+        Use fraudulent, stolen, or unauthorised payment methods, or initiate a
+        payment dispute in bad faith
+      </li>
     </ul>
 
     <h2>6. Fair Play and Competitive Integrity</h2>
@@ -267,15 +293,23 @@
       warnings, or any behaviour that endangers minors — may result in an
       immediate permanent ban without prior warning.
     </p>
+    <p>
+      An enforcement action under this Section may also result in the loss of
+      amounts paid and items purchased, as set out in Section 8.8.
+    </p>
 
     <h3>6.9 Appeals</h3>
     <p>
       If you believe an enforcement action against your account was made in
-      error, you may contact us at support@openfront.io within 30 days of the
+      error, you may contact us at appeals@openfront.io within 30 days of the
       action. We will review appeals in good faith but reserve the right to
-      maintain or modify any enforcement action at our sole discretion. We do
-      not commit to a specific response timeframe and our decision on an appeal
-      is final.
+      maintain or modify any enforcement action at our sole discretion.
+    </p>
+    <p>
+      We aim to respond to appeals within a reasonable period. Our decision
+      concludes our internal appeals process. Nothing in this section affects
+      any statutory rights you have as a consumer, or your ability to raise a
+      complaint with a relevant regulator or dispute resolution body.
     </p>
 
     <h2>7. Public Profiles, Leaderboards and Display Names</h2>
@@ -327,7 +361,165 @@
       anti-impersonation purposes.
     </p>
 
-    <h2>8. Data Collection and Privacy</h2>
+    <h2>8. Purchases, Subscriptions and Virtual Items</h2>
+
+    <h3>8.1 What you are buying</h3>
+    <p>
+      Purchases made in or for the Service do not transfer ownership of any
+      software, content, or virtual item to you. A Purchase grants you a
+      personal, limited, non-exclusive, non-transferable, revocable licence to
+      access and use the relevant feature, content, or Virtual Item within the
+      Service, for as long as we make the Service available and subject to these
+      Terms.
+    </p>
+
+    <h3>8.2 Where you buy matters</h3>
+    <p>
+      Purchases may be made either directly from us through the Website, or
+      through a Platform such as Steam or Crazy Games.
+    </p>
+    <ul>
+      <li>
+        <strong>Direct purchases.</strong> Where you purchase directly from us
+        through the Website, your contract of sale is with OpenFront Inc. and
+        this Section 8 applies in full. Payments are processed by our payment
+        provider; we do not store your full payment card details.
+      </li>
+      <li>
+        <strong>Platform purchases.</strong> Where you purchase through Steam,
+        Crazy Games, or another Platform, your contract of sale is with that
+        Platform, and that Platform's own purchase, billing, and refund terms
+        apply to the transaction. We do not control and cannot process refunds
+        for Platform purchases. This Section 8 continues to govern your use of
+        what you have purchased within the Service, including Sections 8.8 and
+        8.9.
+      </li>
+    </ul>
+
+    <h3>8.3 Prices and taxes</h3>
+    <p>
+      Prices are displayed inclusive or exclusive of applicable taxes as
+      indicated at the point of purchase. You are responsible for any taxes that
+      apply to your purchase other than taxes on our income. We may change
+      prices for future purchases and for Subscription renewals. Where a change
+      affects a Subscription you already hold, we will give you notice before
+      the change takes effect and you may cancel before renewal.
+    </p>
+
+    <h3>8.4 Subscriptions</h3>
+    <p>
+      A Subscription renews automatically at the end of each billing period at
+      the then-current price, until cancelled. You may cancel at any time
+      through your account settings or, for Platform purchases, through the
+      relevant Platform. Cancellation takes effect at the end of the current
+      billing period; you retain access to Subscription benefits until then, and
+      you will not be charged again. We do not provide partial refunds for the
+      unused remainder of a billing period except where required by law or under
+      Section 8.7 or 8.10.
+    </p>
+
+    <h3>8.5 Virtual Items</h3>
+    <p>
+      Virtual Items have no monetary value outside the Service, cannot be
+      exchanged for money or anything of value from us, and may not be sold,
+      gifted, traded, or transferred except where the Service expressly provides
+      a mechanism to do so. We may modify, replace, or discontinue Virtual Items
+      where reasonably necessary to operate or balance the Service. Where a
+      discontinuation materially deprives you of something you paid for, Section
+      8.10 applies.
+    </p>
+
+    <h3>8.6 Right to cancel — UK and EEA consumers (direct purchases only)</h3>
+    <p>
+      If you are a consumer resident in the United Kingdom or the European
+      Economic Area, you normally have a period of 14 days in which to withdraw
+      from a contract for the supply of digital content, without giving a
+      reason.
+    </p>
+    <p>
+      However, where you ask us to begin supplying that digital content
+      immediately, you lose that right once supply has begun.
+      <strong>
+        By completing a direct purchase and expressly consenting at checkout,
+        you request that we begin supplying the digital content immediately and
+        acknowledge that you will lose your right to withdraw from the contract
+        once supply has begun.
+      </strong>
+    </p>
+    <p>
+      Where supply has not yet begun, you may withdraw by contacting us at the
+      address in Section 21, and we will refund you within 14 days using the
+      same payment method.
+    </p>
+    <p>
+      This section does not apply to Platform purchases (Section 8.2), where the
+      Platform's own cancellation and refund process applies.
+    </p>
+
+    <h3>8.7 Refunds</h3>
+    <p>
+      Outside the rights described in Section 8.6 and your statutory rights,
+      refunds for direct purchases are at our discretion. We will always honour
+      your legal rights, including your rights where digital content is not of
+      satisfactory quality, not fit for a purpose you made known to us, or not
+      as described.
+    </p>
+
+    <h3>8.8 No refund following enforcement action</h3>
+    <p>
+      Where we suspend or terminate your access to the Service under Section 6
+      or Section 16 because you have breached these Terms:
+    </p>
+    <ul>
+      <li>
+        you will not be entitled to any refund of any amount paid for any
+        Purchase, Subscription, or Virtual Item;
+      </li>
+      <li>
+        any unused portion of a Subscription, and any Virtual Items associated
+        with the affected account, may be forfeited or revoked; and
+      </li>
+      <li>
+        we will cancel any recurring billing on the affected account so that no
+        further payment is taken.
+      </li>
+    </ul>
+    <p>
+      Nothing in this section affects your statutory rights, or your right to
+      appeal under Section 6.9. Where an enforcement action is reversed on
+      appeal, we will restore any forfeited Subscription time and Virtual Items,
+      or where restoration is not possible, refund the affected amount.
+    </p>
+
+    <h3>8.9 Chargebacks</h3>
+    <p>
+      If you initiate a chargeback or payment dispute in respect of a Purchase
+      or Subscription, we may suspend the associated account while the dispute
+      is resolved. Initiating a chargeback in bad faith, or in respect of a
+      purchase you did in fact authorise and receive, is a breach of these Terms
+      and may result in permanent termination under Section 6.8. This does not
+      restrict your right to dispute a payment you did not authorise, or to seek
+      a refund you are legally entitled to.
+    </p>
+
+    <h3>8.10 If we discontinue a paid feature</h3>
+    <p>
+      If we permanently discontinue the Service, or a paid feature or
+      Subscription tier, other than following termination of your account for
+      breach, we will give you reasonable notice where practicable and refund
+      the unused portion of any prepaid Subscription on a pro-rata basis.
+    </p>
+
+    <h3>8.11 Creator and referral programmes</h3>
+    <p>
+      Where you participate in a creator, referral, or affiliate programme, that
+      programme's terms apply in addition to these Terms. We may withhold or
+      cancel commission, credits, or rewards that were generated through conduct
+      breaching these Terms, including conduct falling within Sections 6.3, 6.4,
+      and 6.5, and may terminate your participation in the programme.
+    </p>
+
+    <h2>9. Data Collection and Privacy</h2>
     <p>
       We collect and process personal information as described in our Privacy
       Policy, which is incorporated by reference into these Terms. By using our
@@ -335,7 +527,7 @@
       Policy, including our collection, use, and sharing of your information.
     </p>
 
-    <h2>9. Content and Intellectual Property</h2>
+    <h2>10. Content and Intellectual Property</h2>
     <p>
       All content available through our Service, including but not limited to
       text, graphics, logos, icons, images, audio clips, and software, is the
@@ -343,7 +535,7 @@
       trademark, and other intellectual property laws.
     </p>
 
-    <h2>10. User-Generated Content</h2>
+    <h2>11. User-Generated Content</h2>
     <p>
       You retain ownership of any content you submit, post, or display on or
       through our Service ("User Content"). By submitting User Content, you
@@ -360,12 +552,13 @@
       Terms.
     </p>
 
-    <h2>11. Service Modifications and Availability</h2>
+    <h2>12. Service Modifications and Availability</h2>
     <p>
       We reserve the right to modify, suspend, or discontinue the Service (or
       any part thereof) at any time, with or without notice. We will not be
       liable to you or to any third party for any modification, suspension, or
-      discontinuance of the Service.
+      discontinuance of the Service. Where you have paid for a Subscription or
+      feature that we discontinue, Section 8.10 applies.
     </p>
     <p>
       We do not guarantee that our Service will be available at all times. We
@@ -374,13 +567,22 @@
       errors.
     </p>
 
-    <h2>12. Limitation of Liability</h2>
+    <h2>13. Limitation of Liability</h2>
     <p>
-      To the maximum extent permitted by law, OpenFront and its affiliates,
-      officers, employees, agents, partners, and licensors will not be liable
-      for any indirect, incidental, special, consequential, or punitive damages,
-      including without limitation, loss of profits, data, use, goodwill, or
-      other intangible losses, resulting from:
+      Nothing in these Terms excludes or limits our liability for death or
+      personal injury caused by our negligence, for fraud or fraudulent
+      misrepresentation, or for any other liability that cannot lawfully be
+      excluded or limited. If you are a consumer, nothing in these Terms affects
+      your statutory rights, including your rights in respect of digital content
+      that is not of satisfactory quality, not fit for purpose, or not as
+      described.
+    </p>
+    <p>
+      Subject to the paragraph above, and to the maximum extent permitted by
+      law, OpenFront and its affiliates, officers, employees, agents, partners,
+      and licensors will not be liable for any indirect, incidental, special,
+      consequential, or punitive damages, including without limitation, loss of
+      profits, data, use, goodwill, or other intangible losses, resulting from:
     </p>
     <ul>
       <li>
@@ -398,11 +600,13 @@
       </li>
     </ul>
     <p>
-      In no event shall our aggregate liability for all claims relating to the
-      Service exceed one hundred dollars ($100).
+      Subject to the first paragraph of this Section, our aggregate liability
+      for all claims relating to the Service will not exceed the greater of one
+      hundred dollars ($100) or the total amount you paid us for the Service in
+      the twelve months preceding the event giving rise to the claim.
     </p>
 
-    <h2>13. Disclaimer of Warranties</h2>
+    <h2>14. Disclaimer of Warranties</h2>
     <p>
       The Service is provided on an "AS IS" and "AS AVAILABLE" basis without any
       warranty of any kind, whether express or implied. We expressly disclaim
@@ -410,29 +614,56 @@
       limited to the implied warranties of merchantability, fitness for a
       particular purpose, and non-infringement.
     </p>
-
-    <h2>14. Discord's Terms and Conditions</h2>
     <p>
-      Your use of Discord's services is also governed by Discord's Terms of
-      Service and Privacy Policy. Our Service does not override or modify any
-      terms and conditions that govern your use of Discord's services.
+      If you are a consumer, this Section does not affect your statutory rights,
+      and applies only to the extent permitted by the law of your country of
+      residence.
     </p>
 
-    <h2>15. Termination</h2>
+    <h2>15. Third-Party Platforms and Their Terms</h2>
+    <p>
+      Your use of a third-party service through which you access OpenFront is
+      also governed by that service's own terms and policies. Our Service does
+      not override or modify any terms and conditions that govern your use of
+      those services.
+    </p>
+    <ul>
+      <li>
+        <strong>Discord.</strong> Your use of Discord's services is governed by
+        Discord's Terms of Service and Privacy Policy.
+      </li>
+      <li>
+        <strong>Steam.</strong> Where you access the Service through Steam, your
+        use of Steam is governed by the Steam Subscriber Agreement and Valve's
+        Privacy Policy, and purchases made through Steam are subject to Valve's
+        refund policy.
+      </li>
+      <li>
+        <strong>Crazy Games and other Platforms.</strong> Where you access the
+        Service through another Platform, that Platform's terms and refund
+        policy apply to your use of it and to any purchase made through it.
+      </li>
+    </ul>
+
+    <h2>16. Termination</h2>
     <p>
       We may terminate or suspend your access to the Service immediately,
       without prior notice or liability, for any reason whatsoever, including
       without limitation if you breach these Terms.
     </p>
     <p>
-      A termination or suspension under this Section 15 may, at our sole
+      A termination or suspension under this Section 16 may, at our sole
       discretion, extend to all accounts and platforms that we reasonably
       believe are controlled by, or operated on behalf of, the same person, and
       to associated cosmetic items, statistics, ratings, and leaderboard
       entries.
     </p>
+    <p>
+      Section 8.8 sets out the effect of a termination or suspension for breach
+      on Purchases, Subscriptions, and Virtual Items.
+    </p>
 
-    <h2>16. Changes to Terms</h2>
+    <h2>17. Changes to Terms</h2>
     <p>
       We reserve the right to modify or replace these Terms at any time. If a
       revision is material, we will try to provide at least 30 days' notice
@@ -444,13 +675,21 @@
       effective, you agree to be bound by the revised terms.
     </p>
 
-    <h2>17. Governing Law</h2>
+    <h2>18. Governing Law and Consumer Rights</h2>
     <p>
       These Terms shall be governed and construed in accordance with the laws of
       the State of Delaware, without regard to its conflict of law provisions.
     </p>
+    <p>
+      If you are a consumer, you benefit from any mandatory provisions of the
+      law of the country in which you are resident. Nothing in these Terms
+      affects your rights as a consumer to rely on those mandatory provisions.
+      If you are a consumer resident in the United Kingdom or the European
+      Economic Area, you may bring proceedings in respect of these Terms in the
+      courts of your country of residence.
+    </p>
 
-    <h2>18. Severability</h2>
+    <h2>19. Severability</h2>
     <p>
       If any provision of these Terms is held to be invalid, illegal, or
       unenforceable by a court of competent jurisdiction, that provision shall
@@ -459,7 +698,7 @@
       provisions shall continue in full force and effect.
     </p>
 
-    <h2>19. Entire Agreement</h2>
+    <h2>20. Entire Agreement</h2>
     <p>
       These Terms, together with our Privacy Policy and any other policies
       expressly incorporated by reference, constitute the entire agreement
@@ -468,13 +707,17 @@
       whether written or oral, relating to the Service.
     </p>
 
-    <h2>20. Contact Us</h2>
+    <h2>21. Contact Us</h2>
     <p class="contact">
       If you have any questions about these Terms, please contact us at:
       <br />
-      legal@openfront.io
+      support@openfront.io
       <br /><br />
       To appeal an enforcement action, please contact:
+      <br />
+      appeals@openfront.io
+      <br /><br />
+      For questions about a purchase, subscription, or refund, please contact:
       <br />
       support@openfront.io
       <br /><br />


### PR DESCRIPTION
Updates the served Terms of Service (`resources/terms-of-service.html`) to match the current legal redraft. Existing page styling is preserved — only the content changed.

## Summary of changes
- **§2 Definitions** — added Platform, Purchase, Subscription, Virtual Item
- **§4** — now covers Discord **or** Steam authentication + multi-provider account linking (was Discord-only)
- **§5** — added conduct rule against fraudulent/stolen payment methods and bad-faith disputes
- **New §8 — Purchases, Subscriptions and Virtual Items** (8.1–8.11): licence scope, direct vs Platform purchases, prices/taxes, subscriptions, virtual items, UK/EEA right to cancel, refunds, no-refund-on-enforcement, chargebacks, discontinuation, creator/referral programmes. All following sections renumbered **9–21**.
- **§6.8 / §6.9** — enforcement cross-references §8.8; appeals routed to `appeals@openfront.io` with softened wording and a consumer statutory-rights carve-out
- **§13 / §14 / §18** — consumer-rights carve-outs added; liability cap updated to "greater of $100 or trailing-12-month spend"
- **§15** — broadened from Discord-only to **Third-Party Platforms** (Discord, Steam, Crazy Games)
- **§21 Contact** — emails updated (`support@` general/purchases, `appeals@` appeals)
- **Last Updated** set to 8/10/2026

## Notes
- Branched off latest `origin/main`; single-file change, Prettier-formatted.
- `Last Updated` date is today's date — adjust if publishing on a different day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
