### PR TITLE
fix(devops): drop the digest suffix for slash/underscore-only subdomains

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,18 +77,23 @@ jobs:
           # become hyphens to keep the name readable (fix/some-bug ->
           # fix-some-bug), anything else outside [a-zA-Z0-9-] is dropped, and the
           # result is capped at the 63-octet label limit with no edge hyphens.
-          LABEL="$(printf '%s' "$RAW_SUBDOMAIN" | tr '_/' '--' | tr -cd 'a-zA-Z0-9-')"
+          READABLE="$(printf '%s' "$RAW_SUBDOMAIN" | tr '_/' '--')"
+          LABEL="$(printf '%s' "$READABLE" | tr -cd 'a-zA-Z0-9-')"
           LABEL="$(printf '%s' "${LABEL:0:63}" | sed 's/^-*//; s/-*$//')"
           if [ -z "$LABEL" ]; then
             echo "Error: subdomain is empty after sanitizing '$RAW_SUBDOMAIN'"
             exit 1
           fi
-          # Normalizing is many-to-one - fix/foo and fixfoo both yield "fixfoo" - so
-          # whenever it altered the name, append a digest of the original to keep
-          # distinct branches on distinct hosts. Names that pass through untouched
-          # (main, nightly, a hand-typed prod subdomain) keep their exact spelling,
-          # which update.sh relies on for its `SUBDOMAIN = main` restart check.
-          if [ "$LABEL" != "$RAW_SUBDOMAIN" ]; then
+          # The hyphen mapping above is deliberately canonical: fix/foo and
+          # fix-foo share a subdomain. But dropping or trimming characters is
+          # lossy in ways that aren't obvious from the branch name (feat/héllo
+          # and feat/hllo would collide), so whenever sanitizing went beyond
+          # the hyphen mapping, append a digest of the original to keep such
+          # branches on distinct hosts. Names that pass through untouched
+          # (main, nightly, a hand-typed prod subdomain) keep their exact
+          # spelling, which update.sh relies on for its `SUBDOMAIN = main`
+          # restart check.
+          if [ "$LABEL" != "$READABLE" ]; then
             HASH="$(printf '%s' "$RAW_SUBDOMAIN" | sha256sum | cut -c1-6)"
             LABEL="$(printf '%s' "${LABEL:0:56}" | sed 's/-*$//')-${HASH}"
           fi


### PR DESCRIPTION
Follow-up to #4956. The digest guard compared the sanitized label against the **raw** branch name, so every `feat/...` or `fix/...` branch differed trivially and still got the `-<hash>` suffix — `feat/replay-older-versions` deployed to `feat-replay-older-versions-974448.openfront.dev` instead of `feat-replay-older-versions.openfront.dev`, defeating the readability fix.

The label is now compared against the readable-mapped name (`_`/`/` → `-`), making that mapping deliberately canonical: `fix/foo` and `fix-foo` share a subdomain (accepted trade-off — two branches differing only in separator are effectively never live at once). The digest still fires whenever sanitizing is genuinely lossy, where collisions aren't obvious from the branch name: dropped characters, trimmed edge hyphens, or 63-octet truncation.

Verified with a harness over the sanitization block:

| branch | subdomain |
|---|---|
| `main` / `nightly` | unchanged (update.sh restart check intact) |
| `feat/replay-older-versions` | `feat-replay-older-versions` |
| `feat_underscore_branch` | `feat-underscore-branch` |
| `feat/héllo` | `feat-hllo-244273` (dropped char → digest) |
| `-leading-hyphen` | `leading-hyphen-9b5613` (edge trim → digest) |
| 87-char branch | truncated to 56 + `-<hash>` (63 octets) |
| `///` | error: empty after sanitizing |

Existing `-<digest>` staging containers simply age out via the 25h timeout; the next push to a branch deploys under its new name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)