### PR TITLE
feat(adminbot): featured lobbies — custom label and a longer listing window

### DIFF
--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -326,20 +326,6 @@ export class GameModeSelector extends LitElement {
     }
 
     const mapName = getMapName(lobby.gameConfig?.gameMap);
-    // A featured lobby names itself; the map drops to the subtitle so nothing is
-    // lost. Interpolated by lit as TEXT, never markup — emoji render because
-    // they are ordinary codepoints, and the accent comes from a closed set so a
-    // label can never restyle the rest of the list.
-    const featuredLabel = lobby.featured ? lobby.label : undefined;
-    const accentClass =
-      featuredLabel === undefined
-        ? ""
-        : {
-            gold: "text-amber-300",
-            blue: "text-sky-300",
-            green: "text-emerald-300",
-            red: "text-rose-300",
-          }[lobby.accent ?? "gold"];
 
     const modifierLabels = getModifierLabels(
       lobby.gameConfig?.publicGameModifiers,
@@ -418,21 +404,15 @@ export class GameModeSelector extends LitElement {
               ></path>
             </svg>
           </span>
-          ${featuredLabel
+          ${mapName
             ? html`<p
-                class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight ${accentClass}"
+                class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"
               >
-                ${featuredLabel}
+                ${mapName}
               </p>`
-            : mapName
-              ? html`<p
-                  class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"
-                >
-                  ${mapName}
-                </p>`
-              : ""}
+            : ""}
           <h3 class="text-xs text-white/70 uppercase tracking-wider text-left">
-            ${featuredLabel && mapName ? mapName : titleContent}
+            ${titleContent}
           </h3>
         </div>
       </button>

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -326,6 +326,20 @@ export class GameModeSelector extends LitElement {
     }
 
     const mapName = getMapName(lobby.gameConfig?.gameMap);
+    // A featured lobby names itself; the map drops to the subtitle so nothing is
+    // lost. Interpolated by lit as TEXT, never markup — emoji render because
+    // they are ordinary codepoints, and the accent comes from a closed set so a
+    // label can never restyle the rest of the list.
+    const featuredLabel = lobby.featured ? lobby.label : undefined;
+    const accentClass =
+      featuredLabel === undefined
+        ? ""
+        : {
+            gold: "text-amber-300",
+            blue: "text-sky-300",
+            green: "text-emerald-300",
+            red: "text-rose-300",
+          }[lobby.accent ?? "gold"];
 
     const modifierLabels = getModifierLabels(
       lobby.gameConfig?.publicGameModifiers,
@@ -404,15 +418,21 @@ export class GameModeSelector extends LitElement {
               ></path>
             </svg>
           </span>
-          ${mapName
+          ${featuredLabel
             ? html`<p
-                class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"
+                class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight ${accentClass}"
               >
-                ${mapName}
+                ${featuredLabel}
               </p>`
-            : ""}
+            : mapName
+              ? html`<p
+                  class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"
+                >
+                  ${mapName}
+                </p>`
+              : ""}
           <h3 class="text-xs text-white/70 uppercase tracking-wider text-left">
-            ${titleContent}
+            ${featuredLabel && mapName ? mapName : titleContent}
           </h3>
         </div>
       </button>

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -302,6 +302,25 @@ export class JoinLobbyModal extends BaseModal {
     const settings = c ? this.notableSettings(c, null) : [];
     const disabledUnitCount = c?.disabledUnits?.length ?? 0;
     const enabled = translateText("common.enabled");
+    // A featured lobby names itself; the map drops to the subtitle so nothing
+    // is lost. Interpolated by lit as TEXT, never markup — emoji render because
+    // they are ordinary codepoints, and the accent comes from a closed set so a
+    // label can never restyle the rest of the list.
+    const featuredLabel = lobby.featured ? lobby.label : undefined;
+    const accentClass =
+      featuredLabel === undefined
+        ? "text-white"
+        : {
+            gold: "text-amber-300",
+            blue: "text-sky-300",
+            green: "text-emerald-300",
+            red: "text-rose-300",
+          }[lobby.accent ?? "gold"];
+    const subtitle = c ? this.modeSubtitle(c) : "";
+    // The map name only moves down here when a label has taken the title line.
+    const subtitleLine = featuredLabel
+      ? [mapName, subtitle].filter(Boolean).join(" · ")
+      : subtitle;
     return html`
       <button
         type="button"
@@ -317,10 +336,10 @@ export class JoinLobbyModal extends BaseModal {
           }}
         />
         <div class="flex flex-col flex-1 min-w-0">
-          <span class="text-sm font-bold text-white truncate">${mapName}</span>
-          <span class="text-xs text-white/60"
-            >${c ? this.modeSubtitle(c) : ""}</span
+          <span class="text-sm font-bold truncate ${accentClass}"
+            >${featuredLabel ?? mapName}</span
           >
+          <span class="text-xs text-white/60">${subtitleLine}</span>
           ${settings.length > 0 || disabledUnitCount > 0
             ? html`<div class="flex flex-wrap gap-1 mt-1">
                 ${settings.map((s) => {

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -197,6 +197,15 @@ export const FEATURED_LOBBY_AUTO_START_MS = 10 * 60 * 1000;
 // cannot crowd out the rest of the list.
 export const LOBBY_LABEL_MAX = 48;
 
+// Labels are capped by CODE POINT, matching sanitizeLobbyLabel. z.string().max()
+// counts UTF-16 code units, so it would reject a legal 48-emoji label (96 units)
+// before the sanitiser ever saw it.
+export const LobbyLabelSchema = z
+  .string()
+  .refine((v) => Array.from(v).length <= LOBBY_LABEL_MAX, {
+    message: `label must be at most ${LOBBY_LABEL_MAX} characters`,
+  });
+
 // Accent applied to a featured lobby's row. A closed set, not free-form CSS:
 // arbitrary styling in a shared list lets one lobby make every other row
 // unreadable.
@@ -221,6 +230,9 @@ export function sanitizeLobbyLabel(raw: string): string {
     if (cp >= 0x202a && cp <= 0x202e) continue;
     if (cp >= 0x2066 && cp <= 0x2069) continue;
     if (cp === 0x200e || cp === 0x200f) continue;
+    if (cp === 0x061c) continue; // ARABIC LETTER MARK — zero-width, bidi-active
+    // NB: U+200D ZERO WIDTH JOINER is deliberately KEPT — emoji sequences like
+    // 👨‍👩‍👧 are built from it, and stripping it would break them apart.
     kept.push(ch);
   }
   return kept
@@ -272,7 +284,7 @@ export const GameInfoSchema = z.object({
   autoStartAt: z.number().optional(),
   // Featured lobbies only (admin bot). Echoed back so the creating bot can
   // confirm the request took effect, the same way it checks `listed`.
-  label: z.string().max(LOBBY_LABEL_MAX).optional(),
+  label: LobbyLabelSchema.optional(),
   accent: LobbyAccentSchema.optional(),
   featured: z.boolean().optional(),
 });
@@ -289,7 +301,7 @@ export const PublicGameInfoSchema = z.object({
   publicGameType: PublicGameTypeSchema,
   // Featured lobbies only. Both optional so a client on an older build simply
   // renders the map name as it does today.
-  label: z.string().max(LOBBY_LABEL_MAX).optional(),
+  label: LobbyLabelSchema.optional(),
   accent: LobbyAccentSchema.optional(),
   featured: z.boolean().optional(),
 });

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -185,6 +185,53 @@ export const MAX_HOSTED_LOBBIES = 10;
 // deadline; relisting starts a fresh one.
 export const HOSTED_LOBBY_AUTO_START_MS = 5 * 60 * 1000;
 
+// Featured lobbies get a longer window. A scheduled event announced ahead of
+// time needs the listing to still be up when its audience arrives, and unlike a
+// subscriber sitting on a listing the host is an authenticated admin bot. Only
+// create_game can set it, so the ordinary deadline still governs every
+// player-hosted lobby.
+export const FEATURED_LOBBY_AUTO_START_MS = 10 * 60 * 1000;
+
+// Longest label a featured lobby may show in the browser. Long enough for
+// "Europe — Official OpenFront Masters Scrims", short enough that one row
+// cannot crowd out the rest of the list.
+export const LOBBY_LABEL_MAX = 48;
+
+// Accent applied to a featured lobby's row. A closed set, not free-form CSS:
+// arbitrary styling in a shared list lets one lobby make every other row
+// unreadable.
+export const LobbyAccentSchema = z.enum(["gold", "blue", "green", "red"]);
+export type LobbyAccent = z.infer<typeof LobbyAccentSchema>;
+
+// A label is host-supplied text on the front page of the game, so it is
+// sanitised before it can reach anyone: control characters and bidi overrides
+// stripped (they let text render as something entirely different), whitespace
+// collapsed, then length-capped. Rendered as TEXT, never markup — emoji work
+// because they are ordinary codepoints.
+export function sanitizeLobbyLabel(raw: string): string {
+  const kept: string[] = [];
+  // Iterated by CODE POINT, not code unit: an emoji is a surrogate pair, and
+  // slicing one in half is how a label turns into a replacement glyph.
+  for (const ch of raw) {
+    const cp = ch.codePointAt(0)!;
+    if (cp < 0x20 || cp === 0x7f) continue; // C0 controls and DEL
+    if (cp >= 0x80 && cp <= 0x9f) continue; // C1 controls
+    // Bidi overrides, isolates and marks: they make following text render in
+    // another direction, which is how a label claims to be something it isn't.
+    if (cp >= 0x202a && cp <= 0x202e) continue;
+    if (cp >= 0x2066 && cp <= 0x2069) continue;
+    if (cp === 0x200e || cp === 0x200f) continue;
+    kept.push(ch);
+  }
+  return kept
+    .join("")
+    .replace(/\s+/g, " ")
+    .trim()
+    .split(/(?:)/u)
+    .slice(0, LOBBY_LABEL_MAX)
+    .join("");
+}
+
 export const UsernameSchema = z
   .string()
   .regex(/^(?=.*\S)[a-zA-Z0-9_ üÜ.]+$/u)
@@ -223,6 +270,11 @@ export const GameInfoSchema = z.object({
   // Listed lobbies only: server timestamp when the lobby starts
   // automatically (hosts can't sit on a public listing indefinitely).
   autoStartAt: z.number().optional(),
+  // Featured lobbies only (admin bot). Echoed back so the creating bot can
+  // confirm the request took effect, the same way it checks `listed`.
+  label: z.string().max(LOBBY_LABEL_MAX).optional(),
+  accent: LobbyAccentSchema.optional(),
+  featured: z.boolean().optional(),
 });
 
 // Browser-facing lobby info. Master/worker-internal fields (the creator hash
@@ -235,6 +287,11 @@ export const PublicGameInfoSchema = z.object({
   startsAt: z.number().optional(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema,
+  // Featured lobbies only. Both optional so a client on an older build simply
+  // renders the map name as it does today.
+  label: z.string().max(LOBBY_LABEL_MAX).optional(),
+  accent: LobbyAccentSchema.optional(),
+  featured: z.boolean().optional(),
 });
 
 export const PublicGamesSchema = z.object({

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -23,7 +23,7 @@ import {
   UnitType,
 } from "./game/Game";
 import { ArchivedPlayerStatsSchema, PlayerStatsSchema } from "./StatsSchemas";
-import { flattenedEmojiTable } from "./Util";
+import { flattenedEmojiTable, LOBBY_LABEL_MAX } from "./Util";
 
 export type GameID = string;
 export type ClientID = string;
@@ -192,11 +192,6 @@ export const HOSTED_LOBBY_AUTO_START_MS = 5 * 60 * 1000;
 // player-hosted lobby.
 export const FEATURED_LOBBY_AUTO_START_MS = 10 * 60 * 1000;
 
-// Longest label a featured lobby may show in the browser. Long enough for
-// "Europe — Official OpenFront Masters Scrims", short enough that one row
-// cannot crowd out the rest of the list.
-export const LOBBY_LABEL_MAX = 48;
-
 // Labels are capped by CODE POINT, matching sanitizeLobbyLabel. z.string().max()
 // counts UTF-16 code units, so it would reject a legal 48-emoji label (96 units)
 // before the sanitiser ever saw it.
@@ -211,38 +206,6 @@ export const LobbyLabelSchema = z
 // unreadable.
 export const LobbyAccentSchema = z.enum(["gold", "blue", "green", "red"]);
 export type LobbyAccent = z.infer<typeof LobbyAccentSchema>;
-
-// A label is host-supplied text on the front page of the game, so it is
-// sanitised before it can reach anyone: control characters and bidi overrides
-// stripped (they let text render as something entirely different), whitespace
-// collapsed, then length-capped. Rendered as TEXT, never markup — emoji work
-// because they are ordinary codepoints.
-export function sanitizeLobbyLabel(raw: string): string {
-  const kept: string[] = [];
-  // Iterated by CODE POINT, not code unit: an emoji is a surrogate pair, and
-  // slicing one in half is how a label turns into a replacement glyph.
-  for (const ch of raw) {
-    const cp = ch.codePointAt(0)!;
-    if (cp < 0x20 || cp === 0x7f) continue; // C0 controls and DEL
-    if (cp >= 0x80 && cp <= 0x9f) continue; // C1 controls
-    // Bidi overrides, isolates and marks: they make following text render in
-    // another direction, which is how a label claims to be something it isn't.
-    if (cp >= 0x202a && cp <= 0x202e) continue;
-    if (cp >= 0x2066 && cp <= 0x2069) continue;
-    if (cp === 0x200e || cp === 0x200f) continue;
-    if (cp === 0x061c) continue; // ARABIC LETTER MARK — zero-width, bidi-active
-    // NB: U+200D ZERO WIDTH JOINER is deliberately KEPT — emoji sequences like
-    // 👨‍👩‍👧 are built from it, and stripping it would break them apart.
-    kept.push(ch);
-  }
-  return kept
-    .join("")
-    .replace(/\s+/g, " ")
-    .trim()
-    .split(/(?:)/u)
-    .slice(0, LOBBY_LABEL_MAX)
-    .join("");
-}
 
 export const UsernameSchema = z
   .string()

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -459,3 +459,46 @@ const CLAN_TAG_INVALID_CHARS = new RegExp(`[^${CLAN_TAG_CHARS}]`, "g");
 export function sanitizeClanTag(tag: string): string {
   return tag.replace(CLAN_TAG_INVALID_CHARS, "").substring(0, 5).toUpperCase();
 }
+
+// Longest label a featured lobby may show in the browser. Long enough for
+// "Europe — Official OpenFront Masters Scrims", short enough that one row
+// cannot crowd out the rest of the list. Lives here rather than in Schemas so
+// the sanitiser that enforces it has no import back into Schemas — that edge
+// would close a require cycle.
+export const LOBBY_LABEL_MAX = 48;
+
+// A featured lobby's label is host-supplied text shown in the lobby browser, so
+// it is sanitised before it can reach anyone: control characters and bidi
+// overrides stripped (they let text render as something entirely different),
+// whitespace collapsed, then length-capped. Rendered as TEXT, never markup —
+// emoji work because they are ordinary codepoints.
+export function sanitizeLobbyLabel(raw: string): string {
+  const kept: string[] = [];
+  // Iterated by CODE POINT, not code unit: an emoji is a surrogate pair, and
+  // slicing one in half is how a label turns into a replacement glyph.
+  for (const ch of raw) {
+    const cp = ch.codePointAt(0)!;
+    // Tab/newline/vertical tab/form feed/carriage return are C0 controls, but
+    // they are also word separators: dropping them outright would weld
+    // "Europe\nScrims" into "EuropeScrims". They become spaces, and the
+    // collapse below folds any run of them into one.
+    if (cp === 0x09 || (cp >= 0x0a && cp <= 0x0d)) {
+      kept.push(" ");
+      continue;
+    }
+    if (cp < 0x20 || cp === 0x7f) continue; // other C0 controls and DEL
+    if (cp >= 0x80 && cp <= 0x9f) continue; // C1 controls
+    // Bidi overrides, isolates and marks: they make following text render in
+    // another direction, which is how a label claims to be something it isn't.
+    if (cp >= 0x202a && cp <= 0x202e) continue;
+    if (cp >= 0x2066 && cp <= 0x2069) continue;
+    if (cp === 0x200e || cp === 0x200f) continue;
+    if (cp === 0x061c) continue; // ARABIC LETTER MARK — zero-width, bidi-active
+    // NB: U+200D ZERO WIDTH JOINER is deliberately KEPT — emoji sequences like
+    // 👨‍👩‍👧 are built from it, and stripping it would break them apart.
+    kept.push(ch);
+  }
+  return Array.from(kept.join("").replace(/\s+/g, " ").trim())
+    .slice(0, LOBBY_LABEL_MAX)
+    .join("");
+}

--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -14,6 +14,8 @@ import {
   GameConfigSchema,
   ID,
   IntentSchema,
+  LOBBY_LABEL_MAX,
+  LobbyAccentSchema,
 } from "../core/Schemas";
 import type { GameManager } from "./GameManager";
 import { ServerEnv } from "./ServerEnv";
@@ -91,8 +93,18 @@ export function registerAdminBotRoutes(opts: {
     // serve a bot: it authorizes via isCreator + subscription, and an admin-bot
     // lobby is deliberately created with NO creatorPersistentID (below), so it has
     // no owner to match and no account to bill.
+    //
+    // `featured` rides alongside for the same reason. It lengthens the listing
+    // deadline and gives the row a label of the host's choosing, which is only
+    // safe because this endpoint is authenticated: an ordinary subscriber must
+    // not be able to name their lobby "Official Event" or hold a listing open.
     const listedParsed = z
-      .object({ listed: z.boolean().optional() })
+      .object({
+        listed: z.boolean().optional(),
+        featured: z.boolean().optional(),
+        label: z.string().max(LOBBY_LABEL_MAX).optional(),
+        accent: LobbyAccentSchema.optional(),
+      })
       .safeParse(req.body ?? {});
     if (!listedParsed.success) {
       return res
@@ -100,6 +112,7 @@ export function registerAdminBotRoutes(opts: {
         .json({ error: z.prettifyError(listedParsed.error) });
     }
     const listed = listedParsed.data.listed === true;
+    const featured = listedParsed.data.featured === true;
 
     // Optional team pinning. Read alongside the config for the same reason as
     // `listed`: it is not a GameConfig field, so the parse above strips it and it
@@ -165,6 +178,12 @@ export function registerAdminBotRoutes(opts: {
         return res.status(409).json({ error: "listing_host_cheats_enabled" });
       }
     }
+    // Featuring only means anything for a listed lobby: it governs the listing
+    // deadline and the browser row. Refuse rather than silently ignore, so a
+    // caller that forgot `listed` finds out.
+    if (featured && !listed) {
+      return res.status(400).json({ error: "featured_requires_listed" });
+    }
 
     const id = ServerEnv.generateGameIdForWorker(workerId);
     if (id === null) {
@@ -186,7 +205,15 @@ export function registerAdminBotRoutes(opts: {
     if (listed) {
       game.setListed(true);
     }
-    log.info(`admin bot created game ${id}`, { listed });
+    // After setListed: the deadline is measured from the listing, and featuring
+    // is what decides how long that deadline is.
+    if (featured) {
+      game.setFeatured({
+        label: listedParsed.data.label,
+        accent: listedParsed.data.accent,
+      });
+    }
+    log.info(`admin bot created game ${id}`, { listed, featured });
     res.json({
       ...game.gameInfo(),
       workerIndex: workerId,

--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -14,8 +14,8 @@ import {
   GameConfigSchema,
   ID,
   IntentSchema,
-  LOBBY_LABEL_MAX,
   LobbyAccentSchema,
+  LobbyLabelSchema,
 } from "../core/Schemas";
 import type { GameManager } from "./GameManager";
 import { ServerEnv } from "./ServerEnv";
@@ -102,7 +102,7 @@ export function registerAdminBotRoutes(opts: {
       .object({
         listed: z.boolean().optional(),
         featured: z.boolean().optional(),
-        label: z.string().max(LOBBY_LABEL_MAX).optional(),
+        label: LobbyLabelSchema.optional(),
         accent: LobbyAccentSchema.optional(),
       })
       .safeParse(req.body ?? {});

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -25,7 +25,6 @@ import {
   PlayerLiveStats,
   PlayerRecord,
   PublicGameType,
-  sanitizeLobbyLabel,
   ServerDesyncSchema,
   ServerErrorMessage,
   ServerLobbyInfoMessage,
@@ -37,7 +36,11 @@ import {
   Tribe,
   Turn,
 } from "../core/Schemas";
-import { createPartialGameRecord, simpleHash } from "../core/Util";
+import {
+  createPartialGameRecord,
+  sanitizeLobbyLabel,
+  simpleHash,
+} from "../core/Util";
 import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
 import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -12,6 +12,7 @@ import {
   ClientMessageSchema,
   ClientSendLiveStatsMessage,
   ClientSendWinnerMessage,
+  FEATURED_LOBBY_AUTO_START_MS,
   GameConfig,
   GameID,
   GameInfo,
@@ -20,9 +21,11 @@ import {
   HOSTED_LOBBY_AUTO_START_MS,
   Intent,
   LiveStats,
+  LobbyAccent,
   PlayerLiveStats,
   PlayerRecord,
   PublicGameType,
+  sanitizeLobbyLabel,
   ServerDesyncSchema,
   ServerErrorMessage,
   ServerLobbyInfoMessage,
@@ -171,6 +174,14 @@ export class GameServer {
   // When the lobby was listed; drives the auto-start deadline. Cleared on
   // delist, so relisting starts a fresh deadline.
   private listedAt?: number;
+
+  // Featured lobbies: a label shown instead of the map name, an accent for the
+  // row, and a longer auto-start deadline. Set once at create_game by an
+  // authenticated admin bot; deliberately unreachable from update_game_config,
+  // like `listed` itself.
+  private label?: string;
+  private accent?: LobbyAccent;
+  private featured = false;
 
   private lobbyInfoIntervalId: ReturnType<typeof setInterval> | null = null;
 
@@ -1632,6 +1643,9 @@ export class GameServer {
       publicGameType: this.publicGameType,
       listed: this.isPublic() ? undefined : this.listed,
       autoStartAt: this.autoStartAt(),
+      label: this.label,
+      accent: this.accent,
+      featured: this.featured ? true : undefined,
     };
   }
 
@@ -1672,9 +1686,34 @@ export class GameServer {
   // Deadline after which a listed lobby starts automatically, so hosts
   // can't sit on a public listing indefinitely.
   public autoStartAt(): number | undefined {
-    return this.listed && this.listedAt !== undefined
-      ? this.listedAt + HOSTED_LOBBY_AUTO_START_MS
-      : undefined;
+    if (!this.listed || this.listedAt === undefined) return undefined;
+    return (
+      this.listedAt +
+      (this.featured
+        ? FEATURED_LOBBY_AUTO_START_MS
+        : HOSTED_LOBBY_AUTO_START_MS)
+    );
+  }
+
+  public isFeatured(): boolean {
+    return this.featured;
+  }
+
+  public lobbyLabel(): string | undefined {
+    return this.label;
+  }
+
+  public lobbyAccent(): LobbyAccent | undefined {
+    return this.accent;
+  }
+
+  // Only create_game calls this. A label is sanitised at the boundary so no
+  // unsanitised text can exist on a GameServer at all.
+  public setFeatured(opts: { label?: string; accent?: LobbyAccent }): void {
+    this.featured = true;
+    const label = opts.label ? sanitizeLobbyLabel(opts.label) : "";
+    this.label = label.length > 0 ? label : undefined;
+    this.accent = opts.accent;
   }
 
   // Called from GameManager's tick while in the Lobby phase: once the

--- a/src/server/MasterLobbyService.ts
+++ b/src/server/MasterLobbyService.ts
@@ -157,6 +157,19 @@ export class MasterLobbyService {
       return true;
     });
 
+    // Featured lobbies keep their place when the list overflows. They are
+    // announced events with a published start time, and delisting is permanent
+    // — the worker clears listedAt, so an event lobby that loses the cap never
+    // comes back and its audience arrives to nothing. Only an admin bot can set
+    // featured, and the per-creator dedup above already caps each host at one
+    // listing, so this cannot be used to crowd the list. Stable within each
+    // group: the sort above still decides order among featured and among the
+    // rest.
+    result.hosted = [
+      ...result.hosted.filter((l) => l.featured),
+      ...result.hosted.filter((l) => !l.featured),
+    ];
+
     // Cluster-wide cap to prevent listing spam. Workers reject listings past
     // the cap too, but their view lags by a broadcast round-trip; overflow
     // (deterministically the sort losers) is delisted like dedup losers.

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -160,6 +160,11 @@ export class WorkerLobbyService {
         gameConfig: gi.gameConfig && publicLobbyGameConfig(gi.gameConfig),
         publicGameType: "hosted",
         creatorID: g.hashedCreatorID(),
+        // Already sanitised on the way in (GameServer.setFeatured), so nothing
+        // unsanitised can reach a browser even if another producer appears.
+        label: g.lobbyLabel(),
+        accent: g.lobbyAccent(),
+        featured: g.isFeatured() ? true : undefined,
       } satisfies InternalGameInfo;
     });
     this.sendToMaster({

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -12,6 +12,7 @@ import {
   FEATURED_LOBBY_AUTO_START_MS,
   HOSTED_LOBBY_AUTO_START_MS,
   LOBBY_LABEL_MAX,
+  LobbyLabelSchema,
   MAX_HOSTED_LOBBIES,
   sanitizeLobbyLabel,
 } from "../../src/core/Schemas";
@@ -945,6 +946,27 @@ describe("featured lobbies", () => {
     // A bidi override renders following text right-to-left, which is how a
     // label gets to claim it is something it is not.
     expect(sanitizeLobbyLabel("🏆 OFM\u202E evil\u0000")).toBe("🏆 OFM evil");
+  });
+
+  it("strips U+061C but keeps the ZWJ that emoji sequences need", () => {
+    // ARABIC LETTER MARK is zero-width and bidi-active, so it goes. U+200D is
+    // what joins 👨‍👩‍👧 into one glyph, so it must stay.
+    expect(sanitizeLobbyLabel("OFM\u061C Scrims")).toBe("OFM Scrims");
+    expect(sanitizeLobbyLabel("\u{1F468}\u200D\u{1F469}\u200D\u{1F467}")).toBe(
+      "\u{1F468}\u200D\u{1F469}\u200D\u{1F467}",
+    );
+  });
+
+  it("accepts a label of exactly LOBBY_LABEL_MAX emoji", () => {
+    // 48 emoji is 96 UTF-16 code units: a z.string().max() cap would reject a
+    // label the sanitiser considers perfectly legal.
+    const label = "\u{1F3C6}".repeat(LOBBY_LABEL_MAX);
+    expect(LobbyLabelSchema.safeParse(label).success).toBe(true);
+    expect(Array.from(sanitizeLobbyLabel(label))).toHaveLength(LOBBY_LABEL_MAX);
+    expect(
+      LobbyLabelSchema.safeParse("\u{1F3C6}".repeat(LOBBY_LABEL_MAX + 1))
+        .success,
+    ).toBe(false);
   });
 
   it("collapses whitespace and caps length", () => {

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -11,11 +11,10 @@ import {
 import {
   FEATURED_LOBBY_AUTO_START_MS,
   HOSTED_LOBBY_AUTO_START_MS,
-  LOBBY_LABEL_MAX,
   LobbyLabelSchema,
   MAX_HOSTED_LOBBIES,
-  sanitizeLobbyLabel,
 } from "../../src/core/Schemas";
+import { LOBBY_LABEL_MAX, sanitizeLobbyLabel } from "../../src/core/Util";
 import { Client } from "../../src/server/Client";
 import { GameManager } from "../../src/server/GameManager";
 import {
@@ -610,6 +609,39 @@ describe("MasterLobbyService hosted lobbies", () => {
     expect(broadcasts[1].delistGameIDs).toEqual([`g${MAX_HOSTED_LOBBIES}`]);
   });
 
+  it("keeps a featured lobby listed when the cap overflows", () => {
+    // Delisting is permanent — the worker clears listedAt — so an announced
+    // event that loses the cap never comes back and its audience arrives to
+    // nothing. The featured lobby here sorts LAST by gameID, so without
+    // priority it is exactly the one the overflow would drop.
+    const { service, workers } = createService();
+    const ordinary = Array.from({ length: MAX_HOSTED_LOBBIES }, (_, i) =>
+      hostedLobby(`g${String(i).padStart(2, "0")}`, `creator-${i}`),
+    );
+    const featured = hostedLobby("zzz", "creator-adminbot", {
+      featured: true,
+      label: "Europe — OFM Scrims",
+    });
+    workers[0].emit("message", {
+      type: "lobbyList",
+      lobbies: [...ordinary, featured],
+    });
+
+    (service as any).broadcastLobbies();
+    (service as any).broadcastLobbies();
+
+    const broadcasts = sentMessages(workers[0]).filter(
+      (m) => m.type === "lobbiesBroadcast",
+    );
+    const hosted = broadcasts[0].publicGames.games.hosted;
+    expect(hosted).toHaveLength(MAX_HOSTED_LOBBIES);
+    expect(hosted[0].gameID).toBe("zzz");
+    // An ordinary lobby takes the overflow instead.
+    expect(broadcasts[1].delistGameIDs).toEqual([
+      `g${String(MAX_HOSTED_LOBBIES - 1).padStart(2, "0")}`,
+    ]);
+  });
+
   it("does not delist when the duplicate disappears after one broadcast", () => {
     const { service, workers } = createService();
     workers[0].emit("message", {
@@ -972,6 +1004,16 @@ describe("featured lobbies", () => {
   it("collapses whitespace and caps length", () => {
     expect(sanitizeLobbyLabel("  a\n\n  b  ")).toBe("a b");
     expect(sanitizeLobbyLabel("x".repeat(200))).toHaveLength(LOBBY_LABEL_MAX);
+  });
+
+  it("turns a line break into a space instead of eating it", () => {
+    // Newline and tab are C0 controls, but they are also word separators:
+    // dropping them the way the other controls are dropped welds the words
+    // together. Note the words here are NOT flanked by spaces — a stray space
+    // either side would hide the bug behind the collapse step.
+    expect(sanitizeLobbyLabel("Europe\nOFM Scrims")).toBe("Europe OFM Scrims");
+    expect(sanitizeLobbyLabel("Europe\tOFM")).toBe("Europe OFM");
+    expect(sanitizeLobbyLabel("Europe\r\n\r\nOFM")).toBe("Europe OFM");
   });
 
   it("stores a sanitised label, never the raw one", () => {

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -9,8 +9,11 @@ import {
   GameType,
 } from "../../src/core/game/Game";
 import {
+  FEATURED_LOBBY_AUTO_START_MS,
   HOSTED_LOBBY_AUTO_START_MS,
+  LOBBY_LABEL_MAX,
   MAX_HOSTED_LOBBIES,
+  sanitizeLobbyLabel,
 } from "../../src/core/Schemas";
 import { Client } from "../../src/server/Client";
 import { GameManager } from "../../src/server/GameManager";
@@ -904,5 +907,81 @@ describe("WorkerLobbyService hosted lobbies", () => {
     ]);
 
     expect(game.isListed()).toBe(false);
+  });
+});
+
+describe("featured lobbies", () => {
+  beforeEach(() => {
+    // The deadline assertions compare absolute timestamps, so time must not
+    // advance mid-test (the same reason the listing suite fakes timers).
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("is not featured by default and carries no label", () => {
+    const game = makeGame();
+    expect(game.isFeatured()).toBe(false);
+    expect(game.lobbyLabel()).toBeUndefined();
+  });
+
+  it("extends the auto-start deadline to the featured window", () => {
+    const game = makeGame();
+    game.setListed(true);
+    expect(game.autoStartAt()).toBe(Date.now() + HOSTED_LOBBY_AUTO_START_MS);
+    game.setFeatured({ label: "Europe — OFM Scrims" });
+    expect(game.autoStartAt()).toBe(Date.now() + FEATURED_LOBBY_AUTO_START_MS);
+  });
+
+  it("has no deadline at all while unlisted", () => {
+    const game = makeGame();
+    game.setFeatured({ label: "Europe — OFM Scrims" });
+    expect(game.autoStartAt()).toBeUndefined();
+  });
+
+  it("keeps emoji but strips control characters and bidi overrides", () => {
+    // A bidi override renders following text right-to-left, which is how a
+    // label gets to claim it is something it is not.
+    expect(sanitizeLobbyLabel("🏆 OFM\u202E evil\u0000")).toBe("🏆 OFM evil");
+  });
+
+  it("collapses whitespace and caps length", () => {
+    expect(sanitizeLobbyLabel("  a\n\n  b  ")).toBe("a b");
+    expect(sanitizeLobbyLabel("x".repeat(200))).toHaveLength(LOBBY_LABEL_MAX);
+  });
+
+  it("stores a sanitised label, never the raw one", () => {
+    const game = makeGame();
+    game.setFeatured({ label: "  OFM\u0007  Scrims  ", accent: "gold" });
+    expect(game.lobbyLabel()).toBe("OFM Scrims");
+    expect(game.lobbyAccent()).toBe("gold");
+  });
+
+  it("drops a label that sanitises away to nothing", () => {
+    const game = makeGame();
+    game.setFeatured({ label: "\u0000\u202E   " });
+    expect(game.lobbyLabel()).toBeUndefined();
+    expect(game.isFeatured()).toBe(true);
+  });
+
+  it("cannot be featured through update_game_config", () => {
+    const game = makeGame();
+    const result = game.handleIntent(
+      {
+        type: "update_game_config",
+        config: { featured: true, label: "Official Event" },
+      } as any,
+      {
+        clientID: "c1",
+        isLobbyCreator: true,
+        isAdmin: false,
+        isAdminBot: false,
+      },
+    );
+    expect(result.status).toBe(200);
+    expect(game.isFeatured()).toBe(false);
+    expect(game.lobbyLabel()).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Description

Lets an admin bot mark a listed lobby as **featured**: it gets its own label in the hosted-lobby list instead of the map name, and a 10-minute auto-start deadline instead of 5.

**Motivation.** OpenFront Masters runs scheduled regional scrims through the admin bot, and two things make a listing unusable for an announced event:

- the row is titled by map name, so "Balkhash" says nothing about whose event it is
- `HOSTED_LOBBY_AUTO_START_MS` force-starts the lobby 5 minutes after listing — before the announced start time

## API

```jsonc
POST /api/adminbot/create_game
{
  "listed": true,
  "featured": true,
  "label": "🏆 Europe — Official OpenFront Masters Scrims",
  "accent": "gold"            // gold | blue | green | red
}
```

`featured` without `listed` is a `400 featured_requires_listed` rather than a silent no-op. Both ride alongside `listed` and for the same reason: they must not be reachable from `update_game_config`.

## Why this doesn't weaken the 5-minute rule

Unchanged for player-hosted lobbies. That deadline exists so a subscriber can't sit on a public listing, which still applies — an admin bot is authenticated and already trusted to start games and manage rosters.

## Where it renders

A featured lobby is Private + listed, so it is always `publicGameType: "hosted"`, and hosted lobbies render through `JoinLobbyModal.renderHostedLobbyRow`. The label takes the title line with its accent colour and the map name moves to the subtitle, so nothing is lost. `GameModeSelector` is untouched — it only ever renders `games.ffa/team/special`.

## Surviving the hosted-lobby cap

`MasterLobbyService.getAllLobbies` delists everything past `MAX_HOSTED_LOBBIES`, and the worker's `setListed(false)` clears `listedAt` permanently — so an announced event could drop out of the browser right after a `200` and never return, defeating the longer window. Featured lobbies now sort ahead within `hosted`. This can't be used to crowd the list: only an admin bot can set `featured`, and the existing per-creator dedup already caps each host at one listing.

## Label safety

Host-supplied text in the lobby list, so:

- control characters and bidi overrides stripped (they let text render as something else entirely), whitespace collapsed, capped at 48 **code points**
- tab/newline/CR become spaces rather than being dropped, so `"Europe\nOFM Scrims"` doesn't weld into `"EuropeOFM Scrims"`
- iterated by code point, so an emoji is never sliced in half and U+200D ZWJ sequences survive
- sanitised at the boundary in `setFeatured`, so no unsanitised label can exist on a `GameServer`
- rendered as text, never markup
- `accent` is a closed enum, not free-form styling, so one row cannot restyle the list

`sanitizeLobbyLabel` lives in `core/Util.ts` next to `sanitize` and `sanitizeClanTag`; `Schemas.ts` keeps only the schema and config. `LOBBY_LABEL_MAX` sits with the sanitiser because `Util`'s import of `Schemas` is type-only and erased at runtime — importing the constant back would close a require cycle.

## Compatibility

Both fields are optional and additive through `PublicGameInfo` / `GameInfo`, so a client on an older build renders the map name exactly as it does today. `sanitizeGames` already spreads the rest, so nothing extra leaks to browsers.

## Tests

Extends `tests/server/HostedLobbyListing.test.ts`: featured extends the deadline to 10 min; no deadline while unlisted; emoji preserved while controls/bidi are stripped; line breaks become spaces; whitespace collapsed and length capped; a label that sanitises to nothing is dropped; featured/label cannot be set via `update_game_config`; and a featured lobby keeps its listing when the hosted cap overflows.

50 tests in that file, 320 across `tests/server` + `tests/LobbySocket.test.ts`, typecheck, lint and prettier clean.

> The `🗺️ Generated maps up to date` gate fails on a stale `resources/maps/lasvegasstrip/thumbnail.webp` already on `v33` — this branch touches no map or resource files. Details in the comment below.
