### PR TITLE
Fix Water Nukes Pathfinding 🚢

### DIFF
--- a/src/core/game/WaterManager.ts
+++ b/src/core/game/WaterManager.ts
@@ -23,6 +23,11 @@ export class WaterManager {
   private _waterStampArr: Uint16Array | null = null;
   private _waterStamp: number = 0;
 
+  // Separate stamp arrays for minimap magnitude BFS (runs after full-map BFS)
+  private _miniDistArr: Uint16Array | null = null;
+  private _miniStampArr: Uint16Array | null = null;
+  private _miniStamp: number = 0;
+
   constructor(
     private map: GameMap,
     private miniMap: GameMap,
@@ -458,6 +463,238 @@ export class WaterManager {
       if (waterCount >= Math.min(3, totalCount)) {
         this.miniMap.setWater(miniTile);
         convertedMiniTiles.add(miniTile);
+      }
+    }
+
+    // ── 4b. Fix minimap ocean + magnitude for converted tiles ────
+    // setWater() zeros the terrain byte (magnitude = 0, ocean = 0).
+    // This makes the pathfinder treat nuked water as "too close to
+    // shore" (3× cost penalty via getMagnitudePenalty) and prevents
+    // LOS smoothing through the crater.  Propagate ocean bits from
+    // existing neighbours and recompute minimap magnitudes via BFS
+    // from all coastlines (including the new crater edges).
+    if (convertedMiniTiles.size > 0) {
+      const miniW = this.miniMap.width();
+
+      // 4b-i. Propagate ocean bit to converted minimap tiles.
+      // Uses BFS so that chains of converted tiles that connect to
+      // the ocean all get marked, even if only the first tile in the
+      // chain touches existing ocean.
+      const miniOceanQueue: TileRef[] = [];
+      for (const mt of convertedMiniTiles) {
+        const mx = this.miniMap.x(mt);
+        const my = this.miniMap.y(mt);
+        let nearOcean = false;
+        if (my > 0 && this.miniMap.isOcean(mt - miniW)) nearOcean = true;
+        if (
+          !nearOcean &&
+          my < this.miniMap.height() - 1 &&
+          this.miniMap.isOcean(mt + miniW)
+        )
+          nearOcean = true;
+        if (!nearOcean && mx > 0 && this.miniMap.isOcean(mt - 1))
+          nearOcean = true;
+        if (!nearOcean && mx < miniW - 1 && this.miniMap.isOcean(mt + 1))
+          nearOcean = true;
+        if (nearOcean) {
+          this.miniMap.setOcean(mt);
+          miniOceanQueue.push(mt);
+        }
+      }
+      let moHead = 0;
+      while (moHead < miniOceanQueue.length) {
+        const tile = miniOceanQueue[moHead++];
+        const tx = tile % miniW;
+        const ty = (tile - tx) / miniW;
+        if (ty > 0) {
+          const n = (tile - miniW) as TileRef;
+          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
+            this.miniMap.setOcean(n);
+            miniOceanQueue.push(n);
+          }
+        }
+        if (ty < this.miniMap.height() - 1) {
+          const n = (tile + miniW) as TileRef;
+          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
+            this.miniMap.setOcean(n);
+            miniOceanQueue.push(n);
+          }
+        }
+        if (tx > 0) {
+          const n = (tile - 1) as TileRef;
+          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
+            this.miniMap.setOcean(n);
+            miniOceanQueue.push(n);
+          }
+        }
+        if (tx < miniW - 1) {
+          const n = (tile + 1) as TileRef;
+          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
+            this.miniMap.setOcean(n);
+            miniOceanQueue.push(n);
+          }
+        }
+      }
+
+      // 4b-ii. Recompute minimap magnitude via BFS from coastlines.
+      //
+      // The previous approach (sampling full-map magnitudes) was wrong:
+      // existing minimap water tiles at the edge of the crater retain
+      // stale pre-computed magnitudes from the terrain file.  When a
+      // nuke creates a new coastline nearby, these tiles should have
+      // LOWER magnitude (closer to the new coast).  Only a BFS on the
+      // minimap can correctly recompute them.
+      //
+      // Mirrors the full-map magnitude BFS (step 2) but runs on the
+      // minimap.  Uses separate stamp/dist arrays to avoid conflicts.
+      const miniTotal = miniW * this.miniMap.height();
+      if (!this._miniDistArr || this._miniDistArr.length !== miniTotal) {
+        this._miniDistArr = new Uint16Array(miniTotal);
+        this._miniStampArr = new Uint16Array(miniTotal);
+        this._miniStamp = 0;
+      }
+      this._miniStamp++;
+      if (this._miniStamp >= 0xffff) {
+        this._miniStampArr!.fill(0);
+        this._miniStamp = 1;
+      }
+      const miniStamp = this._miniStamp;
+      const miniStampArr = this._miniStampArr!;
+      const miniDistArr = this._miniDistArr;
+
+      // Crater bounding box on the full map, mapped to minimap coords.
+      const MINI_MAX_MAG = 31;
+      let mcMinX = w,
+        mcMaxX = 0,
+        mcMinY = h,
+        mcMaxY = 0;
+      for (const tile of converted) {
+        const tx = tile % w;
+        const ty = (tile - tx) / w;
+        if (tx < mcMinX) mcMinX = tx;
+        if (tx > mcMaxX) mcMaxX = tx;
+        if (ty < mcMinY) mcMinY = ty;
+        if (ty > mcMaxY) mcMaxY = ty;
+      }
+      const mcMiniMinX = Math.floor(mcMinX / 2);
+      const mcMiniMaxX = Math.floor(mcMaxX / 2);
+      const mcMiniMinY = Math.floor(mcMinY / 2);
+      const mcMiniMaxY = Math.floor(mcMaxY / 2);
+
+      // Dirty box: minimap tiles whose magnitude may need updating.
+      const mdMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG);
+      const mdMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG);
+      const mdMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG);
+      const mdMaxY = Math.min(
+        this.miniMap.height() - 1,
+        mcMiniMaxY + MINI_MAX_MAG,
+      );
+      // Seed box: coastlines here are seeded; BFS is clipped here.
+      const msMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG * 2);
+      const msMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG * 2);
+      const msMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG * 2);
+      const msMaxY = Math.min(
+        this.miniMap.height() - 1,
+        mcMiniMaxY + MINI_MAX_MAG * 2,
+      );
+
+      // Seed from minimap coastline water tiles inside the seed box.
+      // Coastline = water tile adjacent to at least one land tile.
+      const miniMagQueue: TileRef[] = [];
+      for (let by = msMinY; by <= msMaxY; by++) {
+        const rowStart = by * miniW;
+        for (let bx = msMinX; bx <= msMaxX; bx++) {
+          const tile = (rowStart + bx) as TileRef;
+          if (!this.miniMap.isWater(tile) || miniStampArr[tile] === miniStamp)
+            continue;
+          let isCoast = false;
+          if (by > 0 && this.miniMap.isLand(tile - miniW)) isCoast = true;
+          if (
+            !isCoast &&
+            by < this.miniMap.height() - 1 &&
+            this.miniMap.isLand(tile + miniW)
+          )
+            isCoast = true;
+          if (!isCoast && bx > 0 && this.miniMap.isLand(tile - 1))
+            isCoast = true;
+          if (!isCoast && bx < miniW - 1 && this.miniMap.isLand(tile + 1))
+            isCoast = true;
+          if (isCoast) {
+            miniStampArr[tile] = miniStamp;
+            miniDistArr[tile] = 0;
+            miniMagQueue.push(tile);
+          }
+        }
+      }
+
+      // BFS outward through water, clipped to seed box.
+      let mmHead = 0;
+      while (mmHead < miniMagQueue.length) {
+        const tile = miniMagQueue[mmHead++];
+        const dist = miniDistArr[tile];
+        const nextDist = dist + 1;
+        const tx = tile % miniW;
+        const ty = (tile - tx) / miniW;
+        if (ty > 0) {
+          const n = (tile - miniW) as TileRef;
+          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
+            if (ty - 1 >= msMinY) {
+              miniStampArr[n] = miniStamp;
+              miniDistArr[n] = nextDist;
+              miniMagQueue.push(n);
+            }
+          }
+        }
+        if (ty < this.miniMap.height() - 1) {
+          const n = (tile + miniW) as TileRef;
+          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
+            if (ty + 1 <= msMaxY) {
+              miniStampArr[n] = miniStamp;
+              miniDistArr[n] = nextDist;
+              miniMagQueue.push(n);
+            }
+          }
+        }
+        if (tx > 0) {
+          const n = (tile - 1) as TileRef;
+          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
+            if (tx - 1 >= msMinX) {
+              miniStampArr[n] = miniStamp;
+              miniDistArr[n] = nextDist;
+              miniMagQueue.push(n);
+            }
+          }
+        }
+        if (tx < miniW - 1) {
+          const n = (tile + 1) as TileRef;
+          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
+            if (tx + 1 <= msMaxX) {
+              miniStampArr[n] = miniStamp;
+              miniDistArr[n] = nextDist;
+              miniMagQueue.push(n);
+            }
+          }
+        }
+      }
+
+      // Update magnitudes for ALL minimap water tiles in the dirty box.
+      for (let dy = mdMinY; dy <= mdMaxY; dy++) {
+        const rowStart = dy * miniW;
+        for (let dx = mdMinX; dx <= mdMaxX; dx++) {
+          const tile = (rowStart + dx) as TileRef;
+          if (!this.miniMap.isWater(tile)) continue;
+          const oldMag = this.miniMap.magnitude(tile);
+          let newMag: number;
+          if (miniStampArr[tile] === miniStamp) {
+            newMag = Math.min(Math.ceil(miniDistArr[tile] / 2), 31);
+          } else {
+            // Unreached: nearest coast is >MINI_MAX_MAG*2 away → deep water
+            newMag = 31;
+          }
+          if (oldMag !== newMag) {
+            this.miniMap.setMagnitude(tile, newMag);
+          }
+        }
       }
     }
 

--- a/src/core/game/WaterManager.ts
+++ b/src/core/game/WaterManager.ts
@@ -475,6 +475,22 @@ export class WaterManager {
     // from all coastlines (including the new crater edges).
     if (convertedMiniTiles.size > 0) {
       const miniW = this.miniMap.width();
+      const miniH = this.miniMap.height();
+
+      // Allocation-free cardinal-neighbor helper for all minimap BFSes.
+      // Writes up to 4 neighbors into `out` and returns the count.
+      const pushMiniNeighbors = (tile: TileRef, out: TileRef[]): number => {
+        const x = tile % miniW;
+        const y = (tile - x) / miniW;
+        let count = 0;
+        if (y > 0) out[count++] = (tile - miniW) as TileRef;
+        if (y < miniH - 1) out[count++] = (tile + miniW) as TileRef;
+        if (x > 0) out[count++] = (tile - 1) as TileRef;
+        if (x < miniW - 1) out[count++] = (tile + 1) as TileRef;
+        return count;
+      };
+
+      const miniNb: TileRef[] = new Array(4);
 
       // 4b-i. Propagate ocean bit to converted minimap tiles.
       // Uses BFS so that chains of converted tiles that connect to
@@ -482,20 +498,14 @@ export class WaterManager {
       // chain touches existing ocean.
       const miniOceanQueue: TileRef[] = [];
       for (const mt of convertedMiniTiles) {
-        const mx = this.miniMap.x(mt);
-        const my = this.miniMap.y(mt);
+        const nc = pushMiniNeighbors(mt, miniNb);
         let nearOcean = false;
-        if (my > 0 && this.miniMap.isOcean(mt - miniW)) nearOcean = true;
-        if (
-          !nearOcean &&
-          my < this.miniMap.height() - 1 &&
-          this.miniMap.isOcean(mt + miniW)
-        )
-          nearOcean = true;
-        if (!nearOcean && mx > 0 && this.miniMap.isOcean(mt - 1))
-          nearOcean = true;
-        if (!nearOcean && mx < miniW - 1 && this.miniMap.isOcean(mt + 1))
-          nearOcean = true;
+        for (let i = 0; i < nc; i++) {
+          if (this.miniMap.isOcean(miniNb[i])) {
+            nearOcean = true;
+            break;
+          }
+        }
         if (nearOcean) {
           this.miniMap.setOcean(mt);
           miniOceanQueue.push(mt);
@@ -504,31 +514,9 @@ export class WaterManager {
       let moHead = 0;
       while (moHead < miniOceanQueue.length) {
         const tile = miniOceanQueue[moHead++];
-        const tx = tile % miniW;
-        const ty = (tile - tx) / miniW;
-        if (ty > 0) {
-          const n = (tile - miniW) as TileRef;
-          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
-            this.miniMap.setOcean(n);
-            miniOceanQueue.push(n);
-          }
-        }
-        if (ty < this.miniMap.height() - 1) {
-          const n = (tile + miniW) as TileRef;
-          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
-            this.miniMap.setOcean(n);
-            miniOceanQueue.push(n);
-          }
-        }
-        if (tx > 0) {
-          const n = (tile - 1) as TileRef;
-          if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
-            this.miniMap.setOcean(n);
-            miniOceanQueue.push(n);
-          }
-        }
-        if (tx < miniW - 1) {
-          const n = (tile + 1) as TileRef;
+        const nc = pushMiniNeighbors(tile, miniNb);
+        for (let i = 0; i < nc; i++) {
+          const n = miniNb[i];
           if (this.miniMap.isWater(n) && !this.miniMap.isOcean(n)) {
             this.miniMap.setOcean(n);
             miniOceanQueue.push(n);
@@ -563,7 +551,8 @@ export class WaterManager {
       const miniDistArr = this._miniDistArr;
 
       // Crater bounding box on the full map, mapped to minimap coords.
-      const MINI_MAX_MAG = 31;
+      // MINI_MAX_MAG_DIST = max hops from coast = max_magnitude (31) × 2.
+      const MINI_MAX_MAG_DIST = 62;
       let mcMinX = w,
         mcMaxX = 0,
         mcMinY = h,
@@ -582,25 +571,26 @@ export class WaterManager {
       const mcMiniMaxY = Math.floor(mcMaxY / 2);
 
       // Dirty box: minimap tiles whose magnitude may need updating.
-      const mdMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG);
-      const mdMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG);
-      const mdMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG);
+      const mdMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG_DIST);
+      const mdMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG_DIST);
+      const mdMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG_DIST);
       const mdMaxY = Math.min(
         this.miniMap.height() - 1,
-        mcMiniMaxY + MINI_MAX_MAG,
+        mcMiniMaxY + MINI_MAX_MAG_DIST,
       );
       // Seed box: coastlines here are seeded; BFS is clipped here.
-      const msMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG * 2);
-      const msMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG * 2);
-      const msMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG * 2);
+      const msMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG_DIST * 2);
+      const msMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG_DIST * 2);
+      const msMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG_DIST * 2);
       const msMaxY = Math.min(
         this.miniMap.height() - 1,
-        mcMiniMaxY + MINI_MAX_MAG * 2,
+        mcMiniMaxY + MINI_MAX_MAG_DIST * 2,
       );
 
       // Seed from minimap coastline water tiles inside the seed box.
       // Coastline = water tile adjacent to at least one land tile.
       const miniMagQueue: TileRef[] = [];
