### PR TITLE
game winner deactivates doomclockExecution.

### DIFF
--- a/src/core/execution/DoomsdayClockExecution.ts
+++ b/src/core/execution/DoomsdayClockExecution.ts
@@ -117,10 +117,11 @@ export class DoomsdayClockExecution implements Execution {
     const ffa = mg.config().gameConfig().gameMode === GameMode.FFA;
     const sides = this.sides(contenders, ffa);
 
-    // A winner is already inevitable (one side left): idle. Before the first
-    // wave the bar is 0, so nobody is flagged anyway.
-    if (sides.length < 2) {
+    // Winner is already set/inevitable (one side left): idle.
+    // Before the first wave the bar is 0, nobody is flagged anyway.
+    if (mg.getWinner() !== null || sides.length < 2) {
       for (const p of contenders) p.clearDoomsdayClock();
+      this.active = false;
       return;
     }
 

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -194,11 +194,18 @@ class FakePlayer {
 class FakeGame {
   now = 0;
   gameMode: GameMode = GameMode.FFA;
+  winnerPlayer: FakePlayer | null = null;
   constructor(
     public land: number,
     public sd: SDConfig,
     public ps: FakePlayer[],
   ) {}
+  getWinner(): FakePlayer | null {
+    return this.winnerPlayer;
+  }
+  winner(): FakePlayer | null {
+    return this.winnerPlayer;
+  }
   ticks(): number {
     return this.now;
   }
@@ -362,6 +369,18 @@ describe("DoomsdayClockExecution (logic)", () => {
     runAt(exec, game, WAVE_TICK + 30);
     expect(a.troops()).toBe(1000); // never drained
     expect(b.troops()).toBeLessThan(1000); // bled
+  });
+
+  it("halts execution and clears doomsday clock flags once a game winner is set", () => {
+    const { game, a, b } = twoPlayerGame(150, 100);
+    const exec = makeExec(game);
+    runAt(exec, game, WAVE_TICK);
+    expect(b.inDoomsdayClock()).toBe(true);
+
+    game.winnerPlayer = a;
+    runAt(exec, game, WAVE_TICK + 10);
+    expect(a.inDoomsdayClock()).toBe(false);
+    expect(b.inDoomsdayClock()).toBe(false);
   });
 
   it("applies to nations like players and excludes map bots", () => {


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4803

## Description:

Instead of keeping the UI active, doomsdayclock is disabled. 1 line of core change plus an improvement change to let it waste execution doing nothing. 

Reasoning: The sandbox afterwards is fun and should be preserved, vast majority of players don't play doomsday for the "vibe" but to avoid excessive stalemates, the sandbox after should still be fun.

## Please complete the following:

- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
