### PR TITLE
perf: optimize water-nuke terrain finalize and water graph rebuild

### DIFF
--- a/src/core/game/WaterManager.ts
+++ b/src/core/game/WaterManager.ts
@@ -3,14 +3,44 @@ import {
   AbstractGraphBuilder,
 } from "../pathfinding/algorithms/AbstractGraph";
 import { AStarWaterHierarchical } from "../pathfinding/algorithms/AStar.WaterHierarchical";
+import { BFSGrid } from "../pathfinding/algorithms/BFS.Grid";
+import { ConnectedComponents } from "../pathfinding/algorithms/ConnectedComponents";
 import { PathFinder } from "../pathfinding/types";
+import { DebugSpan } from "../utilities/DebugSpan";
 import { GameMap, TileRef } from "./GameMap";
 
 const WATER_GRAPH_REBUILD_INTERVAL = 20;
 
+// Max BFS hops from a coastline that can affect a magnitude value:
+// magnitude = ceil(dist / 2) capped at 31, so 62 hops.
+const MAX_MAG_DIST = 62;
+
+// Direct terrain-byte masks, mirroring GameMapImpl's private constants
+// (bit 7 = land, low 5 bits = magnitude, magnitude 31 on land = impassable).
+// The magnitude BFS reads terrain bytes directly because method calls
+// dominate its cost on large maps (same precedent as
+// ConnectedComponents.premarkLandTilesDirect).
+const TERRAIN_LAND_MASK = 0x80;
+const TERRAIN_MAG_MASK = 0x1f;
+const IMPASSABLE_MAG = 31;
+
+interface CraterBounds {
+  minX: number;
+  maxX: number;
+  minY: number;
+  maxY: number;
+}
+
 export class WaterManager {
   private _miniWaterGraph: AbstractGraph | null = null;
   private _miniWaterHPA: AStarWaterHierarchical | null = null;
+  // Persistent minimap water components, updated incrementally as nukes
+  // convert land→water (components only grow/merge, never split), so
+  // graph rebuilds skip the full-minimap flood fill.
+  private _miniWaterCC: ConnectedComponents | null = null;
+  // Reusable minimap-sized BFS scratch for graph rebuilds (~20MB on
+  // large maps — allocated once instead of per rebuild).
+  private _builderBFS: BFSGrid | null = null;
   private _waterGraphVersion: number = 0;
   private _waterGraphDirty: boolean = false;
   private _waterGraphLastRebuildTick: number = 0;
@@ -34,7 +64,17 @@ export class WaterManager {
     private disableNavMesh: boolean,
   ) {
     if (!disableNavMesh) {
-      const graphBuilder = new AbstractGraphBuilder(miniMap);
+      this._miniWaterCC = new ConnectedComponents(miniMap);
+      this._miniWaterCC.initialize();
+      this._builderBFS = new BFSGrid(miniMap.width() * miniMap.height());
+      const graphBuilder = new AbstractGraphBuilder(
+        miniMap,
+        AbstractGraphBuilder.CLUSTER_SIZE,
+        undefined,
+        undefined,
+        this._miniWaterCC,
+        this._builderBFS,
+      );
       this._miniWaterGraph = graphBuilder.build();
       this._miniWaterHPA = new AStarWaterHierarchical(
         miniMap,
@@ -86,19 +126,30 @@ export class WaterManager {
     ) {
       this._waterGraphDirty = false;
       this._waterGraphLastRebuildTick = currentTick;
+      DebugSpan.start("WaterManager:rebuildWaterGraph");
       const graphBuilder = new AbstractGraphBuilder(
         this.miniMap,
         AbstractGraphBuilder.CLUSTER_SIZE,
         this._miniWaterGraph ?? undefined,
         this._dirtyMiniTiles.size > 0 ? this._dirtyMiniTiles : undefined,
+        this._miniWaterCC ?? undefined,
+        this._builderBFS ?? undefined,
       );
       this._miniWaterGraph = graphBuilder.build();
       this._dirtyMiniTiles.clear();
-      this._miniWaterHPA = new AStarWaterHierarchical(
-        this.miniMap,
-        this._miniWaterGraph,
-        { cachePaths: true },
-      );
+      DebugSpan.start("hpa");
+      if (this._miniWaterHPA) {
+        // Reuse map-sized scratch buffers; only swap the graph
+        this._miniWaterHPA.setGraph(this._miniWaterGraph);
+      } else {
+        this._miniWaterHPA = new AStarWaterHierarchical(
+          this.miniMap,
+          this._miniWaterGraph,
+          { cachePaths: true },
+        );
+      }
+      DebugSpan.end("hpa");
+      DebugSpan.end("WaterManager:rebuildWaterGraph");
       this._waterGraphVersion++;
     }
 
@@ -209,6 +260,7 @@ export class WaterManager {
     const converted = new Set<TileRef>(convertedTiles);
     if (converted.size === 0) return;
 
+    DebugSpan.start("WaterManager:finalizeWaterChanges");
     const map = this.map;
     const w = map.width();
     const totalTiles = w * map.height();
@@ -236,6 +288,7 @@ export class WaterManager {
     const nb: TileRef[] = new Array(8);
 
     // ── 1. Propagate ocean bit ─────────────────────────────────────
+    DebugSpan.start("ocean");
     const oceanQueue: TileRef[] = [];
     for (const tile of converted) {
       const end = pushNeighbors(tile, nb, 0);
@@ -261,141 +314,56 @@ export class WaterManager {
     }
 
     // ── 2. Recompute magnitude via BFS from remaining land outward ─
+    DebugSpan.end("ocean");
+    DebugSpan.start("magnitude");
     if (!this._waterDistArr || this._waterDistArr.length !== totalTiles) {
       this._waterDistArr = new Uint16Array(totalTiles);
       this._waterStampArr = new Uint16Array(totalTiles);
       this._waterStamp = 0;
     }
-    this._waterStamp++;
-    if (this._waterStamp >= 0xffff) {
-      this._waterStampArr!.fill(0);
-      this._waterStamp = 1;
-    }
-    const stamp = this._waterStamp;
-    const stampArr = this._waterStampArr!;
-    const distArr = this._waterDistArr;
-
-    const magQueue: TileRef[] = [];
-    const h = map.height();
-
     // Magnitude BFS: recompute ceil(manhattan_dist_to_nearest_coast / 2)
     // for tiles affected by the nuke.
     //
-    // Dirty box (±MAX_MAG_DIST from crater bounds): the region where
-    // magnitudes may have changed.  Only tiles here get updated.
-    //
-    // Seed box (±2*MAX_MAG_DIST from crater bounds): coastlines here are
-    // seeded for BFS.  This ensures that every coastline that could be
-    // nearest to a dirty-box tile is included (a dirty-box tile is at most
-    // MAX_MAG_DIST from the crater, and the nearest coast is at most
-    // MAX_MAG_DIST from the tile, so the coast is at most 2*MAX_MAG_DIST
-    // from the crater).
-    //
-    // The BFS runs WITHOUT convergence inside the seed box so that
-    // wavefronts from distant coastlines correctly reach the dirty box.
-    // BFS is clipped at the seed box boundary for performance.
-    const MAX_MAG_DIST = 62; // magnitude 31 ≈ 62 tile hops from coast
-    let cMinX = w,
-      cMaxX = 0,
-      cMinY = h,
-      cMaxY = 0;
-    for (const tile of converted) {
-      const tx = tile % w;
-      const ty = (tile - tx) / w;
-      if (tx < cMinX) cMinX = tx;
-      if (tx > cMaxX) cMaxX = tx;
-      if (ty < cMinY) cMinY = ty;
-      if (ty > cMaxY) cMaxY = ty;
-    }
-    // Dirty box: tiles whose magnitude may need updating.
-    const dMinX = Math.max(0, cMinX - MAX_MAG_DIST);
-    const dMaxX = Math.min(w - 1, cMaxX + MAX_MAG_DIST);
-    const dMinY = Math.max(0, cMinY - MAX_MAG_DIST);
-    const dMaxY = Math.min(h - 1, cMaxY + MAX_MAG_DIST);
-    // Seed box: coastlines here are seeded; BFS is clipped here.
-    const sMinX = Math.max(0, cMinX - MAX_MAG_DIST * 2);
-    const sMaxX = Math.min(w - 1, cMaxX + MAX_MAG_DIST * 2);
-    const sMinY = Math.max(0, cMinY - MAX_MAG_DIST * 2);
-    const sMaxY = Math.min(h - 1, cMaxY + MAX_MAG_DIST * 2);
-
-    // Seed from coastline water tiles inside the seed box.
-    // Impassable terrain is void (like the map edge), so water tiles
-    // adjacent only to impassable terrain are NOT coastline — they should
-    // be uniformly deep with no depth gradient.
-    for (let by = sMinY; by <= sMaxY; by++) {
-      const rowStart = by * w;
-      for (let bx = sMinX; bx <= sMaxX; bx++) {
-        const tile = (rowStart + bx) as TileRef;
-        if (!map.isWater(tile) || stampArr[tile] === stamp) continue;
-        const end = pushNeighbors(tile, nb, 0);
-        for (let i = 0; i < end; i++) {
-          if (map.isLand(nb[i]) && !map.isImpassable(nb[i])) {
-            stampArr[tile] = stamp;
-            distArr[tile] = 0;
-            magQueue.push(tile);
-            break;
-          }
-        }
-      }
+    // Converted tiles are first grouped into spatially separate craters so
+    // that simultaneous distant nukes (barrages, MIRVs) each get a small
+    // local BFS instead of one bounding box spanning most of the map.
+    const groups = this.computeCraterGroups(converted, w, MAX_MAG_DIST);
+    for (const g of groups) {
+      this.recomputeMagnitudesInBox(
+        map,
+        g,
+        this._waterStampArr!,
+        this._waterDistArr,
+        this.bumpFullMapStamp(),
+        true, // impassable terrain is void, not coastline
+        changed,
+      );
     }
 
-    // BFS outward through water, clipped to seed box.
-    // No convergence — every reachable tile inside the seed box is visited
-    // to ensure correct shortest distances reach the dirty box.
-    // Only DIRTY BOX tiles get their magnitude updated.
-    let magHead = 0;
-    while (magHead < magQueue.length) {
-      const tile = magQueue[magHead++];
-      const dist = distArr[tile];
-      const nextDist = dist + 1;
-      const end = pushNeighbors(tile, nb, 0);
-      for (let i = 0; i < end; i++) {
-        const n = nb[i];
-        if (!map.isWater(n) || stampArr[n] === stamp) continue;
-        // Clip to seed box
-        const nx = n % w;
-        const ny = (n - nx) / w;
-        if (nx < sMinX || nx > sMaxX || ny < sMinY || ny > sMaxY) continue;
-        stampArr[n] = stamp;
-        distArr[n] = nextDist;
-        magQueue.push(n);
-      }
-    }
-
-    // Update magnitudes only for dirty-box tiles.
-    for (let dy = dMinY; dy <= dMaxY; dy++) {
-      const rowStart = dy * w;
-      for (let dx = dMinX; dx <= dMaxX; dx++) {
-        const tile = (rowStart + dx) as TileRef;
-        if (!map.isWater(tile)) continue;
-        const oldMag = map.magnitude(tile);
-        let newMag: number;
-        if (stampArr[tile] === stamp) {
-          // Reached by BFS — compute magnitude from distance
-          newMag = Math.min(Math.ceil(distArr[tile] / 2), 31);
-        } else {
-          // Unreached: nearest coast is >MAX_MAG_DIST away → magnitude 31
-          newMag = 31;
-        }
-        if (oldMag !== newMag) {
-          map.setMagnitude(tile, newMag);
-          changed.add(tile);
-        }
-      }
-    }
-
+    DebugSpan.end("magnitude");
+    DebugSpan.start("shoreline");
     // ── 3. Fix shoreline bits ──────────────────────────────────────
     // Only converted tiles changed terrain type (land→water), so only
     // they and their 2-ring neighborhood can have shoreline bit changes.
-    const tilesToCheck = new Set<TileRef>();
+    // Dedup via the reusable stamp array (cheaper than a Set for large
+    // craters).
+    const shoreStamp = this.bumpFullMapStamp();
+    const shoreStampArr = this._waterStampArr!;
+    const tilesToCheck: TileRef[] = [];
+    const pushToCheck = (tile: TileRef): void => {
+      if (shoreStampArr[tile] !== shoreStamp) {
+        shoreStampArr[tile] = shoreStamp;
+        tilesToCheck.push(tile);
+      }
+    };
     for (const tile of converted) {
-      tilesToCheck.add(tile);
+      pushToCheck(tile);
       const end = pushNeighbors(tile, nb, 0);
       for (let i = 0; i < end; i++) {
-        tilesToCheck.add(nb[i]);
+        pushToCheck(nb[i]);
         const end2 = pushNeighbors(nb[i], nb, end);
         for (let j = end; j < end2; j++) {
-          tilesToCheck.add(nb[j]);
+          pushToCheck(nb[j]);
         }
       }
     }
@@ -435,6 +403,8 @@ export class WaterManager {
     }
 
     // ── 4. Update minimap terrain ──────────────────────────────────
+    DebugSpan.end("shoreline");
+    DebugSpan.start("minimap");
     const miniTilesToCheck = new Set<TileRef>();
     const convertedMiniTiles = new Set<TileRef>();
     for (const tile of converted) {
@@ -466,6 +436,8 @@ export class WaterManager {
       }
     }
 
+    DebugSpan.end("minimap");
+    DebugSpan.start("miniMagnitude");
     // ── 4b. Fix minimap ocean + magnitude for converted tiles ────
     // setWater() zeros the terrain byte (magnitude = 0, ocean = 0).
     // This makes the pathfinder treat nuked water as "too close to
@@ -535,136 +507,322 @@ export class WaterManager {
       //
       // Mirrors the full-map magnitude BFS (step 2) but runs on the
       // minimap.  Uses separate stamp/dist arrays to avoid conflicts.
-      const miniTotal = miniW * this.miniMap.height();
+      // Note: unlike the full map, ANY land tile counts as coastline.
+      const miniTotal = miniW * miniH;
       if (!this._miniDistArr || this._miniDistArr.length !== miniTotal) {
         this._miniDistArr = new Uint16Array(miniTotal);
         this._miniStampArr = new Uint16Array(miniTotal);
         this._miniStamp = 0;
       }
-      this._miniStamp++;
-      if (this._miniStamp >= 0xffff) {
-        this._miniStampArr!.fill(0);
-        this._miniStamp = 1;
-      }
-      const miniStamp = this._miniStamp;
-      const miniStampArr = this._miniStampArr!;
-      const miniDistArr = this._miniDistArr;
-
-      // Crater bounding box on the full map, mapped to minimap coords.
-      // MINI_MAX_MAG_DIST = max hops from coast = max_magnitude (31) × 2.
-      const MINI_MAX_MAG_DIST = 62;
-      let mcMinX = w,
-        mcMaxX = 0,
-        mcMinY = h,
-        mcMaxY = 0;
-      for (const tile of converted) {
-        const tx = tile % w;
-        const ty = (tile - tx) / w;
-        if (tx < mcMinX) mcMinX = tx;
-        if (tx > mcMaxX) mcMaxX = tx;
-        if (ty < mcMinY) mcMinY = ty;
-        if (ty > mcMaxY) mcMaxY = ty;
-      }
-      const mcMiniMinX = Math.floor(mcMinX / 2);
-      const mcMiniMaxX = Math.floor(mcMaxX / 2);
-      const mcMiniMinY = Math.floor(mcMinY / 2);
-      const mcMiniMaxY = Math.floor(mcMaxY / 2);
-
-      // Dirty box: minimap tiles whose magnitude may need updating.
-      const mdMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG_DIST);
-      const mdMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG_DIST);
-      const mdMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG_DIST);
-      const mdMaxY = Math.min(
-        this.miniMap.height() - 1,
-        mcMiniMaxY + MINI_MAX_MAG_DIST,
+      const miniGroups = this.computeCraterGroups(
+        convertedMiniTiles,
+        miniW,
+        MAX_MAG_DIST,
       );
-      // Seed box: coastlines here are seeded; BFS is clipped here.
-      const msMinX = Math.max(0, mcMiniMinX - MINI_MAX_MAG_DIST * 2);
-      const msMaxX = Math.min(miniW - 1, mcMiniMaxX + MINI_MAX_MAG_DIST * 2);
-      const msMinY = Math.max(0, mcMiniMinY - MINI_MAX_MAG_DIST * 2);
-      const msMaxY = Math.min(
-        this.miniMap.height() - 1,
-        mcMiniMaxY + MINI_MAX_MAG_DIST * 2,
-      );
-
-      // Seed from minimap coastline water tiles inside the seed box.
-      // Coastline = water tile adjacent to at least one land tile.
-      const miniMagQueue: TileRef[] = [];
-
-      for (let by = msMinY; by <= msMaxY; by++) {
-        const rowStart = by * miniW;
-        for (let bx = msMinX; bx <= msMaxX; bx++) {
-          const tile = (rowStart + bx) as TileRef;
-          if (!this.miniMap.isWater(tile) || miniStampArr[tile] === miniStamp)
-            continue;
-          let isCoast = false;
-          const nc = pushMiniNeighbors(tile, miniNb);
-          for (let i = 0; i < nc; i++) {
-            if (this.miniMap.isLand(miniNb[i])) {
-              isCoast = true;
-              break;
-            }
-          }
-          if (isCoast) {
-            miniStampArr[tile] = miniStamp;
-            miniDistArr[tile] = 0;
-            miniMagQueue.push(tile);
-          }
-        }
-      }
-
-      // BFS outward through water, clipped to seed box.
-      let mmHead = 0;
-      while (mmHead < miniMagQueue.length) {
-        const tile = miniMagQueue[mmHead++];
-        const nextDist = miniDistArr[tile] + 1;
-        const nc = pushMiniNeighbors(tile, miniNb);
-        for (let i = 0; i < nc; i++) {
-          const n = miniNb[i];
-          if (!this.miniMap.isWater(n) || miniStampArr[n] === miniStamp)
-            continue;
-          const nx = n % miniW;
-          const ny = (n - nx) / miniW;
-          if (nx < msMinX || nx > msMaxX || ny < msMinY || ny > msMaxY)
-            continue;
-          miniStampArr[n] = miniStamp;
-          miniDistArr[n] = nextDist;
-          miniMagQueue.push(n);
-        }
-      }
-
-      // Update magnitudes for ALL minimap water tiles in the dirty box.
-      for (let dy = mdMinY; dy <= mdMaxY; dy++) {
-        const rowStart = dy * miniW;
-        for (let dx = mdMinX; dx <= mdMaxX; dx++) {
-          const tile = (rowStart + dx) as TileRef;
-          if (!this.miniMap.isWater(tile)) continue;
-          const oldMag = this.miniMap.magnitude(tile);
-          let newMag: number;
-          if (miniStampArr[tile] === miniStamp) {
-            newMag = Math.min(Math.ceil(miniDistArr[tile] / 2), 31);
-          } else {
-            // Unreached: nearest coast is >MINI_MAX_MAG_DIST*2 away → deep water
-            newMag = 31;
-          }
-          if (oldMag !== newMag) {
-            this.miniMap.setMagnitude(tile, newMag);
-          }
-        }
+      for (const g of miniGroups) {
+        this.recomputeMagnitudesInBox(
+          this.miniMap,
+          g,
+          this._miniStampArr!,
+          this._miniDistArr,
+          this.bumpMiniStamp(),
+          false,
+          null,
+        );
       }
     }
 
+    DebugSpan.end("miniMagnitude");
+
     // ── 5. Mark water graph dirty (rebuilt lazily, throttled) ─────
     if (convertedMiniTiles.size > 0) {
+      // Fold the new water tiles into the persistent component labeling
+      this._miniWaterCC?.addWaterTiles(convertedMiniTiles);
       this._waterGraphDirty = true;
       for (const mt of convertedMiniTiles) {
         this._dirtyMiniTiles.add(mt);
       }
     }
+    DebugSpan.end("WaterManager:finalizeWaterChanges");
 
     // Drain changed set into output array
     for (const tile of changed) {
       changedTiles.push(tile);
+    }
+  }
+
+  private bumpFullMapStamp(): number {
+    this._waterStamp++;
+    if (this._waterStamp >= 0xffff) {
+      this._waterStampArr!.fill(0);
+      this._waterStamp = 1;
+    }
+    return this._waterStamp;
+  }
+
+  private bumpMiniStamp(): number {
+    this._miniStamp++;
+    if (this._miniStamp >= 0xffff) {
+      this._miniStampArr!.fill(0);
+      this._miniStamp = 1;
+    }
+    return this._miniStamp;
+  }
+
+  /**
+   * Group converted tiles into spatially separate crater clusters.
+   *
+   * Tiles are bucketed into coarse cells of maxMagDist, adjacent occupied
+   * cells are unioned into groups, and groups are then merged whenever
+   * merging shrinks the total BFS work (union box area smaller than the
+   * separate box areas combined).  Far-apart simultaneous nukes therefore
+   * keep small independent BFS boxes, while dense clusters collapse into
+   * one box instead of overlapping duplicates.
+   *
+   * Correctness does not depend on the grouping: each group's BFS seeds
+   * every coastline inside its own seed box, so overlapping boxes only
+   * duplicate work, never change results.
+   */
+  private computeCraterGroups(
+    converted: Set<TileRef>,
+    w: number,
+    maxMagDist: number,
+  ): CraterBounds[] {
+    const cellSize = maxMagDist;
+    const cellsX = Math.ceil(w / cellSize);
+
+    // Bucket tiles into coarse cells, tracking per-cell crater bounds
+    const cells = new Map<number, CraterBounds>();
+    for (const tile of converted) {
+      const tx = tile % w;
+      const ty = (tile - tx) / w;
+      const key =
+        Math.floor(ty / cellSize) * cellsX + Math.floor(tx / cellSize);
+      const b = cells.get(key);
+      if (b === undefined) {
+        cells.set(key, { minX: tx, maxX: tx, minY: ty, maxY: ty });
+      } else {
+        if (tx < b.minX) b.minX = tx;
+        if (tx > b.maxX) b.maxX = tx;
+        if (ty < b.minY) b.minY = ty;
+        if (ty > b.maxY) b.maxY = ty;
+      }
+    }
+
+    // Union-find over occupied cells; adjacent cells (8-neighborhood)
+    // belong to the same crater cluster.
+    const parent = new Map<number, number>();
+    for (const key of cells.keys()) parent.set(key, key);
+    const find = (k: number): number => {
+      let root = k;
+      while (parent.get(root)! !== root) root = parent.get(root)!;
+      let cur = k;
+      while (parent.get(cur)! !== root) {
+        const next = parent.get(cur)!;
+        parent.set(cur, root);
+        cur = next;
+      }
+      return root;
+    };
+    for (const key of cells.keys()) {
+      const cx = key % cellsX;
+      const cy = (key - cx) / cellsX;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          if (dx === 0 && dy === 0) continue;
+          const nx = cx + dx;
+          const ny = cy + dy;
+          if (nx < 0 || nx >= cellsX || ny < 0) continue;
+          const nk = ny * cellsX + nx;
+          if (!cells.has(nk)) continue;
+          const ra = find(key);
+          const rb = find(nk);
+          if (ra !== rb) parent.set(Math.max(ra, rb), Math.min(ra, rb));
+        }
+      }
+    }
+
+    // Merge cell bounds per root (Map iteration order is deterministic)
+    const byRoot = new Map<number, CraterBounds>();
+    for (const [key, b] of cells) {
+      const root = find(key);
+      const g = byRoot.get(root);
+      if (g === undefined) {
+        byRoot.set(root, { ...b });
+      } else {
+        if (b.minX < g.minX) g.minX = b.minX;
+        if (b.maxX > g.maxX) g.maxX = b.maxX;
+        if (b.minY < g.minY) g.minY = b.minY;
+        if (b.maxY > g.maxY) g.maxY = b.maxY;
+      }
+    }
+    const groups = [...byRoot.values()];
+
+    // Greedily merge groups when the merged seed box is cheaper to
+    // process than the two separate (possibly overlapping) seed boxes.
+    const pad = 4 * maxMagDist; // seed box adds 2*maxMagDist on each side
+    const boxArea = (g: CraterBounds): number =>
+      (g.maxX - g.minX + pad) * (g.maxY - g.minY + pad);
+    let merged = true;
+    while (merged) {
+      merged = false;
+      for (let i = 0; i < groups.length && !merged; i++) {
+        for (let j = i + 1; j < groups.length; j++) {
+          const a = groups[i];
+          const b = groups[j];
+          const union: CraterBounds = {
+            minX: Math.min(a.minX, b.minX),
+            maxX: Math.max(a.maxX, b.maxX),
+            minY: Math.min(a.minY, b.minY),
+            maxY: Math.max(a.maxY, b.maxY),
+          };
+          if (boxArea(union) < boxArea(a) + boxArea(b)) {
+            groups[i] = union;
+            groups.splice(j, 1);
+            merged = true;
+            break;
+          }
+        }
+      }
+    }
+    return groups;
+  }
+
+  /**
+   * Recompute water magnitudes (ceil(dist_to_nearest_coast / 2), capped
+   * at 31) for all water tiles within MAX_MAG_DIST of the crater bounds.
+   *
+   * Dirty box (±MAX_MAG_DIST from crater bounds): the region where
+   * magnitudes may have changed.  Only tiles here get updated.
+   *
+   * Seed box (±2*MAX_MAG_DIST from crater bounds): coastlines here are
+   * seeded for BFS.  This ensures that every coastline that could be
+   * nearest to a dirty-box tile is included (a dirty-box tile is at most
+   * MAX_MAG_DIST from the crater, and the nearest coast is at most
+   * MAX_MAG_DIST from the tile, so the coast is at most 2*MAX_MAG_DIST
+   * from the crater).  The BFS runs WITHOUT convergence inside the seed
+   * box so that wavefronts from distant coastlines correctly reach the
+   * dirty box, and is clipped at the seed box boundary for performance.
+   *
+   * Reads terrain bytes directly — these loops dominate finalize cost on
+   * large maps.
+   *
+   * @param passableCoastOnly When true, impassable terrain is void (like
+   *   the map edge), so water tiles adjacent only to impassable terrain
+   *   are NOT coastline — they stay uniformly deep with no gradient.
+   *   (Used on the full map; the minimap counts any land as coastline.)
+   * @param changed When set, tiles whose magnitude changed are recorded
+   *   for client updates.
+   */
+  private recomputeMagnitudesInBox(
+    map: GameMap,
+    bounds: CraterBounds,
+    stampArr: Uint16Array,
+    distArr: Uint16Array,
+    stamp: number,
+    passableCoastOnly: boolean,
+    changed: Set<TileRef> | null,
+  ): void {
+    const w = map.width();
+    const h = map.height();
+    // Direct terrain access, same precedent as ConnectedComponents
+    const terrain = (map as unknown as { terrain: Uint8Array }).terrain;
+
+    // Dirty box: tiles whose magnitude may need updating.
+    const dMinX = Math.max(0, bounds.minX - MAX_MAG_DIST);
+    const dMaxX = Math.min(w - 1, bounds.maxX + MAX_MAG_DIST);
+    const dMinY = Math.max(0, bounds.minY - MAX_MAG_DIST);
+    const dMaxY = Math.min(h - 1, bounds.maxY + MAX_MAG_DIST);
+    // Seed box: coastlines here are seeded; BFS is clipped here.
+    const sMinX = Math.max(0, bounds.minX - MAX_MAG_DIST * 2);
+    const sMaxX = Math.min(w - 1, bounds.maxX + MAX_MAG_DIST * 2);
+    const sMinY = Math.max(0, bounds.minY - MAX_MAG_DIST * 2);
+    const sMaxY = Math.min(h - 1, bounds.maxY + MAX_MAG_DIST * 2);
+
+    const isCoastByte = (b: number): boolean =>
+      (b & TERRAIN_LAND_MASK) !== 0 &&
+      (!passableCoastOnly || (b & TERRAIN_MAG_MASK) !== IMPASSABLE_MAG);
+
+    // Seed from coastline water tiles inside the seed box.
+    const queue: TileRef[] = [];
+    for (let y = sMinY; y <= sMaxY; y++) {
+      const rowStart = y * w;
+      for (let x = sMinX; x <= sMaxX; x++) {
+        const tile = (rowStart + x) as TileRef;
+        if ((terrain[tile] & TERRAIN_LAND_MASK) !== 0) continue;
+        if (stampArr[tile] === stamp) continue;
+        const isCoast =
+          (y > 0 && isCoastByte(terrain[tile - w])) ||
+          (y < h - 1 && isCoastByte(terrain[tile + w])) ||
+          (x > 0 && isCoastByte(terrain[tile - 1])) ||
+          (x < w - 1 && isCoastByte(terrain[tile + 1]));
+        if (isCoast) {
+          stampArr[tile] = stamp;
+          distArr[tile] = 0;
+          queue.push(tile);
+        }
+      }
+    }
+
+    // BFS outward through water, clipped to the seed box.
+    let head = 0;
+    while (head < queue.length) {
+      const tile = queue[head++];
+      const nextDist = distArr[tile] + 1;
+      const x = tile % w;
+      const y = (tile - x) / w;
+      if (y > sMinY) {
+        const n = tile - w;
+        if ((terrain[n] & TERRAIN_LAND_MASK) === 0 && stampArr[n] !== stamp) {
+          stampArr[n] = stamp;
+          distArr[n] = nextDist;
+          queue.push(n as TileRef);
+        }
+      }
+      if (y < sMaxY) {
+        const n = tile + w;
+        if ((terrain[n] & TERRAIN_LAND_MASK) === 0 && stampArr[n] !== stamp) {
+          stampArr[n] = stamp;
+          distArr[n] = nextDist;
+          queue.push(n as TileRef);
+        }
+      }
+      if (x > sMinX) {
+        const n = tile - 1;
+        if ((terrain[n] & TERRAIN_LAND_MASK) === 0 && stampArr[n] !== stamp) {
+          stampArr[n] = stamp;
+          distArr[n] = nextDist;
+          queue.push(n as TileRef);
+        }
+      }
+      if (x < sMaxX) {
+        const n = tile + 1;
+        if ((terrain[n] & TERRAIN_LAND_MASK) === 0 && stampArr[n] !== stamp) {
+          stampArr[n] = stamp;
+          distArr[n] = nextDist;
+          queue.push(n as TileRef);
+        }
+      }
+    }
+
+    // Update magnitudes only for dirty-box tiles.
+    for (let y = dMinY; y <= dMaxY; y++) {
+      const rowStart = y * w;
+      for (let x = dMinX; x <= dMaxX; x++) {
+        const tile = (rowStart + x) as TileRef;
+        const b = terrain[tile];
+        if ((b & TERRAIN_LAND_MASK) !== 0) continue;
+        // Reached by BFS → magnitude from distance; unreached → nearest
+        // coast is >MAX_MAG_DIST away → deep water (31).
+        const newMag =
+          stampArr[tile] === stamp
+            ? Math.min(Math.ceil(distArr[tile] / 2), 31)
+            : 31;
+        if ((b & TERRAIN_MAG_MASK) !== newMag) {
+          map.setMagnitude(tile, newMag);
+          changed?.add(tile);
+        }
+      }
     }
   }
 }

--- a/src/core/pathfinding/algorithms/AStar.WaterHierarchical.ts
+++ b/src/core/pathfinding/algorithms/AStar.WaterHierarchical.ts
@@ -50,6 +50,19 @@ export class AStarWaterHierarchical implements PathFinder<number> {
     this.sourceResolver = new SourceResolver(this.map, this.graph);
   }
 
+  /**
+   * Swap in a rebuilt abstract graph, reusing the map-sized search
+   * scratch buffers (BFSGrid alone is ~20MB on large maps — reallocating
+   * it on every water-graph rebuild causes GC churn).  Only the
+   * graph-derived helpers are recreated.  Path caches live on the graph
+   * itself, so they reset naturally with the new graph.
+   */
+  setGraph(graph: AbstractGraph): void {
+    this.graph = graph;
+    this.abstractAStar = new AbstractGraphAStar(graph);
+    this.sourceResolver = new SourceResolver(this.map, graph);
+  }
+
   findPath(from: number | number[], to: number): number[] | null {
     return DebugSpan.wrap("AStar.WaterHierarchical:findPath", () => {
       DebugSpan.set("$to", () => to);

--- a/src/core/pathfinding/algorithms/AbstractGraph.ts
+++ b/src/core/pathfinding/algorithms/AbstractGraph.ts
@@ -234,13 +234,20 @@ export class AbstractGraphBuilder {
     private readonly clusterSize: number = AbstractGraphBuilder.CLUSTER_SIZE,
     private readonly oldGraph?: AbstractGraph,
     private readonly dirtyMiniTiles?: Set<TileRef>,
+    // An already-initialized ConnectedComponents kept up to date by the
+    // caller (see WaterManager). Skips the full-map flood fill per build.
+    private readonly sharedWaterComponents?: ConnectedComponents,
+    // Reusable map-sized BFS scratch (stateless between searches).  Avoids
+    // reallocating ~20MB of typed arrays on every water-graph rebuild.
+    sharedTileBFS?: BFSGrid,
   ) {
     this.width = map.width();
     this.height = map.height();
     this.clustersX = Math.ceil(this.width / clusterSize);
     this.clustersY = Math.ceil(this.height / clusterSize);
-    this.tileBFS = new BFSGrid(this.width * this.height);
-    this.waterComponents = new ConnectedComponents(map);
+    this.tileBFS = sharedTileBFS ?? new BFSGrid(this.width * this.height);
+    this.waterComponents =
+      sharedWaterComponents ?? new ConnectedComponents(map);
   }
 
   build(): AbstractGraph {
@@ -252,8 +259,10 @@ export class AbstractGraphBuilder {
       this.clustersY,
     );
 
-    // Initialize water components
-    this.waterComponents.initialize();
+    // Initialize water components (shared ones are maintained by the caller)
+    if (!this.sharedWaterComponents) {
+      this.waterComponents.initialize();
+    }
 
     // Compute partial rebuild info (which clusters can skip BFS)
     if (this.oldGraph && this.dirtyMiniTiles && this.dirtyMiniTiles.size > 0) {

--- a/src/core/pathfinding/algorithms/ConnectedComponents.ts
+++ b/src/core/pathfinding/algorithms/ConnectedComponents.ts
@@ -21,6 +21,14 @@ export class ConnectedComponents {
   private componentIds: Uint8Array | Uint16Array | null = null;
   private _componentSizes: number[] = [];
 
+  // Incremental update state (see addWaterTiles): water tiles are only
+  // ever ADDED to the map (land→water via water nukes), so components can
+  // only grow or merge — never split.  Merges are tracked with a
+  // union-find alias table instead of relabeling tiles.
+  private parents: number[] = [];
+  private maxId = 0;
+  private landMarker: number = LAND_MARKER;
+
   constructor(
     private readonly map: GameMap,
     private readonly accessTerrainDirectly: boolean = true,
@@ -67,7 +75,108 @@ export class ConnectedComponents {
 
     this.componentIds = ids;
     this.queue = null;
+
+    // Set up union-find state for incremental updates
+    this.landMarker =
+      ids instanceof Uint16Array ? LAND_MARKER_WIDE : LAND_MARKER;
+    this.maxId = nextId;
+    this.parents = new Array(nextId + 1);
+    for (let i = 0; i <= nextId; i++) this.parents[i] = i;
+
     DebugSpan.end();
+  }
+
+  /**
+   * Incrementally add newly converted water tiles (land→water).
+   *
+   * Because water is only ever added, a new water tile either joins an
+   * adjacent component, merges several adjacent components (bridging),
+   * or starts a new component (isolated crater).  Merges are recorded in
+   * a union-find alias table, so no tiles need relabeling and the cost
+   * is O(tiles added) instead of a full-map flood fill.
+   *
+   * Tiles must already be water in the map. No-op before initialize().
+   */
+  addWaterTiles(tiles: Iterable<TileRef>): void {
+    if (!this.componentIds) return;
+
+    for (const tile of tiles) {
+      let ids = this.componentIds;
+      if (ids[tile] !== this.landMarker) continue; // already labeled water
+
+      // Collect distinct component roots among cardinal water neighbors
+      const x = tile % this.width;
+      let r0 = 0;
+      let r1 = 0;
+      let r2 = 0;
+      let r3 = 0;
+      if (tile >= this.width) r0 = this.rootAt(tile - this.width);
+      if (tile < this.lastRowStart) r1 = this.rootAt(tile + this.width);
+      if (x > 0) r2 = this.rootAt(tile - 1);
+      if (x < this.width - 1) r3 = this.rootAt(tile + 1);
+
+      // Canonical id: smallest non-zero root (deterministic)
+      let canon = 0;
+      for (const r of [r0, r1, r2, r3]) {
+        if (r !== 0 && (canon === 0 || r < canon)) canon = r;
+      }
+
+      if (canon === 0) {
+        // Isolated new water: allocate a fresh component id
+        const id = this.allocComponentId();
+        ids = this.componentIds; // may have been upgraded to Uint16Array
+        ids[tile] = id;
+        this._componentSizes[id] = 1;
+        continue;
+      }
+
+      ids[tile] = canon;
+      this._componentSizes[canon] = (this._componentSizes[canon] ?? 0) + 1;
+
+      // Union any other adjacent components into the canonical one
+      for (const r of [r0, r1, r2, r3]) {
+        if (r !== 0 && r !== canon && this.parents[r] !== canon) {
+          this.parents[r] = canon;
+          this._componentSizes[canon] =
+            (this._componentSizes[canon] ?? 0) + (this._componentSizes[r] ?? 0);
+          this._componentSizes[r] = 0;
+        }
+      }
+    }
+  }
+
+  /** Component root of the water tile at index, or 0 if land/unlabeled. */
+  private rootAt(index: number): number {
+    const id = this.componentIds![index];
+    if (id === 0 || id === this.landMarker) return 0;
+    return this.find(id);
+  }
+
+  private find(id: number): number {
+    const parents = this.parents;
+    let root = id;
+    while (parents[root] !== root) root = parents[root];
+    // Path compression (pure optimization — resolved roots are identical)
+    let cur = id;
+    while (parents[cur] !== root) {
+      const next = parents[cur];
+      parents[cur] = root;
+      cur = next;
+    }
+    return root;
+  }
+
+  private allocComponentId(): number {
+    // Saturate at the last usable id (0xFFFF is the land marker after
+    // Uint16Array promotion).  Unreachable in practice.
+    if (this.maxId >= 0xfffe) return this.maxId;
+    const id = ++this.maxId;
+    if (id >= 253 && this.componentIds instanceof Uint8Array) {
+      this.componentIds = this.upgradeToUint16Array(this.componentIds);
+      this.landMarker = LAND_MARKER_WIDE;
+    }
+    this.parents[id] = id;
+    return id;
   }
 
   /**
@@ -205,11 +314,14 @@ export class ConnectedComponents {
 
   getComponentId(tile: TileRef): number {
     if (!this.componentIds) return 0;
-    return this.componentIds[tile] ?? 0;
+    const id = this.componentIds[tile] ?? 0;
+    if (id === 0 || id === this.landMarker) return id;
+    return this.find(id);
   }
 
   /** Returns the number of water tiles in the given component, or 0 if unknown. */
   getComponentSize(componentId: number): number {
-    return this._componentSizes[componentId] ?? 0;
+    if (componentId <= 0 || componentId > this.maxId) return 0;
+    return this._componentSizes[this.find(componentId)] ?? 0;
   }
 }

--- a/tests/core/pathfinding/PathFinding.WaterNukes.test.ts
+++ b/tests/core/pathfinding/PathFinding.WaterNukes.test.ts
@@ -1,0 +1,705 @@
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { Game } from "../../../src/core/game/Game";
+import { GameMap, TileRef } from "../../../src/core/game/GameMap";
+import { AbstractGraphBuilder } from "../../../src/core/pathfinding/algorithms/AbstractGraph";
+import { ConnectedComponents } from "../../../src/core/pathfinding/algorithms/ConnectedComponents";
+import { PathFinding } from "../../../src/core/pathfinding/PathFinder";
+import { setup } from "../../util/Setup";
+
+/**
+ * Pathfinding-focused coverage for water nukes: component merging,
+ * magnitude recomputation, incremental graph rebuilds, and end-to-end
+ * boat pathing through nuked terrain.
+ *
+ * `plains` (100x100, all land) is used as a canvas: every water tile is
+ * crater water created by our own code, so results can be compared
+ * exactly against from-scratch oracles.
+ */
+
+const WATER_NUKE_CONFIG = {
+  waterNukes: true,
+  disableNavMesh: false,
+};
+
+/** Queue a circular land→water crater, like NukeExecution does on impact. */
+function nukeCircle(game: Game, cx: number, cy: number, r: number): void {
+  const r2 = r * r;
+  const x0 = Math.max(0, cx - r);
+  const y0 = Math.max(0, cy - r);
+  const x1 = Math.min(game.width() - 1, cx + r);
+  const y1 = Math.min(game.height() - 1, cy + r);
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      if (dx * dx + dy * dy > r2) continue;
+      const tile = game.ref(x, y);
+      if (
+        game.isLand(tile) &&
+        !game.hasOwner(tile) &&
+        !game.map().isImpassable(tile)
+      ) {
+        game.queueWaterConversion(tile);
+      }
+    }
+  }
+}
+
+/** Tick until the throttled water graph rebuild fires. */
+function tickUntilRebuild(game: Game, maxTicks = 40): void {
+  const version = game.waterGraphVersion();
+  for (let i = 0; i < maxTicks; i++) {
+    game.executeNextTick();
+    if (game.waterGraphVersion() > version) return;
+  }
+  throw new Error(
+    `water graph did not rebuild within ${maxTicks} ticks (version ${version})`,
+  );
+}
+
+/**
+ * Oracle: from-scratch magnitude computation over the whole map.
+ * magnitude = ceil(BFS_dist_to_nearest_coastline / 2), capped at 31;
+ * water unreachable from any coastline is 31 (deep).
+ */
+function scratchMagnitudes(
+  map: GameMap,
+  passableCoastOnly: boolean,
+): Int32Array {
+  const w = map.width();
+  const h = map.height();
+  const n = w * h;
+  const dist = new Int32Array(n).fill(-1);
+  const queue = new Int32Array(n);
+  let tail = 0;
+  const isCoast = (t: number): boolean =>
+    map.isLand(t) && (!passableCoastOnly || !map.isImpassable(t));
+  for (let t = 0; t < n; t++) {
+    if (map.isLand(t)) continue;
+    const x = t % w;
+    const y = (t - x) / w;
+    const coast =
+      (y > 0 && isCoast(t - w)) ||
+      (y < h - 1 && isCoast(t + w)) ||
+      (x > 0 && isCoast(t - 1)) ||
+      (x < w - 1 && isCoast(t + 1));
+    if (coast) {
+      dist[t] = 0;
+      queue[tail++] = t;
+    }
+  }
+  let head = 0;
+  while (head < tail) {
+    const t = queue[head++];
+    const d = dist[t] + 1;
+    const x = t % w;
+    const y = (t - x) / w;
+    if (y > 0 && !map.isLand(t - w) && dist[t - w] < 0) {
+      dist[t - w] = d;
+      queue[tail++] = t - w;
+    }
+    if (y < h - 1 && !map.isLand(t + w) && dist[t + w] < 0) {
+      dist[t + w] = d;
+      queue[tail++] = t + w;
+    }
+    if (x > 0 && !map.isLand(t - 1) && dist[t - 1] < 0) {
+      dist[t - 1] = d;
+      queue[tail++] = t - 1;
+    }
+    if (x < w - 1 && !map.isLand(t + 1) && dist[t + 1] < 0) {
+      dist[t + 1] = d;
+      queue[tail++] = t + 1;
+    }
+  }
+  const mags = new Int32Array(n).fill(-1);
+  for (let t = 0; t < n; t++) {
+    if (map.isLand(t)) continue;
+    mags[t] = dist[t] < 0 ? 31 : Math.min(Math.ceil(dist[t] / 2), 31);
+  }
+  return mags;
+}
+
+function expectMagnitudesMatchOracle(map: GameMap, passableCoastOnly: boolean) {
+  const oracle = scratchMagnitudes(map, passableCoastOnly);
+  let mismatches = 0;
+  let firstMismatch = "";
+  for (let t = 0; t < map.width() * map.height(); t++) {
+    if (map.isLand(t)) continue;
+    if (map.magnitude(t) !== oracle[t]) {
+      if (mismatches === 0) {
+        firstMismatch = `tile (${map.x(t)},${map.y(t)}): actual=${map.magnitude(t)} expected=${oracle[t]}`;
+      }
+      mismatches++;
+    }
+  }
+  expect(mismatches, `magnitude mismatches, first: ${firstMismatch}`).toBe(0);
+}
+
+/** Edge map keyed by canonical tile pair, for graph equality checks. */
+function edgeCostMap(
+  graph: NonNullable<ReturnType<Game["miniWaterGraph"]>>,
+): Map<string, number> {
+  const edges = new Map<string, number>();
+  for (const edge of graph.getAllEdges()) {
+    const a = graph.getNode(edge.nodeA)!.tile;
+    const b = graph.getNode(edge.nodeB)!.tile;
+    const key = a < b ? `${a}:${b}` : `${b}:${a}`;
+    const existing = edges.get(key);
+    if (existing === undefined || edge.cost < existing) {
+      edges.set(key, edge.cost);
+    }
+  }
+  return edges;
+}
+
+describe("water components after nukes (plains)", () => {
+  let game: Game;
+
+  beforeEach(async () => {
+    game = await setup("plains", WATER_NUKE_CONFIG);
+  });
+
+  it("an isolated crater forms a single new water component", () => {
+    nukeCircle(game, 30, 30, 8);
+    tickUntilRebuild(game);
+
+    const center = game.ref(30, 30);
+    expect(game.isWater(center)).toBe(true);
+
+    const comp = game.getWaterComponent(center);
+    expect(comp).not.toBeNull();
+
+    // All water in the crater shares the component
+    for (const [x, y] of [
+      [30, 24],
+      [30, 36],
+      [24, 30],
+      [36, 30],
+    ]) {
+      const t = game.ref(x, y);
+      expect(game.isWater(t)).toBe(true);
+      expect(game.getWaterComponent(t)).toBe(comp);
+      expect(game.hasWaterComponent(t, comp!)).toBe(true);
+    }
+
+    // Size is in full-map tile units: crater is ~π*8² ≈ 200 tiles
+    const size = game.getWaterComponentSize(center);
+    expect(size).not.toBeNull();
+    expect(size!).toBeGreaterThan(100);
+    expect(size!).toBeLessThan(400);
+  });
+
+  it("separate craters get distinct components", () => {
+    nukeCircle(game, 25, 30, 7);
+    nukeCircle(game, 70, 30, 7);
+    tickUntilRebuild(game);
+
+    const lakeA = game.ref(25, 30);
+    const lakeB = game.ref(70, 30);
+    const compA = game.getWaterComponent(lakeA);
+    const compB = game.getWaterComponent(lakeB);
+    expect(compA).not.toBeNull();
+    expect(compB).not.toBeNull();
+    expect(compA).not.toBe(compB);
+    expect(game.hasWaterComponent(lakeA, compB!)).toBe(false);
+    expect(game.hasWaterComponent(lakeB, compA!)).toBe(false);
+
+    // No boat path between disconnected lakes
+    const path = PathFinding.Water(game).findPath(lakeA, lakeB);
+    expect(path).toBeNull();
+  });
+
+  it("a nuked channel merges two lakes and enables pathfinding across", () => {
+    nukeCircle(game, 25, 30, 7);
+    nukeCircle(game, 70, 30, 7);
+    tickUntilRebuild(game);
+
+    const lakeA = game.ref(25, 30);
+    const lakeB = game.ref(70, 30);
+    const compABefore = game.getWaterComponent(lakeA);
+    const compBBefore = game.getWaterComponent(lakeB);
+    expect(compABefore).not.toBe(compBBefore);
+
+    // Carve a channel between the lakes with a chain of nukes
+    for (let x = 30; x <= 65; x += 5) {
+      nukeCircle(game, x, 30, 5);
+    }
+    tickUntilRebuild(game);
+
+    const merged = game.getWaterComponent(lakeA);
+    expect(merged).not.toBeNull();
+    expect(game.getWaterComponent(lakeB)).toBe(merged);
+    expect(game.hasWaterComponent(lakeB, merged!)).toBe(true);
+    // Mid-channel water is part of the same component
+    const mid = game.ref(47, 30);
+    expect(game.isWater(mid)).toBe(true);
+    expect(game.getWaterComponent(mid)).toBe(merged);
+
+    // The merged lake is bigger than either original crater
+    const size = game.getWaterComponentSize(lakeA);
+    expect(size!).toBeGreaterThan(300);
+
+    // Boats can now cross
+    const path = PathFinding.Water(game).findPath(lakeA, lakeB);
+    expect(path).not.toBeNull();
+    expect(path![0]).toBe(lakeA);
+    expect(path![path!.length - 1]).toBe(lakeB);
+  });
+
+  it("component queries are already consistent before the throttled rebuild", () => {
+    nukeCircle(game, 30, 30, 8);
+    // Flush conversions (finalize runs) but do NOT wait for the rebuild
+    game.executeNextTick();
+
+    const center = game.ref(30, 30);
+    expect(game.isWater(center)).toBe(true);
+    // The incrementally-updated components already know the crater
+    const comp = game.getWaterComponent(center);
+    expect(comp).not.toBeNull();
+    expect(game.hasWaterComponent(game.ref(34, 30), comp!)).toBe(true);
+  });
+});
+
+describe("crater connecting to ocean (half_land_half_ocean)", () => {
+  it("nuked land next to ocean joins the ocean component and gets the ocean bit", async () => {
+    const game = await setup("half_land_half_ocean", WATER_NUKE_CONFIG);
+    const map = game.map();
+
+    // Find a land tile with an ocean neighbor
+    let target: TileRef | null = null;
+    let oceanTile: TileRef | null = null;
+    outer: for (let y = 1; y < game.height() - 1; y++) {
+      for (let x = 1; x < game.width() - 1; x++) {
+        const t = game.ref(x, y);
+        if (!game.isLand(t)) continue;
+        for (const n of [
+          game.ref(x - 1, y),
+          game.ref(x + 1, y),
+          game.ref(x, y - 1),
+          game.ref(x, y + 1),
+        ]) {
+          if (map.isOcean(n)) {
+            target = t;
+            oceanTile = n;
+            break outer;
+          }
+        }
+      }
+    }
+    expect(target).not.toBeNull();
+    expect(oceanTile).not.toBeNull();
+
+    nukeCircle(game, game.x(target!), game.y(target!), 3);
+    tickUntilRebuild(game);
+
+    // Converted tiles connected to the ocean become ocean
+    expect(game.isWater(target!)).toBe(true);
+    expect(map.isOcean(target!)).toBe(true);
+    // ...and share the ocean's water component
+    expect(game.getWaterComponent(target!)).toBe(
+      game.getWaterComponent(oceanTile!),
+    );
+  });
+});
+
+describe("magnitudes after nukes match a from-scratch BFS (plains)", () => {
+  let game: Game;
+
+  beforeEach(async () => {
+    game = await setup("plains", WATER_NUKE_CONFIG);
+  });
+
+  it("single crater", () => {
+    nukeCircle(game, 40, 40, 10);
+    tickUntilRebuild(game);
+
+    expectMagnitudesMatchOracle(game.map(), true);
+    expectMagnitudesMatchOracle(game.miniMap(), false);
+  });
+
+  it("simultaneous distant craters (barrage — exercises crater grouping)", () => {
+    // Three spread-out craters landing on the same tick form separate
+    // BFS groups internally; results must be identical to a global BFS.
+    nukeCircle(game, 15, 15, 6);
+    nukeCircle(game, 80, 80, 6);
+    nukeCircle(game, 80, 15, 6);
+    tickUntilRebuild(game);
+
+    expectMagnitudesMatchOracle(game.map(), true);
+    expectMagnitudesMatchOracle(game.miniMap(), false);
+  });
+
+  it("overlapping repeat nukes on the same area", () => {
+    nukeCircle(game, 40, 40, 8);
+    tickUntilRebuild(game);
+    nukeCircle(game, 46, 40, 8);
+    tickUntilRebuild(game);
+    nukeCircle(game, 52, 44, 8);
+    tickUntilRebuild(game);
+
+    expectMagnitudesMatchOracle(game.map(), true);
+    expectMagnitudesMatchOracle(game.miniMap(), false);
+  });
+
+  it("coastline far outside the dirty box still shapes crater-area magnitudes", () => {
+    // Carve a large open-water pool (~x 7..83, y 17..93). Interior tiles
+    // have their nearest coast 20-40 tiles away — well below the 31 cap.
+    for (let cy = 25; cy <= 85; cy += 10) {
+      for (let cx = 15; cx <= 75; cx += 10) {
+        nukeCircle(game, cx, cy, 8);
+      }
+    }
+    tickUntilRebuild(game);
+
+    // Now nuke a small crater far east of the pool. Its dirty box reaches
+    // deep into the pool, but the pool's WEST coast (the nearest coast for
+    // much of that water) lies outside the dirty box — only the larger
+    // seed box includes it. A too-small seed box recomputes those tiles
+    // from farther coasts and corrupts their magnitudes.
+    nukeCircle(game, 95, 55, 4);
+    tickUntilRebuild(game);
+
+    expectMagnitudesMatchOracle(game.map(), true);
+    expectMagnitudesMatchOracle(game.miniMap(), false);
+
+    // Non-vacuity guard: this pool tile sits inside the second nuke's
+    // dirty box and its nearest coast is the pool's west edge (~28 away,
+    // magnitude ~14). If the pool geometry ever changes such that a
+    // nearer coast exists, this assertion flags the test as no longer
+    // exercising the far-coastline case.
+    const probe = game.ref(35, 55);
+    expect(game.isWater(probe)).toBe(true);
+    expect(game.map().magnitude(probe)).toBeLessThan(16);
+  });
+
+  it("interior crater water is not treated as shoreline (magnitude > 0)", () => {
+    nukeCircle(game, 40, 40, 10);
+    tickUntilRebuild(game);
+
+    // Crater center is far from the new coast on both maps
+    const center = game.ref(40, 40);
+    expect(game.map().magnitude(center)).toBeGreaterThan(0);
+
+    const mini = game.miniMap();
+    const miniCenter = mini.ref(20, 20);
+    expect(mini.isWater(miniCenter)).toBe(true);
+    expect(mini.magnitude(miniCenter)).toBeGreaterThan(0);
+  });
+});
+
+describe("graph rebuild consistency (plains)", () => {
+  let game: Game;
+
+  beforeEach(async () => {
+    game = await setup("plains", WATER_NUKE_CONFIG);
+    // A sequence of nukes with rebuilds in between, ending with a channel
+    // that merges lakes — a worst case for incremental bookkeeping.
+    nukeCircle(game, 25, 30, 7);
+    nukeCircle(game, 70, 30, 7);
+    tickUntilRebuild(game);
+    for (let x = 30; x <= 65; x += 5) {
+      nukeCircle(game, x, 30, 5);
+    }
+    tickUntilRebuild(game);
+    nukeCircle(game, 50, 70, 9);
+    tickUntilRebuild(game);
+  });
+
+  it("incremental rebuild produces the same graph as a full rebuild", () => {
+    const incremental = game.miniWaterGraph();
+    expect(incremental).not.toBeNull();
+
+    // Full rebuild from scratch: no old graph, no dirty tiles, fresh CC
+    const full = new AbstractGraphBuilder(game.miniMap()).build();
+
+    const incNodes = new Set(incremental!.getAllNodes().map((n) => n.tile));
+    const fullNodes = new Set(full.getAllNodes().map((n) => n.tile));
+    expect(incNodes).toEqual(fullNodes);
+
+    expect(edgeCostMap(incremental!)).toEqual(edgeCostMap(full));
+  });
+
+  it("incremental components match a fresh flood fill", () => {
+    const graph = game.miniWaterGraph()!;
+    const mini = game.miniMap();
+    const fresh = new ConnectedComponents(mini);
+    fresh.initialize();
+
+    const freshToInc = new Map<number, number>();
+    const incToFresh = new Map<number, number>();
+    for (let t = 0; t < mini.width() * mini.height(); t++) {
+      if (!mini.isWater(t)) continue;
+      const f = fresh.getComponentId(t);
+      const i = graph.getComponentId(t);
+      if (!freshToInc.has(f) && !incToFresh.has(i)) {
+        freshToInc.set(f, i);
+        incToFresh.set(i, f);
+      }
+      expect(freshToInc.get(f)).toBe(i);
+      expect(incToFresh.get(i)).toBe(f);
+      expect(graph.getComponentSize(i)).toBe(fresh.getComponentSize(f));
+    }
+    expect(freshToInc.size).toBeGreaterThan(0);
+  });
+
+  it("the same nuke sequence is deterministic across two games", async () => {
+    const game2 = await setup("plains", WATER_NUKE_CONFIG);
+    nukeCircle(game2, 25, 30, 7);
+    nukeCircle(game2, 70, 30, 7);
+    tickUntilRebuild(game2);
+    for (let x = 30; x <= 65; x += 5) {
+      nukeCircle(game2, x, 30, 5);
+    }
+    tickUntilRebuild(game2);
+    nukeCircle(game2, 50, 70, 9);
+    tickUntilRebuild(game2);
+
+    // Identical terrain bytes on both maps
+    for (let t = 0; t < game.width() * game.height(); t++) {
+      if (game.map().terrainByte(t) !== game2.map().terrainByte(t)) {
+        throw new Error(`terrain differs at (${game.x(t)},${game.y(t)})`);
+      }
+    }
+    const mini = game.miniMap();
+    const mini2 = game2.miniMap();
+    for (let t = 0; t < mini.width() * mini.height(); t++) {
+      if (mini.terrainByte(t) !== mini2.terrainByte(t)) {
+        throw new Error(`minimap terrain differs at tile ${t}`);
+      }
+    }
+
+    // Identical graphs
+    expect(edgeCostMap(game.miniWaterGraph()!)).toEqual(
+      edgeCostMap(game2.miniWaterGraph()!),
+    );
+  });
+});
+
+describe("cluster boundary rebuild (plains)", () => {
+  it("a crater creating a gateway into a clean neighboring cluster updates that cluster's edges", async () => {
+    // The 50x50 minimap has a cluster boundary between minimap columns
+    // 31 and 32 (cluster size 32). First carve a lake strictly in the
+    // eastern cluster whose water reaches minimap column 32, rebuild,
+    // then carve a lake strictly in the western cluster reaching column
+    // 31. The second rebuild dirties only the western cluster's tiles,
+    // but the new gateway nodes on the shared boundary need edges inside
+    // the EASTERN (otherwise clean) cluster too — that is what the
+    // 1-ring dirty-cluster expansion in the partial rebuild is for.
+    const game = await setup("plains", WATER_NUKE_CONFIG);
+
+    // Lake strictly east of minimap col 32, spanning DOWN across the
+    // y=31/32 cluster boundary as well — this gives the eastern cluster a
+    // pre-existing gateway node on its bottom edge, so the new western
+    // gateway created later must gain an edge to it inside the eastern
+    // cluster.
+    nukeCircle(game, 71, 40, 7);
+    nukeCircle(game, 71, 50, 7);
+    nukeCircle(game, 71, 60, 7);
+    nukeCircle(game, 71, 66, 7); // reaches minimap rows >= 32
+    tickUntilRebuild(game);
+    nukeCircle(game, 56, 40, 7); // minimap cols 24..31 (western cluster)
+    tickUntilRebuild(game);
+
+    // Non-vacuity: water on both sides of the cluster boundary
+    const mini = game.miniMap();
+    expect(mini.isWater(mini.ref(31, 20))).toBe(true);
+    expect(mini.isWater(mini.ref(32, 20))).toBe(true);
+
+    // Incremental graph must equal a full rebuild
+    const incremental = game.miniWaterGraph()!;
+    const full = new AbstractGraphBuilder(game.miniMap()).build();
+    const incNodes = new Set(incremental.getAllNodes().map((n) => n.tile));
+    const fullNodes = new Set(full.getAllNodes().map((n) => n.tile));
+    expect(incNodes).toEqual(fullNodes);
+    expect(edgeCostMap(incremental)).toEqual(edgeCostMap(full));
+
+    // And boats can cross the boundary through the merged lakes
+    const path = PathFinding.Water(game).findPath(
+      game.ref(56, 40),
+      game.ref(71, 40),
+    );
+    expect(path).not.toBeNull();
+  });
+});
+
+describe("world map pathfinding across water-nuke rebuilds", () => {
+  let game: Game;
+  let oceanA: TileRef;
+  let oceanB: TileRef;
+
+  beforeAll(async () => {
+    game = await setup("world", WATER_NUKE_CONFIG);
+
+    // Two far-apart ocean tiles in the same water component
+    const y = 500;
+    let first: TileRef | null = null;
+    for (let x = 5; x < game.width(); x++) {
+      const t = game.ref(x, y);
+      if (game.map().isOcean(t)) {
+        first = t;
+        break;
+      }
+    }
+    expect(first).not.toBeNull();
+    oceanA = first!;
+    const compA = game.getWaterComponent(oceanA);
+    let last: TileRef | null = null;
+    for (let x = game.width() - 5; x > game.x(oceanA) + 800; x--) {
+      const t = game.ref(x, y);
+      if (game.map().isOcean(t) && game.getWaterComponent(t) === compA) {
+        last = t;
+        break;
+      }
+    }
+    expect(last).not.toBeNull();
+    oceanB = last!;
+  });
+
+  function findCoastalLand(): TileRef {
+    // A land tile on the shoreline, away from the map edge
+    for (let y = 300; y < game.height() - 100; y += 3) {
+      for (let x = 100; x < game.width() - 100; x += 3) {
+        const t = game.ref(x, y);
+        if (game.isLand(t) && game.map().isShoreline(t)) return t;
+      }
+    }
+    throw new Error("no coastal land found");
+  }
+
+  it("long ocean paths keep working across repeated nukes and rebuilds", () => {
+    // Baseline: long path across the ocean
+    const before = PathFinding.Water(game).findPath(oceanA, oceanB);
+    expect(before).not.toBeNull();
+
+    // Nuke a coastal area, wait for rebuild (reuses the HPA via setGraph)
+    const target1 = findCoastalLand();
+    nukeCircle(game, game.x(target1), game.y(target1), 12);
+    tickUntilRebuild(game);
+
+    const after1 = PathFinding.Water(game).findPath(oceanA, oceanB);
+    expect(after1).not.toBeNull();
+    expect(after1![0]).toBe(oceanA);
+    expect(after1![after1!.length - 1]).toBe(oceanB);
+
+    // Second nuke + rebuild: exercises repeated graph swaps
+    const target2 = findCoastalLand(); // now water or new shoreline nearby
+    nukeCircle(game, game.x(target2), game.y(target2), 12);
+    tickUntilRebuild(game);
+
+    const after2 = PathFinding.Water(game).findPath(oceanA, oceanB);
+    expect(after2).not.toBeNull();
+  });
+
+  it("boats can traverse a nuked canal to a deep-inland lake", () => {
+    // Find a deep-inland land tile: everything within ±100 tiles is land.
+    // The old water graph has no nodes anywhere near it, so this only
+    // works if the rebuilt graph (and the pathfinder's graph-derived
+    // helpers) fully reflect the new water.
+    const R = 100;
+    let lake: TileRef | null = null;
+    let channelDir: [number, number] | null = null;
+    let channelEnd: TileRef | null = null;
+    outer: for (let y = 150; y < game.height() - 150; y += 25) {
+      for (let x = 150; x < game.width() - 150; x += 25) {
+        let allLand = true;
+        for (let dy = -R; dy <= R && allLand; dy += 5) {
+          for (let dx = -R; dx <= R; dx += 5) {
+            const t = game.ref(x + dx, y + dy);
+            if (!game.isLand(t) || game.map().isImpassable(t)) {
+              allLand = false;
+              break;
+            }
+          }
+        }
+        if (!allLand) continue;
+
+        // Walk each cardinal direction looking for a clean straight line
+        // of passable land ending at ocean.
+        for (const [sx, sy] of [
+          [1, 0],
+          [-1, 0],
+          [0, 1],
+          [0, -1],
+        ] as const) {
+          let cx = x;
+          let cy = y;
+          let ok = true;
+          while (ok) {
+            cx += sx;
+            cy += sy;
+            if (
+              cx < 10 ||
+              cx >= game.width() - 10 ||
+              cy < 10 ||
+              cy >= game.height() - 10
+            ) {
+              ok = false;
+              break;
+            }
+            const t = game.ref(cx, cy);
+            if (game.map().isOcean(t)) break; // reached the ocean
+            if (game.map().isImpassable(t) || game.hasOwner(t)) {
+              ok = false;
+            }
+          }
+          if (ok) {
+            lake = game.ref(x, y);
+            channelDir = [sx, sy];
+            channelEnd = game.ref(cx, cy);
+            break outer;
+          }
+        }
+      }
+    }
+    expect(lake, "no deep-inland lake site found on world map").not.toBeNull();
+
+    // Carve the lake and a canal to the ocean in one strike wave
+    const lx = game.x(lake!);
+    const ly = game.y(lake!);
+    nukeCircle(game, lx, ly, 10);
+    const [sx, sy] = channelDir!;
+    const ex = game.x(channelEnd!);
+    const ey = game.y(channelEnd!);
+    const steps = Math.max(Math.abs(ex - lx), Math.abs(ey - ly));
+    for (let i = 4; i <= steps; i += 4) {
+      nukeCircle(game, lx + sx * i, ly + sy * i, 6);
+    }
+    tickUntilRebuild(game);
+
+    // The lake is now water, in the same component as the ocean
+    expect(game.isWater(lake!)).toBe(true);
+    expect(game.getWaterComponent(lake!)).toBe(
+      game.getWaterComponent(channelEnd!),
+    );
+
+    // A boat from the distant open ocean can navigate the canal into the
+    // inland lake (target resolution + abstract routing must use the
+    // rebuilt graph, not stale pre-nuke state).
+    const start =
+      game.getWaterComponent(oceanA) === game.getWaterComponent(lake!)
+        ? oceanA
+        : channelEnd!;
+    const path = PathFinding.Water(game).findPath(start, lake!);
+    expect(path).not.toBeNull();
+    expect(path![path!.length - 1]).toBe(lake!);
+  });
+
+  it("boats can path into a coastal nuke crater", () => {
+    const target = findCoastalLand();
+    const tx = game.x(target);
+    const ty = game.y(target);
+    nukeCircle(game, tx, ty, 12);
+    tickUntilRebuild(game);
+
+    // The crater is now ocean-connected water
+    expect(game.isWater(target)).toBe(true);
+    const craterComp = game.getWaterComponent(target);
+    expect(craterComp).not.toBeNull();
+    expect(craterComp).toBe(game.getWaterComponent(oceanA));
+
+    // A boat from the open ocean can reach the crater center
+    const path = PathFinding.Water(game).findPath(oceanA, target);
+    expect(path).not.toBeNull();
+    expect(path![path!.length - 1]).toBe(target);
+  });
+});

--- a/tests/core/pathfinding/WaterComponents.test.ts
+++ b/tests/core/pathfinding/WaterComponents.test.ts
@@ -212,4 +212,131 @@ describe("ConnectedComponents", () => {
       }
     });
   });
+
+  describe("addWaterTiles (incremental land→water updates)", () => {
+    it("is a no-op before initialization", () => {
+      const map = createGameMap(twoComponentsMapData);
+      const wc = new ConnectedComponents(map);
+
+      const tile = map.ref(2, 0);
+      map.setWater(tile);
+      wc.addWaterTiles([tile]);
+
+      expect(wc.getComponentId(tile)).toBe(0);
+    });
+
+    it("joins a new water tile to the adjacent component", () => {
+      const map = createGameMap(twoComponentsMapData);
+      const wc = new ConnectedComponents(map);
+      wc.initialize();
+
+      const leftId = wc.getComponentId(map.ref(0, 0));
+      expect(wc.getComponentSize(leftId)).toBe(10);
+
+      const tile = map.ref(2, 0); // land adjacent to left water column
+      map.setWater(tile);
+      wc.addWaterTiles([tile]);
+
+      expect(wc.getComponentId(tile)).toBe(leftId);
+      expect(wc.getComponentSize(leftId)).toBe(11);
+    });
+
+    it("creates a new component for isolated water", () => {
+      const map = createGameMap(twoComponentsMapData);
+      const wc = new ConnectedComponents(map);
+      wc.initialize();
+
+      const leftId = wc.getComponentId(map.ref(0, 0));
+      const rightId = wc.getComponentId(map.ref(5, 0));
+
+      const tile = map.ref(3, 0); // center column, all neighbors land
+      map.setWater(tile);
+      wc.addWaterTiles([tile]);
+
+      const newId = wc.getComponentId(tile);
+      expect(newId).toBeGreaterThan(0);
+      expect(newId).not.toBe(LAND_MARKER);
+      expect(newId).not.toBe(leftId);
+      expect(newId).not.toBe(rightId);
+      expect(wc.getComponentSize(newId)).toBe(1);
+    });
+
+    it("merges two components bridged by new water", () => {
+      const map = createGameMap(twoComponentsMapData);
+      const wc = new ConnectedComponents(map);
+      wc.initialize();
+
+      const leftBefore = wc.getComponentId(map.ref(0, 0));
+      const rightBefore = wc.getComponentId(map.ref(5, 0));
+      expect(leftBefore).not.toBe(rightBefore);
+
+      // Carve a horizontal bridge across the land strip at y=2
+      const bridge = [map.ref(2, 2), map.ref(3, 2), map.ref(4, 2)];
+      for (const t of bridge) map.setWater(t);
+      wc.addWaterTiles(bridge);
+
+      const merged = wc.getComponentId(map.ref(0, 0));
+      expect(wc.getComponentId(map.ref(6, 4))).toBe(merged);
+      for (const t of bridge) expect(wc.getComponentId(t)).toBe(merged);
+
+      // 10 left + 10 right + 3 bridge tiles
+      expect(wc.getComponentSize(merged)).toBe(23);
+      // Old ids resolve to the merged component (union-find aliasing)
+      expect(wc.getComponentSize(leftBefore)).toBe(23);
+      expect(wc.getComponentSize(rightBefore)).toBe(23);
+    });
+
+    it("ignores tiles that are already labeled water", () => {
+      const map = createGameMap(twoComponentsMapData);
+      const wc = new ConnectedComponents(map);
+      wc.initialize();
+
+      const leftId = wc.getComponentId(map.ref(0, 0));
+      const tile = map.ref(2, 0);
+      map.setWater(tile);
+      wc.addWaterTiles([tile]);
+      wc.addWaterTiles([tile]); // double add must not double count
+
+      expect(wc.getComponentSize(leftId)).toBe(11);
+    });
+
+    it("matches a fresh flood fill after incremental updates", () => {
+      const map = createGameMap(twoComponentsMapData);
+      const wc = new ConnectedComponents(map);
+      wc.initialize();
+
+      // Bridge at y=1, isolated pond at (3,3), extension at (2,4)
+      const added = [
+        map.ref(2, 1),
+        map.ref(3, 1),
+        map.ref(4, 1),
+        map.ref(3, 3),
+        map.ref(2, 4),
+      ];
+      for (const t of added) map.setWater(t);
+      wc.addWaterTiles(added);
+
+      const fresh = new ConnectedComponents(map);
+      fresh.initialize();
+
+      // Same partition (ids may differ) and same sizes per component
+      const freshToInc = new Map<number, number>();
+      const incToFresh = new Map<number, number>();
+      for (let t = 0; t < map.width() * map.height(); t++) {
+        if (!map.isWater(t)) {
+          expect(wc.getComponentId(t)).toBe(LAND_MARKER);
+          continue;
+        }
+        const f = fresh.getComponentId(t);
+        const i = wc.getComponentId(t);
+        if (!freshToInc.has(f) && !incToFresh.has(i)) {
+          freshToInc.set(f, i);
+          incToFresh.set(i, f);
+        }
+        expect(freshToInc.get(f)).toBe(i);
+        expect(incToFresh.get(i)).toBe(f);
+        expect(wc.getComponentSize(i)).toBe(fresh.getComponentSize(f));
+      }
+    });
+  });
 });

--- a/tests/perf/WaterNukeRebuildPerf.ts
+++ b/tests/perf/WaterNukeRebuildPerf.ts
@@ -1,0 +1,306 @@
+/**
+ * Measures the cost of water-nuke terrain fixup (finalizeWaterChanges) and
+ * the throttled water graph rebuild on the giant world map.
+ *
+ * Craters are queued directly via game.queueWaterConversion() — the same
+ * call NukeExecution makes on impact — so the test exercises the exact
+ * WaterManager code path without silo/gold/travel bookkeeping.
+ *
+ * Run with: npx tsx tests/perf/WaterNukeRebuildPerf.ts
+ */
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { Game } from "../../src/core/game/Game";
+import { DebugSpan } from "../../src/core/utilities/DebugSpan";
+import { setup } from "../util/Setup";
+
+type Span = {
+  name: string;
+  duration?: number;
+  children: Span[];
+};
+
+DebugSpan.enable();
+
+function spans(): Span[] {
+  return (globalThis as any).__DEBUG_SPANS__ ?? [];
+}
+
+/** Recursively find the first span with `name` in a span tree. */
+function findSpan(root: Span, name: string): Span | undefined {
+  if (root.name === name) return root;
+  for (const child of root.children) {
+    const found = findSpan(child, name);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+/** Find the most recent root span with `name` at index >= fromIndex. */
+function lastRootSpan(name: string, fromIndex: number): Span | undefined {
+  const all = spans();
+  for (let i = all.length - 1; i >= fromIndex; i--) {
+    if (all[i].name === name) return all[i];
+  }
+  return undefined;
+}
+
+function ms(v: number | undefined): string {
+  return v === undefined ? "-" : v.toFixed(1);
+}
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+
+console.log("Loading giant world map (4108x1948)...");
+const setupStart = performance.now();
+const game: Game = await setup(
+  "giantworldmap",
+  {
+    waterNukes: true,
+    disableNavMesh: false,
+  },
+  [],
+  currentDir,
+);
+const setupMs = performance.now() - setupStart;
+const initialBuild = lastRootSpan("AbstractGraphBuilder:build", 0);
+console.log(
+  `Setup done in ${ms(setupMs)}ms (initial graph build: ${ms(initialBuild?.duration)}ms)`,
+);
+
+/**
+ * Find spread-out coastal land targets (land shoreline tiles at least
+ * `minDist` apart). Coastal nukes are the common case and produce
+ * ocean-connected craters.
+ */
+function findCoastalTargets(
+  count: number,
+  minDist: number,
+): { x: number; y: number }[] {
+  const targets: { x: number; y: number }[] = [];
+  const w = game.width();
+  const h = game.height();
+  for (let y = 120; y < h - 120 && targets.length < count; y += 11) {
+    for (let x = 120; x < w - 120 && targets.length < count; x += 11) {
+      const tile = game.ref(x, y);
+      if (!game.isLand(tile) || !game.isShoreline(tile)) continue;
+      let tooClose = false;
+      for (const t of targets) {
+        const dx = t.x - x;
+        const dy = t.y - y;
+        if (dx * dx + dy * dy < minDist * minDist) {
+          tooClose = true;
+          break;
+        }
+      }
+      if (!tooClose) targets.push({ x, y });
+    }
+  }
+  return targets;
+}
+
+/** Queue a circular crater of land->water conversions, like NukeExecution. */
+function queueCrater(cx: number, cy: number, radius: number): number {
+  let queued = 0;
+  const r2 = radius * radius;
+  const x0 = Math.max(0, cx - radius);
+  const y0 = Math.max(0, cy - radius);
+  const x1 = Math.min(game.width() - 1, cx + radius);
+  const y1 = Math.min(game.height() - 1, cy + radius);
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      const dx = x - cx;
+      const dy = y - cy;
+      if (dx * dx + dy * dy > r2) continue;
+      const tile = game.ref(x, y);
+      if (game.isLand(tile) && !game.hasOwner(tile)) {
+        game.queueWaterConversion(tile);
+        queued++;
+      }
+    }
+  }
+  return queued;
+}
+
+interface Result {
+  label: string;
+  tiles: number;
+  finalizeTickMs: number;
+  finalizeMs?: number;
+  oceanMs?: number;
+  magnitudeMs?: number;
+  shorelineMs?: number;
+  minimapMs?: number;
+  miniMagnitudeMs?: number;
+  rebuildTickMs?: number;
+  rebuildMs?: number;
+  buildMs?: number;
+  ccMs?: number;
+  nodesMs?: number;
+  edgesMs?: number;
+  hpaMs?: number;
+}
+
+const results: Result[] = [];
+
+/**
+ * Queue craters, tick once (flushes conversions -> finalizeWaterChanges),
+ * then tick until the graph rebuild fires (20-tick throttle) and record
+ * the duration of the rebuild tick.
+ */
+function runScenario(
+  label: string,
+  craters: { x: number; y: number; radius: number }[],
+): void {
+  const spanIndex = spans().length;
+
+  let tiles = 0;
+  for (const c of craters) {
+    tiles += queueCrater(c.x, c.y, c.radius);
+  }
+
+  const t0 = performance.now();
+  game.executeNextTick();
+  const finalizeTickMs = performance.now() - t0;
+
+  const versionBefore = game.waterGraphVersion();
+  let rebuildTickMs: number | undefined;
+  for (let i = 0; i < 30; i++) {
+    const t1 = performance.now();
+    game.executeNextTick();
+    const tickMs = performance.now() - t1;
+    if (game.waterGraphVersion() > versionBefore) {
+      rebuildTickMs = tickMs;
+      break;
+    }
+  }
+
+  const finalize = lastRootSpan("WaterManager:finalizeWaterChanges", spanIndex);
+  const rebuild = lastRootSpan("WaterManager:rebuildWaterGraph", spanIndex);
+  const build = rebuild && findSpan(rebuild, "AbstractGraphBuilder:build");
+
+  results.push({
+    label,
+    tiles,
+    finalizeTickMs,
+    finalizeMs: finalize?.duration,
+    oceanMs: finalize && findSpan(finalize, "ocean")?.duration,
+    magnitudeMs: finalize && findSpan(finalize, "magnitude")?.duration,
+    shorelineMs: finalize && findSpan(finalize, "shoreline")?.duration,
+    minimapMs: finalize && findSpan(finalize, "minimap")?.duration,
+    miniMagnitudeMs: finalize && findSpan(finalize, "miniMagnitude")?.duration,
+    rebuildTickMs,
+    rebuildMs: rebuild?.duration,
+    buildMs: build?.duration,
+    ccMs: build && findSpan(build, "ConnectedComponents:initialize")?.duration,
+    nodesMs: build && findSpan(build, "nodes")?.duration,
+    edgesMs: build && findSpan(build, "edges")?.duration,
+    hpaMs: rebuild && findSpan(rebuild, "hpa")?.duration,
+  });
+}
+
+// ── Scenarios ────────────────────────────────────────────────────────
+const ATOM_RADIUS = 30;
+const HYDROGEN_RADIUS = 100;
+
+const targets = findCoastalTargets(16, 400);
+if (targets.length < 16) {
+  throw new Error(`Only found ${targets.length}/16 coastal targets`);
+}
+
+// 8 single atom bombs at spread-out coastal locations
+for (let i = 0; i < 8; i++) {
+  runScenario(`atom coastal #${i + 1}`, [
+    { ...targets[i], radius: ATOM_RADIUS },
+  ]);
+}
+
+// 3 single hydrogen bombs
+for (let i = 0; i < 3; i++) {
+  runScenario(`hydrogen coastal #${i + 1}`, [
+    { ...targets[8 + i], radius: HYDROGEN_RADIUS },
+  ]);
+}
+
+// Barrage: 5 atom bombs landing on the same tick at spread-out locations
+// (worst case: the finalize bounding boxes span most of the map)
+runScenario(
+  "barrage 5x atom same tick",
+  targets.slice(11, 16).map((t) => ({ ...t, radius: ATOM_RADIUS })),
+);
+
+// MIRV-like: many small warheads landing the same tick, spread across
+// the map (union bounding box ~ whole map)
+const mirvTargets = findCoastalTargets(40, 250);
+runScenario(
+  "mirv 40x warheads same tick",
+  mirvTargets.map((t) => ({ ...t, radius: 18 })),
+);
+
+// Repeat bombardment: hydrogen bombs walking along the first target area
+// (rebuild on already-cratered terrain)
+const base = targets[8];
+for (let i = 0; i < 3; i++) {
+  runScenario(`hydrogen repeat #${i + 1}`, [
+    { x: base.x + 40 * (i + 1), y: base.y, radius: HYDROGEN_RADIUS },
+  ]);
+}
+
+// ── Report ───────────────────────────────────────────────────────────
+console.log("\n=== Water Nuke Rebuild Performance (giant world map) ===\n");
+const header = [
+  "scenario".padEnd(26),
+  "tiles".padStart(7),
+  "finalize".padStart(9),
+  "ocean".padStart(7),
+  "magn".padStart(7),
+  "shore".padStart(7),
+  "mini".padStart(6),
+  "miniMag".padStart(8),
+  "| rebuild".padStart(10),
+  "build".padStart(8),
+  "CC".padStart(7),
+  "nodes".padStart(7),
+  "edges".padStart(8),
+  "hpa".padStart(6),
+].join(" ");
+console.log(header);
+console.log("-".repeat(header.length));
+for (const r of results) {
+  console.log(
+    [
+      r.label.padEnd(26),
+      String(r.tiles).padStart(7),
+      ms(r.finalizeMs).padStart(9),
+      ms(r.oceanMs).padStart(7),
+      ms(r.magnitudeMs).padStart(7),
+      ms(r.shorelineMs).padStart(7),
+      ms(r.minimapMs).padStart(6),
+      ms(r.miniMagnitudeMs).padStart(8),
+      ("| " + ms(r.rebuildMs)).padStart(10),
+      ms(r.buildMs).padStart(8),
+      ms(r.ccMs).padStart(7),
+      ms(r.nodesMs).padStart(7),
+      ms(r.edgesMs).padStart(8),
+      ms(r.hpaMs).padStart(6),
+    ].join(" "),
+  );
+}
+
+const rebuilds = results
+  .map((r) => r.rebuildMs)
+  .filter((v): v is number => v !== undefined)
+  .sort((a, b) => a - b);
+const finalizes = results.map((r) => r.finalizeMs ?? 0).sort((a, b) => a - b);
+const sum = (a: number[]) => a.reduce((x, y) => x + y, 0);
+console.log(
+  `\nfinalize ms  — median ${ms(finalizes[Math.floor(finalizes.length / 2)])}, ` +
+    `mean ${ms(sum(finalizes) / finalizes.length)}, max ${ms(finalizes[finalizes.length - 1])}`,
+);
+console.log(
+  `rebuild ms   — median ${ms(rebuilds[Math.floor(rebuilds.length / 2)])}, ` +
+    `mean ${ms(sum(rebuilds) / rebuilds.length)}, max ${ms(rebuilds[rebuilds.length - 1])}`,
+);
+console.log(
+  `initial build (full, no dirty-cluster cache): ${ms(initialBuild?.duration)}ms`,
+);


### PR DESCRIPTION
## Description:

Water nukes caused lag spikes when a nuke landed on large maps: the terrain fixup and water-graph rebuild together took **~50–120ms per nuke** on Giant World Map, and up to **~340ms** for MIRV-style simultaneous strikes.

This PR adds a perf harness for the water-nuke path (`npx tsx tests/perf/WaterNukeRebuildPerf.ts`) and optimizes the hot spots it found:

- **Incremental ConnectedComponents** — terrain only ever converts land→water, so water components can only grow or merge, never split. `WaterManager` now keeps one persistent minimap `ConnectedComponents` updated per converted tile via a union-find alias table, eliminating the full-minimap flood fill (14–60ms) from every graph rebuild.
- **Grouped magnitude BFS** — converted tiles are clustered into spatially separate crater groups (merged only when merging shrinks total BFS area), so simultaneous distant nukes (barrage/MIRV) no longer produce one map-spanning BFS box. The BFS hot loops read terrain bytes directly (same precedent as `ConnectedComponents.premarkLandTilesDirect`).
- **Scratch buffer reuse** — `AStarWaterHierarchical` persists across rebuilds via a new `setGraph()` and `AbstractGraphBuilder` accepts a shared `BFSGrid`, avoiding ~40MB of map-sized typed-array allocations (and GC churn) per rebuild.
- **Shoreline pass** dedups via the reusable stamp array instead of a `Set`.

### Results (Giant World Map)

| metric | before | after |
|---|---|---|
| finalize median | 18.3ms | **7.9ms** |
| rebuild median | 26.5ms | **9.5ms** |
| per-nuke spike (finalize + rebuild) | ~50–120ms | **~15–25ms** |
| 40-warhead MIRV same-tick finalize | 307.9ms | **110.9ms** |

### Correctness

All changes are deterministic and were verified against independent oracles:

- Game hash remains unchanged
- Incremental component partition and sizes match a fresh flood fill exactly (0 mismatches across 1.46M water tiles after mixed bombardment on GWM).
- All magnitudes near craters match a from-scratch global BFS on both the full map and minimap (0 mismatches across ~308k checked tiles).

### Tests

- `WaterComponents.test.ts`: unit tests for incremental `addWaterTiles` (join / bridge-merge / isolated / idempotency / fresh-flood-fill equivalence).
- New `PathFinding.WaterNukes.test.ts` (17 tests): component merging with actual boat paths across nuked channels, whole-map magnitude comparisons against a from-scratch BFS oracle (single crater, same-tick barrage, repeat nukes, far-coastline seed-box case), incremental-vs-full graph rebuild equality (including a cluster-boundary gateway case), cross-game determinism, and world-map pathfinding across repeated rebuilds — including a nuked canal to a deep-inland lake.
- Every new test was validated by mutation testing: seed-box shrink, union-find skip, missing incremental update, missing dirty-cluster ring expansion, and stale `setGraph` helpers each cause specific test failures.

## Please complete the following:

- [x] I have added screenshots for all UI updates (no UI changes)
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file (no user-visible text)
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

(maintainer PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
