### PR TITLE
Use toast notifications for copy feedback instead of inline copied text

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -297,6 +297,7 @@ export async function copyToClipboard(
     }
   } catch (err) {
     console.warn("Failed to copy to clipboard", err);
+    throw err;
   }
 }
 

--- a/src/client/components/CopyButton.ts
+++ b/src/client/components/CopyButton.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ClientEnv } from "src/client/ClientEnv";
 import { UserSettings } from "../../core/game/UserSettings";
 import { crazyGamesSDK } from "../CrazyGamesSDK";
-import { copyToClipboard, translateText } from "../Utils";
+import { copyToClipboard, showToast, translateText } from "../Utils";
 
 @customElement("copy-button")
 export class CopyButton extends LitElement {
@@ -24,7 +24,6 @@ export class CopyButton extends LitElement {
   showCopyIcon = true;
   @property({ type: Boolean }) compact = false;
 
-  @state() private copySuccess = false;
   @state() private lobbyIdVisible = true;
 
   private userSettings: UserSettings = new UserSettings();
@@ -39,10 +38,6 @@ export class CopyButton extends LitElement {
   ) {
     if (changedProperties.has("lobbyId")) {
       this.lobbyIdVisible = this.userSettings.lobbyIdVisibility();
-      this.copySuccess = false;
-    }
-    if (changedProperties.has("copyText")) {
-      this.copySuccess = false;
     }
     if (
       changedProperties.has("showVisibilityToggle") ||
@@ -90,11 +85,13 @@ export class CopyButton extends LitElement {
       alert("Error copying game id");
       return;
     }
-    await copyToClipboard(
-      text,
-      () => (this.copySuccess = true),
-      () => (this.copySuccess = false),
-    );
+
+    try {
+      await copyToClipboard(text);
+      showToast(translateText("common.copied"), "green");
+    } catch {
+      showToast(translateText("error_modal.failed_copy"), "red");
+    }
   }
 
   private canCopy() {
@@ -107,11 +104,7 @@ export class CopyButton extends LitElement {
     const rawLabel =
       this.displayContent ??
       (this.displayText || this.lobbyId || this.copyText);
-    const label = this.copySuccess
-      ? translateText("common.copied")
-      : allowMask && !this.lobbyIdVisible
-        ? this.maskLabel
-        : rawLabel;
+    const label = allowMask && !this.lobbyIdVisible ? this.maskLabel : rawLabel;
     const disabledClass = canCopy ? "" : "opacity-60 cursor-not-allowed";
     const toggleDisabled = !this.lobbyId;
     const toggleClass = toggleDisabled ? "opacity-60 cursor-not-allowed" : "";

--- a/tests/client/GameStatsModal.test.ts
+++ b/tests/client/GameStatsModal.test.ts
@@ -12,10 +12,12 @@ import {
 const copyToClipboardMock = vi.hoisted(() =>
   vi.fn(async (_text: string, onSuccess?: () => void) => onSuccess?.()),
 );
+const showToastMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/client/Utils", () => ({
   translateText: vi.fn((key: string) => key),
   copyToClipboard: copyToClipboardMock,
+  showToast: showToastMock,
 }));
 
 vi.mock("../../src/client/components/baseComponents/stats/GameInfoView", () => {
@@ -106,14 +108,11 @@ describe("public game stats route", () => {
     );
     copyActions[0].click();
     await vi.waitFor(() =>
-      expect(copyToClipboardMock).toHaveBeenCalledWith(
-        "public-game",
-        expect.any(Function),
-        expect.any(Function),
-      ),
+      expect(copyToClipboardMock).toHaveBeenCalledWith("public-game"),
     );
     await copyButton.updateComplete;
-    expect(copyButton.textContent).toContain("common.copied");
+    expect(copyButton.textContent).toContain("public-game");
+    expect(showToastMock).toHaveBeenCalledWith("common.copied", "green");
 
     expect(document.querySelector("account-modal")).toBeNull();
     expect(window.location.hash).toBe("#modal=stats&gameID=public-game");


### PR DESCRIPTION
## Description:

This change updates the copy interaction to use toast notifications instead of replacing the copied ID/text inline.

https://github.com/user-attachments/assets/5cf9a408-1b0f-4fc0-86eb-2c247402e1df

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri