### PR TITLE
fix(devops): stop branch pushes from evicting queued main deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,8 +42,16 @@ on:
 
 permissions: {}
 
+# GitHub keeps only ONE pending run per concurrency group - each new run
+# cancels the previously pending one, even across branches. With a single
+# shared group, a feature-branch push could evict a queued main deploy and
+# main.openfront.dev silently stayed stale until the next merge. So scope the
+# group to the deploy target instead: per branch for pushes, a dedicated group
+# for the nightly, per host for manual dispatches. Runs for different targets
+# may then overlap on the staging host; deploy.sh serializes the host-side
+# update with flock, so only the CI-side image builds actually run in parallel.
 concurrency:
-  group: ${{ github.event_name == 'workflow_dispatch' && inputs.target_host || 'staging' }}
+  group: ${{ github.event_name == 'workflow_dispatch' && inputs.target_host || github.event_name == 'schedule' && 'staging-nightly' || format('staging-{0}', github.ref_name) }}
   cancel-in-progress: false
 
 jobs:

--- a/deploy.sh
+++ b/deploy.sh
@@ -109,7 +109,13 @@ fi
 UPDATE_SCRIPT="./update.sh" # Path to your update script
 REMOTE_USER="openfront"
 REMOTE_UPDATE_PATH="/home/$REMOTE_USER"
-REMOTE_UPDATE_SCRIPT="$REMOTE_UPDATE_PATH/update-openfront.sh" # Where to place the script on server
+# Randomize the remote script name so concurrent deployments (different
+# branches share the staging host) don't overwrite each other's copy while
+# one of them is executing it.
+REMOTE_UPDATE_SCRIPT="$REMOTE_UPDATE_PATH/update-openfront-${SUBDOMAIN}-${RANDOM}.sh"
+# Lock serializing the host-side update (container swap, docker prune) across
+# concurrent deployments to the same host.
+REMOTE_LOCK_FILE="$REMOTE_UPDATE_PATH/update-openfront.lock"
 
 # Check if update script exists
 if [ ! -f "$UPDATE_SCRIPT" ]; then
@@ -164,7 +170,8 @@ OTEL_EXPORTER_OTLP_ENDPOINT=$OTEL_EXPORTER_OTLP_ENDPOINT
 OTEL_AUTH_HEADER=$OTEL_AUTH_HEADER
 EOL
 chmod 600 $ENV_FILE && \
-$REMOTE_UPDATE_SCRIPT $ENV_FILE"
+flock -w 900 $REMOTE_LOCK_FILE $REMOTE_UPDATE_SCRIPT $ENV_FILE && \
+rm -f $REMOTE_UPDATE_SCRIPT"
 
 if [ $? -ne 0 ]; then
     echo "❌ Failed to execute update script on server."


### PR DESCRIPTION
## Description:

Merged PRs sometimes never reached main.openfront.dev. All push-triggered deploy runs shared the single concurrency group `staging`, and GitHub keeps only **one pending run per group** — each new run cancels the previously pending one, *even across branches*. So a feature-branch push could evict a queued main deploy, and main.openfront.dev silently stayed stale until the next merge (the nightly doesn't help — it deploys to nightly.openfront.dev).

Real occurrence (Aug 10): the deploys for #4916 (21:38 UTC) and #4913 (21:39 UTC) were both cancelled after being bumped out of the queue by later pushes; main.openfront.dev only caught up because #4923 happened to merge two minutes later.

### Changes

**`.github/workflows/deploy.yml`** — scope the concurrency group to the deploy target instead of one shared group:

- push → `staging-<branch>` (so only a newer push to the *same* branch supersedes a queued deploy — which is the desired latest-wins behavior)
- nightly schedule → `staging-nightly`
- manual dispatch → per host (unchanged)

**`deploy.sh`** — the old global group was accidentally serializing shared state on the staging host, so make the now-possible overlap safe:

- The remote update script gets a unique per-deploy filename (`update-openfront-<subdomain>-$RANDOM.sh`, same pattern the env file already uses) instead of a fixed path that concurrent deploys overwrote while another might be executing it. Cleaned up after a successful run.
- The host-side update runs under `flock -w 900`, so the container swap and `docker image/container prune` in `update.sh` stay serialized per host. Only the CI-side image builds (the slow part) run in parallel; the 15-min lock wait plus build fits inside the job's 30-min timeout, and the commit.txt readiness poll only starts after the swap completes.

Not touched, but noting: the `VERSION_TAG: latest` env in the Deploy step is dead (`build-deploy.sh` generates its own timestamp tag and shadows it), and `build.sh` tags every build `:latest` — with parallel builds that tag is no longer guaranteed to be the newest push, though nothing in this repo consumes it for deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)