### PR TITLE
Feat: Allow F and escape to cancel warship selection

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -600,12 +600,26 @@ export class InputHandler {
 
       if (e.code === "Escape") {
         e.preventDefault();
-        this.eventBus.emit(new CloseViewEvent());
-        this.setGhostStructure(null);
-        if (this.selectionBoxActive || this.multiSelectionActive) {
+        let closedUI = false;
+
+        if (this.uiState.ghostStructure !== null) {
+          this.setGhostStructure(null);
+          closedUI = true;
+        }
+
+        if (this.selectionBoxActive) {
           this.selectionBoxActive = false;
-          this.multiSelectionActive = false;
           this.eventBus.emit(new WarshipSelectionBoxCancelEvent());
+          closedUI = true;
+        }
+
+        this.eventBus.emit(new CloseViewEvent());
+
+        if (
+          !closedUI &&
+          (this.unitSelectionActive || this.multiSelectionActive)
+        ) {
+          this.eventBus.emit(new UnitSelectionEvent(null, false));
         }
       }
 

--- a/src/client/controllers/WarshipSelectionController.ts
+++ b/src/client/controllers/WarshipSelectionController.ts
@@ -275,19 +275,32 @@ export class WarshipSelectionController implements Controller {
     this.eventBus.emit(new UnitSelectionEvent(null, true, selected));
   }
 
-  private onSelectAllWarships() {
+  private getAllWarships(): UnitView[] {
     const myPlayer = this.game.myPlayer();
-    if (!myPlayer) return;
-
-    const allWarships = this.game
+    if (!myPlayer) return [];
+    return this.game
       .units(UnitType.Warship)
       .filter((u) => u.isActive() && u.owner() === myPlayer);
+  }
+
+  public selectedAllWarships(): boolean {
+    const allWarships = this.getAllWarships();
+    return (
+      allWarships.length > 0 &&
+      this.multiSelectedWarships.length === allWarships.length
+    );
+  }
+
+  private onSelectAllWarships() {
+    const allWarships = this.getAllWarships();
     if (allWarships.length === 0) return;
 
     if (this.selectedUnit) {
       this.eventBus.emit(new UnitSelectionEvent(this.selectedUnit, false));
     }
-    this.eventBus.emit(new UnitSelectionEvent(null, true, allWarships));
+    this.eventBus.emit(
+      new UnitSelectionEvent(null, !this.selectedAllWarships(), allWarships),
+    );
   }
 
   /**

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -1165,4 +1165,61 @@ describe("InputHandler right-click cancels unit selection (#4692)", () => {
     // ...and the context menu must NOT open.
     expect(emitted.some((e) => e instanceof ContextMenuEvent)).toBe(false);
   });
+
+  it("emits UnitSelectionEvent(null, false) on Escape when warships are selected", () => {
+    eventBus.emit(
+      new UnitSelectionEvent({ id: () => 1 } as unknown as UnitView, true),
+    );
+    const emit = vi.spyOn(eventBus, "emit");
+
+    const escEvent = new KeyboardEvent("keydown", { code: "Escape" });
+    window.dispatchEvent(escEvent);
+
+    const emitted = emit.mock.calls.map((c: unknown[]) => c[0]);
+    const deselect = emitted.find(
+      (e): e is UnitSelectionEvent =>
+        e instanceof UnitSelectionEvent && !e.isSelected,
+    );
+    expect(deselect).toBeDefined();
+    expect(deselect!.unit).toBeNull();
+  });
+
+  it("does NOT deselect warships on Escape if ghost structure is active", () => {
+    eventBus.emit(
+      new UnitSelectionEvent({ id: () => 1 } as unknown as UnitView, true),
+    );
+    inputHandler["uiState"].ghostStructure = 1 as any;
+    const emit = vi.spyOn(eventBus, "emit");
+
+    const escEvent = new KeyboardEvent("keydown", { code: "Escape" });
+    window.dispatchEvent(escEvent);
+
+    const emitted = emit.mock.calls.map((c: unknown[]) => c[0]);
+    const deselect = emitted.find(
+      (e): e is UnitSelectionEvent =>
+        e instanceof UnitSelectionEvent && !e.isSelected,
+    );
+    expect(deselect).toBeUndefined();
+  });
+
+  it("does NOT deselect warships on Escape if selectionBoxActive is true", () => {
+    eventBus.emit(
+      new UnitSelectionEvent({ id: () => 1 } as unknown as UnitView, true),
+    );
+    inputHandler["selectionBoxActive"] = true;
+    const emit = vi.spyOn(eventBus, "emit");
+
+    const escEvent = new KeyboardEvent("keydown", { code: "Escape" });
+    window.dispatchEvent(escEvent);
+
+    const emitted = emit.mock.calls.map((c: unknown[]) => c[0]);
+    const deselect = emitted.find(
+      (e): e is UnitSelectionEvent =>
+        e instanceof UnitSelectionEvent && !e.isSelected,
+    );
+    expect(deselect).toBeUndefined();
+    expect(
+      emitted.some((e) => e instanceof WarshipSelectionBoxCancelEvent),
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
…

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #4846

## Description:

Add F cancel warship selection + add escape cancel selection if no UI priority elements.
Add tests for both.

All tests pass.
## Please complete the following:

- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
