### PR TITLE
fix(devops): keep slashes readable as hyphens in deploy subdomains

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,10 +65,11 @@ jobs:
         run: |
           # A branch name can hold characters that are illegal in a DNS label, a
           # Docker container name, and a file path (e.g. "fix/some-bug"), so
-          # normalize it to an RFC 1123 label first: underscores become hyphens to
-          # keep the name readable, anything else outside [a-zA-Z0-9-] is dropped,
-          # and the result is capped at the 63-octet label limit with no edge hyphens.
-          LABEL="$(printf '%s' "$RAW_SUBDOMAIN" | tr '_' '-' | tr -cd 'a-zA-Z0-9-')"
+          # normalize it to an RFC 1123 label first: underscores and slashes
+          # become hyphens to keep the name readable (fix/some-bug ->
+          # fix-some-bug), anything else outside [a-zA-Z0-9-] is dropped, and the
+          # result is capped at the 63-octet label limit with no edge hyphens.
+          LABEL="$(printf '%s' "$RAW_SUBDOMAIN" | tr '_/' '--' | tr -cd 'a-zA-Z0-9-')"
           LABEL="$(printf '%s' "${LABEL:0:63}" | sed 's/^-*//; s/-*$//')"
           if [ -z "$LABEL" ]; then
             echo "Error: subdomain is empty after sanitizing '$RAW_SUBDOMAIN'"


### PR DESCRIPTION
## Description:

The deploy sanitize step (#4878) drops any character outside `[a-zA-Z0-9-]`, so slash branch names lose their word boundary in the deploy URL: `fix/game-end-doomsday` currently deploys to `fixgame-end-doomsday-6613ad.openfront.dev`.

This translates `/` to `-` the same way `_` already is, so the same branch deploys to `fix-game-end-doomsday-6613ad.openfront.dev` instead.

### Behavior notes

- The 6-char hash suffix still applies whenever normalization altered the name — it's what keeps `fix/foo` and `fix-foo` on distinct hosts, so it can't be dropped.
- Names that pass through untouched (`main`, `nightly`, hand-typed prod subdomains) still keep their exact spelling, which `update.sh` relies on for its `SUBDOMAIN = main` restart check.
- Existing slash-branch containers on the staging host keep their old names until their branch is next pushed; the orphaned ones run with `restart=no` and die off on their own (same transition as when #4878 first changed the naming).

Sanitize-step mapping, simulated against representative names:

| Branch | Before | After |
| --- | --- | --- |
| `fix/game-end-doomsday` | `fixgame-end-doomsday-6613ad` | `fix-game-end-doomsday-6613ad` |
| `dependabot/npm_and_yarn/npm_and_yarn-aee2e42890` | `dependabotnpm-and-yarnnpm-and-yarn-aee2e42890-f4d323` | `dependabot-npm-and-yarn-npm-and-yarn-aee2e42890-f4d323` |
| `feat/UI_polish` | `featUI-polish-add197` | `feat-UI-polish-add197` |
| `main` / `nightly` / `v33-hot-patch` | unchanged | unchanged |

🤖 Generated with [Claude Code](https://claude.com/claude-code)