### PR TITLE
feat(adminbot): let create_game pin teams

### DIFF
--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -8,7 +8,7 @@ import type {
 } from "express";
 import type { Logger } from "winston";
 import { z } from "zod";
-import { GameType } from "../core/game/Game";
+import { GameMode, GameType } from "../core/game/Game";
 import {
   ADMIN_BOT_CLIENT_ID,
   GameConfigSchema,
@@ -17,6 +17,11 @@ import {
 } from "../core/Schemas";
 import type { GameManager } from "./GameManager";
 import { ServerEnv } from "./ServerEnv";
+
+// Team-pinning caps. A lobby tops out well below these; they exist so a bad
+// request can't allocate unbounded work, matching allowedPublicIds' own cap.
+const MAX_TEAMS = 200;
+const MAX_TEAM_MEMBERS = 50;
 
 function timingSafeEqualStr(a: string, b: string): boolean {
   const ab = Buffer.from(a);
@@ -95,6 +100,48 @@ export function registerAdminBotRoutes(opts: {
         .json({ error: z.prettifyError(listedParsed.error) });
     }
     const listed = listedParsed.data.listed === true;
+
+    // Optional team pinning. Read alongside the config for the same reason as
+    // `listed`: it is not a GameConfig field, so the parse above strips it and it
+    // can never be smuggled in through update_game_config after the fact.
+    //
+    // Entries are publicIds. assignTeams honours a pinned slot unconditionally —
+    // before and regardless of clan/friend grouping — so this is how a tournament
+    // bot says who plays with whom instead of letting the balancer decide.
+    const teamsParsed = z
+      .object({
+        teams: z
+          .array(z.array(z.string()).max(MAX_TEAM_MEMBERS))
+          .max(MAX_TEAMS)
+          .optional(),
+      })
+      .safeParse(req.body ?? {});
+    if (!teamsParsed.success) {
+      return res
+        .status(400)
+        .json({ error: z.prettifyError(teamsParsed.error) });
+    }
+    const teams = teamsParsed.data.teams;
+    if (teams !== undefined) {
+      // FFA never runs assignTeams, so a pin there would be silently inert.
+      // Refuse rather than accept a request that cannot do what it asks.
+      if (config.gameMode !== GameMode.Team) {
+        return res.status(400).json({ error: "teams require gameMode Team" });
+      }
+      // A publicId in two teams has no single answer (findIndex takes the first),
+      // so the caller would get a team it did not ask for.
+      const seen = new Set<string>();
+      for (const team of teams) {
+        for (const publicId of team) {
+          if (seen.has(publicId)) {
+            return res
+              .status(400)
+              .json({ error: `publicId in more than one team: ${publicId}` });
+          }
+          seen.add(publicId);
+        }
+      }
+    }
     // Private only: reject Public and Singleplayer. An omitted gameType defaults
     // to Private in createGame, so it's allowed through.
     if (config.gameType !== undefined && config.gameType !== GameType.Private) {
@@ -125,7 +172,14 @@ export function registerAdminBotRoutes(opts: {
       return res.status(500).json({ error: "Could not allocate game id" });
     }
 
-    const game = gm.createGame(id, config, undefined);
+    const game = gm.createGame(
+      id,
+      config,
+      undefined,
+      undefined,
+      undefined,
+      teams,
+    );
     if (game === null) {
       return res.status(409).json({ error: "Game ID already exists" });
     }

--- a/tests/server/AdminBotCreateTeams.test.ts
+++ b/tests/server/AdminBotCreateTeams.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerAdminBotRoutes } from "../../src/server/AdminBotRoutes";
+import { ServerEnv } from "../../src/server/ServerEnv";
+
+// Capture the create_game handler off a fake Express app, recording what reaches
+// GameManager.createGame — the pinned teams arrive as its 6th argument, and must
+// never appear inside GameConfig.
+function captureCreateHandler() {
+  const routes: Record<string, (req: any, res: any) => void> = {};
+  const app: any = {
+    post(path: string, ...handlers: ((req: any, res: any) => void)[]) {
+      routes[path] = handlers[handlers.length - 1];
+    },
+    get() {},
+  };
+  const created: {
+    config?: Record<string, unknown>;
+    teams?: string[][];
+  } = {};
+  const gm: any = {
+    createGame(
+      _id: string,
+      config: Record<string, unknown>,
+      _creator?: string,
+      _startsAt?: number,
+      _publicGameType?: unknown,
+      matchmakingTeams?: string[][],
+    ) {
+      created.config = config;
+      created.teams = matchmakingTeams;
+      return { setListed: vi.fn(), gameInfo: () => ({ gameID: "x" }) };
+    },
+  };
+  const log: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  registerAdminBotRoutes({ app, gm, workerId: 0, log });
+  return { handler: routes["/api/adminbot/create_game"], created };
+}
+
+function mockRes() {
+  const res: any = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+const TEAM = { gameMap: "World", gameMode: "Team" };
+const FFA = { gameMap: "World", gameMode: "Free For All" };
+
+beforeEach(() => {
+  vi.spyOn(ServerEnv, "generateGameIdForWorker").mockReturnValue("aaaaaaaa");
+  vi.spyOn(ServerEnv, "workerPath").mockReturnValue("w0");
+});
+
+describe("admin bot create_game team pinning", () => {
+  it("passes the pinned teams through to createGame", () => {
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    const teams = [
+      ["pubA", "pubB"],
+      ["pubC", "pubD"],
+    ];
+    handler({ body: { ...TEAM, teams } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(created.teams).toEqual(teams);
+  });
+
+  it("keeps teams OUT of GameConfig", () => {
+    // Same rule as `listed`: not a GameConfig field, so update_game_config can
+    // never set it after the lobby exists.
+    const { handler, created } = captureCreateHandler();
+    handler({ body: { ...TEAM, teams: [["pubA", "pubB"]] } }, mockRes());
+    expect(created.config).not.toHaveProperty("teams");
+    expect(created.config).not.toHaveProperty("matchmakingTeams");
+  });
+
+  it("creates an unpinned game when teams are omitted", () => {
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler({ body: { ...TEAM } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(created.teams).toBeUndefined();
+  });
+
+  it("refuses teams in FFA, where a pin would be silently inert", () => {
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler({ body: { ...FFA, teams: [["pubA", "pubB"]] } }, res);
+    expect(res.statusCode).toBe(400);
+    expect(created.teams).toBeUndefined();
+  });
+
+  it("refuses a publicId listed in two teams", () => {
+    // findIndex takes the first match, so the caller would silently get a team
+    // it did not ask for.
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler({ body: { ...TEAM, teams: [["pubA", "pubB"], ["pubA"]] } }, res);
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toContain("pubA");
+    expect(created.teams).toBeUndefined();
+  });
+
+  it("rejects a malformed teams payload", () => {
+    const { handler } = captureCreateHandler();
+    const res = mockRes();
+    handler({ body: { ...TEAM, teams: ["not-an-array"] } }, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("accepts an empty teams list without pinning anyone", () => {
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler({ body: { ...TEAM, teams: [] } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(created.teams).toEqual([]);
+  });
+});


### PR DESCRIPTION
Lets a bot say who plays with whom in a Team game.

`GameManager.createGame` already accepts `matchmakingTeams`, and `GameServer` already resolves a client's pinned slot from it — but the admin-bot route called `createGame` with three arguments, so it was always `undefined`. A bot could create a Team game but not control the pairings; the balancer decided, which is no use for a tournament running fixed pairs.

`create_game` now takes an optional `teams: string[][]` of publicIds, read alongside the config rather than through `GameConfig` — same treatment as `listed`, so it can't be set later via `update_game_config`.

Rejects two cases rather than accepting a request that can't do what it asks:
- `teams` in FFA, where `assignTeams` never runs so the pin would be silently inert
- a publicId in two teams, where `findIndex` takes the first and the caller would get a team they didn't ask for

Follow-up (not here): teams can't be amended after create, so a player added to the allowlist pre-start can't be pinned to their partner.