### PR TITLE
Prevent iOS double-tap page zoom from softlocking the HUD

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,6 +53,13 @@
         min-height: 100%;
         min-height: -webkit-fill-available;
       }
+
+      /* Disable iOS double-tap "smart zoom" on the page; the game has its
+         own map zoom. Panning/scrolling stays allowed. See issue #4609. */
+      html,
+      body {
+        touch-action: manipulation;
+      }
     </style>
 
     <!-- SEO -->

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -77,7 +77,10 @@ import { incrementGamesPlayed, translateText } from "./Utils";
 import { isReplayShellHost } from "./VersionedReplay";
 import "./components/BannedModal";
 import "./components/MarketingConsentToast";
-import { installSafariPinchZoomBlocker } from "./utilities/DisableSafariPinchZoom";
+import {
+  installDoubleTapZoomBlocker,
+  installSafariPinchZoomBlocker,
+} from "./utilities/DisableSafariPinchZoom";
 
 import "./components/DesktopNavBar";
 import "./components/Footer";
@@ -1172,6 +1175,10 @@ const bootstrap = () => {
   // Prevent Safari's page-level pinch-zoom, which ignores `user-scalable=no`
   // on iOS and can softlock the HUD. See issue #2330.
   installSafariPinchZoomBlocker();
+
+  // Same for double-tap "smart zoom", which `touch-action: manipulation`
+  // alone does not reliably stop on iOS. See issue #4609.
+  installDoubleTapZoomBlocker();
 
   initLayout();
   new Client().initialize();

--- a/src/client/utilities/DisableSafariPinchZoom.ts
+++ b/src/client/utilities/DisableSafariPinchZoom.ts
@@ -34,3 +34,67 @@ export function installSafariPinchZoomBlocker(
     target.addEventListener(type, block);
   }
 }
+
+/** Two taps this close together in time and space form a double-tap. */
+const DOUBLE_TAP_WINDOW_MS = 350;
+const DOUBLE_TAP_RADIUS_PX = 30;
+
+const INTERACTIVE_TARGET_SELECTOR =
+  "a[href], button, input, label, select, summary, textarea, [contenteditable], [role='button']";
+
+function tapsInteractiveElement(e: Event): boolean {
+  return e
+    .composedPath()
+    .some(
+      (el) => el instanceof Element && el.matches(INTERACTIVE_TARGET_SELECTOR),
+    );
+}
+
+/**
+ * Blocks the page-level double-tap "smart zoom" gesture on Safari / WebKit.
+ *
+ * Like pinch zoom, double-tap zoom ignores `user-scalable=no` on iOS.
+ * `touch-action: manipulation` (set on `html`/`body` in index.html) is the
+ * declarative fix, but WebKit still zooms in some cases when the double-tap
+ * lands on HUD chrome, leaving the page stuck at a zoom level the game's own
+ * controls cannot undo. As a fallback, cancel the `touchend` that completes
+ * a double-tap — the event whose default action triggers the zoom.
+ *
+ * Cancelling `touchend` also suppresses the synthesized `click` for that
+ * tap, so the guard skips taps on interactive elements: rapid taps on
+ * buttons keep clicking, and WebKit does not smart-zoom clickable targets
+ * anyway. Map input is unaffected either way — the canvas overlay sets
+ * `touch-action: none` and is driven by pointer events (see
+ * {@link ../InputHandler}), which still fire for cancelled touches.
+ *
+ * @param target - The EventTarget to attach the listener to. Defaults to
+ *   `document`.
+ *
+ * @see https://github.com/openfrontio/OpenFrontIO/issues/4609
+ */
+export function installDoubleTapZoomBlocker(
+  target: EventTarget = document,
+): void {
+  let lastTapTime = Number.NEGATIVE_INFINITY;
+  let lastTapX = 0;
+  let lastTapY = 0;
+
+  target.addEventListener(
+    "touchend",
+    (e) => {
+      const touch = (e as TouchEvent).changedTouches?.[0];
+      const x = touch?.clientX ?? 0;
+      const y = touch?.clientY ?? 0;
+      const isDoubleTap =
+        e.timeStamp - lastTapTime <= DOUBLE_TAP_WINDOW_MS &&
+        Math.hypot(x - lastTapX, y - lastTapY) <= DOUBLE_TAP_RADIUS_PX;
+      lastTapTime = e.timeStamp;
+      lastTapX = x;
+      lastTapY = y;
+      if (isDoubleTap && e.cancelable && !tapsInteractiveElement(e)) {
+        e.preventDefault();
+      }
+    },
+    { passive: false },
+  );
+}

