### PR TITLE
Feat: Show team name and territory share on spawn timer hover (#4700)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1531,6 +1531,9 @@
     "toggle_achievements": "Toggle achievements",
     "water_nukes": "Water nukes"
   },
+  "spawn_timer": {
+    "team_percent_tooltip": "{team}: {percent}"
+  },
   "steam_link_modal": {
     "code_placeholder": "XXXX-XXXX",
     "code_prompt": "Enter the code shown on your Steam desktop app.",

--- a/src/client/hud/layers/SpawnTimer.ts
+++ b/src/client/hud/layers/SpawnTimer.ts
@@ -155,7 +155,9 @@ export class SpawnTimer extends LitElement implements Controller {
     }
 
     // Keep the tooltip fully on-screen: it sits centered over its segment, but
-    // clamps toward the nearer edge so it never overflows the screen.
+    // clamps toward the nearer edge so it never overflows the screen. The
+    // element is kept to a bounded width (max-width) so the 64px clamp always
+    // covers half its width, even for long translated or raw team names.
     const clampedLeft = `clamp(64px, ${center}%, calc(100% - 64px))`;
 
     // Fall back to the raw team name when it has no team_colors key (e.g.
@@ -166,8 +168,8 @@ export class SpawnTimer extends LitElement implements Controller {
 
     return html`
       <div
-        class="absolute top-3.5 -translate-x-1/2 z-999 px-2 py-1 rounded bg-black/85 text-white text-xs whitespace-nowrap pointer-events-none"
-        style="left: ${clampedLeft}"
+        class="absolute top-3.5 -translate-x-1/2 z-999 px-2 py-1 rounded bg-black/85 text-white text-xs text-center break-words pointer-events-none"
+        style="left: ${clampedLeft}; max-width: 128px"
       >
         ${translateText("spawn_timer.team_percent_tooltip", {
           team: teamName,

--- a/src/client/hud/layers/SpawnTimer.ts
+++ b/src/client/hud/layers/SpawnTimer.ts
@@ -1,10 +1,11 @@
-import { LitElement, html } from "lit";
-import { customElement } from "lit/decorators.js";
+import { LitElement, html, nothing } from "lit";
+import { customElement, state } from "lit/decorators.js";
 import { EventBus, GameEvent } from "../../../core/EventBus";
 import { GameMode, GameType, Team } from "../../../core/game/Game";
 import { Controller } from "../../Controller";
 import { themeProvider } from "../../theme/ThemeProvider";
 import { TransformHandler } from "../../TransformHandler";
+import { formatPercentage, translateText } from "../../Utils";
 import { GameView } from "../../view";
 
 export class SpawnBarVisibleEvent implements GameEvent {
@@ -19,12 +20,16 @@ export class SpawnTimer extends LitElement implements Controller {
 
   private ratios = [0];
   private _barVisible = false;
+  private teams: Team[] = [];
   private colors = [
     "rgb(from var(--color-bright-blue) r g b / 0.85)",
     "rgba(0, 0, 0, 0.5)",
   ];
 
   private isVisible = false;
+
+  @state()
+  private hoveredIndex: number | null = null;
 
   createRenderRoot() {
     this.style.position = "fixed";
@@ -48,6 +53,7 @@ export class SpawnTimer extends LitElement implements Controller {
     ) {
       // Singleplayer has no spawn countdown.
       this.ratios = [];
+      this.teams = [];
       this.colors = [];
       this.requestUpdate();
       return;
@@ -58,9 +64,11 @@ export class SpawnTimer extends LitElement implements Controller {
       this.ratios = [
         this.game.ticks() / this.game.config().numSpawnPhaseTurns(),
       ];
+      this.teams = [];
       this.colors = ["rgb(from var(--color-bright-blue) r g b / 0.85)"];
     } else {
       this.ratios = [];
+      this.teams = [];
       this.colors = [];
 
       if (this.game.config().gameConfig().gameMode === GameMode.Team) {
@@ -78,6 +86,7 @@ export class SpawnTimer extends LitElement implements Controller {
           for (const [team, count] of teamTiles) {
             const ratio = count / total;
             this.ratios.push(ratio);
+            this.teams.push(team);
             this.colors.push(theme.teamColor(team).toRgbString());
           }
         }
@@ -113,15 +122,56 @@ export class SpawnTimer extends LitElement implements Controller {
     }
 
     return html`
-      <div class="w-full h-full flex z-999">
+      <div class="relative w-full h-full flex z-999">
         ${this.ratios.map((ratio, i) => {
           const color = this.colors[i] || "rgba(0, 0, 0, 0.5)";
           return html`
             <div
-              class="h-full transition-all duration-100 ease-in-out w-(--width) bg-(--bg) border-b-3 border-r-2 border-black"
+              class="h-full pointer-events-auto transition-all duration-100 ease-in-out w-(--width) bg-(--bg) border-b-3 border-r-2 border-black"
               style="--width: ${ratio * 100}%; --bg: ${color};"
+              @mouseenter=${() => (this.hoveredIndex = i)}
+              @mouseleave=${() => (this.hoveredIndex = null)}
             ></div>
           `;
+        })}
+        ${this.renderTooltip()}
+      </div>
+    `;
+  }
+
+  private renderTooltip() {
+    const index = this.hoveredIndex;
+    const team = index === null ? undefined : this.teams[index];
+    if (index === null || team === undefined) {
+      return nothing;
+    }
+
+    // Center the tooltip over its segment using cumulative segment widths.
+    let cumulative = 0;
+    let center = 0;
+    for (let i = 0; i <= index; i++) {
+      center = (cumulative + this.ratios[i] / 2) * 100;
+      cumulative += this.ratios[i];
+    }
+
+    // Keep the tooltip fully on-screen: it sits centered over its segment, but
+    // clamps toward the nearer edge so it never overflows the screen.
+    const clampedLeft = `clamp(64px, ${center}%, calc(100% - 64px))`;
+
+    // Fall back to the raw team name when it has no team_colors key (e.g.
+    // numbered teams like "Team 1"), mirroring TeamStats.
+    const labelKey = `team_colors.${team.toLowerCase()}`;
+    const translatedName = translateText(labelKey);
+    const teamName = translatedName === labelKey ? team : translatedName;
+
+    return html`
+      <div
+        class="absolute top-3.5 -translate-x-1/2 z-999 px-2 py-1 rounded bg-black/85 text-white text-xs whitespace-nowrap pointer-events-none"
+        style="left: ${clampedLeft}"
+      >
+        ${translateText("spawn_timer.team_percent_tooltip", {
+          team: teamName,
+          percent: formatPercentage(this.ratios[index]),
         })}
       </div>
     `;


### PR DESCRIPTION
Closes #4700

## Description
In team mode, the thin progress bar at the very top of the screen (`<spawn-timer>`) shows each team's territory share as colored segments, but it wasn't clear which segment belonged to which team or what percentage of the map each team controlled.

This PR adds an inline tooltip when hovering over a team's segment showing:
- The team name (reusing the existing `team_colors.<team>` translation key, consistent with `TeamStats`)
- The occupation percentage (via `formatPercentage`)

**Note:** The native `title` tooltip was unreliable here because the bar re-renders every tick, so a custom tooltip is rendered on hover instead.

## Changes
- `src/client/hud/layers/SpawnTimer.ts`: track the team per segment and render a custom tooltip on hover.
- `resources/lang/en.json`: add `spawn_timer.team_percent_tooltip` translation key (other languages are managed via Crowdin).

## Behavior details
- Tooltip sits centered over its segment and clamps toward the nearer edge so it never overflows the screen.
- Teams without a `team_colors` key (e.g. numbered teams like "Team 1") fall back to their raw name, mirroring `TeamStats`.