### PR TITLE
feat: key cosmetic selections by player id so they're restored on login

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -37,6 +37,7 @@ import {
   ArchivedAnalyticsRecordSchema,
   GameInfo,
 } from "../core/Schemas";
+import { UserSettings } from "../core/game/UserSettings";
 import { getAuthHeader, getPlayToken, logOut, userAuth } from "./Auth";
 import { ClientEnv } from "./ClientEnv";
 
@@ -195,6 +196,9 @@ export async function getUserMe(): Promise<UserMeResponse | false> {
         console.error("Invalid response", error);
         return false;
       }
+      // Activate this player's cosmetic selections (and adopt any made while
+      // logged out) before the profile is handed to callers.
+      UserSettings.setPlayerId(result.data.player.publicId);
       return result.data;
     } catch (e) {
       return false;

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -38,7 +38,13 @@ import {
   GameInfo,
 } from "../core/Schemas";
 import { UserSettings } from "../core/game/UserSettings";
-import { getAuthHeader, getPlayToken, logOut, userAuth } from "./Auth";
+import {
+  getAuthHeader,
+  getPlayToken,
+  isSessionActive,
+  logOut,
+  userAuth,
+} from "./Auth";
 import { ClientEnv } from "./ClientEnv";
 
 export async function fetchPlayerById(
@@ -176,7 +182,7 @@ export async function getUserMe(): Promise<UserMeResponse | false> {
     try {
       const userAuthResult = await userAuth();
       if (!userAuthResult) return false;
-      const { jwt } = userAuthResult;
+      const { jwt, claims } = userAuthResult;
 
       // Get the user object
       const response = await fetch(getApiBase() + "/users/@me", {
@@ -197,8 +203,12 @@ export async function getUserMe(): Promise<UserMeResponse | false> {
         return false;
       }
       // Activate this player's cosmetic selections (and adopt any made while
-      // logged out) before the profile is handed to callers.
-      UserSettings.setPlayerId(result.data.player.publicId);
+      // logged out) before the profile is handed to callers — but not if the
+      // session changed (logout, account switch) while the request was in
+      // flight: a stale response must not reactivate the old player's scope.
+      if (isSessionActive(claims.sub)) {
+        UserSettings.setPlayerId(result.data.player.publicId);
+      }
       return result.data;
     } catch (e) {
       return false;

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -101,8 +101,10 @@ export async function logOut(allSessions: boolean = false): Promise<boolean> {
   } finally {
     __jwt = null;
     localStorage.removeItem(PERSISTENT_ID_KEY);
-    new UserSettings().clearFlag();
-    new UserSettings().setSelectedPatternName(undefined);
+    // Switch cosmetics back to the logged-out scope. The player's own
+    // selections stay stored under their publicId and are restored on the
+    // next login (#4955).
+    UserSettings.setPlayerId(null);
   }
 }
 

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -113,6 +113,18 @@ export async function isLoggedIn(): Promise<boolean> {
   return userAuthResult !== false;
 }
 
+// True when the in-memory session still belongs to the given JWT subject.
+// Lets callers of authenticated endpoints discard a response that arrived
+// after a logout or session change invalidated the request's session.
+export function isSessionActive(sub: string): boolean {
+  if (__jwt === null) return false;
+  try {
+    return decodeJwt(__jwt).sub === sub;
+  } catch {
+    return false;
+  }
+}
+
 export async function userAuth(
   shouldRefresh: boolean = true,
 ): Promise<UserAuth> {

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -636,6 +636,10 @@ export function resolvedToPlayerPattern(
 
 export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
   const userSettings = new UserSettings();
+  // Resolve the profile first: getUserMe activates the per-player cosmetics
+  // scope (UserSettings.setPlayerId), which must happen before selections are
+  // read below.
+  await getUserMe();
   const cosmetics = await fetchCosmetics();
   let pattern: PlayerPattern | null =
     userSettings.getSelectedPatternName(cosmetics);

--- a/src/core/game/UserSettings.ts
+++ b/src/core/game/UserSettings.ts
@@ -77,8 +77,59 @@ const STATS_COLUMNS_KEYS: Record<StatsTableKind, string> = {
   team: TEAM_STATS_COLUMNS_KEY,
 };
 
+/**
+ * Cosmetic selections are stored per player: while logged in, the storage key
+ * is suffixed with the player's publicId so selections survive logout and are
+ * restored on the next login (#4955). Logged out, the bare key is used.
+ */
+const PER_PLAYER_KEYS: readonly string[] = [
+  PATTERN_KEY,
+  FLAG_KEY,
+  CROWN_KEY,
+  EFFECTS_KEY,
+];
+
 export class UserSettings {
   private static cache = new Map<string, string | null>();
+  /** publicId of the logged-in player, or null when logged out. */
+  private static playerId: string | null = null;
+
+  /**
+   * Sets which player's cosmetic selections are active. Called with the
+   * player's publicId when /users/@me resolves, and with null on logout.
+   *
+   * Selections made while logged out — including values written by builds
+   * that predate per-player keying — are moved into the player's scope,
+   * overwriting the stored ones (the most recent selection wins), so existing
+   * users keep their cosmetics.
+   */
+  static setPlayerId(playerId: string | null): void {
+    if (UserSettings.playerId === playerId) return;
+    UserSettings.playerId = playerId;
+    const settings = new UserSettings();
+    if (playerId !== null) {
+      for (const key of PER_PLAYER_KEYS) {
+        const bare = localStorage.getItem(key);
+        if (bare === null) continue;
+        const scopedKey = `${key}:${playerId}`;
+        localStorage.setItem(scopedKey, bare);
+        UserSettings.cache.set(scopedKey, bare);
+        localStorage.removeItem(key);
+        UserSettings.cache.set(key, null);
+      }
+    }
+    // The active selections changed with the identity; let listeners re-read.
+    for (const key of PER_PLAYER_KEYS) {
+      settings.emitChange(key, settings.getCached(key));
+    }
+  }
+
+  private storageKey(key: string): string {
+    if (UserSettings.playerId !== null && PER_PLAYER_KEYS.includes(key)) {
+      return `${key}:${UserSettings.playerId}`;
+    }
+    return key;
+  }
 
   private emitChange(key: string, value: any): void {
     try {
@@ -95,23 +146,28 @@ export class UserSettings {
   }
 
   private getCached(key: string): string | null {
-    if (!UserSettings.cache.has(key)) {
-      UserSettings.cache.set(key, localStorage.getItem(key));
+    const storageKey = this.storageKey(key);
+    if (!UserSettings.cache.has(storageKey)) {
+      UserSettings.cache.set(storageKey, localStorage.getItem(storageKey));
     }
-    return UserSettings.cache.get(key) ?? null;
+    return UserSettings.cache.get(storageKey) ?? null;
   }
 
+  // Change events always use the base key — listeners subscribe with the
+  // exported key constants, not the per-player storage key.
   private setCached(key: string, value: string, emitChange: boolean = true) {
-    localStorage.setItem(key, value);
-    UserSettings.cache.set(key, value);
+    const storageKey = this.storageKey(key);
+    localStorage.setItem(storageKey, value);
+    UserSettings.cache.set(storageKey, value);
     if (emitChange) {
       this.emitChange(key, value);
     }
   }
 
   public removeCached(key: string, emitChange: boolean = true) {
-    localStorage.removeItem(key);
-    UserSettings.cache.set(key, null);
+    const storageKey = this.storageKey(key);
+    localStorage.removeItem(storageKey);
+    UserSettings.cache.set(storageKey, null);
     if (emitChange) {
       this.emitChange(key, null);
     }

--- a/tests/UserSettings.test.ts
+++ b/tests/UserSettings.test.ts
@@ -1,19 +1,28 @@
 import {
+  CROWN_KEY,
   EFFECTS_KEY,
+  FLAG_KEY,
+  PATTERN_KEY,
   PLAYER_STATS_COLUMNS_KEY,
   TEAM_STATS_COLUMNS_KEY,
+  USER_SETTINGS_CHANGED_EVENT,
   UserSettings,
 } from "../src/core/game/UserSettings";
 
+// UserSettings keeps a static in-memory cache and the active player id; reset
+// both so each test reads fresh from the (cleared) localStorage as logged out.
+function resetUserSettingsState() {
+  localStorage.clear();
+  const statics = UserSettings as unknown as {
+    cache: Map<string, string | null>;
+    playerId: string | null;
+  };
+  statics.cache.clear();
+  statics.playerId = null;
+}
+
 describe("UserSettings effect selection", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    // UserSettings keeps a static in-memory cache; reset it too so each test
-    // reads fresh from the (cleared) localStorage.
-    (
-      UserSettings as unknown as { cache: Map<string, string | null> }
-    ).cache.clear();
-  });
+  beforeEach(resetUserSettingsState);
 
   it("sets and reads a per-effectType selection", () => {
     const s = new UserSettings();
@@ -65,12 +74,7 @@ describe("UserSettings effect selection", () => {
 });
 
 describe("UserSettings stats columns", () => {
-  beforeEach(() => {
-    localStorage.clear();
-    (
-      UserSettings as unknown as { cache: Map<string, string | null> }
-    ).cache.clear();
-  });
+  beforeEach(resetUserSettingsState);
 
   it("returns defaults when nothing is stored", () => {
     // The player table opens with the clan tag shown; a team has no tag.
@@ -137,5 +141,121 @@ describe("UserSettings stats columns", () => {
     expect(s.statsColumns("player")).toEqual(["gold"]);
     expect(s.statsColumns("team")).toEqual(["warships"]);
     expect(localStorage.getItem(TEAM_STATS_COLUMNS_KEY)).toBe('["warships"]');
+  });
+});
+
+describe("UserSettings per-player cosmetics (#4955)", () => {
+  beforeEach(resetUserSettingsState);
+
+  it("stores a logged-in player's selections under publicId-scoped keys", () => {
+    UserSettings.setPlayerId("p1");
+    const s = new UserSettings();
+    s.setSelectedCrownName("golden");
+    s.setFlag("flag:premium");
+    expect(localStorage.getItem(`${CROWN_KEY}:p1`)).toBe("golden");
+    expect(localStorage.getItem(`${FLAG_KEY}:p1`)).toBe("flag:premium");
+    expect(localStorage.getItem(CROWN_KEY)).toBeNull();
+    expect(localStorage.getItem(FLAG_KEY)).toBeNull();
+  });
+
+  it("restores a player's cosmetics after logout and login", () => {
+    UserSettings.setPlayerId("p1");
+    const s = new UserSettings();
+    s.setSelectedCrownName("golden");
+    s.setFlag("flag:premium");
+    s.setSelectedPatternName("skin:cool");
+    s.setSelectedEffectName("transportShipTrail", "spectrum");
+
+    UserSettings.setPlayerId(null); // logout
+    expect(s.getSelectedCrownName()).toBeNull();
+    expect(s.getFlag()).toBeNull();
+    expect(s.getSelectedSkinName()).toBeNull();
+    expect(s.getSelectedEffectName("transportShipTrail")).toBeNull();
+
+    UserSettings.setPlayerId("p1"); // login again
+    expect(s.getSelectedCrownName()).toBe("golden");
+    expect(s.getFlag()).toBe("flag:premium");
+    expect(s.getSelectedSkinName()).toBe("cool");
+    expect(s.getSelectedEffectName("transportShipTrail")).toBe("spectrum");
+  });
+
+  it("keeps different players' selections separate", () => {
+    UserSettings.setPlayerId("p1");
+    const s = new UserSettings();
+    s.setSelectedCrownName("golden");
+
+    UserSettings.setPlayerId(null);
+    UserSettings.setPlayerId("p2");
+    expect(s.getSelectedCrownName()).toBeNull();
+    s.setSelectedCrownName("silver");
+
+    UserSettings.setPlayerId(null);
+    UserSettings.setPlayerId("p1");
+    expect(s.getSelectedCrownName()).toBe("golden");
+  });
+
+  it("adopts pre-existing bare-key selections on login (legacy migration)", () => {
+    // Builds that predate per-player keying wrote selections to bare keys.
+    localStorage.setItem(CROWN_KEY, "golden");
+    localStorage.setItem(FLAG_KEY, "flag:premium");
+    localStorage.setItem(PATTERN_KEY, "skin:cool");
+    localStorage.setItem(
+      EFFECTS_KEY,
+      JSON.stringify({ transportShipTrail: "spectrum" }),
+    );
+
+    UserSettings.setPlayerId("p1");
+    const s = new UserSettings();
+    expect(s.getSelectedCrownName()).toBe("golden");
+    expect(s.getFlag()).toBe("flag:premium");
+    expect(s.getSelectedSkinName()).toBe("cool");
+    expect(s.getSelectedEffectName("transportShipTrail")).toBe("spectrum");
+
+    // Moved, not copied: the logged-out scope no longer has them.
+    UserSettings.setPlayerId(null);
+    expect(s.getSelectedCrownName()).toBeNull();
+    expect(localStorage.getItem(CROWN_KEY)).toBeNull();
+  });
+
+  it("a selection made while logged out wins over the stored one on login", () => {
+    UserSettings.setPlayerId("p1");
+    const s = new UserSettings();
+    s.setSelectedCrownName("golden");
+
+    UserSettings.setPlayerId(null);
+    // e.g. picked (or purchased via #purchase-completed) before logging in
+    s.setSelectedCrownName("silver");
+
+    UserSettings.setPlayerId("p1");
+    expect(s.getSelectedCrownName()).toBe("silver");
+  });
+
+  it("emits change events under the base key when the player changes", () => {
+    const events: (string | null)[] = [];
+    const listener = (e: Event) => events.push((e as CustomEvent).detail);
+    window.addEventListener(
+      `${USER_SETTINGS_CHANGED_EVENT}:${CROWN_KEY}`,
+      listener,
+    );
+    try {
+      UserSettings.setPlayerId("p1"); // nothing stored yet
+      new UserSettings().setSelectedCrownName("golden");
+      UserSettings.setPlayerId(null); // logout: guest scope is empty
+      UserSettings.setPlayerId("p1"); // login: selection restored
+      expect(events).toEqual([null, "golden", null, "golden"]);
+    } finally {
+      window.removeEventListener(
+        `${USER_SETTINGS_CHANGED_EVENT}:${CROWN_KEY}`,
+        listener,
+      );
+    }
+  });
+
+  it("does not scope non-cosmetic settings", () => {
+    UserSettings.setPlayerId("p1");
+    const s = new UserSettings();
+    s.setAttackRatio(0.5);
+    UserSettings.setPlayerId(null);
+    expect(s.attackRatio()).toBe(0.5);
   });
 });


### PR DESCRIPTION
Fixes #4955

## Problem

Equipped cosmetics were stored under fixed localStorage keys and got wiped whenever the player logged out: `logOut()` cleared flag + pattern outright (and it also fires on transient 401s, so cosmetics could vanish on an auth blip), while the entitlement checks in `Cosmetics.ts` cleared the rest once the logged-out player was no longer entitled. Every login meant re-selecting everything.

## Solution

Cosmetic selections are now keyed by the player's `publicId`, per the issue:

- **`UserSettings`**: the four cosmetic keys (`territoryPattern`, `flag`, `crown`, `settings.effects`) are suffixed with the logged-in player's `publicId` via a new static `UserSettings.setPlayerId()`. Change events still fire under the **base** key names, so all existing listeners (CosmeticsModal, CosmeticsInput, FlagInput, EffectsGrid, CosmeticBackground) work unchanged. Non-cosmetic settings are untouched.
- **`Api.ts`**: `getUserMe()` activates the player's scope as soon as the profile resolves.
- **`Auth.ts`**: logout no longer deletes selections — it just switches back to the logged-out scope. The player's selections stay stored under their id and reappear on the next login. This also fixes cosmetics being nuked by transient-401 `logOut()` calls.
- **`Cosmetics.ts`**: `getPlayerCosmeticsRefs()` awaits `getUserMe()` before reading selections, so payloads built early (e.g. `#join=` deep links) never read the wrong scope.

## Backwards compatibility

On login, values under the old bare keys are **moved** into the player's scope, so existing users keep their current cosmetics the first time they log in after this ships. The moved value wins over a previously stored one — deliberately: it covers picking a flag while logged out and the `#purchase-completed` flow, which writes the bought cosmetic in a `beforeunload` handler right before the token-login reload.

## Notes

- Client-only per the issue text: cosmetics restore per browser, not across devices. Cross-device restore (DB-backed, as raised in the issue comments) would be an infra follow-up.
- The entitlement validation in `Cosmetics.ts` is unchanged; while logged in it now clears the *scoped* key, which is the correct per-account behavior when a cosmetic is genuinely no longer owned.

## Tests

New "per-player cosmetics (#4955)" suite in `tests/UserSettings.test.ts`: scoped storage, restore after logout/login, multi-account isolation, legacy bare-key migration, logged-out-selection-wins, base-key event emission, and non-cosmetic settings staying unscoped. Full suite (298 tests), `tsc`, and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)