--- a/tests/client/DisableSafariPinchZoom.test.ts
+++ b/tests/client/DisableSafariPinchZoom.test.ts
@@ -1,4 +1,7 @@
-import { installSafariPinchZoomBlocker } from "../../src/client/utilities/DisableSafariPinchZoom";
+import {
+  installDoubleTapZoomBlocker,
+  installSafariPinchZoomBlocker,
+} from "../../src/client/utilities/DisableSafariPinchZoom";
 
 const GESTURE_EVENTS = ["gesturestart", "gesturechange", "gestureend"] as const;
 
@@ -60,5 +63,92 @@ describe("installSafariPinchZoomBlocker", () => {
     const event = new Event("touchstart", { bubbles: true, cancelable: true });
     target.dispatchEvent(event);
     expect(event.defaultPrevented).toBe(false);
+  });
+});
+
+function dispatchTouchEnd(
+  target: EventTarget,
+  timeStamp: number,
+  position?: { x: number; y: number },
+): Event {
+  // jsdom has no TouchEvent constructor; dispatch a plain cancelable Event
+  // with the read-only timeStamp (and, when given, changedTouches) stubbed.
+  const event = new Event("touchend", {
+    bubbles: true,
+    cancelable: true,
+    composed: true,
+  });
+  Object.defineProperty(event, "timeStamp", { value: timeStamp });
+  if (position) {
+    Object.defineProperty(event, "changedTouches", {
+      value: [{ clientX: position.x, clientY: position.y }],
+    });
+  }
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("installDoubleTapZoomBlocker", () => {
+  it("cancels the second tap of a double-tap", () => {
+    const target = document.createElement("div");
+    installDoubleTapZoomBlocker(target);
+
+    expect(dispatchTouchEnd(target, 1000).defaultPrevented).toBe(false);
+    expect(dispatchTouchEnd(target, 1200).defaultPrevented).toBe(true);
+  });
+
+  it("leaves taps alone when they are too far apart in time", () => {
+    const target = document.createElement("div");
+    installDoubleTapZoomBlocker(target);
+
+    expect(dispatchTouchEnd(target, 1000).defaultPrevented).toBe(false);
+    expect(dispatchTouchEnd(target, 2000).defaultPrevented).toBe(false);
+  });
+
+  it("leaves taps alone when they are too far apart on screen", () => {
+    const target = document.createElement("div");
+    installDoubleTapZoomBlocker(target);
+
+    dispatchTouchEnd(target, 1000, { x: 0, y: 0 });
+    const second = dispatchTouchEnd(target, 1200, { x: 400, y: 300 });
+    expect(second.defaultPrevented).toBe(false);
+  });
+
+  it("does not cancel double-taps on interactive elements", () => {
+    const scope = document.createElement("div");
+    const button = scope.appendChild(document.createElement("button"));
+    installDoubleTapZoomBlocker(scope);
+
+    expect(dispatchTouchEnd(button, 1000).defaultPrevented).toBe(false);
+    expect(dispatchTouchEnd(button, 1200).defaultPrevented).toBe(false);
+  });
+
+  it("recognizes interactive elements inside shadow DOM", () => {
+    const scope = document.createElement("div");
+    const host = scope.appendChild(document.createElement("div"));
+    const shadow = host.attachShadow({ mode: "open" });
+    const button = shadow.appendChild(document.createElement("button"));
+    installDoubleTapZoomBlocker(scope);
+
+    expect(dispatchTouchEnd(button, 1000).defaultPrevented).toBe(false);
+    expect(dispatchTouchEnd(button, 1200).defaultPrevented).toBe(false);
+  });
+
+  it("defaults to attaching the listener to document", () => {
+    const addEventListenerSpy = vi
+      .spyOn(document, "addEventListener")
+      .mockImplementation(() => {});
+
+    try {
+      installDoubleTapZoomBlocker();
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "touchend",
+        expect.any(Function),
+        { passive: false },
+      );
+    } finally {
+      addEventListenerSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION

## Resolves Issue #4609

## Description:

Double-tapping HUD chrome on iOS/WebKit triggers the browser's own "smart zoom", which the game's zoom controls can't undo — the page gets stuck zoomed-in with the HUD partially off-screen. The existing `installSafariPinchZoomBlocker` only covers pinch (`gesture*` events), and the map canvas already opts out via `touch-action: none`, which is why the zoom only fires from taps on the HUD.

Two-layer fix:

1. **`touch-action: manipulation` on `html`/`body`** (index.html) — the standard declarative way to disable double-tap zoom. It only removes the double-tap gesture; panning/scrolling and clicks are unaffected, and it gates descendants too (zoom is only allowed if every element from the touch target up to the document permits it).
2. **A `touchend` double-tap guard** (`installDoubleTapZoomBlocker` in `DisableSafariPinchZoom.ts`, installed in `Main.ts` next to the pinch blocker) as a fallback for WebKit builds that still zoom. It cancels only the *second* `touchend` within 350 ms / 30 px of the previous tap — the event whose default action triggers the zoom.

Why not just block `touchend` globally (as suggested in the issue): cancelling `touchend` suppresses the synthesized `click` for that tap, so blocking it unconditionally would break every tap on iOS. The guard therefore (a) only cancels the second tap of an actual double-tap, and (b) skips taps whose composed path contains an interactive element (`button`, `a[href]`, inputs, `[role=button]`, …) — including inside shadow DOM — so rapid taps on buttons keep clicking. Game input is untouched either way: the map is driven by pointer events, which still fire for cancelled touches.

## Please complete the following:

- [x] I have added screenshots for all UI updates — n/a: nothing visual changes. The fix suppresses a browser gesture, so there is no before/after to capture.
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — n/a: no user-visible text is added.
- [x] I have added relevant tests to the test directory

**Testing performed:**

- 6 new unit tests in `tests/client/DisableSafariPinchZoom.test.ts`, 10 in the file total (double-tap cancelled; slow taps, distant taps, and taps on interactive elements — incl. shadow DOM — left alone; listener attached to `document` with `passive: false`).
- `npx vitest run tests/client/DisableSafariPinchZoom.test.ts` — 10/10 passing.
- `npm test` — 2966 of 2967 tests passing across 256 files. The one failure is a 5 s timeout in `tests/client/InventoryModal.test.ts` under full-suite parallel load on my machine. That file is new in `main` (#4962), is untouched by this PR, passes in isolation (21/21), and fails the same way on a clean `main` checkout — so it is unrelated to this change.
- `npm run lint` (Oxlint + ESLint), Prettier, `npx tsc --noEmit`, and `git diff --check` all clean.
- Verified in the running dev client (headless Chromium): computed `touch-action` is `manipulation` on `html`/`body`, first synthetic tap is not cancelled, second tap within the window is cancelled, no new console errors.
- Rebased onto current `main` (`3aafa964`) and re-verified; the rebase was conflict-free.

**Note on the PR gate**

The linked issue #4609 carries the `approved` label and I am assigned to it. The separate `Has Milestone` check is expected to stay red until a reviewer assigns this PR's milestone; contributors cannot set that themselves.

## Discord: Kronbii
