### PR TITLE
Replay archived games from older builds via versioned CDN shells

### DIFF
--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -9,7 +9,7 @@ import {
   renderDuration,
   translateText,
 } from "../client/Utils";
-import { assetUrl, getCdnBase } from "../core/AssetUrls";
+import { assetUrl } from "../core/AssetUrls";
 import { EventBus } from "../core/EventBus";
 import {
   ClientInfo,
@@ -1189,7 +1189,11 @@ export class JoinLobbyModal extends BaseModal {
     if (isVersionedReplayPage(window.location.pathname)) {
       return false;
     }
-    const url = versionedReplayUrl(getCdnBase(), recordCommit, lobbyId);
+    const url = versionedReplayUrl(
+      ClientEnv.jwtAudience(),
+      recordCommit,
+      lobbyId,
+    );
     if (url === null) {
       return false;
     }

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -9,7 +9,7 @@ import {
   renderDuration,
   translateText,
 } from "../client/Utils";
-import { assetUrl } from "../core/AssetUrls";
+import { assetUrl, getCdnBase } from "../core/AssetUrls";
 import { EventBus } from "../core/EventBus";
 import {
   ClientInfo,
@@ -33,6 +33,7 @@ import { PublicLobbySocket } from "./LobbySocket";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 import { normaliseMapKey } from "./Utils";
+import { isVersionedReplayPage, versionedReplayUrl } from "./VersionedReplay";
 import { BaseModal } from "./components/BaseModal";
 import "./components/CopyButton";
 import "./components/LobbyConfigItem";
@@ -399,6 +400,9 @@ export class JoinLobbyModal extends BaseModal {
       // Active lobby not found, check if it's an archived game
       switch (await this.checkArchivedGame(lobbyId)) {
         case "success":
+          return;
+        case "redirected":
+          // Navigating to the versioned replay shell; leave state as-is.
           return;
         case "not_found":
           this.resetTrackingState();
@@ -1037,6 +1041,9 @@ export class JoinLobbyModal extends BaseModal {
       switch (await this.checkArchivedGame(lobbyId)) {
         case "success":
           return;
+        case "redirected":
+          // Navigating to the versioned replay shell; leave state as-is.
+          return;
         case "not_found":
           this.resetTrackingState();
           this.showMessage(translateText("private_lobby.not_found"), "red");
@@ -1117,7 +1124,9 @@ export class JoinLobbyModal extends BaseModal {
 
   private async checkArchivedGame(
     lobbyId: string,
-  ): Promise<"success" | "not_found" | "version_mismatch" | "error"> {
+  ): Promise<
+    "success" | "redirected" | "not_found" | "version_mismatch" | "error"
+  > {
     const archiveResponse = await fetch(`${getApiBase()}/game/${lobbyId}`, {
       method: "GET",
       headers: {
@@ -1145,6 +1154,9 @@ export class JoinLobbyModal extends BaseModal {
         `Git commit hash mismatch for game ${safeLobbyId}`,
         archiveData.details,
       );
+      if (await this.redirectToVersionedShell(parsed.data.gitCommit, lobbyId)) {
+        return "redirected";
+      }
       return "version_mismatch";
     }
 
@@ -1163,5 +1175,37 @@ export class JoinLobbyModal extends BaseModal {
       }),
     );
     return "success";
+  }
+
+  // The record was produced by a different build. A matching versioned shell
+  // (index-<short-commit>.html, uploaded by update.sh on every deploy) may
+  // exist on the CDN; if so, navigate there and let that build replay the game
+  // (#4934). The probe requires text/html because shells uploaded before the
+  // API stored HTML with a real content type would download instead of render.
+  private async redirectToVersionedShell(
+    recordCommit: string,
+    lobbyId: string,
+  ): Promise<boolean> {
+    if (isVersionedReplayPage(window.location.pathname)) {
+      return false;
+    }
+    const url = versionedReplayUrl(getCdnBase(), recordCommit, lobbyId);
+    if (url === null) {
+      return false;
+    }
+    try {
+      const probe = await fetch(url.split("#")[0], { method: "HEAD" });
+      if (!probe.ok) {
+        return false;
+      }
+      const contentType = probe.headers.get("content-type") ?? "";
+      if (!contentType.includes("text/html")) {
+        return false;
+      }
+    } catch {
+      return false;
+    }
+    window.location.href = url;
+    return true;
   }
 }

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -33,7 +33,7 @@ import { PublicLobbySocket } from "./LobbySocket";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 import { normaliseMapKey } from "./Utils";
-import { isVersionedReplayPage, versionedReplayUrl } from "./VersionedReplay";
+import { isReplayShellHost, versionedReplayUrl } from "./VersionedReplay";
 import { BaseModal } from "./components/BaseModal";
 import "./components/CopyButton";
 import "./components/LobbyConfigItem";
@@ -1154,7 +1154,7 @@ export class JoinLobbyModal extends BaseModal {
         `Git commit hash mismatch for game ${safeLobbyId}`,
         archiveData.details,
       );
-      if (await this.redirectToVersionedShell(parsed.data.gitCommit, lobbyId)) {
+      if (await this.redirectToVersionedShell(lobbyId)) {
         return "redirected";
       }
       return "version_mismatch";
@@ -1177,28 +1177,21 @@ export class JoinLobbyModal extends BaseModal {
     return "success";
   }
 
-  // The record was produced by a different build. A matching versioned shell
-  // (index-<short-commit>.html, uploaded by update.sh on every deploy) may
-  // exist on the CDN; if so, navigate there and let that build replay the game
-  // (#4934). The probe requires text/html because shells uploaded before the
-  // API stored HTML with a real content type would download instead of render.
-  private async redirectToVersionedShell(
-    recordCommit: string,
-    lobbyId: string,
-  ): Promise<boolean> {
-    if (isVersionedReplayPage(window.location.pathname)) {
+  // The record was produced by a different build. replay.<domain>/<gameId>
+  // serves the matching versioned shell (uploaded by update.sh on every
+  // deploy); if it exists, navigate there and let that build replay the game
+  // (#4934). The probe requires text/html so a misrouted host that answers
+  // 200 with something else can't strand the player on a broken page.
+  private async redirectToVersionedShell(lobbyId: string): Promise<boolean> {
+    if (isReplayShellHost(window.location.hostname)) {
       return false;
     }
-    const url = versionedReplayUrl(
-      ClientEnv.jwtAudience(),
-      recordCommit,
-      lobbyId,
-    );
+    const url = versionedReplayUrl(ClientEnv.jwtAudience(), lobbyId);
     if (url === null) {
       return false;
     }
     try {
-      const probe = await fetch(url.split("#")[0], { method: "HEAD" });
+      const probe = await fetch(url, { method: "HEAD" });
       if (!probe.ok) {
         return false;
       }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1040,18 +1040,32 @@ class Client {
       crazyGamesSDK.gameplayStart();
       document.body.classList.add("in-game");
 
-      // Ensure there's a homepage entry in history before adding the lobby entry
-      if (window.location.hash === "" || window.location.hash === "#") {
-        history.replaceState(null, "", window.location.origin + "#refresh");
-      }
       const lobbyIdHidden = !this.userSettings.lobbyIdVisibility();
-      history.pushState(
-        null,
-        "",
-        lobbyIdHidden
-          ? "/streamer-mode"
-          : `/${ClientEnv.workerPath(lobby.gameID)}/game/${lobby.gameID}?live`,
-      );
+      if (isVersionedReplayPage(window.location.pathname)) {
+        // Keep the versioned shell pathname: /game/<id> and the #refresh
+        // trampoline only exist on the game-server origin, so rewriting here
+        // would leave a URL that 404s on the CDN when reloaded or shared.
+        // #join= is the shell's own join URL shape (see VersionedReplay.ts).
+        history.pushState(
+          null,
+          "",
+          lobbyIdHidden
+            ? window.location.pathname
+            : `${window.location.pathname}#join=${lobby.gameID}`,
+        );
+      } else {
+        // Ensure there's a homepage entry in history before adding the lobby entry
+        if (window.location.hash === "" || window.location.hash === "#") {
+          history.replaceState(null, "", window.location.origin + "#refresh");
+        }
+        history.pushState(
+          null,
+          "",
+          lobbyIdHidden
+            ? "/streamer-mode"
+            : `/${ClientEnv.workerPath(lobby.gameID)}/game/${lobby.gameID}?live`,
+        );
+      }
 
       // Store current URL for popstate confirmation
       this.currentUrl = window.location.href;
@@ -1060,9 +1074,20 @@ class Client {
 
   private updateJoinUrlForShare(lobbyId: string) {
     const lobbyIdHidden = !this.userSettings.lobbyIdVisibility();
-    const targetUrl = lobbyIdHidden
-      ? "/streamer-mode"
-      : `/${ClientEnv.workerPath(lobbyId)}/game/${lobbyId}`;
+    let targetUrl: string;
+    if (isVersionedReplayPage(window.location.pathname)) {
+      // Keep the versioned shell pathname: /game/<id> only exists on the
+      // game-server origin, so rewriting here would leave a URL that 404s on
+      // the CDN when reloaded or shared. #join= is the shell's own join URL
+      // shape (see VersionedReplay.ts).
+      targetUrl = lobbyIdHidden
+        ? window.location.pathname
+        : `${window.location.pathname}#join=${lobbyId}`;
+    } else if (lobbyIdHidden) {
+      targetUrl = "/streamer-mode";
+    } else {
+      targetUrl = `/${ClientEnv.workerPath(lobbyId)}/game/${lobbyId}`;
+    }
     const currentUrl = window.location.pathname;
 
     if (currentUrl !== targetUrl) {

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -77,6 +77,7 @@ import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
 import { genAnonUsername, UsernameInput } from "./UsernameInput";
 import { incrementGamesPlayed, isInIframe, translateText } from "./Utils";
+import { isVersionedReplayPage } from "./VersionedReplay";
 import "./components/BannedModal";
 import "./components/MarketingConsentToast";
 import { installSafariPinchZoomBlocker } from "./utilities/DisableSafariPinchZoom";
@@ -249,9 +250,15 @@ class Client {
     // Prefetch turnstile token so it is available when the user joins a lobby.
     // Desktop (Steam) has no Turnstile script and is server-side exempt, so
     // skip it — otherwise getTurnstileToken() throws "Failed to load Turnstile
-    // script" after its load wait.
+    // script" after its load wait. Also skip on the versioned replay shells:
+    // the CDN origin is not on the Turnstile site key's domain allowlist, so
+    // rendering the widget there alerts and rejects — and replays never send
+    // a token anyway (see getTurnstileToken below).
     this.turnstileTokenPromise =
-      ClientEnv.instanceId() === "desktop" ? null : getTurnstileToken();
+      ClientEnv.instanceId() === "desktop" ||
+      isVersionedReplayPage(window.location.pathname)
+        ? null
+        : getTurnstileToken();
 
     // Wait for components to render before setting version
     await customElements.whenDefined("mobile-nav-bar");
@@ -813,6 +820,17 @@ class Client {
       return;
     }
 
+    // #join=<gameId>: hash-based equivalent of the /game/<id> path below, used
+    // by the versioned replay shells on the CDN, where there is no path
+    // routing (see VersionedReplay.ts).
+    const joinMatch = decodedHash.match(/^#join=(.*)$/);
+    if (joinMatch && GAME_ID_REGEX.test(joinMatch[1])) {
+      window.showPage?.("page-join-lobby");
+      this.joinModal.open({ lobbyId: joinMatch[1] });
+      console.log(`joining lobby ${joinMatch[1]} from hash`);
+      return;
+    }
+
     const pathMatch = window.location.pathname.match(
       /^\/(?:w\d+\/)?game\/([^/]+)/,
     );
@@ -1146,7 +1164,11 @@ class Client {
     if (
       ClientEnv.env() === GameEnv.Dev ||
       ClientEnv.instanceId() === "desktop" ||
-      lobby.gameStartInfo?.config.gameType === GameType.Singleplayer
+      lobby.gameStartInfo?.config.gameType === GameType.Singleplayer ||
+      // Replays simulate locally from the archived record; there is no
+      // server to verify a token (and on the CDN replay shells Turnstile
+      // cannot load at all).
+      lobby.gameRecord !== undefined
     ) {
       return null;
     }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -77,7 +77,7 @@ import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
 import { genAnonUsername, UsernameInput } from "./UsernameInput";
 import { incrementGamesPlayed, isInIframe, translateText } from "./Utils";
-import { isVersionedReplayPage } from "./VersionedReplay";
+import { isReplayShellHost } from "./VersionedReplay";
 import "./components/BannedModal";
 import "./components/MarketingConsentToast";
 import { installSafariPinchZoomBlocker } from "./utilities/DisableSafariPinchZoom";
@@ -251,12 +251,12 @@ class Client {
     // Desktop (Steam) has no Turnstile script and is server-side exempt, so
     // skip it — otherwise getTurnstileToken() throws "Failed to load Turnstile
     // script" after its load wait. Also skip on the versioned replay shells:
-    // the CDN origin is not on the Turnstile site key's domain allowlist, so
-    // rendering the widget there alerts and rejects — and replays never send
-    // a token anyway (see getTurnstileToken below).
+    // the replay host may not be on the Turnstile site key's domain allowlist,
+    // so rendering the widget there alerts and rejects — and replays never
+    // send a token anyway (see getTurnstileToken below).
     this.turnstileTokenPromise =
       ClientEnv.instanceId() === "desktop" ||
-      isVersionedReplayPage(window.location.pathname)
+      isReplayShellHost(window.location.hostname)
         ? null
         : getTurnstileToken();
 
@@ -820,15 +820,17 @@ class Client {
       return;
     }
 
-    // #join=<gameId>: hash-based equivalent of the /game/<id> path below, used
-    // by the versioned replay shells on the CDN, where there is no path
-    // routing (see VersionedReplay.ts).
-    const joinMatch = decodedHash.match(/^#join=(.*)$/);
-    if (joinMatch && GAME_ID_REGEX.test(joinMatch[1])) {
-      window.showPage?.("page-join-lobby");
-      this.joinModal.open({ lobbyId: joinMatch[1] });
-      console.log(`joining lobby ${joinMatch[1]} from hash`);
-      return;
+    // On a versioned replay shell the pathname IS the game id: the worker
+    // serves the record's matching build at replay.<domain>/<gameId> (see
+    // VersionedReplay.ts).
+    if (isReplayShellHost(window.location.hostname)) {
+      const replayGameId = window.location.pathname.slice(1);
+      if (GAME_ID_REGEX.test(replayGameId)) {
+        window.showPage?.("page-join-lobby");
+        this.joinModal.open({ lobbyId: replayGameId });
+        console.log(`joining replay ${replayGameId}`);
+        return;
+      }
     }
 
     const pathMatch = window.location.pathname.match(
@@ -1041,18 +1043,12 @@ class Client {
       document.body.classList.add("in-game");
 
       const lobbyIdHidden = !this.userSettings.lobbyIdVisibility();
-      if (isVersionedReplayPage(window.location.pathname)) {
-        // Keep the versioned shell pathname: /game/<id> and the #refresh
-        // trampoline only exist on the game-server origin, so rewriting here
-        // would leave a URL that 404s on the CDN when reloaded or shared.
-        // #join= is the shell's own join URL shape (see VersionedReplay.ts).
-        history.pushState(
-          null,
-          "",
-          lobbyIdHidden
-            ? window.location.pathname
-            : `${window.location.pathname}#join=${lobby.gameID}`,
-        );
+      if (isReplayShellHost(window.location.hostname)) {
+        // Keep the canonical replay URL (replay.<domain>/<gameId>): the
+        // /game/<id> shape and the #refresh trampoline only exist on the
+        // game-server origin, so rewriting here would leave a URL that 404s
+        // when reloaded or shared (see VersionedReplay.ts).
+        history.pushState(null, "", window.location.pathname);
       } else {
         // Ensure there's a homepage entry in history before adding the lobby entry
         if (window.location.hash === "" || window.location.hash === "#") {
@@ -1075,14 +1071,12 @@ class Client {
   private updateJoinUrlForShare(lobbyId: string) {
     const lobbyIdHidden = !this.userSettings.lobbyIdVisibility();
     let targetUrl: string;
-    if (isVersionedReplayPage(window.location.pathname)) {
-      // Keep the versioned shell pathname: /game/<id> only exists on the
-      // game-server origin, so rewriting here would leave a URL that 404s on
-      // the CDN when reloaded or shared. #join= is the shell's own join URL
-      // shape (see VersionedReplay.ts).
-      targetUrl = lobbyIdHidden
-        ? window.location.pathname
-        : `${window.location.pathname}#join=${lobbyId}`;
+    if (isReplayShellHost(window.location.hostname)) {
+      // Keep the canonical replay URL (replay.<domain>/<gameId>): the
+      // /game/<id> shape only exists on the game-server origin, so rewriting
+      // here would leave a URL that 404s when reloaded or shared (see
+      // VersionedReplay.ts).
+      targetUrl = window.location.pathname;
     } else if (lobbyIdHidden) {
       targetUrl = "/streamer-mode";
     } else {

--- a/src/client/VersionedReplay.ts
+++ b/src/client/VersionedReplay.ts
@@ -1,10 +1,10 @@
 // Versioned app shells let archived games from older builds be replayed after
 // their deployment is gone (#4934). Every deploy uploads a fully-rendered
-// index-<short-commit>.html next to the hashed assets on the CDN (see
-// update.sh); when a replay's record was produced by a different build, the
-// client navigates to the matching shell, whose baked gitCommit satisfies the
-// version check and whose bundle simulates the game with the rules it was
-// played under.
+// index-<short-commit>.html next to the hashed assets in the public bucket
+// (see update.sh), and the API worker serves it on replay.<domain>; when a
+// replay's record was produced by a different build, the client navigates to
+// the matching shell, whose baked gitCommit satisfies the version check and
+// whose bundle simulates the game with the rules it was played under.
 
 import { GameID } from "../core/Schemas";
 
@@ -12,18 +12,19 @@ import { GameID } from "../core/Schemas";
 const SHORT_COMMIT_LENGTH = 7;
 
 // URL of the versioned shell for a game record, with the game id in the hash
-// (#join=<id>, handled in Main.ts) because static CDN hosting has no path
-// routing. Null when no shell can exist: no CDN configured (dev), or the
-// record's commit is not a full SHA (e.g. "DEV").
+// (#join=<id>, handled in Main.ts) because static shell hosting has no path
+// routing. The replay host derives from the JWT audience exactly like
+// getApiBase() derives api.<audience>. Null when no shell can exist: dev
+// (localhost audience), or the record's commit is not a full SHA (e.g. "DEV").
 export function versionedReplayUrl(
-  cdnBase: string,
+  audience: string,
   recordCommit: string,
   gameID: GameID,
 ): string | null {
-  if (cdnBase === "") return null;
+  if (audience === "" || audience === "localhost") return null;
   if (!/^[0-9a-f]{40}$/.test(recordCommit)) return null;
   const shortCommit = recordCommit.slice(0, SHORT_COMMIT_LENGTH);
-  return `${cdnBase.replace(/\/+$/, "")}/index-${shortCommit}.html#join=${gameID}`;
+  return `https://replay.${audience}/index-${shortCommit}.html#join=${gameID}`;
 }
 
 // True when the current document is itself a versioned shell. Used to stop a

--- a/src/client/VersionedReplay.ts
+++ b/src/client/VersionedReplay.ts
@@ -1,0 +1,34 @@
+// Versioned app shells let archived games from older builds be replayed after
+// their deployment is gone (#4934). Every deploy uploads a fully-rendered
+// index-<short-commit>.html next to the hashed assets on the CDN (see
+// update.sh); when a replay's record was produced by a different build, the
+// client navigates to the matching shell, whose baked gitCommit satisfies the
+// version check and whose bundle simulates the game with the rules it was
+// played under.
+
+import { GameID } from "../core/Schemas";
+
+// update.sh derives the same prefix from commit.txt with ${FULL_COMMIT:0:7}.
+const SHORT_COMMIT_LENGTH = 7;
+
+// URL of the versioned shell for a game record, with the game id in the hash
+// (#join=<id>, handled in Main.ts) because static CDN hosting has no path
+// routing. Null when no shell can exist: no CDN configured (dev), or the
+// record's commit is not a full SHA (e.g. "DEV").
+export function versionedReplayUrl(
+  cdnBase: string,
+  recordCommit: string,
+  gameID: GameID,
+): string | null {
+  if (cdnBase === "") return null;
+  if (!/^[0-9a-f]{40}$/.test(recordCommit)) return null;
+  const shortCommit = recordCommit.slice(0, SHORT_COMMIT_LENGTH);
+  return `${cdnBase.replace(/\/+$/, "")}/index-${shortCommit}.html#join=${gameID}`;
+}
+
+// True when the current document is itself a versioned shell. Used to stop a
+// second redirect: if the record still mismatches there (e.g. a short-commit
+// collision), redirecting again would loop forever.
+export function isVersionedReplayPage(pathname: string): boolean {
+  return /\/index-[0-9a-f]+\.html$/.test(pathname);
+}

--- a/src/client/VersionedReplay.ts
+++ b/src/client/VersionedReplay.ts
@@ -1,35 +1,28 @@
 // Versioned app shells let archived games from older builds be replayed after
 // their deployment is gone (#4934). Every deploy uploads a fully-rendered
 // index-<short-commit>.html next to the hashed assets in the public bucket
-// (see update.sh), and the API worker serves it on replay.<domain>; when a
-// replay's record was produced by a different build, the client navigates to
-// the matching shell, whose baked gitCommit satisfies the version check and
-// whose bundle simulates the game with the rules it was played under.
+// (see update.sh). The API worker serves them on replay.<domain>, with
+// replay.<domain>/<gameId> as the canonical URL: the worker resolves the
+// archived record's gitCommit and serves the matching shell there, so a
+// mismatched replay just navigates to that URL and the shell's build
+// simulates the game with the rules it was played under.
 
 import { GameID } from "../core/Schemas";
 
-// update.sh derives the same prefix from commit.txt with ${FULL_COMMIT:0:7}.
-const SHORT_COMMIT_LENGTH = 7;
-
-// URL of the versioned shell for a game record, with the game id in the hash
-// (#join=<id>, handled in Main.ts) because static shell hosting has no path
-// routing. The replay host derives from the JWT audience exactly like
-// getApiBase() derives api.<audience>. Null when no shell can exist: dev
-// (localhost audience), or the record's commit is not a full SHA (e.g. "DEV").
+// Canonical replay URL for a game. The replay host derives from the JWT
+// audience exactly like getApiBase() derives api.<audience>. Null in dev
+// (localhost audience), where no replay host exists.
 export function versionedReplayUrl(
   audience: string,
-  recordCommit: string,
   gameID: GameID,
 ): string | null {
   if (audience === "" || audience === "localhost") return null;
-  if (!/^[0-9a-f]{40}$/.test(recordCommit)) return null;
-  const shortCommit = recordCommit.slice(0, SHORT_COMMIT_LENGTH);
-  return `https://replay.${audience}/index-${shortCommit}.html#join=${gameID}`;
+  return `https://replay.${audience}/${gameID}`;
 }
 
-// True when the current document is itself a versioned shell. Used to stop a
-// second redirect: if the record still mismatches there (e.g. a short-commit
-// collision), redirecting again would loop forever.
-export function isVersionedReplayPage(pathname: string): boolean {
-  return /\/index-[0-9a-f]+\.html$/.test(pathname);
+// True when the current document is served from a replay shell host. Used to
+// stop a second redirect (if the record still mismatches on the shell,
+// redirecting again would loop forever) and to keep shell URLs intact.
+export function isReplayShellHost(hostname: string): boolean {
+  return hostname.startsWith("replay.");
 }

--- a/src/server/RenderStaticIndex.ts
+++ b/src/server/RenderStaticIndex.ts
@@ -1,0 +1,18 @@
+// Renders the app shell exactly as the running server would - same env, same
+// asset manifest, same EJS template - and writes it to stdout. update.sh runs
+// this inside the freshly built image at deploy time and uploads the result to
+// the CDN as index-<short-commit>.html, so games archived from this build stay
+// replayable after the deployment itself is gone (#4934).
+import path from "path";
+import { fileURLToPath } from "url";
+import { renderHtmlContent } from "./RenderHtml";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+renderHtmlContent(path.join(__dirname, "../../static/index.html")).then(
+  (html) => process.stdout.write(html),
+  (error: unknown) => {
+    console.error("Failed to render static index:", error);
+    process.exit(1);
+  },
+);

--- a/tests/VersionedReplay.test.ts
+++ b/tests/VersionedReplay.test.ts
@@ -1,44 +1,37 @@
 import {
-  isVersionedReplayPage,
+  isReplayShellHost,
   versionedReplayUrl,
 } from "../src/client/VersionedReplay";
 
-const COMMIT = "0847945e3b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e";
-
 describe("versionedReplayUrl", () => {
-  test("builds the replay-host URL from the audience, short commit, and game id", () => {
-    expect(versionedReplayUrl("openfront.io", COMMIT, "abcd1234")).toBe(
-      "https://replay.openfront.io/index-0847945.html#join=abcd1234",
+  test("builds the canonical replay URL from the audience and game id", () => {
+    expect(versionedReplayUrl("openfront.io", "abcd1234")).toBe(
+      "https://replay.openfront.io/abcd1234",
     );
-    expect(versionedReplayUrl("openfront.dev", COMMIT, "abcd1234")).toBe(
-      "https://replay.openfront.dev/index-0847945.html#join=abcd1234",
+    expect(versionedReplayUrl("openfront.dev", "abcd1234")).toBe(
+      "https://replay.openfront.dev/abcd1234",
     );
   });
 
   test("returns null in dev (localhost or empty audience)", () => {
-    expect(versionedReplayUrl("localhost", COMMIT, "abcd1234")).toBeNull();
-    expect(versionedReplayUrl("", COMMIT, "abcd1234")).toBeNull();
+    expect(versionedReplayUrl("localhost", "abcd1234")).toBeNull();
+    expect(versionedReplayUrl("", "abcd1234")).toBeNull();
   });
-
-  test.each(["DEV", "unknown", "0847945", COMMIT.toUpperCase()])(
-    "returns null when the record commit is not a full SHA (%s)",
-    (commit) => {
-      expect(versionedReplayUrl("openfront.io", commit, "abcd1234")).toBeNull();
-    },
-  );
 });
 
-describe("isVersionedReplayPage", () => {
-  test("matches the pathname of a generated shell URL (loop guard)", () => {
-    const url = versionedReplayUrl("openfront.io", COMMIT, "abcd1234");
+describe("isReplayShellHost", () => {
+  test("matches the hostname of a generated replay URL (loop guard)", () => {
+    const url = versionedReplayUrl("openfront.io", "abcd1234");
     expect(url).not.toBeNull();
-    expect(isVersionedReplayPage(new URL(url!).pathname)).toBe(true);
+    expect(isReplayShellHost(new URL(url!).hostname)).toBe(true);
   });
 
-  test.each(["/", "/index.html", "/game/abcd1234"])(
-    "does not match ordinary app URLs (%s)",
-    (pathname) => {
-      expect(isVersionedReplayPage(pathname)).toBe(false);
-    },
-  );
+  test.each([
+    "openfront.io",
+    "main.openfront.dev",
+    "localhost",
+    "cdn.ofedge.dev",
+  ])("does not match ordinary app hosts (%s)", (hostname) => {
+    expect(isReplayShellHost(hostname)).toBe(false);
+  });
 });

--- a/tests/VersionedReplay.test.ts
+++ b/tests/VersionedReplay.test.ts
@@ -6,55 +6,31 @@ import {
 const COMMIT = "0847945e3b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e";
 
 describe("versionedReplayUrl", () => {
-  test("builds the shell URL from the short commit and game id", () => {
-    expect(
-      versionedReplayUrl(
-        "https://cdn.ofedge.io/game_assets",
-        COMMIT,
-        "abcd1234",
-      ),
-    ).toBe(
-      "https://cdn.ofedge.io/game_assets/index-0847945.html#join=abcd1234",
+  test("builds the replay-host URL from the audience, short commit, and game id", () => {
+    expect(versionedReplayUrl("openfront.io", COMMIT, "abcd1234")).toBe(
+      "https://replay.openfront.io/index-0847945.html#join=abcd1234",
+    );
+    expect(versionedReplayUrl("openfront.dev", COMMIT, "abcd1234")).toBe(
+      "https://replay.openfront.dev/index-0847945.html#join=abcd1234",
     );
   });
 
-  test("trims trailing slashes from the CDN base", () => {
-    expect(
-      versionedReplayUrl(
-        "https://cdn.ofedge.io/game_assets/",
-        COMMIT,
-        "abcd1234",
-      ),
-    ).toBe(
-      "https://cdn.ofedge.io/game_assets/index-0847945.html#join=abcd1234",
-    );
-  });
-
-  test("returns null without a CDN base (dev)", () => {
+  test("returns null in dev (localhost or empty audience)", () => {
+    expect(versionedReplayUrl("localhost", COMMIT, "abcd1234")).toBeNull();
     expect(versionedReplayUrl("", COMMIT, "abcd1234")).toBeNull();
   });
 
   test.each(["DEV", "unknown", "0847945", COMMIT.toUpperCase()])(
     "returns null when the record commit is not a full SHA (%s)",
     (commit) => {
-      expect(
-        versionedReplayUrl(
-          "https://cdn.ofedge.io/game_assets",
-          commit,
-          "abcd1234",
-        ),
-      ).toBeNull();
+      expect(versionedReplayUrl("openfront.io", commit, "abcd1234")).toBeNull();
     },
   );
 });
 
 describe("isVersionedReplayPage", () => {
   test("matches the pathname of a generated shell URL (loop guard)", () => {
-    const url = versionedReplayUrl(
-      "https://cdn.ofedge.io/game_assets",
-      COMMIT,
-      "abcd1234",
-    );
+    const url = versionedReplayUrl("openfront.io", COMMIT, "abcd1234");
     expect(url).not.toBeNull();
     expect(isVersionedReplayPage(new URL(url!).pathname)).toBe(true);
   });

--- a/tests/VersionedReplay.test.ts
+++ b/tests/VersionedReplay.test.ts
@@ -1,0 +1,68 @@
+import {
+  isVersionedReplayPage,
+  versionedReplayUrl,
+} from "../src/client/VersionedReplay";
+
+const COMMIT = "0847945e3b1c2d3e4f5a6b7c8d9e0f1a2b3c4d5e";
+
+describe("versionedReplayUrl", () => {
+  test("builds the shell URL from the short commit and game id", () => {
+    expect(
+      versionedReplayUrl(
+        "https://cdn.ofedge.io/game_assets",
+        COMMIT,
+        "abcd1234",
+      ),
+    ).toBe(
+      "https://cdn.ofedge.io/game_assets/index-0847945.html#join=abcd1234",
+    );
+  });
+
+  test("trims trailing slashes from the CDN base", () => {
+    expect(
+      versionedReplayUrl(
+        "https://cdn.ofedge.io/game_assets/",
+        COMMIT,
+        "abcd1234",
+      ),
+    ).toBe(
+      "https://cdn.ofedge.io/game_assets/index-0847945.html#join=abcd1234",
+    );
+  });
+
+  test("returns null without a CDN base (dev)", () => {
+    expect(versionedReplayUrl("", COMMIT, "abcd1234")).toBeNull();
+  });
+
+  test.each(["DEV", "unknown", "0847945", COMMIT.toUpperCase()])(
+    "returns null when the record commit is not a full SHA (%s)",
+    (commit) => {
+      expect(
+        versionedReplayUrl(
+          "https://cdn.ofedge.io/game_assets",
+          commit,
+          "abcd1234",
+        ),
+      ).toBeNull();
+    },
+  );
+});
+
+describe("isVersionedReplayPage", () => {
+  test("matches the pathname of a generated shell URL (loop guard)", () => {
+    const url = versionedReplayUrl(
+      "https://cdn.ofedge.io/game_assets",
+      COMMIT,
+      "abcd1234",
+    );
+    expect(url).not.toBeNull();
+    expect(isVersionedReplayPage(new URL(url!).pathname)).toBe(true);
+  });
+
+  test.each(["/", "/index.html", "/game/abcd1234"])(
+    "does not match ordinary app URLs (%s)",
+    (pathname) => {
+      expect(isVersionedReplayPage(pathname)).toBe(false);
+    },
+  );
+});

--- a/update.sh
+++ b/update.sh
@@ -146,6 +146,44 @@ else
     echo "✅ Uploaded $MISSING_COUNT asset(s) to R2."
 fi
 
+# Publish a fully-rendered app shell as index-<short-commit>.html next to the
+# hashed assets, so games archived from this build can still be replayed after
+# this deployment is torn down (#4934). Old clients find it via the same short
+# prefix of the record's gitCommit (see src/client/VersionedReplay.ts).
+# Rendered inside the image with the same env file the live container gets, so
+# the baked BOOTSTRAP_CONFIG matches what the server would have served.
+FULL_COMMIT="$(tr -d '[:space:]' < "$STATIC_DIR/commit.txt" 2> /dev/null || true)"
+if [[ ! "$FULL_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "⚠️ Skipping versioned index upload: commit.txt is not a full SHA ('$FULL_COMMIT')"
+else
+    INDEX_KEY="index-${FULL_COMMIT:0:7}.html"
+    echo "Rendering $INDEX_KEY..."
+    if ! docker run --rm --env-file "$ENV_FILE" --entrypoint npx \
+        "${GHCR_IMAGE}" tsx src/server/RenderStaticIndex.ts \
+        > "$EXTRACT_DIR/$INDEX_KEY"; then
+        echo "❌ Failed to render $INDEX_KEY"
+        exit 1
+    fi
+    # Guard against uploading an empty or non-shell document (e.g. a renderer
+    # crash that still exited 0 upstream of the redirect).
+    if ! grep -q "BOOTSTRAP_CONFIG" "$EXTRACT_DIR/$INDEX_KEY"; then
+        echo "❌ Rendered $INDEX_KEY looks wrong (no BOOTSTRAP_CONFIG)"
+        exit 1
+    fi
+    if ! curl -fsS \
+        --retry 5 --retry-all-errors --retry-delay 2 \
+        --connect-timeout 10 --max-time 120 \
+        -X PUT \
+        "$R2_ENDPOINT/game_assets/upload/$INDEX_KEY" \
+        -H "X-API-Key: $API_KEY" \
+        -H "Content-Type: application/octet-stream" \
+        --data-binary "@$EXTRACT_DIR/$INDEX_KEY" > /dev/null; then
+        echo "❌ Failed to upload $INDEX_KEY"
+        exit 1
+    fi
+    echo "✅ Uploaded $INDEX_KEY."
+fi
+
 echo "Checking for existing container..."
 # Use docker ps with filter for exact name match
 RUNNING_CONTAINER="$(docker ps --filter "name=^${CONTAINER_NAME}$" -q)"


### PR DESCRIPTION
Fixes #4934

Archived games can only be replayed by the exact build that produced them - the client refuses mismatched `gitCommit`s because the deterministic sim would desync. Once a deployment is replaced, its games become unwatchable. This PR keeps every build replayable by publishing a static, self-contained copy of the app shell per deploy and redirecting mismatched replays to it.

## Upload side (`update.sh` + `RenderStaticIndex.ts`)

After the existing asset upload, the deploy renders the app shell inside the freshly built image (`docker run --entrypoint npx <image> tsx src/server/RenderStaticIndex.ts`, a thin wrapper around the server's own `renderHtmlContent`) using the same env file the live container gets, so the baked `BOOTSTRAP_CONFIG` (gitCommit, cdnBase, jwtAudience, ...) matches what the server would have served. The result is PUT to R2 as `index-<short-commit>.html` next to the hashed assets it references. Since hashed assets are immutable and never deleted, the shell + CDN + API are enough to replay - no game server involved.

## Redirect side

The canonical replay URL is **`https://replay.<domain>/<gameId>`** (openfrontio/infra#514): the API worker reads the archived record's `gitCommit` and serves the matching shell at that URL, so the address players see and share carries only the game id. The client derives the host from the JWT audience, exactly like `getApiBase()` derives `api.<audience>` - no new config.

- `JoinLobbyModal.checkArchivedGame`: on commit mismatch, HEAD-probe `replay.<audience>/<gameId>` and navigate there. The probe requires 200 **and** `text/html`; games from builds that predate this feature 404 (no shell uploaded) and fall back to the existing version-mismatch message.
- `Main.ts`: on a replay shell host the pathname IS the game id - the shell parses it and starts the join flow. The active-lobby check fails harmlessly (relative URL), the archive fetch succeeds (`replay.<aud>` is covered by the API's subdomain CORS rule), the commit matches, and the replay runs locally.
- The canonical URL is preserved through join and game start (reload/share keeps working); non-shell pages keep the existing `/game/<id>` URL behavior.
- `VersionedReplay.ts`: pure URL helpers, unit-tested. Loop guard: pages on a `replay.*` host never redirect again, so a bad record cannot loop.
- Replays no longer request a Turnstile token (`lobby.gameRecord` set -> `null`, mirroring the singleplayer exemption - replays run through `LocalServer`, nothing consumes a token), and shell hosts skip the prefetch entirely: the replay host may not be on the Turnstile site key's allowlist, where the widget would alert and reject.

## Deploy order

Requires openfrontio/infra#514 (serve shells on `replay.<domain>`; supersedes the serving half of infra#513, whose special grants it reverts). Safe to merge in either order: until infra deploys, the client probe fails and behavior is unchanged (version-mismatch message).

## Testing

- `tests/VersionedReplay.test.ts` covers URL building (audience-derived host, localhost -> null) and the host-based loop-guard invariant.
- Renderer verified end-to-end locally: prod build, then `RenderStaticIndex.ts` with staging-like env produced a self-contained shell with the full commit, cdnBase, and absolute CDN asset URLs baked in.
- Full redirect + replay loop e2e-verified on staging (with the interim CDN-host URLs): game `mcKawtSy` archived at one commit, opened on a deployment of another -> redirect -> shell replayed it (sim ticking, map rendered, URL preserved). Re-verification with the canonical URLs planned after infra#514 deploys.
- Full suite, tsc, and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)