### PR TITLE
Small fix: prevent nukes from firing in same tick

### DIFF
--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -195,14 +195,18 @@ export class NukeExecution implements Execution {
       const silo = this.player
         .units(UnitType.MissileSilo)
         .find((silo) => silo.tile() === spawn);
-      // Stacked purchases launch several nukes on the same tick; delay each
-      // by the number of same-tick launches already claimed on this silo so
-      // missiles from one silo trail each other instead of overlapping,
-      // while separate silos still fire simultaneously.
+      // Stacked purchases launch several nukes across ticks; delay each missile
+      // so launches from the same silo trail each other instead of overlapping,
+      // need to check the entire queue because even if nukes have waitticks,
+      // the silo queue will be filled with the same tick.
       if (silo !== undefined) {
-        this.waitTicks += silo
-          .missileTimerQueue()
-          .filter((t) => t === this.mg.ticks()).length;
+        let lastDep = 0;
+        for (const launchTick of silo.missileTimerQueue()) {
+          lastDep = Math.max(launchTick + 1, lastDep + 1);
+        }
+        if (lastDep > this.mg.ticks()) {
+          this.waitTicks += lastDep - this.mg.ticks();
+        }
       }
       this.nuke = this.player.buildUnit(this.nukeType, this.src, {
         targetTile: this.dst,

--- a/tests/core/executions/NukeExecution.test.ts
+++ b/tests/core/executions/NukeExecution.test.ts
@@ -481,4 +481,46 @@ describe("NukeExecution", () => {
     collect();
     expect(seen.size).toBe(1);
   });
+
+  test("stacked atom bombs launched across successive ticks stagger continuously without overlapping", () => {
+    (game.config() as TestConfig).setDefaultNukeSpeed(20);
+
+    const silo = player.buildUnit(UnitType.MissileSilo, game.ref(50, 50), {});
+    for (let i = 0; i < 9; i++) {
+      silo.increaseLevel();
+      silo.reloadMissile();
+    }
+
+    // Click 1: launch 3 nukes at current tick
+    game.addExecution(
+      new ConstructionExecution(
+        player,
+        UnitType.AtomBomb,
+        game.ref(150, 150),
+        undefined,
+        3,
+      ),
+    );
+
+    // Advance 1 tick, then Click 2: launch 3 more nukes at next tick
+    executeTicks(game, 1);
+    game.addExecution(
+      new ConstructionExecution(
+        player,
+        UnitType.AtomBomb,
+        game.ref(150, 150),
+        undefined,
+        3,
+      ),
+    );
+
+    // Give all 6 nukes time to depart the silo
+    executeTicks(game, 7);
+
+    // Every launched nuke should occupy a distinct tile (no 2 nukes overlapping on same tile)
+    const nukes = player.units(UnitType.AtomBomb);
+    expect(nukes).toHaveLength(6);
+    const tiles = nukes.map((n) => n.tile());
+    expect(new Set(tiles).size).toBe(6);
+  });
 });


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

## Description:

This is a minor fix to a bug introduced in the stack / bulk building upgrade (PR #4640)
When a PC player double hits 8, they can send 5 nukes at a time.
The code tried to space nukes out by one tick by reading the missile Queue of the silo - however the nukeExecution gets instantiated with waitTicks 0 / 1 / 2 / 3 / 4, however the silo itself is not able to account for it, all cooldowns are from the same starting Tick (IE [100, 100, 100, 100, 100] - Thus to fix this we iterate through the queue and count em up to queue them after each other.

## Please complete the following:

- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
