### PR TITLE
fix: show the x5 ghost badge when infinite gold zeroes costs

### DIFF
--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1042,20 +1042,25 @@ export class GPURenderer {
     this.railroadPass.updateGhostPreview(data);
     this.rangeCirclePass.updateGhostPreview(data);
     this.crosshairPass.updateGhostPreview(data);
+    // The multiplier badge (x5) rides on the cost label but must show even
+    // when there is no cost line — e.g. infinite gold (cost 0) or the
+    // cursor-cost-label setting turned off.
+    const topText =
+      data?.multiplier && data.multiplier > 1
+        ? translateText("build_menu.upgrade_amount", {
+            amount: data.multiplier.toString(),
+          })
+        : undefined;
+    const showCost = data !== null && data.showCost && data.cost > 0;
     this.worldTextPass.setGhostCostLabel(
-      data && data.showCost && data.cost > 0
+      data && (showCost || topText !== undefined)
         ? {
             tileX: data.tileX,
             tileY: data.tileY,
-            cost: data.cost,
+            cost: showCost ? data.cost : 0,
             canAfford: data.canAfford,
             canPlace: data.canBuild || data.canUpgrade,
-            topText:
-              data.multiplier && data.multiplier > 1
-                ? translateText("build_menu.upgrade_amount", {
-                    amount: data.multiplier.toString(),
-                  })
-                : undefined,
+            topText,
           }
         : null,
     );

--- a/src/client/render/gl/passes/WorldTextPass.ts
+++ b/src/client/render/gl/passes/WorldTextPass.ts
@@ -358,7 +358,8 @@ export class WorldTextPass {
     this.ghostCostLabel = {
       x: label.tileX,
       y: label.tileY,
-      text: renderNumber(label.cost),
+      // cost 0 means "no cost line" (multiplier-badge-only label).
+      text: label.cost > 0 ? renderNumber(label.cost) : "",
       topText: label.topText,
       colorR: r,
       colorG: g,
@@ -520,30 +521,32 @@ export class WorldTextPass {
         }
       }
 
-      layoutString(
-        label.text,
-        this.glyph,
-        this.kernTable,
-        this.charCodes,
-        this.cursors,
-      );
-      const len = Math.min(label.text.length, MAX_CHARS);
-      for (let i = 0; i < len; i++) {
-        if (this.charCodes[i] === 0) continue;
-        if (count >= this.maxInstances) this.growBuffer();
+      if (label.text) {
+        layoutString(
+          label.text,
+          this.glyph,
+          this.kernTable,
+          this.charCodes,
+          this.cursors,
+        );
+        const len = Math.min(label.text.length, MAX_CHARS);
+        for (let i = 0; i < len; i++) {
+          if (this.charCodes[i] === 0) continue;
+          if (count >= this.maxInstances) this.growBuffer();
 
-        const off = count * FLOATS_PER_INSTANCE;
-        this.instanceData[off + 0] = label.x;
-        this.instanceData[off + 1] = ghostY;
-        this.instanceData[off + 2] = this.cursors[i];
-        this.instanceData[off + 3] = this.charCodes[i];
-        this.instanceData[off + 4] = 1;
-        this.instanceData[off + 5] = label.colorR;
-        this.instanceData[off + 6] = label.colorG;
-        this.instanceData[off + 7] = label.colorB;
-        this.instanceData[off + 8] = ghostScale;
-        this.instanceData[off + 9] = GHOST_COST_OUTLINE_WIDTH;
-        count++;
+          const off = count * FLOATS_PER_INSTANCE;
+          this.instanceData[off + 0] = label.x;
+          this.instanceData[off + 1] = ghostY;
+          this.instanceData[off + 2] = this.cursors[i];
+          this.instanceData[off + 3] = this.charCodes[i];
+          this.instanceData[off + 4] = 1;
+          this.instanceData[off + 5] = label.colorR;
+          this.instanceData[off + 6] = label.colorG;
+          this.instanceData[off + 7] = label.colorB;
+          this.instanceData[off + 8] = ghostScale;
+          this.instanceData[off + 9] = GHOST_COST_OUTLINE_WIDTH;
+          count++;
+        }
       }
     }
 


### PR DESCRIPTION
## Description:

Regression from #4640. The bulk-purchase multiplier badge ("x5") renders as `topText` inside the ghost cost label, and that label is gated on `showCost && cost > 0` in `GPURenderer.updateGhostPreview`. With the infinite gold setting every cost is 0, so arming x5 with the hotkey double-press gave no visual feedback at all — the upgrade itself worked, only the badge was missing. The same gate also dropped the badge for players who turned the cursor cost label setting off.

### Fix

- `Renderer.ts`: compute the multiplier `topText` first and set the ghost label whenever there is a badge to show **or** a real cost line (`showCost || topText`), passing cost 0 when the cost line should be hidden.
- `WorldTextPass.ts`: treat cost 0 as "no cost line" — a badge-only label renders just the multiplier text.

### Testing

Verified headless in a real singleplayer game (all four states screenshot-checked):

- Infinite gold + x5 armed: **"x5" now renders above the ghost**, no cost line (before: nothing).
- Infinite gold + x1: clean ghost, no label (unchanged).
- Normal gold + x5: "x5" above, bulk total below (unchanged).
- Normal gold + x1: cost only (unchanged).

`npm run lint`, `tsc --noEmit`, and the `tests/client` suite (926 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)