### PR TITLE
perf: batch water-nuke terrain deltas into row-span GPU uploads

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -491,13 +491,14 @@ function mountWebGLFrameLoop(
 
     // Full upload of terrain, territory & trail state
     const mapSize = mapWidth * mapHeight;
-    const allRefs = new Array(mapSize);
     const allTerrain = new Uint8Array(mapSize);
     for (let i = 0; i < mapSize; i++) {
-      allRefs[i] = i;
       allTerrain[i] = gameView.terrainByte(i);
     }
-    view.applyTerrainDelta(allRefs, allTerrain);
+    view.applyTerrainRects(
+      [{ x: 0, y: 0, w: mapWidth, h: mapHeight }],
+      allTerrain,
+    );
 
     const frameData = gameView.frameData();
     view.uploadTileAndTrailState(frameData.tileState, frameData.trailState);

--- a/src/client/WebGLFrameBuilder.ts
+++ b/src/client/WebGLFrameBuilder.ts
@@ -12,9 +12,10 @@ import {
   TRAIL_EFFECT_TYPES,
   type TrailEffectAttributes,
 } from "../core/CosmeticSchemas";
-import { decodePatternData } from "../core/PatternDecoder";
 import { PlayerType } from "../core/game/Game";
+import { decodePatternData } from "../core/PatternDecoder";
 import { getCachedCosmetics } from "./Cosmetics";
+import { buildTerrainRowSpans } from "./render/frame/derive/TerrainRowSpans";
 import { uploadFrameData } from "./render/frame/Upload";
 // Type-only: a value import would pull GPURenderer and its `.glsl?raw` shader
 // imports into any non-Vite consumer (e.g. the Node perf harness).
@@ -155,8 +156,6 @@ export class WebGLFrameBuilder {
   // unit colors, and SAM-radius perspective work. Push it once the local
   // player's update arrives (may take several ticks during join).
   private localPlayerSmallID = 0;
-  // Scratch buffer for terrain-delta uploads (parallel to the refs list).
-  private terrainDeltaBytes: Uint8Array = new Uint8Array(0);
 
   constructor(private readonly view: MapRenderer) {
     this.palette = new Float32Array(PALETTE_SIZE * 2 * 4);
@@ -279,18 +278,19 @@ export class WebGLFrameBuilder {
    * Water-nuke conversions (land → water) mutate the underlying terrain.
    * Forward this tick's terrain-changed refs to the renderer so it can
    * re-upload those texels in both the RGBA color texture and the R8UI
-   * water-detection texture used by railroads/bridges.
+   * water-detection texture used by railroads/bridges. Refs are batched into
+   * per-row spans — a massive bomb changes tens of thousands of tiles, and
+   * per-tile 1×1 uploads cost hundreds of ms of GL driver time.
    */
   private syncTerrainDeltas(gameView: GameView): void {
     const refs = gameView.recentlyUpdatedTerrainTiles();
     if (refs.length === 0) return;
-    if (this.terrainDeltaBytes.length < refs.length) {
-      this.terrainDeltaBytes = new Uint8Array(refs.length);
-    }
-    for (let i = 0; i < refs.length; i++) {
-      this.terrainDeltaBytes[i] = gameView.terrainByte(refs[i]);
-    }
-    this.view.applyTerrainDelta(refs, this.terrainDeltaBytes);
+    const { rects, bytes } = buildTerrainRowSpans(
+      refs,
+      gameView.width(),
+      (ref) => gameView.terrainByte(ref),
+    );
+    this.view.applyTerrainRects(rects, bytes);
   }
 
   /**

--- a/src/client/render/frame/derive/TerrainRowSpans.ts
+++ b/src/client/render/frame/derive/TerrainRowSpans.ts
@@ -1,0 +1,57 @@
+import type { TerrainRect } from "../../types";
+
+export interface TerrainRowSpansResult {
+  rects: TerrainRect[];
+  bytes: Uint8Array;
+}
+
+/**
+ * Group terrain-changed tile refs into one span per map row (min..max x),
+ * reading the CURRENT terrain byte for every tile in each span. A massive
+ * water nuke changes tens of thousands of tiles in one tick; uploading them
+ * as individual 1×1 texSubImage2D calls costs hundreds of ms of driver time,
+ * while a few hundred row spans upload in ~1ms. Unchanged tiles inside a span
+ * re-upload their current byte — harmless.
+ *
+ * Spans are returned in ascending row order; `bytes` holds each span's data
+ * concatenated in that order.
+ */
+export function buildTerrainRowSpans(
+  refs: readonly number[],
+  mapW: number,
+  terrainByteAt: (ref: number) => number,
+): TerrainRowSpansResult {
+  const rows = new Map<number, { min: number; max: number }>();
+  for (const ref of refs) {
+    const x = ref % mapW;
+    const y = (ref - x) / mapW;
+    const row = rows.get(y);
+    if (row === undefined) {
+      rows.set(y, { min: x, max: x });
+    } else {
+      if (x < row.min) row.min = x;
+      if (x > row.max) row.max = x;
+    }
+  }
+
+  const ys = [...rows.keys()].sort((a, b) => a - b);
+  let total = 0;
+  for (const y of ys) {
+    const row = rows.get(y)!;
+    total += row.max - row.min + 1;
+  }
+
+  const bytes = new Uint8Array(total);
+  const rects: TerrainRect[] = new Array(ys.length);
+  let offset = 0;
+  for (let i = 0; i < ys.length; i++) {
+    const y = ys[i];
+    const { min, max } = rows.get(y)!;
+    const rowStart = y * mapW;
+    for (let x = min; x <= max; x++) {
+      bytes[offset++] = terrainByteAt(rowStart + x);
+    }
+    rects[i] = { x: min, y, w: max - min + 1, h: 1 };
+  }
+  return { rects, bytes };
+}

--- a/src/client/render/gl/MapRenderer.ts
+++ b/src/client/render/gl/MapRenderer.ts
@@ -27,6 +27,7 @@ import type {
   PlayerStatic,
   PlayerStatusData,
   RendererConfig,
+  TerrainRect,
   UnitState,
 } from "../types";
 import type { SpawnCenter } from "./passes/SpawnOverlayPass";
@@ -227,9 +228,13 @@ export class MapRenderer {
   applyRailroadDust(tileRefs: number[]): void {
     this.renderer?.applyRailroadDust(tileRefs);
   }
-  /** Refresh terrain texels whose underlying terrain byte changed (water nukes). */
-  applyTerrainDelta(refs: readonly number[], terrainBytes: Uint8Array): void {
-    this.renderer?.applyTerrainDelta(refs, terrainBytes);
+  /**
+   * Refresh terrain texels whose underlying terrain byte changed (water
+   * nukes). Each rect's bytes are stored row-major, concatenated in `bytes`
+   * in rect order.
+   */
+  applyTerrainRects(rects: readonly TerrainRect[], bytes: Uint8Array): void {
+    this.renderer?.applyTerrainRects(rects, bytes);
   }
 
   /** Rebuild the terrain texture from current settings (e.g. ocean color). */

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -26,6 +26,7 @@ import type {
   PlayerStatic,
   PlayerStatusData,
   RendererConfig,
+  TerrainRect,
   UnitState,
 } from "../types";
 import { Camera } from "./Camera";
@@ -158,8 +159,6 @@ export class GPURenderer {
   private storedLayers: MapLayer[] = [];
   /** Stored layer images for context-restore re-creation. */
   private storedLayerImages: Map<string, ImageBitmap> = new Map();
-  /** Scratch buffer for per-tile terrain byte uploads (avoids allocations). */
-  private terrainDeltaScratch = new Uint8Array(1);
 
   private paletteTex: WebGLTexture;
   private paletteData: Float32Array;
@@ -947,51 +946,37 @@ export class GPURenderer {
   }
 
   /**
-   * Update terrain texels for tiles whose terrain byte changed (e.g. water
-   * nukes converting land → water). `terrainBytes[i]` is the new byte for
-   * `refs[i]`. Forwards to both TerrainPass (RGBA color) and RailroadPass
-   * (R8UI water-detection for bridges).
+   * Update terrain texels for regions whose terrain bytes changed (e.g. water
+   * nukes converting land → water). Each rect's bytes are stored row-major,
+   * concatenated in `bytes` in rect order. Forwards to both TerrainPass (RGBA
+   * color) and RailroadPass (R8UI water-detection for bridges). One
+   * texSubImage2D per rect — per-tile uploads cost hundreds of ms for a
+   * massive bomb.
    */
-  applyTerrainDelta(refs: readonly number[], terrainBytes: Uint8Array): void {
-    if (refs.length === 0) return;
-    this.terrainPass.applyTerrainDelta(refs, terrainBytes);
-    this.railroadPass.applyTerrainDelta(refs, terrainBytes);
+  applyTerrainRects(rects: readonly TerrainRect[], bytes: Uint8Array): void {
+    if (rects.length === 0) return;
+    this.terrainPass.applyTerrainRects(rects, bytes);
+    this.railroadPass.applyTerrainRects(rects, bytes);
     // Update the shared R8UI terrain-bytes texture used by map-layer passes.
     if (!this.terrainBytesTex) return;
     const gl = this.gl;
     gl.bindTexture(gl.TEXTURE_2D, this.terrainBytesTex);
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
-    // Full-map fast path: single texSubImage2D instead of per-tile uploads.
-    if (refs.length === this.mapW * this.mapH) {
+    let offset = 0;
+    for (const r of rects) {
       gl.texSubImage2D(
         gl.TEXTURE_2D,
         0,
-        0,
-        0,
-        this.mapW,
-        this.mapH,
+        r.x,
+        r.y,
+        r.w,
+        r.h,
         gl.RED_INTEGER,
         gl.UNSIGNED_BYTE,
-        terrainBytes,
+        bytes,
+        offset,
       );
-      return;
-    }
-    for (let i = 0; i < refs.length; i++) {
-      const ref = refs[i];
-      const x = ref % this.mapW;
-      const y = Math.floor(ref / this.mapW);
-      this.terrainDeltaScratch[0] = terrainBytes[i];
-      gl.texSubImage2D(
-        gl.TEXTURE_2D,
-        0,
-        x,
-        y,
-        1,
-        1,
-        gl.RED_INTEGER,
-        gl.UNSIGNED_BYTE,
-        this.terrainDeltaScratch,
-      );
+      offset += r.w * r.h;
     }
   }
 

--- a/src/client/render/gl/passes/RailroadPass.ts
+++ b/src/client/render/gl/passes/RailroadPass.ts
@@ -16,7 +16,7 @@
  *   RGBA32F paletteTex        → player color lookup
  */
 
-import type { GhostPreviewData } from "../../types";
+import type { GhostPreviewData, TerrainRect } from "../../types";
 import type { RenderSettings } from "../RenderSettings";
 import overlayVertSrc from "../shaders/map-overlay/overlay.vert.glsl?raw";
 import railroadFragSrc from "../shaders/railroad/railroad.frag.glsl?raw";
@@ -129,8 +129,6 @@ export class RailroadPass {
 
   private localPlayerID = 0;
   private localRailColor: [number, number, number] = [0.75, 0.75, 0.75];
-  /** Scratch buffer for per-tile terrain byte uploads (avoids allocations). */
-  private terrainDeltaScratch = new Uint8Array(1);
 
   constructor(
     private gl: WebGL2RenderingContext,
@@ -239,46 +237,31 @@ export class RailroadPass {
   }
 
   /**
-   * Sub-upload terrain bytes for tiles that changed (water-nuke conversions).
-   * Keeps the R8UI water-detection texture in sync with the simulation.
-   * `bytes[i]` is the new terrain byte for `refs[i]` (parallel arrays).
+   * Sub-upload terrain bytes for regions that changed (water-nuke
+   * conversions). Keeps the R8UI water-detection texture in sync with the
+   * simulation. Each rect's bytes are stored row-major, concatenated in
+   * `bytes` in rect order; one texSubImage2D per rect.
    */
-  applyTerrainDelta(refs: readonly number[], bytes: Uint8Array): void {
-    if (refs.length === 0) return;
+  applyTerrainRects(rects: readonly TerrainRect[], bytes: Uint8Array): void {
+    if (rects.length === 0) return;
     const gl = this.gl;
     gl.bindTexture(gl.TEXTURE_2D, this.terrainTex);
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
-    // Full-map fast path: single texSubImage2D instead of per-tile uploads.
-    if (refs.length === this.mapW * this.mapH) {
+    let offset = 0;
+    for (const r of rects) {
       gl.texSubImage2D(
         gl.TEXTURE_2D,
         0,
-        0,
-        0,
-        this.mapW,
-        this.mapH,
+        r.x,
+        r.y,
+        r.w,
+        r.h,
         gl.RED_INTEGER,
         gl.UNSIGNED_BYTE,
         bytes,
+        offset,
       );
-      return;
-    }
-    for (let i = 0; i < refs.length; i++) {
-      const ref = refs[i];
-      const x = ref % this.mapW;
-      const y = (ref - x) / this.mapW;
-      this.terrainDeltaScratch[0] = bytes[i];
-      gl.texSubImage2D(
-        gl.TEXTURE_2D,
-        0,
-        x,
-        y,
-        1,
-        1,
-        gl.RED_INTEGER,
-        gl.UNSIGNED_BYTE,
-        this.terrainDeltaScratch,
-      );
+      offset += r.w * r.h;
     }
   }
 

--- a/src/client/render/gl/passes/TerrainPass.ts
+++ b/src/client/render/gl/passes/TerrainPass.ts
@@ -1,13 +1,14 @@
 /**
  * TerrainPass — renders the terrain map as a textured quad.
  *
- * Initial upload happens once; per-tile updates flow through
- * applyTerrainDelta() so water-nuke conversions (land → water) are reflected
+ * Initial upload happens once; incremental updates flow through
+ * applyTerrainRects() so water-nuke conversions (land → water) are reflected
  * live. Vertex shader transforms the map quad by the camera mat3; fragment
  * shader samples the RGBA8 terrain texture with nearest-neighbour filtering
  * so each terrain cell stays pixel-crisp at every zoom level.
  */
 
+import type { TerrainRect } from "../../types";
 import terrainFragSrc from "../shaders/terrain/terrain.frag.glsl?raw";
 import terrainVertSrc from "../shaders/terrain/terrain.vert.glsl?raw";
 import {
@@ -33,10 +34,11 @@ export class TerrainPass {
   private uCamera: WebGLUniformLocation;
   private mapW: number;
   private mapH: number;
-  // Base ocean (deep water) color; reused by applyTerrainDelta and rebuilds.
+  // Base ocean (deep water) color; reused by applyTerrainRects and rebuilds.
   private terrainColors: TerrainColorOverrides | undefined;
-  // Scratch buffer for 1×1 sub-uploads; reused across applyTerrainDelta calls.
-  private readonly pixelScratch = new Uint8Array(4);
+  // Scratch RGBA buffer for rect sub-uploads; grown as needed and reused
+  // across applyTerrainRects calls.
+  private rgbaScratch = new Uint8Array(0);
 
   constructor(
     private gl: WebGL2RenderingContext,
@@ -101,38 +103,45 @@ export class TerrainPass {
   }
 
   /**
-   * Update a subset of terrain tiles in-place (e.g. land→water from a water
-   * nuke). `bytes[i]` is the new terrain byte for `refs[i]` (parallel arrays).
-   * One 1×1 texSubImage2D per ref — fine for the small bursts a single nuke
-   * produces. A later full re-upload (setTerrainColors) regenerates from
-   * terrainSource, whose backing game map already reflects these conversions.
+   * Update terrain regions in-place (e.g. land→water from a water nuke).
+   * Each rect's terrain bytes are stored row-major, concatenated in `bytes`
+   * in rect order. One texSubImage2D per rect — a massive bomb changes tens
+   * of thousands of tiles, so per-tile 1×1 uploads are too slow. A later full
+   * re-upload (setTerrainColors) regenerates from terrainSource, whose
+   * backing game map already reflects these conversions.
    */
-  applyTerrainDelta(refs: readonly number[], bytes: Uint8Array): void {
-    if (refs.length === 0) return;
-    // Full-map fast path: rebuild the entire RGBA texture in one upload.
-    if (refs.length === this.mapW * this.mapH) {
-      this.setTerrainColors(this.terrainColors);
-      return;
-    }
+  applyTerrainRects(rects: readonly TerrainRect[], bytes: Uint8Array): void {
+    if (rects.length === 0) return;
     const gl = this.gl;
     gl.bindTexture(gl.TEXTURE_2D, this.tex);
     gl.pixelStorei(gl.UNPACK_ALIGNMENT, 1);
-    for (let i = 0; i < refs.length; i++) {
-      const ref = refs[i];
-      const x = ref % this.mapW;
-      const y = (ref - x) / this.mapW;
-      encodeTerrainTile(bytes[i], this.pixelScratch, 0, this.terrainColors);
+    let offset = 0;
+    for (const r of rects) {
+      const count = r.w * r.h;
+      if (this.rgbaScratch.length < count * 4) {
+        this.rgbaScratch = new Uint8Array(count * 4);
+      }
+      for (let i = 0; i < count; i++) {
+        encodeTerrainTile(
+          bytes[offset + i],
+          this.rgbaScratch,
+          i * 4,
+          this.terrainColors,
+        );
+      }
       gl.texSubImage2D(
         gl.TEXTURE_2D,
         0,
-        x,
-        y,
-        1,
-        1,
+        r.x,
+        r.y,
+        r.w,
+        r.h,
         gl.RGBA,
         gl.UNSIGNED_BYTE,
-        this.pixelScratch,
+        this.rgbaScratch,
+        0,
       );
+      offset += count;
     }
   }
 

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -255,6 +255,19 @@ export interface NukeTrajectoryData {
   tSamIntercept: number;
 }
 
+/**
+ * A rectangular region of terrain texels to re-upload, with its bytes stored
+ * row-major in a shared buffer (rects are concatenated in array order).
+ * Water-nuke deltas use one-row rects (h = 1); a full re-upload (context
+ * restore) is a single map-sized rect.
+ */
+export interface TerrainRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
 /** Input data for attack ring visualization. */
 export interface AttackRingInput {
   x: number;

--- a/src/client/render/types/index.ts
+++ b/src/client/render/types/index.ts
@@ -21,6 +21,7 @@ export type {
   PlayerStatic,
   PlayerStatusData,
   RendererConfig,
+  TerrainRect,
   UnitState,
 } from "./Renderer";
 

--- a/tests/client/render/frame/derive/terrain-row-spans.test.ts
+++ b/tests/client/render/frame/derive/terrain-row-spans.test.ts
@@ -1,0 +1,63 @@
+/**
+ * buildTerrainRowSpans groups terrain-changed tile refs into one span per map
+ * row (min..max x) so the renderer uploads a few hundred row rects instead of
+ * one 1×1 texel per changed tile. Bytes come from the provided lookup for
+ * EVERY tile in the span — including unchanged gap tiles, which must carry
+ * their current value.
+ */
+
+import { describe, expect, it } from "vitest";
+import { buildTerrainRowSpans } from "../../../../../src/client/render/frame/derive/TerrainRowSpans";
+
+const MAP_W = 10;
+
+/** Terrain byte lookup that encodes the ref itself (mod 256) for asserting. */
+const byteAt = (ref: number) => ref % 256;
+
+describe("buildTerrainRowSpans", () => {
+  it("returns no rects for no refs", () => {
+    const { rects, bytes } = buildTerrainRowSpans([], MAP_W, byteAt);
+    expect(rects).toEqual([]);
+    expect(bytes.length).toBe(0);
+  });
+
+  it("produces a 1×1 rect for a single ref", () => {
+    // ref 23 → x=3, y=2
+    const { rects, bytes } = buildTerrainRowSpans([23], MAP_W, byteAt);
+    expect(rects).toEqual([{ x: 3, y: 2, w: 1, h: 1 }]);
+    expect([...bytes]).toEqual([23]);
+  });
+
+  it("merges refs in the same row into one min..max span with gap bytes", () => {
+    // Row y=1: x=2 and x=5 changed. Span covers x=2..5; gap tiles (x=3,4)
+    // are included with their current bytes.
+    const { rects, bytes } = buildTerrainRowSpans([15, 12], MAP_W, byteAt);
+    expect(rects).toEqual([{ x: 2, y: 1, w: 4, h: 1 }]);
+    expect([...bytes]).toEqual([12, 13, 14, 15]);
+  });
+
+  it("emits one span per row, ordered by ascending y, bytes concatenated", () => {
+    // y=3: x=7..8; y=0: x=0. Passed out of order.
+    const { rects, bytes } = buildTerrainRowSpans([38, 0, 37], MAP_W, byteAt);
+    expect(rects).toEqual([
+      { x: 0, y: 0, w: 1, h: 1 },
+      { x: 7, y: 3, w: 2, h: 1 },
+    ]);
+    expect([...bytes]).toEqual([0, 37, 38]);
+  });
+
+  it("covers a blob the way a nuke crater changes tiles", () => {
+    // 3×3 blob centered at (5,5): every span is exactly the blob's row.
+    const refs: number[] = [];
+    for (let y = 4; y <= 6; y++) {
+      for (let x = 4; x <= 6; x++) refs.push(y * MAP_W + x);
+    }
+    const { rects, bytes } = buildTerrainRowSpans(refs, MAP_W, byteAt);
+    expect(rects).toEqual([
+      { x: 4, y: 4, w: 3, h: 1 },
+      { x: 4, y: 5, w: 3, h: 1 },
+      { x: 4, y: 6, w: 3, h: 1 },
+    ]);
+    expect([...bytes]).toEqual([44, 45, 46, 54, 55, 56, 64, 65, 66]);
+  });
+});

--- a/tests/perf/client/ClientUpdatePerf.ts
+++ b/tests/perf/client/ClientUpdatePerf.ts
@@ -169,8 +169,8 @@ function createGlStub() {
     setLocalRailColor: noop("setLocalRailColor"),
     updateSpawnOverlay: noop("updateSpawnOverlay"),
     initSkinAtlas: noop("initSkinAtlas"),
-    applyTerrainDelta: (refs: number[]) =>
-      bump("applyTerrainDelta", refs.length),
+    applyTerrainRects: (rects: unknown[]) =>
+      bump("applyTerrainRects", rects.length),
     // uploadFrameData dispatch targets (FrameUploadTarget)
     uploadTileAndTrailState: noop("uploadTileAndTrailState"),
     uploadLiveDelta: (_: unknown, changed: unknown[]) => {


### PR DESCRIPTION
## Problem

With water nukes enabled, landing a massive bomb stalls the render thread for **~356ms** (profiled in `applyTerrainDelta`). A hydrogen bomb (outer radius 100) converts ~30k land tiles to water in a single tick, and each changed tile was uploaded as its own 1×1 `texSubImage2D` — **three times per tile** (TerrainPass RGBA color, RailroadPass R8UI water-detection, and the shared terrain-bytes texture in `Renderer.ts`). That's ~90k GL driver calls in one frame; the cost is per-call driver overhead, not upload bandwidth.

#4703 addressed the adjacent cases — the context-restore full-map upload (`refs.length === mapW*mapH` fast path) and the map-layer destroyed-mask batching — but any *partial* delta still fell through to the per-tile loop, which was written when nuke bursts were assumed small.

## Fix

Batch by row. A new pure helper `buildTerrainRowSpans` (`render/frame/derive/TerrainRowSpans.ts`) groups the changed refs into one min..max span per map row, sourcing the **current** terrain byte for every tile in the span from `GameView` — unchanged gap tiles simply re-upload their existing value. A hydro crater becomes ~200 one-row rects instead of ~30k tiles, so each texture does ~200 uploads instead of ~30k.

- API: `applyTerrainDelta(refs, bytes)` → `applyTerrainRects(rects, bytes)` through `MapRenderer` / `Renderer` / `TerrainPass` / `RailroadPass`; each rect is one `texSubImage2D` (TerrainPass encodes RGBA into a reused scratch buffer).
- Context restore now sends a single map-sized rect, which subsumes the per-pass full-map fast paths from #4703 (deleted).
- Row spans stay efficient for scattered deltas too (e.g. MIRV volleys don't degrade into one giant bounding box).

## Verification

- New unit test for the span builder (`tests/client/render/frame/derive/terrain-row-spans.test.ts`); existing render tests, `tsc`, and lint pass. The perf-harness GL stub is updated to the new method.
- E2E in the real game (headless Chromium, ANGLE Metal): solo game with water nukes on, hydrogen bomb onto a fully-land area. The crater converts and renders correctly, including the recomputed sand shoreline at the rim (rim fixup tiles flow through the same path, exercising the gap-tile bytes). A rAF-gap monitor through launch + impact measured a **22ms** max main-thread stall (down from 356ms), with no WebGL errors.

| | before | after |
|---|---|---|
| GL calls for a hydro crater | ~90k | ~600 |
| max main-thread stall at impact | 356ms | 22ms |

🤖 Generated with [Claude Code](https://claude.com/claude-code)