+
       for (let by = msMinY; by <= msMaxY; by++) {
         const rowStart = by * miniW;
         for (let bx = msMinX; bx <= msMaxX; bx++) {
@@ -608,17 +598,13 @@ export class WaterManager {
           if (!this.miniMap.isWater(tile) || miniStampArr[tile] === miniStamp)
             continue;
           let isCoast = false;
-          if (by > 0 && this.miniMap.isLand(tile - miniW)) isCoast = true;
-          if (
-            !isCoast &&
-            by < this.miniMap.height() - 1 &&
-            this.miniMap.isLand(tile + miniW)
-          )
-            isCoast = true;
-          if (!isCoast && bx > 0 && this.miniMap.isLand(tile - 1))
-            isCoast = true;
-          if (!isCoast && bx < miniW - 1 && this.miniMap.isLand(tile + 1))
-            isCoast = true;
+          const nc = pushMiniNeighbors(tile, miniNb);
+          for (let i = 0; i < nc; i++) {
+            if (this.miniMap.isLand(miniNb[i])) {
+              isCoast = true;
+              break;
+            }
+          }
           if (isCoast) {
             miniStampArr[tile] = miniStamp;
             miniDistArr[tile] = 0;
@@ -631,49 +617,19 @@ export class WaterManager {
       let mmHead = 0;
       while (mmHead < miniMagQueue.length) {
         const tile = miniMagQueue[mmHead++];
-        const dist = miniDistArr[tile];
-        const nextDist = dist + 1;
-        const tx = tile % miniW;
-        const ty = (tile - tx) / miniW;
-        if (ty > 0) {
-          const n = (tile - miniW) as TileRef;
-          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
-            if (ty - 1 >= msMinY) {
-              miniStampArr[n] = miniStamp;
-              miniDistArr[n] = nextDist;
-              miniMagQueue.push(n);
-            }
-          }
-        }
-        if (ty < this.miniMap.height() - 1) {
-          const n = (tile + miniW) as TileRef;
-          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
-            if (ty + 1 <= msMaxY) {
-              miniStampArr[n] = miniStamp;
-              miniDistArr[n] = nextDist;
-              miniMagQueue.push(n);
-            }
-          }
-        }
-        if (tx > 0) {
-          const n = (tile - 1) as TileRef;
-          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
-            if (tx - 1 >= msMinX) {
-              miniStampArr[n] = miniStamp;
-              miniDistArr[n] = nextDist;
-              miniMagQueue.push(n);
-            }
-          }
-        }
-        if (tx < miniW - 1) {
-          const n = (tile + 1) as TileRef;
-          if (this.miniMap.isWater(n) && miniStampArr[n] !== miniStamp) {
-            if (tx + 1 <= msMaxX) {
-              miniStampArr[n] = miniStamp;
-              miniDistArr[n] = nextDist;
-              miniMagQueue.push(n);
-            }
-          }
+        const nextDist = miniDistArr[tile] + 1;
+        const nc = pushMiniNeighbors(tile, miniNb);
+        for (let i = 0; i < nc; i++) {
+          const n = miniNb[i];
+          if (!this.miniMap.isWater(n) || miniStampArr[n] === miniStamp)
+            continue;
+          const nx = n % miniW;
+          const ny = (n - nx) / miniW;
+          if (nx < msMinX || nx > msMaxX || ny < msMinY || ny > msMaxY)
+            continue;
+          miniStampArr[n] = miniStamp;
+          miniDistArr[n] = nextDist;
+          miniMagQueue.push(n);
         }
       }
 
@@ -688,7 +644,7 @@ export class WaterManager {
           if (miniStampArr[tile] === miniStamp) {
             newMag = Math.min(Math.ceil(miniDistArr[tile] / 2), 31);
           } else {
-            // Unreached: nearest coast is >MINI_MAX_MAG*2 away → deep water
+            // Unreached: nearest coast is >MINI_MAX_MAG_DIST*2 away → deep water
             newMag = 31;
           }
           if (oldMag !== newMag) {

--- a/tests/nukes/WaterNukes.test.ts
+++ b/tests/nukes/WaterNukes.test.ts
@@ -136,6 +136,139 @@ describe("Water Nukes", () => {
 
       expect(navGame.waterGraphVersion()).toBeGreaterThan(versionBefore);
     });
+
+    test("minimap tiles get correct magnitude after water nuke", async () => {
+      // Need nav mesh to verify minimap pathfinding-relevant state
+      const navGame = await setup(
+        "plains",
+        {
+          infiniteGold: true,
+          instantBuild: true,
+          waterNukes: true,
+          disableNavMesh: false,
+        },
+        [info],
+      );
+      const player2 = navGame.player(info.id);
+      player2.conquer(navGame.ref(1, 1));
+      constructionExecution(navGame, player2, 1, 1, UnitType.MissileSilo);
+
+      const target = navGame.ref(50, 50);
+      navGame.addExecution(
+        new NukeExecution(UnitType.AtomBomb, player2, target, null),
+      );
+      for (let i = 0; i < 80; i++) navGame.executeNextTick();
+
+      const miniMap = navGame.miniMap();
+      const fullMap = navGame.map();
+      const tx = fullMap.x(target);
+      const ty = fullMap.y(target);
+      const mt = miniMap.ref(Math.floor(tx / 2), Math.floor(ty / 2));
+
+      // The minimap tile at the nuke center should be water
+      if (miniMap.isWater(mt)) {
+        // Magnitude must be in valid range — the BFS must have run.
+        // For a small nuke the tile is at the coastline so magnitude 0
+        // is the correct expected value (not a stale value from the
+        // terrain file).
+        const mag = miniMap.magnitude(mt);
+        expect(mag).toBeGreaterThanOrEqual(0);
+        expect(mag).toBeLessThanOrEqual(31);
+
+        // If the tile is NOT adjacent to land it must have magnitude > 0.
+        const mw = miniMap.width();
+        let adjacentToLand = false;
+        if (miniMap.y(mt) > 0 && miniMap.isLand(mt - mw)) adjacentToLand = true;
+        if (
+          !adjacentToLand &&
+          miniMap.y(mt) < miniMap.height() - 1 &&
+          miniMap.isLand(mt + mw)
+        )
+          adjacentToLand = true;
+        if (!adjacentToLand && miniMap.x(mt) > 0 && miniMap.isLand(mt - 1))
+          adjacentToLand = true;
+        if (!adjacentToLand && miniMap.x(mt) < mw - 1 && miniMap.isLand(mt + 1))
+          adjacentToLand = true;
+        if (!adjacentToLand) {
+          // Interior water tile — should not be treated as shore
+          expect(mag).toBeGreaterThan(0);
+        }
+      }
+    });
+
+    test("minimap ocean bit propagates to nuked water near ocean", async () => {
+      const navGame = await setup(
+        "plains",
+        {
+          infiniteGold: true,
+          instantBuild: true,
+          waterNukes: true,
+          disableNavMesh: false,
+        },
+        [info],
+      );
+      const player2 = navGame.player(info.id);
+      player2.conquer(navGame.ref(1, 1));
+      constructionExecution(navGame, player2, 1, 1, UnitType.MissileSilo);
+
+      // Find an ocean tile on the minimap, then nuke nearby land
+      const miniMap = navGame.miniMap();
+      const fullMap = navGame.map();
+
+      // Scan for a minimap ocean tile to find where ocean is
+      let oceanMiniX = -1;
+      let oceanMiniY = -1;
+      for (let y = 0; y < miniMap.height() && oceanMiniX < 0; y++) {
+        for (let x = 0; x < miniMap.width() && oceanMiniX < 0; x++) {
+          if (miniMap.isOcean(miniMap.ref(x, y))) {
+            oceanMiniX = x;
+            oceanMiniY = y;
+          }
+        }
+      }
+
+      if (oceanMiniX >= 0) {
+        // Find land next to the ocean on the full map
+        // Nuke at an offset from the ocean tile that's on land
+        const landX = oceanMiniX * 2 + 4; // 4 full-map tiles from ocean edge
+        const landY = oceanMiniY * 2;
+        if (fullMap.isValidCoord(landX, landY)) {
+          const nukeTarget = fullMap.ref(landX, landY);
+          if (fullMap.isLand(nukeTarget)) {
+            navGame.addExecution(
+              new NukeExecution(UnitType.AtomBomb, player2, nukeTarget, null),
+            );
+            for (let i = 0; i < 80; i++) navGame.executeNextTick();
+
+            // Check if the converted minimap tile got the ocean bit
+            const nukeMiniX = Math.floor(landX / 2);
+            const nukeMiniY = Math.floor(landY / 2);
+            if (miniMap.isValidCoord(nukeMiniX, nukeMiniY)) {
+              const nukeMini = miniMap.ref(nukeMiniX, nukeMiniY);
+              if (miniMap.isWater(nukeMini)) {
+                // If this tile is adjacent to ocean on the minimap,
+                // it should have the ocean bit set
+                let adjacentToOcean = false;
+                if (
+                  nukeMiniY > 0 &&
+                  miniMap.isOcean(nukeMini - miniMap.width())
+                )
+                  adjacentToOcean = true;
+                if (
+                  !adjacentToOcean &&
+                  nukeMiniX > 0 &&
+                  miniMap.isOcean(nukeMini - 1)
+                )
+                  adjacentToOcean = true;
+                if (adjacentToOcean) {
+                  expect(miniMap.isOcean(nukeMini)).toBe(true);
+                }
+              }
+            }
+          }
+        }
+      }
+    });
   });
 
   describe("when waterNukes is disabled (default)", () => {

--- a/tests/nukes/WaterNukes.test.ts
+++ b/tests/nukes/WaterNukes.test.ts
@@ -138,7 +138,6 @@ describe("Water Nukes", () => {
     });
 
     test("minimap tiles get correct magnitude after water nuke", async () => {
-      // Need nav mesh to verify minimap pathfinding-relevant state
       const navGame = await setup(
         "plains",
         {
@@ -161,44 +160,37 @@ describe("Water Nukes", () => {
 
       const miniMap = navGame.miniMap();
       const fullMap = navGame.map();
-      const tx = fullMap.x(target);
-      const ty = fullMap.y(target);
-      const mt = miniMap.ref(Math.floor(tx / 2), Math.floor(ty / 2));
+      const mt = miniMap.ref(
+        Math.floor(fullMap.x(target) / 2),
+        Math.floor(fullMap.y(target) / 2),
+      );
 
-      // The minimap tile at the nuke center should be water
-      if (miniMap.isWater(mt)) {
-        // Magnitude must be in valid range — the BFS must have run.
-        // For a small nuke the tile is at the coastline so magnitude 0
-        // is the correct expected value (not a stale value from the
-        // terrain file).
-        const mag = miniMap.magnitude(mt);
-        expect(mag).toBeGreaterThanOrEqual(0);
-        expect(mag).toBeLessThanOrEqual(31);
+      // The minimap tile at the nuke center should be water after the nuke.
+      expect(miniMap.isWater(mt)).toBe(true);
 
-        // If the tile is NOT adjacent to land it must have magnitude > 0.
-        const mw = miniMap.width();
-        let adjacentToLand = false;
-        if (miniMap.y(mt) > 0 && miniMap.isLand(mt - mw)) adjacentToLand = true;
-        if (
-          !adjacentToLand &&
-          miniMap.y(mt) < miniMap.height() - 1 &&
-          miniMap.isLand(mt + mw)
-        )
-          adjacentToLand = true;
-        if (!adjacentToLand && miniMap.x(mt) > 0 && miniMap.isLand(mt - 1))
-          adjacentToLand = true;
-        if (!adjacentToLand && miniMap.x(mt) < mw - 1 && miniMap.isLand(mt + 1))
-          adjacentToLand = true;
-        if (!adjacentToLand) {
-          // Interior water tile — should not be treated as shore
-          expect(mag).toBeGreaterThan(0);
-        }
+      // Magnitude must be in valid range (0-31) — the BFS ran.
+      const mag = miniMap.magnitude(mt);
+      expect(mag).toBeGreaterThanOrEqual(0);
+      expect(mag).toBeLessThanOrEqual(31);
+
+      // An interior water tile (not adjacent to any land) must have
+      // magnitude > 0 — it should not be treated as shoreline.
+      const mw = miniMap.width();
+      const my = miniMap.y(mt);
+      const mx = miniMap.x(mt);
+      const adjacentToLand =
+        (my > 0 && miniMap.isLand(mt - mw)) ||
+        (my < miniMap.height() - 1 && miniMap.isLand(mt + mw)) ||
+        (mx > 0 && miniMap.isLand(mt - 1)) ||
+        (mx < mw - 1 && miniMap.isLand(mt + 1));
+      if (!adjacentToLand) {
+        expect(mag).toBeGreaterThan(0);
       }
     });
 
     test("minimap ocean bit propagates to nuked water near ocean", async () => {
       const navGame = await setup(
-        "plains",
+        "ocean_and_land",
         {
           infiniteGold: true,
           instantBuild: true,
@@ -211,62 +203,61 @@ describe("Water Nukes", () => {
       player2.conquer(navGame.ref(1, 1));
       constructionExecution(navGame, player2, 1, 1, UnitType.MissileSilo);
 
-      // Find an ocean tile on the minimap, then nuke nearby land
       const miniMap = navGame.miniMap();
       const fullMap = navGame.map();
 
-      // Scan for a minimap ocean tile to find where ocean is
-      let oceanMiniX = -1;
-      let oceanMiniY = -1;
-      for (let y = 0; y < miniMap.height() && oceanMiniX < 0; y++) {
-        for (let x = 0; x < miniMap.width() && oceanMiniX < 0; x++) {
-          if (miniMap.isOcean(miniMap.ref(x, y))) {
-            oceanMiniX = x;
-            oceanMiniY = y;
-          }
-        }
-      }
-
-      if (oceanMiniX >= 0) {
-        // Find land next to the ocean on the full map
-        // Nuke at an offset from the ocean tile that's on land
-        const landX = oceanMiniX * 2 + 4; // 4 full-map tiles from ocean edge
-        const landY = oceanMiniY * 2;
-        if (fullMap.isValidCoord(landX, landY)) {
-          const nukeTarget = fullMap.ref(landX, landY);
-          if (fullMap.isLand(nukeTarget)) {
-            navGame.addExecution(
-              new NukeExecution(UnitType.AtomBomb, player2, nukeTarget, null),
-            );
-            for (let i = 0; i < 80; i++) navGame.executeNextTick();
-
-            // Check if the converted minimap tile got the ocean bit
-            const nukeMiniX = Math.floor(landX / 2);
-            const nukeMiniY = Math.floor(landY / 2);
-            if (miniMap.isValidCoord(nukeMiniX, nukeMiniY)) {
-              const nukeMini = miniMap.ref(nukeMiniX, nukeMiniY);
-              if (miniMap.isWater(nukeMini)) {
-                // If this tile is adjacent to ocean on the minimap,
-                // it should have the ocean bit set
-                let adjacentToOcean = false;
-                if (
-                  nukeMiniY > 0 &&
-                  miniMap.isOcean(nukeMini - miniMap.width())
-                )
-                  adjacentToOcean = true;
-                if (
-                  !adjacentToOcean &&
-                  nukeMiniX > 0 &&
-                  miniMap.isOcean(nukeMini - 1)
-                )
-                  adjacentToOcean = true;
-                if (adjacentToOcean) {
-                  expect(miniMap.isOcean(nukeMini)).toBe(true);
-                }
-              }
+      // Find a minimap ocean tile that has an adjacent land tile (coastline).
+      let oceanMt: TileRef | null = null;
+      let landMt: TileRef | null = null;
+      const mw = miniMap.width();
+      for (let y = 1; y < miniMap.height() - 1 && oceanMt === null; y++) {
+        for (let x = 1; x < mw - 1; x++) {
+          const t = miniMap.ref(x, y);
+          if (!miniMap.isOcean(t)) continue;
+          // Check cardinal neighbors for land
+          for (const n of [t - mw, t + mw, t - 1, t + 1]) {
+            if (miniMap.isLand(n)) {
+              oceanMt = t;
+              landMt = n;
+              break;
             }
           }
+          if (oceanMt) break;
         }
+      }
+      expect(oceanMt).not.toBeNull();
+      expect(landMt).not.toBeNull();
+
+      // Nuke the land tile adjacent to ocean on the full map.
+      const landMiniX = miniMap.x(landMt!);
+      const landMiniY = miniMap.y(landMt!);
+      const landX = landMiniX * 2 + 1;
+      const landY = landMiniY * 2 + 1;
+      expect(fullMap.isValidCoord(landX, landY)).toBe(true);
+      const nukeTarget = fullMap.ref(landX, landY);
+      expect(fullMap.isLand(nukeTarget)).toBe(true);
+
+      navGame.addExecution(
+        new NukeExecution(UnitType.AtomBomb, player2, nukeTarget, null),
+      );
+      for (let i = 0; i < 80; i++) navGame.executeNextTick();
+
+      // The nuke should have converted the minimap tile to water.
+      const nukeMiniX = Math.floor(landX / 2);
+      const nukeMiniY = Math.floor(landY / 2);
+      expect(miniMap.isValidCoord(nukeMiniX, nukeMiniY)).toBe(true);
+      const nukeMini = miniMap.ref(nukeMiniX, nukeMiniY);
+      expect(miniMap.isWater(nukeMini)).toBe(true);
+
+      // If the converted tile is adjacent to ocean on the minimap,
+      // the ocean bit should have been propagated.
+      const nmy = miniMap.y(nukeMini);
+      const nmx = miniMap.x(nukeMini);
+      const adjacentToOcean =
+        (nmy > 0 && miniMap.isOcean(nukeMini - mw)) ||
+        (nmx > 0 && miniMap.isOcean(nukeMini - 1));
+      if (adjacentToOcean) {
+        expect(miniMap.isOcean(nukeMini)).toBe(true);
       }
     });
   });


### PR DESCRIPTION
## Description:

Fixes #4760. Check the images there. Pathfinding in water-nuked areas was sometimes weird.
Performance seems to be similar.

## World map, Canada to Madagascar, Africa is waternuked

PROD situation:

<img width="915" height="760" alt="Screenshot 2026-08-12 171341" src="https://github.com/user-attachments/assets/13fd48ae-f538-45a7-ace2-e1b9583c5337" />

This PR fixes the path:

<img width="859" height="682" alt="Screenshot 2026-08-12 171302" src="https://github.com/user-attachments/assets/bf6fecee-8096-4871-a87d-b1b0032fdbb0" />

## Technical

After water nukes convert minimap tiles to water, `setWater()` zeros the terrain byte, leaving magnitude at 0 and clearing the ocean bit. The existing full-map magnitude recomputation (step 2 of `finalizeWaterChanges`) never runs on the minimap, so all nuked minimap tiles get stuck with magnitude 0 permanently.

This causes two pathfinding issues:
1. `AStarWaterBounded` applies a 3x cost penalty per step through magnitude < 3 tiles (cost 400 vs 100), making the pathfinder strongly avoid routing through nuked water
2. `SmoothingWaterTransformer` rejects LOS shortcuts through magnitude < 2 tiles (pass 1) and < 3 tiles (pass 2), preventing path smoothing through crater areas

Additionally, existing minimap water tiles at the edge of a nuke crater retain stale pre-computed magnitudes from the terrain file. When a nuke creates a new coastline nearby, these tiles should have lower magnitude (closer to the new coast) but keep their old high values.

The fix adds step 4b in `finalizeWaterChanges()`:
- **Ocean propagation**: BFS from existing ocean minimap tiles into newly converted tiles, so nuked water connecting to the ocean is correctly marked
- **Magnitude BFS on minimap**: Mirrors the full-map magnitude BFS (step 2) but runs on the minimap. Seeds from all minimap coastlines (including the new crater edges), BFS outward through water, and updates magnitudes for ALL affected minimap water tiles in the dirty box. Uses separate stamp/dist arrays to avoid conflicts with the full-map BFS.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin