### PR TITLE
Archive singleplayer games at win time instead of page teardown

### DIFF
--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -58,7 +58,10 @@ export class LocalServer {
   private clientID: ClientID | undefined;
   private winner: ClientSendWinnerMessage | null = null;
   private allPlayersStats: AllPlayersStats = {};
+  // Set only once an upload got a 2xx, so endGame() retries failed or
+  // skipped win-time uploads during teardown.
   private archived = false;
+  private archiveInFlight = false;
 
   private turnsExecuted = 0;
   private turnStartTime = 0;
@@ -283,7 +286,7 @@ export class LocalServer {
   }
 
   private archiveGameRecord(unloading: boolean) {
-    if (this.archived) {
+    if (this.archived || this.archiveInFlight) {
       return;
     }
     const players: PlayerRecord[] = [
@@ -316,7 +319,6 @@ export class LocalServer {
       return;
     }
 
-    this.archived = true;
     this.archiveGame(result.data, unloading);
   }
 
@@ -324,6 +326,7 @@ export class LocalServer {
     record: PartialGameRecord,
     unloading: boolean,
   ): Promise<void> {
+    this.archiveInFlight = true;
     try {
       const authHeader = await getAuthHeader();
       if (authHeader === "") {
@@ -353,13 +356,17 @@ export class LocalServer {
           keepalive: unloading,
         },
       );
-      if (!response.ok) {
+      if (response.ok) {
+        this.archived = true;
+      } else {
         console.error(
           `Failed to archive singleplayer game: ${response.status}`,
         );
       }
     } catch (error) {
       console.error("Failed to archive singleplayer game:", error);
+    } finally {
+      this.archiveInFlight = false;
     }
   }
 }

--- a/src/client/LocalServer.ts
+++ b/src/client/LocalServer.ts
@@ -58,6 +58,7 @@ export class LocalServer {
   private clientID: ClientID | undefined;
   private winner: ClientSendWinnerMessage | null = null;
   private allPlayersStats: AllPlayersStats = {};
+  private archived = false;
 
   private turnsExecuted = 0;
   private turnStartTime = 0;
@@ -231,6 +232,12 @@ export class LocalServer {
     if (clientMsg.type === "winner") {
       this.winner = clientMsg;
       this.allPlayersStats = clientMsg.allPlayersStats;
+      if (!this.isReplay) {
+        // Archive as soon as the game is decided: endGame() only runs during
+        // page teardown, where the auth refresh and upload race document
+        // destruction and can silently lose the record (#4931).
+        this.archiveGameRecord(false);
+      }
     }
   }
 
@@ -270,6 +277,15 @@ export class LocalServer {
     if (this.isReplay) {
       return;
     }
+    // Fallback for games that end without a winner (e.g. quitting early);
+    // decided games were already archived at win time.
+    this.archiveGameRecord(true);
+  }
+
+  private archiveGameRecord(unloading: boolean) {
+    if (this.archived) {
+      return;
+    }
     const players: PlayerRecord[] = [
       {
         persistentID: getPersistentID(),
@@ -300,10 +316,14 @@ export class LocalServer {
       return;
     }
 
-    this.archiveGame(result.data);
+    this.archived = true;
+    this.archiveGame(result.data, unloading);
   }
 
-  private async archiveGame(record: PartialGameRecord): Promise<void> {
+  private async archiveGame(
+    record: PartialGameRecord,
+    unloading: boolean,
+  ): Promise<void> {
     try {
       const authHeader = await getAuthHeader();
       if (authHeader === "") {
@@ -318,16 +338,26 @@ export class LocalServer {
         replacer,
       );
       const compressedData = await compress(jsonString);
-      await fetch(`${getApiBase()}/archive_singleplayer_game`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          "Content-Encoding": "gzip",
-          Authorization: authHeader,
+      const response = await fetch(
+        `${getApiBase()}/archive_singleplayer_game`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Encoding": "gzip",
+            Authorization: authHeader,
+          },
+          body: compressedData,
+          // keepalive lets the request outlive page teardown but caps the body
+          // at 64 KiB, so only set it when the page is actually unloading.
+          keepalive: unloading,
         },
-        body: compressedData,
-        keepalive: true, // Ensures request completes even if page unloads
-      });
+      );
+      if (!response.ok) {
+        console.error(
+          `Failed to archive singleplayer game: ${response.status}`,
+        );
+      }
     } catch (error) {
       console.error("Failed to archive singleplayer game:", error);
     }

--- a/src/client/hud/layers/WinModal.ts
+++ b/src/client/hud/layers/WinModal.ts
@@ -320,6 +320,7 @@ export class WinModal extends LitElement implements Controller {
         history.replaceState(null, "", `${window.location.pathname}?replay`);
         this.show();
       } else if (wu.winner[0] === "nation") {
+        this.eventBus.emit(new SendWinnerEvent(wu.winner, wu.allPlayersStats));
         this._title = translateText("win_modal.nation_won", {
           nation: wu.winner[1],
         });

--- a/tests/client/LocalServer.test.ts
+++ b/tests/client/LocalServer.test.ts
@@ -122,6 +122,45 @@ describe("LocalServer archiving", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  it("retries at endGame with keepalive when the win-time upload failed", async () => {
+    fetchMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+    const server = makeServer(false);
+    server.start();
+
+    server.onMessage(winnerMsg);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    // Let the failed attempt settle so it is no longer in flight.
+    await new Promise((r) => setTimeout(r, 0));
+
+    server.endGame();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2));
+
+    const [, init] = fetchMock.mock.calls[1];
+    expect(init.keepalive).toBe(true);
+    expect(archivedRecord(fetchMock.mock.calls[1]).info.winner).toEqual([
+      "player",
+      CLIENT_ID,
+    ]);
+  });
+
+  it("does not start a second upload while one is in flight", async () => {
+    let resolveFetch!: (response: Response) => void;
+    fetchMock.mockImplementationOnce(
+      () => new Promise<Response>((r) => (resolveFetch = r)),
+    );
+    const server = makeServer(false);
+    server.start();
+
+    server.onMessage(winnerMsg);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    // Exit while the win-time upload is still pending.
+    server.endGame();
+    resolveFetch(new Response(null, { status: 200 }));
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("still archives at endGame when the game had no winner", async () => {
     const server = makeServer(false);
     server.start();

--- a/tests/client/LocalServer.test.ts
+++ b/tests/client/LocalServer.test.ts
@@ -1,0 +1,146 @@
+import { gunzipSync } from "node:zlib";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import type { ClientMessage, GameStartInfo } from "../../src/core/Schemas";
+
+vi.mock("../../src/client/Auth", () => ({
+  getAuthHeader: vi.fn(async () => "Bearer test-jwt"),
+  getPersistentID: vi.fn(() => "123e4567-e89b-12d3-a456-426614174000"),
+}));
+
+vi.mock("../../src/client/Api", () => ({
+  getApiBase: vi.fn(() => "https://api.test"),
+}));
+
+vi.mock("src/client/ClientEnv", () => ({
+  ClientEnv: {
+    turnIntervalMs: vi.fn(() => 100),
+    gitCommit: vi.fn(() => "DEV"),
+  },
+}));
+
+import { LocalServer } from "../../src/client/LocalServer";
+
+// jsdom doesn't provide CompressionStream; use Node's implementation.
+if (typeof globalThis.CompressionStream === "undefined") {
+  const streamWeb = await import("node:stream/web");
+  (globalThis as any).CompressionStream = streamWeb.CompressionStream;
+}
+
+const CLIENT_ID = "abCD1234";
+
+function makeGameStartInfo(): GameStartInfo {
+  return {
+    gameID: "gameID12",
+    lobbyCreatedAt: 1000,
+    config: {
+      gameMap: "Africa",
+      difficulty: "Medium",
+      donateGold: false,
+      donateTroops: false,
+      gameType: "Singleplayer",
+      gameMode: "Free For All",
+      gameMapSize: "Normal",
+      nations: "default",
+      bots: 400,
+      infiniteGold: false,
+      infiniteTroops: false,
+      instantBuild: false,
+      randomSpawn: false,
+    },
+    players: [
+      {
+        clientID: CLIENT_ID,
+        username: "TestUser",
+        clanTag: null,
+      },
+    ],
+  } as GameStartInfo;
+}
+
+function makeServer(isReplay: boolean): LocalServer {
+  const server = new LocalServer(
+    {
+      gameStartInfo: makeGameStartInfo(),
+      playerName: "TestUser",
+      playerClanTag: null,
+    } as any,
+    isReplay,
+    new EventBus(),
+  );
+  server.updateCallback(
+    () => {},
+    () => {},
+  );
+  return server;
+}
+
+const winnerMsg: ClientMessage = {
+  type: "winner",
+  winner: ["player", CLIENT_ID],
+  allPlayersStats: { [CLIENT_ID]: { attacks: [100n] } },
+};
+
+function archivedRecord(call: any) {
+  const body = call[1].body as ArrayBuffer;
+  return JSON.parse(gunzipSync(Buffer.from(body)).toString());
+}
+
+describe("LocalServer archiving", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn(async () => new Response(null, { status: 200 }));
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("archives at win time, without keepalive, and not again at endGame", async () => {
+    const server = makeServer(false);
+    server.start();
+
+    server.onMessage(winnerMsg);
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe("https://api.test/archive_singleplayer_game");
+    expect(init.method).toBe("POST");
+    expect(init.keepalive).toBe(false);
+    expect(init.headers.Authorization).toBe("Bearer test-jwt");
+
+    const record = archivedRecord(fetchMock.mock.calls[0]);
+    expect(record.gitCommit).toBe("DEV");
+    expect(record.info.winner).toEqual(["player", CLIENT_ID]);
+    expect(record.info.players[0].clientID).toBe(CLIENT_ID);
+
+    // Exiting afterwards must not archive the same game twice.
+    server.endGame();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("still archives at endGame when the game had no winner", async () => {
+    const server = makeServer(false);
+    server.start();
+
+    server.endGame();
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+
+    const [, init] = fetchMock.mock.calls[0];
+    expect(init.keepalive).toBe(true);
+    expect(archivedRecord(fetchMock.mock.calls[0]).info.winner).toBeUndefined();
+  });
+
+  it("never archives replays", async () => {
+    const server = makeServer(true);
+    server.start();
+
+    server.onMessage(winnerMsg);
+    server.endGame();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Fixes #4931 (and the singleplayer side of #4875).

## Problem

Since v0.33.0 (#4787), the singleplayer archive POST only ran during page teardown: every exit path funnels through `window.location.href = "/"` → `beforeunload` → `ClientGameRunner.stop()` → `LocalServer.endGame()` → `archiveGame()`. That whole sequence races document destruction, and it now starts with an auth round trip: the session JWT is memory-only with a ~15 min TTL and nothing refreshes it during gameplay, so after any medal-length game `getAuthHeader()` must complete a cross-origin `POST /auth/refresh` (no `keepalive`) inside the dying page. When the navigation kills that fetch, the JWT is cleared and `archiveGame()` hits the silent early-return — the archive POST is never issued at all, so the API never grants the medal and the game never appears in profile history. All failures were invisible: the response status was never checked.

## Fix

- **Archive at win time.** `LocalServer` now builds and uploads the record as soon as the `winner` message arrives, while the page is fully alive — auth refresh, compression, and the POST all run normally. Replays are excluded, same as before.
- **`endGame()` stays as a fallback** for games that end without a winner (quitting early), deduped via an `archived` flag so a decided game is never posted twice.
- **`keepalive` only on the teardown fallback.** At win time it's unnecessary, and its 64 KiB body cap would reject long games' records outright.
- **Non-2xx responses are now logged** instead of looking identical to success.
- **Nation wins record a winner:** the nation branch of `WinModal.tick()` now emits `SendWinnerEvent` like the player/team branches (`WinnerSchema` already supports `["nation", name]`), so losing to a nation also triggers the win-time archive and no longer produces a winnerless record.

## Tradeoffs

- The archived record now snapshots turns at the moment the game is decided, so post-win "keep playing" turns are no longer in the replay. If the API dedupes by gameID we could re-archive the full record at teardown as a follow-up.
- Quit-without-win games still ride the teardown path and keep its pre-existing best-effort behavior.

## Testing

- New `tests/client/LocalServer.test.ts`: archive fires at win time without `keepalive` and is not duplicated at `endGame` (decompresses the body to verify winner + `gitCommit` land in the record); the no-winner teardown fallback still archives with `keepalive`; replays never archive.
- `npx vitest tests/client --run`: 68 files / 833 tests pass; `tsc --noEmit` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)