### PR TITLE
Show alliance expiry countdown in player panel alliances list ⏳

### DIFF
--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -658,6 +658,18 @@ export class PlayerPanel extends LitElement implements Controller {
       nameCollator.compare(a.displayName(), b.displayName()),
     );
 
+    // Map ally PlayerID → expiry tick so each ally shows its own remaining time.
+    const expiryByAlly = new Map<string, number>();
+    for (const alliance of other.alliances()) {
+      expiryByAlly.set(alliance.other, alliance.expiresAt);
+    }
+    const remainingSecondsFor = (ally: PlayerView): number | null => {
+      const expiresAt = expiryByAlly.get(ally.id());
+      if (expiresAt === undefined) return null;
+      const remainingTicks = expiresAt - this.g.ticks();
+      return Math.max(0, Math.floor(remainingTicks / 10)); // 10 ticks per second
+    };
+
     return html`
       <div class="select-none">
         <div class="flex items-center justify-between mb-2">
@@ -691,18 +703,26 @@ export class PlayerPanel extends LitElement implements Controller {
               ? html`<li class="text-zinc-400 text-[14px] px-1">
                   ${translateText("common.none")}
                 </li>`
-              : alliesSorted.map(
-                  (p) =>
-                    html`<li
-                      class="max-w-full inline-flex items-center gap-1.5
-                             rounded-md border border-white/10 bg-white/5
-                             px-2.5 py-1 text-[14px] text-zinc-100
-                             hover:bg-white/8 active:scale-[0.99] transition"
-                      title=${p.displayName()}
-                    >
-                      <span class="truncate">${p.displayName()}</span>
-                    </li>`,
-                )}
+              : alliesSorted.map((p) => {
+                  const remainingSeconds = remainingSecondsFor(p);
+                  return html`<li
+                    class="max-w-full inline-flex items-center gap-1.5
+                           rounded-md border border-white/10 bg-white/5
+                           px-2.5 py-1 text-[14px] text-zinc-100
+                           hover:bg-white/8 active:scale-[0.99] transition"
+                    title=${p.displayName()}
+                  >
+                    <span class="truncate">${p.displayName()}</span>
+                    ${remainingSeconds !== null
+                      ? html`<span
+                          class="text-[11px] font-semibold leading-none tabular-nums ${this.getExpiryColorClass(
+                            remainingSeconds,
+                          )}"
+                          >${renderDuration(remainingSeconds)}</span
+                        >`
+                      : ""}
+                  </li>`;
+                })}
           </ul>
         </div>
       </div>

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -160,8 +160,10 @@ export class PlayerPanel extends LitElement implements Controller {
           this.allianceExpirySeconds = null;
           this.allianceExpiryText = null;
         }
-        this.requestUpdate();
       }
+      // Keep repainting while the panel is visible so live values (e.g. the
+      // alliance countdowns) keep updating even after the local player dies.
+      this.requestUpdate();
     }
   }
 

--- a/tests/client/graphics/layers/PlayerPanelAllianceCountdown.test.ts
+++ b/tests/client/graphics/layers/PlayerPanelAllianceCountdown.test.ts
@@ -1,0 +1,93 @@
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  renderDuration: vi.fn(),
+  renderNumber: vi.fn(),
+  renderTroops: vi.fn(),
+}));
+
+vi.mock("../../../../src/client/components/ui/ActionButton", () => ({
+  actionButton: vi.fn((props: unknown) => props),
+}));
+
+vi.mock("../../../../src/client/InGameModal", () => ({
+  showInGameConfirm: vi.fn(),
+  showInGameAlert: vi.fn(),
+}));
+
+import { PlayerPanel } from "../../../../src/client/hud/layers/PlayerPanel";
+import { PlayerView } from "../../../../src/client/view";
+
+describe("PlayerPanel - alliance countdown keeps updating after local player death", () => {
+  let panel: PlayerPanel;
+
+  beforeEach(() => {
+    panel = new PlayerPanel();
+    (panel as any).requestUpdate = vi.fn();
+    (panel as any).isVisible = true;
+    (panel as any).tile = { x: 0, y: 0 };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeGame(alive: () => boolean) {
+    const myPlayer = {
+      isAlive: alive,
+      actions: () => Promise.resolve({ interaction: {} }),
+    } as unknown as PlayerView;
+    return {
+      owner: () => null,
+      myPlayer: () => myPlayer,
+      ticks: () => 100,
+    };
+  }
+
+  test("tick() repaints while the panel is visible and the local player is alive", async () => {
+    (panel as any).g = makeGame(() => true);
+
+    await (panel as any).tick();
+
+    expect((panel as any).requestUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  test("tick() keeps repainting after the local player dies so the alliance countdown continues updating", async () => {
+    let alive = true;
+    (panel as any).g = makeGame(() => alive);
+
+    await (panel as any).tick();
+    expect((panel as any).requestUpdate).toHaveBeenCalledTimes(1);
+
+    // Local player dies while the panel stays open.
+    alive = false;
+    await (panel as any).tick();
+
+    expect((panel as any).requestUpdate).toHaveBeenCalledTimes(2);
+  });
+
+  test("tick() does not repaint when the panel is hidden", async () => {
+    (panel as any).g = makeGame(() => true);
+    (panel as any).isVisible = false;
+
+    await (panel as any).tick();
+
+    expect((panel as any).requestUpdate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description:

Scripts can show that, so we need to show it too.

<img width="381" height="610" alt="Screenshot 2026-08-14 002244" src="https://github.com/user-attachments/assets/6799753f-50c6-4ea5-9f13-642f71a59dd1" />

## AI Text

Adds a live countdown to each alliance entry in the player panel's Alliances list. Each ally now shows how much time is left on their alliance in minutes and seconds, using the same renderDuration format as the player info overlay. The countdown is color coded by urgency (green above 60s, yellow in the last 60s, red in the last 30s) and refreshes every tick while the panel is open.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin