### PR TITLE
feat (alliance cooldown) Add alliance request cooldown to main dial

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -510,7 +510,6 @@
     "about_to_expire": "Your alliance with {name} is about to expire!",
     "accept_alliance": "Accept",
     "alliance_accepted": "accepted",
-    "alliance_cooldown_text": "{amount}",
     "alliance_expired": "Your alliance with {name} expired",
     "alliance_nukes_destroyed_incoming": "{count, plural, one {# nuke launched by {name} was destroyed due to the alliance} other {# nukes launched by {name} were destroyed due to the alliance}}",
     "alliance_nukes_destroyed_outgoing": "{count, plural, one {# nuke launched toward {name} was destroyed due to the alliance} other {# nukes launched toward {name} were destroyed due to the alliance}}",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -545,7 +545,8 @@
     "trade_ship_captured": "Your trade ship was captured by {name}",
     "unit_destroyed": "Your {unit} was destroyed",
     "unit_voluntarily_deleted": "Unit voluntarily deleted",
-    "wants_to_renew_alliance": "{name} wants to renew your alliance"
+    "wants_to_renew_alliance": "{name} wants to renew your alliance",
+    "alliance_cooldown_text": "{amount}"
   },
   "featured_stream": {
     "expand": "Expand",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -510,6 +510,7 @@
     "about_to_expire": "Your alliance with {name} is about to expire!",
     "accept_alliance": "Accept",
     "alliance_accepted": "accepted",
+    "alliance_cooldown_text": "{amount}",
     "alliance_expired": "Your alliance with {name} expired",
     "alliance_nukes_destroyed_incoming": "{count, plural, one {# nuke launched by {name} was destroyed due to the alliance} other {# nukes launched by {name} were destroyed due to the alliance}}",
     "alliance_nukes_destroyed_outgoing": "{count, plural, one {# nuke launched toward {name} was destroyed due to the alliance} other {# nukes launched toward {name} were destroyed due to the alliance}}",
@@ -545,8 +546,7 @@
     "trade_ship_captured": "Your trade ship was captured by {name}",
     "unit_destroyed": "Your {unit} was destroyed",
     "unit_voluntarily_deleted": "Unit voluntarily deleted",
-    "wants_to_renew_alliance": "{name} wants to renew your alliance",
-    "alliance_cooldown_text": "{amount}"
+    "wants_to_renew_alliance": "{name} wants to renew your alliance"
   },
   "featured_stream": {
     "expand": "Expand",

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -4,7 +4,7 @@ import { EventBus, GameEvent } from "../../../core/EventBus";
 import { Controller } from "../../Controller";
 import { CloseViewEvent } from "../../InputHandler";
 import { PlaySoundEffectEvent } from "../../sound/Sounds";
-import { getSvgAspectRatio, translateText } from "../../Utils";
+import { getSvgAspectRatio, renderDuration, translateText } from "../../Utils";
 import {
   CenterButtonElement,
   COLORS,
@@ -716,11 +716,7 @@ export class RadialMenu implements Controller {
             content
               .append("text")
               .attr("class", `cooldown-text`)
-              .text(
-                translateText("events_display.alliance_cooldown_text", {
-                  amount: cooldown,
-                }),
-              )
+              .text(renderDuration(cooldown))
               .attr("fill", "white")
               .attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1)
               .attr("font-size", "20px")
@@ -1251,11 +1247,7 @@ export class RadialMenu implements Controller {
                 }
 
                 cooldownText
-                  .text(
-                    translateText("events_display.alliance_cooldown_text", {
-                      amount: cooldown,
-                    }),
-                  )
+                  .text(renderDuration(cooldown))
                   .attr(
                     "opacity",
                     isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1,

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -687,15 +687,17 @@ export class RadialMenu implements Controller {
             .attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
 
           getSvgAspectRatio(d.data.icon!).then((aspect) => {
-            if (!aspect || aspect === 1) return;
-
             let width = this.config.iconSize;
             let height = this.config.iconSize;
-            const biggerLength = Math.round(width * aspect);
-            if (aspect > 1) {
-              width = biggerLength;
-            } else {
-              height = biggerLength;
+
+            if (aspect !== null && aspect !== 1) {
+              const biggerLength = Math.round(width * aspect);
+
+              if (aspect > 1) {
+                width = biggerLength;
+              } else {
+                height = biggerLength;
+              }
             }
 
             imgSel

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -336,13 +336,14 @@ export class RadialMenu implements Controller {
 
         const isAllianceCooldown =
           d.data.id === "ally_request" &&
-          (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+          (this.params?.playerActions?.interaction
+            ?.allianceRequestCooldownRemaining ?? 0) > 0;
 
         const color = isAllianceCooldown
           ? "#0891b2"
           : disabled
-          ? this.config.disabledColor
-          : (resolveColor(d.data, this.params) ?? "#1e3a5f");
+            ? this.config.disabledColor
+            : (resolveColor(d.data, this.params) ?? "#1e3a5f");
 
         const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
 
@@ -358,13 +359,16 @@ export class RadialMenu implements Controller {
           ? "not-allowed"
           : "pointer",
       )
-      
+
       .style("opacity", (d) => {
         const disabled = this.params === null || d.data.disabled(this.params);
-        const isAllianceCooldown = d.data.id === "ally_request" && (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+        const isAllianceCooldown =
+          d.data.id === "ally_request" &&
+          (this.params?.playerActions?.interaction
+            ?.allianceRequestCooldownRemaining ?? 0) > 0;
         //to remove the fade down change 0.85 to 1
         return isAllianceCooldown ? 0.85 : disabled ? 0.5 : 1;
-  })
+      })
 
       .style(
         "transition",
@@ -435,15 +439,23 @@ export class RadialMenu implements Controller {
 
         const isAllianceCooldown =
           d.data.id === "ally_request" &&
-          (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+          (this.params?.playerActions?.interaction
+            ?.allianceRequestCooldownRemaining ?? 0) > 0;
         const color = isAllianceCooldown
           ? "#0891b2"
           : this.params === null || d.data.disabled(this.params)
-          ? this.config.disabledColor
-          : (resolveColor(d.data, this.params) ?? "#1e3a5f");
+            ? this.config.disabledColor
+            : (resolveColor(d.data, this.params) ?? "#1e3a5f");
 
-        const opacity = isAllianceCooldown ? 0.82 : this.params === null || d.data.disabled(this.params) ? 0.4 : 0.82;
-        path.attr("fill", d3.color(color)?.copy({ opacity: opacity })?.toString() ?? color);
+        const opacity = isAllianceCooldown
+          ? 0.82
+          : this.params === null || d.data.disabled(this.params)
+            ? 0.4
+            : 0.82;
+        path.attr(
+          "fill",
+          d3.color(color)?.copy({ opacity: opacity })?.toString() ?? color,
+        );
       }
     });
 
@@ -506,11 +518,14 @@ export class RadialMenu implements Controller {
       path.style("filter", null);
       const isAllianceCooldown =
         d.data.id === "ally_request" &&
-        (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
-      const color = isAllianceCooldown? "#0891b2": disabled
-        ? this.config.disabledColor
-        : (resolveColor(d.data, this.params) ?? "#333333");
-       const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
+        (this.params?.playerActions?.interaction
+          ?.allianceRequestCooldownRemaining ?? 0) > 0;
+      const color = isAllianceCooldown
+        ? "#0891b2"
+        : disabled
+          ? this.config.disabledColor
+          : (resolveColor(d.data, this.params) ?? "#333333");
+      const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
 
       if (d.data.timerFraction) {
         path.attr("fill", `url(#timer-gradient-${d.data.id})`);
@@ -621,7 +636,8 @@ export class RadialMenu implements Controller {
         const disabled = this.isItemDisabled(d.data);
         const isAllianceCooldown =
           d.data.id === "ally_request" &&
-           (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+          (this.params?.playerActions?.interaction
+            ?.allianceRequestCooldownRemaining ?? 0) > 0;
 
         if (d.data.renderType && this.params) {
           const stateKey = this.getStateKeyByType(
@@ -681,7 +697,10 @@ export class RadialMenu implements Controller {
               .attr("width", width)
               .attr("height", height)
               .attr("x", arc.centroid(d)[0] - width / 2)
-              .attr("y", isAllianceCooldown ? 42 : arc.centroid(d)[1] - height / 2);
+              .attr(
+                "y",
+                isAllianceCooldown ? 42 : arc.centroid(d)[1] - height / 2,
+              );
           });
 
           if (this.params && d.data.cooldown?.(this.params)) {
@@ -1146,11 +1165,16 @@ export class RadialMenu implements Controller {
     this.menuPaths.forEach((path, itemId) => {
       const item = this.findMenuItem(itemId);
       if (item) {
-        const isAllianceCooldown = item.id === "ally_request" && (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+        const isAllianceCooldown =
+          item.id === "ally_request" &&
+          (this.params?.playerActions?.interaction
+            ?.allianceRequestCooldownRemaining ?? 0) > 0;
         const disabled = this.isItemDisabled(item);
-        const color = isAllianceCooldown ? "#0891b2" : disabled
-          ? this.config.disabledColor
-          : (resolveColor(item, this.params) ?? "#333333");
+        const color = isAllianceCooldown
+          ? "#0891b2"
+          : disabled
+            ? this.config.disabledColor
+            : (resolveColor(item, this.params) ?? "#333333");
         const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
         // Update path appearance (skip fill for timer items — gradient handles it)
         if (!item.timerFraction) {
@@ -1171,13 +1195,19 @@ export class RadialMenu implements Controller {
             // Update text opacity
             const textElement = icon.select("text");
             if (!textElement.empty()) {
-              textElement.style("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
+              textElement.style(
+                "opacity",
+                isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1,
+              );
             }
 
             // Update image opacity
             const imageElement = icon.select("image");
             if (!imageElement.empty()) {
-              imageElement.attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
+              imageElement.attr(
+                "opacity",
+                isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1,
+              );
             }
 
             // Update cooldown text if applicable

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -694,7 +694,8 @@ export class RadialMenu implements Controller {
               .attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1)
               .attr("font-size", "20px")
               .attr("font-weight", "bold")
-              .attr("x", arc.centroid(d)[0] - this.config.iconSize / 4)
+              .attr("text-anchor", "middle")
+              .attr("x", arc.centroid(d)[0])
               .attr("y", arc.centroid(d)[1] + this.config.iconSize / 2 + 7);
           }
         }
@@ -1314,11 +1315,11 @@ export class RadialMenu implements Controller {
     const otherAgreed = interaction?.allianceInfo?.otherAgreedToExtend ?? false;
 
     const ns = "http://www.w3.org/2000/svg";
-    const smallSize = iconSize;
+    const smallSize = iconSize * 0.8;
     const iconUrl = icon ?? "";
 
     getSvgAspectRatio(iconUrl).then((ratio) => {
-      const width = smallSize;
+      const width = smallSize * (ratio ?? 1);
       const gap = 2;
       const totalWidth = width * 2 + gap;
 

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -1264,27 +1264,28 @@ export class RadialMenu implements Controller {
     const stateChanged = stateKey !== prevState;
 
     if (!cooldownChanged && !stateChanged) {
-      icon.attr("data-cooldown-active", cooldownActive ? "true" : "false");
-
-      const cx = parseFloat(icon.attr("data-cx") || "0");
-      const cy = parseFloat(icon.attr("data-cy") || "0");
-
-      if (stateKey) {
-        icon.attr("data-prev-state", stateKey);
-        // State unchanged, skip re-render to preserve animations
-      } else {
-        this.renderAllyExtendIcon(
-          icon.node()! as SVGGElement,
-          cx,
-          cy,
-          this.config.iconSize,
-          disabled,
-          this.params,
-          item.icon,
-          true,
-        );
-      }
+      return;
     }
+
+    icon.attr("data-cooldown-active", cooldownActive ? "true" : "false");
+
+    const cx = parseFloat(icon.attr("data-cx") || "0");
+    const cy = parseFloat(icon.attr("data-cy") || "0");
+
+    if (stateKey) {
+      icon.attr("data-prev-state", stateKey);
+      // State unchanged, skip re-render to preserve animations
+    }
+    this.renderAllyExtendIcon(
+      icon.node()! as SVGGElement,
+      cx,
+      cy,
+      this.config.iconSize,
+      disabled,
+      this.params,
+      item.icon,
+      true,
+    );
   }
 
   private maybeUpdateTimerGradient(

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -330,12 +330,21 @@ export class RadialMenu implements Controller {
       .append("path")
       .attr("class", "menu-item-path")
       .attr("d", arc)
+      .attr("alliance", true)
       .attr("fill", (d) => {
         const disabled = this.params === null || d.data.disabled(this.params);
-        const color = disabled
+
+        const isAllianceCooldown =
+          d.data.id === "ally_request" &&
+          (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+
+        const color = isAllianceCooldown
+          ? "#0891b2"
+          : disabled
           ? this.config.disabledColor
           : (resolveColor(d.data, this.params) ?? "#1e3a5f");
-        const opacity = disabled ? 0.4 : 0.82;
+
+        const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
 
         if (d.data.id === this.selectedItemId && this.currentLevel > level) {
           return color;
@@ -349,9 +358,14 @@ export class RadialMenu implements Controller {
           ? "not-allowed"
           : "pointer",
       )
-      .style("opacity", (d) =>
-        this.params === null || d.data.disabled(this.params) ? 0.5 : 1,
-      )
+      
+      .style("opacity", (d) => {
+        const disabled = this.params === null || d.data.disabled(this.params);
+        const isAllianceCooldown = d.data.id === "ally_request" && (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+        //to remove the fade down change 0.85 to 1
+        return isAllianceCooldown ? 0.85 : disabled ? 0.5 : 1;
+  })
+
       .style(
         "transition",
         `filter ${this.config.menuTransitionDuration / 2}ms, fill ${this.config.menuTransitionDuration / 2}ms`,
@@ -419,11 +433,17 @@ export class RadialMenu implements Controller {
       ) {
         path.attr("filter", "url(#glow)");
 
-        const color =
-          this.params === null || d.data.disabled(this.params)
-            ? this.config.disabledColor
-            : (resolveColor(d.data, this.params) ?? "#1e3a5f");
-        path.attr("fill", color);
+        const isAllianceCooldown =
+          d.data.id === "ally_request" &&
+          (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+        const color = isAllianceCooldown
+          ? "#0891b2"
+          : this.params === null || d.data.disabled(this.params)
+          ? this.config.disabledColor
+          : (resolveColor(d.data, this.params) ?? "#1e3a5f");
+
+        const opacity = isAllianceCooldown ? 0.82 : this.params === null || d.data.disabled(this.params) ? 0.4 : 0.82;
+        path.attr("fill", d3.color(color)?.copy({ opacity: opacity })?.toString() ?? color);
       }
     });
 
@@ -484,10 +504,13 @@ export class RadialMenu implements Controller {
       )
         return;
       path.style("filter", null);
-      const color = disabled
+      const isAllianceCooldown =
+        d.data.id === "ally_request" &&
+        (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
+      const color = isAllianceCooldown? "#0891b2": disabled
         ? this.config.disabledColor
         : (resolveColor(d.data, this.params) ?? "#333333");
-      const opacity = disabled ? 0.4 : 0.82;
+       const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
 
       if (d.data.timerFraction) {
         path.attr("fill", `url(#timer-gradient-${d.data.id})`);
@@ -596,6 +619,9 @@ export class RadialMenu implements Controller {
         const contentId = d.data.id;
         const content = d3.select(`g[data-id="${contentId}"]`);
         const disabled = this.isItemDisabled(d.data);
+        const isAllianceCooldown =
+          d.data.id === "ally_request" &&
+           (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
 
         if (d.data.renderType && this.params) {
           const stateKey = this.getStateKeyByType(
@@ -627,7 +653,7 @@ export class RadialMenu implements Controller {
             .attr("fill", "white")
             .attr("font-size", d.data.fontSize ?? "12px")
             .attr("font-family", "Arial, sans-serif")
-            .style("opacity", disabled ? 0.5 : 1)
+            .style("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1)
             .text(d.data.text);
         } else {
           const imgSel = content
@@ -637,7 +663,7 @@ export class RadialMenu implements Controller {
             .attr("height", this.config.iconSize)
             .attr("x", arc.centroid(d)[0] - this.config.iconSize / 2)
             .attr("y", arc.centroid(d)[1] - this.config.iconSize / 2)
-            .attr("opacity", disabled ? 0.5 : 1);
+            .attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
 
           getSvgAspectRatio(d.data.icon!).then((aspect) => {
             if (!aspect || aspect === 1) return;
@@ -655,7 +681,7 @@ export class RadialMenu implements Controller {
               .attr("width", width)
               .attr("height", height)
               .attr("x", arc.centroid(d)[0] - width / 2)
-              .attr("y", arc.centroid(d)[1] - height / 2);
+              .attr("y", isAllianceCooldown ? 42 : arc.centroid(d)[1] - height / 2);
           });
 
           if (this.params && d.data.cooldown?.(this.params)) {
@@ -663,10 +689,10 @@ export class RadialMenu implements Controller {
             content
               .append("text")
               .attr("class", `cooldown-text`)
-              .text(cooldown + "s")
+              .text(String(cooldown))
               .attr("fill", "white")
-              .attr("opacity", disabled ? 0.5 : 1)
-              .attr("font-size", "14px")
+              .attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1)
+              .attr("font-size", "20px")
               .attr("font-weight", "bold")
               .attr("x", arc.centroid(d)[0] - this.config.iconSize / 4)
               .attr("y", arc.centroid(d)[1] + this.config.iconSize / 2 + 7);
@@ -1119,12 +1145,12 @@ export class RadialMenu implements Controller {
     this.menuPaths.forEach((path, itemId) => {
       const item = this.findMenuItem(itemId);
       if (item) {
+        const isAllianceCooldown = item.id === "ally_request" && (this.params?.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0;
         const disabled = this.isItemDisabled(item);
-        const color = disabled
+        const color = isAllianceCooldown ? "#0891b2" : disabled
           ? this.config.disabledColor
           : (resolveColor(item, this.params) ?? "#333333");
-        const opacity = disabled ? 0.4 : 0.82;
-
+        const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
         // Update path appearance (skip fill for timer items — gradient handles it)
         if (!item.timerFraction) {
           path.attr(
@@ -1132,7 +1158,7 @@ export class RadialMenu implements Controller {
             d3.color(color)?.copy({ opacity: opacity })?.toString() ?? color,
           );
         }
-        path.style("opacity", disabled ? 0.5 : 1);
+        path.style("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
         path.style("cursor", disabled ? "not-allowed" : "pointer");
 
         // Update icon/text appearance using the same logic as renderIconsAndText
@@ -1144,13 +1170,13 @@ export class RadialMenu implements Controller {
             // Update text opacity
             const textElement = icon.select("text");
             if (!textElement.empty()) {
-              textElement.style("opacity", disabled ? 0.5 : 1);
+              textElement.style("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
             }
 
             // Update image opacity
             const imageElement = icon.select("image");
             if (!imageElement.empty()) {
-              imageElement.attr("opacity", disabled ? 0.5 : 1);
+              imageElement.attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1);
             }
 
             // Update cooldown text if applicable
@@ -1160,7 +1186,7 @@ export class RadialMenu implements Controller {
               if (cooldown <= 0) {
                 cooldownElement.remove();
               } else {
-                cooldownElement.text(cooldown + "s");
+                cooldownElement.text(cooldown);
               }
             }
           }
@@ -1288,11 +1314,11 @@ export class RadialMenu implements Controller {
     const otherAgreed = interaction?.allianceInfo?.otherAgreedToExtend ?? false;
 
     const ns = "http://www.w3.org/2000/svg";
-    const smallSize = iconSize * 0.8;
+    const smallSize = iconSize;
     const iconUrl = icon ?? "";
 
     getSvgAspectRatio(iconUrl).then((ratio) => {
-      const width = smallSize * (ratio ?? 1);
+      const width = smallSize;
       const gap = 2;
       const totalWidth = width * 2 + gap;
 

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -1399,7 +1399,7 @@ export class RadialMenu implements Controller {
 
     getSvgAspectRatio(iconUrl).then((ratio) => {
       if (
-        Number(content.getAttribute("data-render-gneration")) !== generation
+        Number(content.getAttribute("data-render-genration")) !== generation
       ) {
         return;
       }

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -1254,10 +1254,10 @@ export class RadialMenu implements Controller {
                   );
               }
             }
-
-            // Update timer gradient
-            this.maybeUpdateTimerGradient(item, color, opacity);
           }
+          // Update timer gradient
+          this.maybeUpdateTimerGradient(item, color, opacity);
+          
         }
       }
     });
@@ -1399,7 +1399,7 @@ export class RadialMenu implements Controller {
 
     getSvgAspectRatio(iconUrl).then((ratio) => {
       if (
-        Number(content.getAttribute("data-render-genration")) !== generation
+        Number(content.getAttribute("data-render-generation")) !== generation
       ) {
         return;
       }

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -7,6 +7,7 @@ import { PlaySoundEffectEvent } from "../../sound/Sounds";
 import { getSvgAspectRatio, translateText } from "../../Utils";
 import {
   CenterButtonElement,
+  COLORS,
   MenuElement,
   MenuElementParams,
   TooltipKey,
@@ -330,7 +331,6 @@ export class RadialMenu implements Controller {
       .append("path")
       .attr("class", "menu-item-path")
       .attr("d", arc)
-      .attr("alliance", true)
       .attr("fill", (d) => {
         const disabled = this.params === null || d.data.disabled(this.params);
 
@@ -340,7 +340,7 @@ export class RadialMenu implements Controller {
             ?.allianceRequestCooldownRemaining ?? 0) > 0;
 
         const color = isAllianceCooldown
-          ? "#0891b2"
+          ? COLORS.allianceTimeLeft
           : disabled
             ? this.config.disabledColor
             : (resolveColor(d.data, this.params) ?? "#1e3a5f");
@@ -442,7 +442,7 @@ export class RadialMenu implements Controller {
           (this.params?.playerActions?.interaction
             ?.allianceRequestCooldownRemaining ?? 0) > 0;
         const color = isAllianceCooldown
-          ? "#0891b2"
+          ? COLORS.allianceTimeLeft
           : this.params === null || d.data.disabled(this.params)
             ? this.config.disabledColor
             : (resolveColor(d.data, this.params) ?? "#1e3a5f");
@@ -521,7 +521,7 @@ export class RadialMenu implements Controller {
         (this.params?.playerActions?.interaction
           ?.allianceRequestCooldownRemaining ?? 0) > 0;
       const color = isAllianceCooldown
-        ? "#0891b2"
+        ? COLORS.allianceTimeLeft
         : disabled
           ? this.config.disabledColor
           : (resolveColor(d.data, this.params) ?? "#333333");
@@ -638,6 +638,11 @@ export class RadialMenu implements Controller {
           d.data.id === "ally_request" &&
           (this.params?.playerActions?.interaction
             ?.allianceRequestCooldownRemaining ?? 0) > 0;
+
+        content.attr(
+          "data-cooldown-active",
+          isAllianceCooldown ? "true" : "false",
+        );
 
         if (d.data.renderType && this.params) {
           const stateKey = this.getStateKeyByType(
@@ -1171,7 +1176,7 @@ export class RadialMenu implements Controller {
             ?.allianceRequestCooldownRemaining ?? 0) > 0;
         const disabled = this.isItemDisabled(item);
         const color = isAllianceCooldown
-          ? "#0891b2"
+          ? COLORS.allianceTimeLeft
           : disabled
             ? this.config.disabledColor
             : (resolveColor(item, this.params) ?? "#333333");
@@ -1248,28 +1253,37 @@ export class RadialMenu implements Controller {
     );
     const prevState = icon.attr("data-prev-state");
 
-    if (stateKey && stateKey === prevState) {
-      // State unchanged, skip re-render to preserve animations
-    } else {
+    const cooldownActive =
+      (this.params?.playerActions?.interaction
+        ?.allianceRequestCooldownRemaining ?? 0) > 0;
+
+    const previousCooldownActive = icon.attr("data-cooldown-active") === "true";
+
+    const cooldownChanged = cooldownActive !== previousCooldownActive;
+
+    const stateChanged = stateKey !== prevState;
+
+    if (!cooldownChanged && !stateChanged) {
+      icon.attr("data-cooldown-active", cooldownActive ? "true" : "false");
+
       const cx = parseFloat(icon.attr("data-cx") || "0");
       const cy = parseFloat(icon.attr("data-cy") || "0");
 
       if (stateKey) {
         icon.attr("data-prev-state", stateKey);
+        // State unchanged, skip re-render to preserve animations
       } else {
-        icon.selectAll("*").remove();
+        this.renderAllyExtendIcon(
+          icon.node()! as SVGGElement,
+          cx,
+          cy,
+          this.config.iconSize,
+          disabled,
+          this.params,
+          item.icon,
+          true,
+        );
       }
-
-      this.renderAllyExtendIcon(
-        icon.node()! as SVGGElement,
-        cx,
-        cy,
-        this.config.iconSize,
-        disabled,
-        this.params,
-        item.icon,
-        true,
-      );
     }
   }
 

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -712,10 +712,15 @@ export class RadialMenu implements Controller {
 
           if (this.params && d.data.cooldown?.(this.params)) {
             const cooldown = Math.ceil(d.data.cooldown?.(this.params));
+
             content
               .append("text")
               .attr("class", `cooldown-text`)
-              .text(String(cooldown))
+              .text(
+                translateText("events_display.alliance_cooldown_text", {
+                  amount: cooldown,
+                }),
+              )
               .attr("fill", "white")
               .attr("opacity", isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1)
               .attr("font-size", "20px")
@@ -1208,9 +1213,14 @@ export class RadialMenu implements Controller {
               );
             }
 
-            // Update image opacity
+            // Update image opacity and position
             const imageElement = icon.select("image");
             if (!imageElement.empty()) {
+              const height = parseFloat(imageElement.attr("height") ?? "0");
+              const cy = parseFloat(icon.attr("data-cy") ?? "0");
+
+              imageElement.attr("y", isAllianceCooldown ? 42 : cy - height / 2);
+
               imageElement.attr(
                 "opacity",
                 isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1,
@@ -1218,19 +1228,44 @@ export class RadialMenu implements Controller {
             }
 
             // Update cooldown text if applicable
-            const cooldownElement = icon.select(".cooldown-text");
-            if (this.params && !cooldownElement.empty() && item.cooldown) {
+            if (this.params && item.cooldown) {
               const cooldown = Math.ceil(item.cooldown(this.params));
+              let cooldownText = icon.select<SVGTextElement>(".cooldown-text");
+
               if (cooldown <= 0) {
-                cooldownElement.remove();
+                cooldownText.remove();
               } else {
-                cooldownElement.text(cooldown);
+                if (cooldownText.empty()) {
+                  const cx = parseFloat(icon.attr("data-cx") ?? "0");
+                  const cy = parseFloat(icon.attr("data-cy") ?? "0");
+
+                  cooldownText = icon
+                    .append("text")
+                    .attr("class", "cooldown-text")
+                    .attr("fill", "white")
+                    .attr("font-size", "20px")
+                    .attr("font-weight", "bold")
+                    .attr("text-anchor", "middle")
+                    .attr("x", cx)
+                    .attr("y", cy + this.config.iconSize / 2 + 7);
+                }
+
+                cooldownText
+                  .text(
+                    translateText("events_display.alliance_cooldown_text", {
+                      amount: cooldown,
+                    }),
+                  )
+                  .attr(
+                    "opacity",
+                    isAllianceCooldown ? 0.82 : disabled ? 0.5 : 1,
+                  );
               }
             }
-          }
 
-          // Update timer gradient
-          this.maybeUpdateTimerGradient(item, color, opacity);
+            // Update timer gradient
+            this.maybeUpdateTimerGradient(item, color, opacity);
+          }
         }
       }
     });
@@ -1353,6 +1388,11 @@ export class RadialMenu implements Controller {
     icon?: string,
     update?: boolean,
   ): void {
+    const generation =
+      Number(content.getAttribute("data-render-generation") ?? "0") + 1;
+
+    content.setAttribute("data-render-generation", generation.toString());
+
     if (update) {
       while (content.firstChild) content.removeChild(content.firstChild);
     }
@@ -1366,6 +1406,12 @@ export class RadialMenu implements Controller {
     const iconUrl = icon ?? "";
 
     getSvgAspectRatio(iconUrl).then((ratio) => {
+      if (
+        Number(content.getAttribute("data-render-gneration")) !== generation
+      ) {
+        return;
+      }
+
       const width = smallSize * (ratio ?? 1);
       const gap = 2;
       const totalWidth = width * 2 + gap;

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -1257,7 +1257,6 @@ export class RadialMenu implements Controller {
           }
           // Update timer gradient
           this.maybeUpdateTimerGradient(item, color, opacity);
-          
         }
       }
     });

--- a/src/client/hud/layers/RadialMenu.ts
+++ b/src/client/hud/layers/RadialMenu.ts
@@ -345,7 +345,8 @@ export class RadialMenu implements Controller {
             ? this.config.disabledColor
             : (resolveColor(d.data, this.params) ?? "#1e3a5f");
 
-        const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
+        //const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 1;
+        const opacity = disabled ? 0.4 : 1;
 
         if (d.data.id === this.selectedItemId && this.currentLevel > level) {
           return color;
@@ -367,7 +368,8 @@ export class RadialMenu implements Controller {
           (this.params?.playerActions?.interaction
             ?.allianceRequestCooldownRemaining ?? 0) > 0;
         //to remove the fade down change 0.85 to 1
-        return isAllianceCooldown ? 0.85 : disabled ? 0.5 : 1;
+        //return isAllianceCooldown ? 0.82 : disabled ? 0.4 : 1;  
+        return disabled ? 0.4 : 1;
       })
 
       .style(
@@ -380,11 +382,11 @@ export class RadialMenu implements Controller {
     arcs.each((d) => {
       if (d.data.timerFraction && this.params) {
         const fraction = d.data.timerFraction(this.params);
-        const disabled = this.params === null || d.data.disabled(this.params);
+        const disabled = d.data.disabled(this.params);
         const baseColor = disabled
           ? this.config.disabledColor
           : (resolveColor(d.data, this.params) ?? "#1e3a5f");
-        const opacity = disabled ? 0.4 : 0.82;
+        const opacity = disabled ? 0.4 : 0.82; 
 
         const normalColor =
           d3.color(baseColor)?.copy({ opacity: opacity })?.toString() ??
@@ -525,10 +527,18 @@ export class RadialMenu implements Controller {
         : disabled
           ? this.config.disabledColor
           : (resolveColor(d.data, this.params) ?? "#333333");
-      const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
+      //const opacity = isAllianceCooldown ? 0.82 : disabled ? 0.4 : 0.82;
+      const opacity = disabled ? 0.4 : 0.82
 
       if (d.data.timerFraction) {
-        path.attr("fill", `url(#timer-gradient-${d.data.id})`);
+        //something has to go here 
+
+        path.attr(
+          "fill",
+          d3.color(color)?.copy({ opacity: opacity })?.toString() ?? color,
+        );
+
+        //path.attr("fill", `url(#timer-gradient-${d.data.id})`);
       } else {
         path.attr(
           "fill",
@@ -704,10 +714,7 @@ export class RadialMenu implements Controller {
               .attr("width", width)
               .attr("height", height)
               .attr("x", arc.centroid(d)[0] - width / 2)
-              .attr(
-                "y",
-                isAllianceCooldown ? 42 : arc.centroid(d)[1] - height / 2,
-              );
+              .attr("y", arc.centroid(d)[1] - height / 2);
           });
 
           if (this.params && d.data.cooldown?.(this.params)) {
@@ -722,7 +729,7 @@ export class RadialMenu implements Controller {
               .attr("font-size", "20px")
               .attr("font-weight", "bold")
               .attr("text-anchor", "middle")
-              .attr("x", arc.centroid(d)[0])
+              .attr("x", arc.centroid(d)[0] - this.config.iconSize / 4)
               .attr("y", arc.centroid(d)[1] + this.config.iconSize / 2 + 7);
           }
         }
@@ -1212,10 +1219,6 @@ export class RadialMenu implements Controller {
             // Update image opacity and position
             const imageElement = icon.select("image");
             if (!imageElement.empty()) {
-              const height = parseFloat(imageElement.attr("height") ?? "0");
-              const cy = parseFloat(icon.attr("data-cy") ?? "0");
-
-              imageElement.attr("y", isAllianceCooldown ? 42 : cy - height / 2);
 
               imageElement.attr(
                 "opacity",
@@ -1324,7 +1327,6 @@ export class RadialMenu implements Controller {
     if (!item.timerFraction || !this.params) {
       return;
     }
-
     const fraction = item.timerFraction(this.params);
     const gradient = this.menuElement.select(`#timer-gradient-${item.id}`);
     if (!gradient.empty()) {

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -96,6 +96,7 @@ export const COLORS = {
   boat: "#2a82c9",
   disabled: "#94a3b8",
   ally: "#4ade80",
+  alianceTimeLeft: "#0891b2",
   breakAlly: "#dc2626",
   breakAllyNoDebuff: "#d97706",
   delete: "#ef4444",
@@ -218,6 +219,8 @@ const allyRequestElement: MenuElement = {
   name: "request",
   disabled: (params: MenuElementParams) =>
     !params.playerActions?.interaction?.canSendAllianceRequest,
+  cooldown: (params: MenuElementParams) =>
+    params.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0,
   displayed: (params: MenuElementParams) =>
     !params.playerActions?.interaction?.canBreakAlliance,
   color: COLORS.ally,

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -96,7 +96,7 @@ export const COLORS = {
   boat: "#2a82c9",
   disabled: "#94a3b8",
   ally: "#4ade80",
-  alianceTimeLeft: "#0891b2",
+  allianceTimeLeft: "#0891b2",
   breakAlly: "#dc2626",
   breakAllyNoDebuff: "#d97706",
   delete: "#ef4444",

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -219,12 +219,21 @@ const allyRequestElement: MenuElement = {
   name: "request",
   disabled: (params: MenuElementParams) =>
     !params.playerActions?.interaction?.canSendAllianceRequest,
-  cooldown: (params: MenuElementParams) =>
-    params.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0,
   displayed: (params: MenuElementParams) =>
     !params.playerActions?.interaction?.canBreakAlliance,
-  color: COLORS.ally,
+  color: (params: MenuElementParams) =>
+    (params.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0) > 0 //check this 
+      ? COLORS.allianceTimeLeft
+      : COLORS.ally,
   icon: allianceIcon,
+  timerFraction: (params: MenuElementParams): number => {
+    const remaining = Math.max( //in ticks
+      0,
+      params.playerActions?.interaction?.allianceRequestCooldownRemaining ?? 0, 
+    );
+    const cooldown = Math.max(1, params.game.config().allianceRequestCooldown()); //in ticks
+    return Math.max(0, Math.min(1, remaining / cooldown));
+  },
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleAllianceRequest(
       params.myPlayer,

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -262,6 +262,8 @@ export class GameRunner {
         canSendEmoji: player.canSendEmoji(other),
         canTarget: player.canTarget(other),
         canSendAllianceRequest: player.canSendAllianceRequest(other),
+        allianceRequestCooldownRemaining:
+          player.allianceRequestCooldownRemaining(other),
         canBreakAlliance: player.isAlliedWith(other),
         canDonateGold: player.canDonateGold(other),
         canDonateTroops: player.canDonateTroops(other),

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -668,6 +668,7 @@ export interface Player {
   allianceWith(other: Player): MutableAlliance | null;
   allianceInfo(other: Player): AllianceInfo | null;
   canSendAllianceRequest(other: Player): boolean;
+  allianceRequestCooldownRemaining(other: Player): number;
   breakAlliance(alliance: Alliance): void;
   removeAllAlliances(): void;
   createAllianceRequest(recipient: Player): AllianceRequest | null;
@@ -964,6 +965,7 @@ export interface PlayerInteraction {
   sharedBorder: boolean;
   canSendEmoji: boolean;
   canSendAllianceRequest: boolean;
+  allianceRequestCooldownRemaining?: number;
   canBreakAlliance: boolean;
   canTarget: boolean;
   canDonateGold: boolean;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -736,6 +736,25 @@ export class PlayerImpl implements Player {
     return delta >= this.mg.config().allianceRequestCooldown();
   }
 
+  allianceRequestCooldownRemaining(other: Player): number {
+
+    if (this.isFriendly(other)) {
+      return 0;
+    }
+
+        const recent = this.pastOutgoingAllianceRequests
+      .filter((ar) => ar.recipient() === other)
+      .sort((a, b) => b.createdAt() - a.createdAt());
+
+    if (recent.length === 0) {
+      return 0;
+    }
+
+    const delta = this.mg.ticks() - recent[0].createdAt();
+
+    return Math.max((this.mg.config().allianceRequestCooldown() - delta) / 10, 0);
+  }
+
   breakAlliance(alliance: MutableAlliance): void {
     this.mg.breakAlliance(this, alliance);
   }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -737,12 +737,11 @@ export class PlayerImpl implements Player {
   }
 
   allianceRequestCooldownRemaining(other: Player): number {
-
     if (this.isFriendly(other)) {
       return 0;
     }
 
-        const recent = this.pastOutgoingAllianceRequests
+    const recent = this.pastOutgoingAllianceRequests
       .filter((ar) => ar.recipient() === other)
       .sort((a, b) => b.createdAt() - a.createdAt());
 
@@ -752,7 +751,10 @@ export class PlayerImpl implements Player {
 
     const delta = this.mg.ticks() - recent[0].createdAt();
 
-    return Math.max((this.mg.config().allianceRequestCooldown() - delta) / 10, 0);
+    return Math.max(
+      (this.mg.config().allianceRequestCooldown() - delta) / 10,
+      0,
+    );
   }
 
   breakAlliance(alliance: MutableAlliance): void {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -737,7 +737,36 @@ export class PlayerImpl implements Player {
   }
 
   allianceRequestCooldownRemaining(other: Player): number {
-    if (this.isFriendly(other)) {
+    if (this.mg.config().disableAlliances()) {
+      return 0;
+    }
+    if (other === this) {
+      return 0;
+    }
+    if (this.isDisconnected() || other.isDisconnected()) {
+      // Disconnected players are marked as not-friendly even if they are allies,
+      // so we need to return early if either player is disconnected.
+      // Otherwise we could end up sending an alliance request to someone
+      // we are already allied with.
+      return 0;
+    }
+    if (this.isFriendly(other) || !this.isAlive()) {
+      return 0;
+    }
+
+    const hasPending = this.outgoingAllianceRequests().some(
+      (ar) => ar.recipient() === other,
+    );
+
+    if (hasPending) {
+      return 0;
+    }
+
+    const hasIncoming = this.incomingAllianceRequests().some(
+      (ar) => ar.requestor() === other,
+    );
+
+    if (hasIncoming) {
       return 0;
     }
 
@@ -751,10 +780,9 @@ export class PlayerImpl implements Player {
 
     const delta = this.mg.ticks() - recent[0].createdAt();
 
-    return Math.max(
-      (this.mg.config().allianceRequestCooldown() - delta) / 10,
-      0,
-    );
+    const remainingTicks = this.mg.config().allianceRequestCooldown() - delta;
+
+    return Math.max(Math.floor((remainingTicks + 9) / 10), 0);
   }
 
   breakAlliance(alliance: MutableAlliance): void {

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -737,6 +737,8 @@ export class PlayerImpl implements Player {
   }
 
   allianceRequestCooldownRemaining(other: Player): number {
+  //return ticks remaining
+
     if (this.mg.config().disableAlliances()) {
       return 0;
     }
@@ -782,7 +784,7 @@ export class PlayerImpl implements Player {
 
     const remainingTicks = this.mg.config().allianceRequestCooldown() - delta;
 
-    return Math.max(Math.floor((remainingTicks + 9) / 10), 0);
+    return Math.max(0, remainingTicks);
   }
 
   breakAlliance(alliance: MutableAlliance): void {

--- a/tests/PlayerImpl.test.ts
+++ b/tests/PlayerImpl.test.ts
@@ -169,4 +169,110 @@ describe("PlayerImpl", () => {
       expect(player.numTilesOwned()).toBe(0);
     });
   });
+
+  describe("allianceRequestCooldownRemaining()", () => {
+    let other: Player;
+    let friend: Player;
+
+    beforeEach(async () => {
+      game = await setup("plains", { instantBuild: true }, [
+        new PlayerInfo("player", PlayerType.Human, null, "player_id"),
+        new PlayerInfo("other", PlayerType.Human, null, "other_id"),
+        new PlayerInfo("friend", PlayerType.Human, null, "friend_id"),
+      ]);
+
+      player = game.player("player_id");
+      other = game.player("other_id");
+      friend = game.player("friend_id");
+
+      player.conquer(game.ref(0, 0));
+      other.conquer(game.ref(50, 50));
+      friend.conquer(game.ref(30, 30));
+    });
+
+    test("returns 0 when alliances are disabled", async () => {
+      const disabledGame = await setup(
+        "plains",
+        { instantBuild: true, disableAlliances: true },
+        [
+          new PlayerInfo("player", PlayerType.Human, null, "player_id"),
+          new PlayerInfo("other", PlayerType.Human, null, "other_id"),
+        ],
+      );
+      const disabledPlayer = disabledGame.player("player_id");
+      const disabledOther = disabledGame.player("other_id");
+      disabledPlayer.conquer(disabledGame.ref(0, 0));
+      disabledOther.conquer(disabledGame.ref(50, 50));
+
+      expect(
+        disabledPlayer.allianceRequestCooldownRemaining(disabledOther),
+      ).toBe(0);
+    });
+
+    test("returns 0 for self", () => {
+      expect(player.allianceRequestCooldownRemaining(player)).toBe(0);
+    });
+
+    test("returns 0 when either player is disconnected", () => {
+      player.markDisconnected(true);
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+      player.markDisconnected(false);
+      other.markDisconnected(true);
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+
+    test("returns 0 for friendly players", () => {
+      const request = player.createAllianceRequest(other);
+      expect(request).not.toBeNull();
+      request!.accept();
+
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+
+    test("returns 0 for dead players", () => {
+      const allTiles = Array.from(player.tiles());
+      for (const tile of allTiles) {
+        player.relinquish(tile);
+      }
+      expect(player.isAlive()).toBe(false);
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+
+    test("returns 0 while a request is pending", () => {
+      const request = player.createAllianceRequest(other);
+      expect(request).not.toBeNull();
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+
+    test("returns 0 while an incoming request exists", () => {
+      const request = other.createAllianceRequest(player);
+      expect(request).not.toBeNull();
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+
+    test("returns 0 when no recent request exists", () => {
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+
+    test("rounds remaining cooldown up to whole seconds and expires", () => {
+      const request = player.createAllianceRequest(other);
+      expect(request).not.toBeNull();
+      request!.reject();
+
+      const cooldownTicks = game.config().allianceRequestCooldown();
+      const expectedSeconds = Math.floor((cooldownTicks + 9) / 10);
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(
+        expectedSeconds,
+      );
+
+      const ticksUntilLastSecond = cooldownTicks - 1;
+      for (let i = 0; i < ticksUntilLastSecond; i++) {
+        game.executeNextTick();
+      }
+
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(1);
+      game.executeNextTick();
+      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+    });
+  });
 });

--- a/tests/PlayerImpl.test.ts
+++ b/tests/PlayerImpl.test.ts
@@ -254,25 +254,27 @@ describe("PlayerImpl", () => {
       expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
     });
 
-    test("rounds remaining cooldown up to whole seconds and expires", () => {
+    test("returns remaining cooldown in ticks and expires", () => {
       const request = player.createAllianceRequest(other);
-      expect(request).not.toBeNull();
-      request!.reject();
+  expect(request).not.toBeNull();
+  request!.reject();
 
-      const cooldownTicks = game.config().allianceRequestCooldown();
-      const expectedSeconds = Math.floor((cooldownTicks + 9) / 10);
-      expect(player.allianceRequestCooldownRemaining(other)).toBe(
-        expectedSeconds,
-      );
+  const cooldownTicks = game.config().allianceRequestCooldown();
 
-      const ticksUntilLastSecond = cooldownTicks - 1;
-      for (let i = 0; i < ticksUntilLastSecond; i++) {
-        game.executeNextTick();
-      }
+  expect(player.allianceRequestCooldownRemaining(other)).toBe(
+    cooldownTicks,
+  );
 
-      expect(player.allianceRequestCooldownRemaining(other)).toBe(1);
-      game.executeNextTick();
-      expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
+  const ticksUntilLastTick = cooldownTicks - 1;
+  for (let i = 0; i < ticksUntilLastTick; i++) {
+    game.executeNextTick();
+  }
+
+  expect(player.allianceRequestCooldownRemaining(other)).toBe(1);
+
+  game.executeNextTick();
+
+  expect(player.allianceRequestCooldownRemaining(other)).toBe(0);
     });
   });
 });

--- a/tests/core/GameRunner.test.ts
+++ b/tests/core/GameRunner.test.ts
@@ -1,8 +1,8 @@
+import { Executor } from "../../src/core/execution/ExecutionManager";
 import { NationExecution } from "../../src/core/execution/NationExecution";
 import { SpawnExecution } from "../../src/core/execution/SpawnExecution";
-import { Executor } from "../../src/core/execution/ExecutionManager";
-import { GameRunner } from "../../src/core/GameRunner";
 import { Cell, Nation, PlayerInfo, PlayerType } from "../../src/core/game/Game";
+import { GameRunner } from "../../src/core/GameRunner";
 import { GameConfig, GameID } from "../../src/core/Schemas";
 import { setup } from "../util/Setup";
 import { executeTicks } from "../util/utils";
@@ -124,9 +124,12 @@ describe("GameRunner playerActions interaction payload", () => {
       () => {},
     );
 
+    const request = player.createAllianceRequest(other);
+    expect(request).not.toBeNull();
+    request!.reject();
     const expected = player.allianceRequestCooldownRemaining(other);
+    expect(expected).toBeGreaterThan(0);
     const actions = runner.playerActions(player.id(), 50, 50);
-
     expect(actions.interaction).toBeDefined();
     expect(actions.interaction?.allianceRequestCooldownRemaining).toBe(
       expected,

--- a/tests/core/GameRunner.test.ts
+++ b/tests/core/GameRunner.test.ts
@@ -1,5 +1,7 @@
 import { NationExecution } from "../../src/core/execution/NationExecution";
 import { SpawnExecution } from "../../src/core/execution/SpawnExecution";
+import { Executor } from "../../src/core/execution/ExecutionManager";
+import { GameRunner } from "../../src/core/GameRunner";
 import { Cell, Nation, PlayerInfo, PlayerType } from "../../src/core/game/Game";
 import { GameConfig, GameID } from "../../src/core/Schemas";
 import { setup } from "../util/Setup";
@@ -101,5 +103,33 @@ describe("Nation spawn ordering with random spawn", () => {
 
     expect(game.player(nations[0].info.id).hasSpawned()).toBe(true);
     expect(game.player(nations[0].info.id).isAlive()).toBe(true);
+  });
+});
+
+describe("GameRunner playerActions interaction payload", () => {
+  test("forwards player alliance cooldown remaining through playerActions", async () => {
+    const game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("player", PlayerType.Human, null, "player_id"),
+      new PlayerInfo("other", PlayerType.Human, null, "other_id"),
+    ]);
+
+    const player = game.player("player_id");
+    const other = game.player("other_id");
+    player.conquer(game.ref(0, 0));
+    other.conquer(game.ref(50, 50));
+
+    const runner = new GameRunner(
+      game,
+      new Executor(game, gameID, undefined, []),
+      () => {},
+    );
+
+    const expected = player.allianceRequestCooldownRemaining(other);
+    const actions = runner.playerActions(player.id(), 50, 50);
+
+    expect(actions.interaction).toBeDefined();
+    expect(actions.interaction?.allianceRequestCooldownRemaining).toBe(
+      expected,
+    );
   });
 });


### PR DESCRIPTION
Resolves #4970

## Description:

Currently its impossible to know how long left before you can re-alliance someone, unless you have cheats. I would like to expose this information to the user and make it so that they are able to see when they can next send an alliance request. I added this in the exact same place that someone would go to send an alliance request (if they arent using hotkeys.) 

<img width="279" height="236" alt="image" src="https://github.com/user-attachments/assets/1ec52a3c-6bb4-4794-8ac3-933b5b474ee2" />
<img width="264" height="252" alt="image" src="https://github.com/user-attachments/assets/fd09e4a3-31be-486f-9a10-196ad8dd5a87" />


Addition of alliance cooldown onto the radial menu. The colour is easily changeable as its a constant used throughout. 

## Please complete the following:

- [x] I have added screenshots for all UI updates

## Please put your Discord username so you can be contacted if a bug or regression is found: LDTigerboy
