### PR TITLE
Fix issue with context menu blocking building

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -850,7 +850,8 @@ export class InputHandler {
       if (
         !this.userSettings.leftClickOpensMenu() ||
         event.shiftKey ||
-        this.gameView.inSpawnPhase() // No Radial Menu during spawn phase, only spawn point selection
+        this.gameView.inSpawnPhase() || // No Radial Menu during spawn phase, only spawn point selection
+        this.uiState.ghostStructure !== null // Block radial menu on left click if building
       ) {
         this.eventBus.emit(new MouseUpEvent(event.x, event.y));
       } else {

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -290,6 +290,77 @@ describe("InputHandler AutoUpgrade", () => {
     });
   });
 
+  describe("Left-click menu with ghost structure (#4789)", () => {
+    test("should emit MouseUpEvent and not ContextMenuEvent when placing a ghost structure with left-click menu enabled", () => {
+      const mockEmit = vi.spyOn(eventBus, "emit");
+
+      inputHandler["userSettings"].leftClickOpensMenu = () => true;
+      inputHandler["uiState"].ghostStructure = UnitType.City;
+
+      const pointerEvent = new PointerEvent("pointerup", {
+        button: 0,
+        clientX: 150,
+        clientY: 250,
+      });
+      inputHandler["lastPointerDownX"] = 149;
+      inputHandler["lastPointerDownY"] = 249;
+
+      inputHandler["onPointerUp"](pointerEvent);
+
+      const emittedTypes = mockEmit.mock.calls.map(
+        (call) => call[0].constructor.name,
+      );
+      expect(emittedTypes).toContain("MouseUpEvent");
+      expect(emittedTypes).not.toContain("ContextMenuEvent");
+    });
+
+    test("should emit MouseUpEvent and not ContextMenuEvent when placing a warship with left-click menu enabled", () => {
+      const mockEmit = vi.spyOn(eventBus, "emit");
+
+      inputHandler["userSettings"].leftClickOpensMenu = () => true;
+      inputHandler["uiState"].ghostStructure = UnitType.Warship;
+
+      const pointerEvent = new PointerEvent("pointerup", {
+        button: 0,
+        clientX: 150,
+        clientY: 250,
+      });
+      inputHandler["lastPointerDownX"] = 149;
+      inputHandler["lastPointerDownY"] = 249;
+
+      inputHandler["onPointerUp"](pointerEvent);
+
+      const emittedTypes = mockEmit.mock.calls.map(
+        (call) => call[0].constructor.name,
+      );
+      expect(emittedTypes).toContain("MouseUpEvent");
+      expect(emittedTypes).not.toContain("ContextMenuEvent");
+    });
+
+    test("should still emit ContextMenuEvent on left click release when no ghost structure is active", () => {
+      const mockEmit = vi.spyOn(eventBus, "emit");
+
+      inputHandler["userSettings"].leftClickOpensMenu = () => true;
+      expect(inputHandler["uiState"].ghostStructure).toBeNull();
+
+      const pointerEvent = new PointerEvent("pointerup", {
+        button: 0,
+        clientX: 150,
+        clientY: 250,
+      });
+      inputHandler["lastPointerDownX"] = 149;
+      inputHandler["lastPointerDownY"] = 249;
+
+      inputHandler["onPointerUp"](pointerEvent);
+
+      const emittedTypes = mockEmit.mock.calls.map(
+        (call) => call[0].constructor.name,
+      );
+      expect(emittedTypes).toContain("ContextMenuEvent");
+      expect(emittedTypes).not.toContain("MouseUpEvent");
+    });
+  });
+
   describe("Pointer Event Handling", () => {
     test("should handle pointer events with different pointer IDs", () => {
       const mockEmit = vi.spyOn(eventBus, "emit");


### PR DESCRIPTION
#4789 

Resolves #4789 

## Description:

This resolves #4789. When attempting to create a new building from the number shortcuts, there was a conditional missing to check whether the left-click mode had been enabled. In this case, the context menu should not be shown and instead the building should be placed. 

This has been resolved and I've added some tests. 

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

`sjg.`
