### PR TITLE
Use toast notifications for copy feedback

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -286,7 +286,7 @@ export async function copyToClipboard(
   onSuccess?: () => void,
   onReset?: () => void,
   timeout = 2000,
-): Promise<void> {
+): Promise<boolean> {
   try {
     await navigator.clipboard.writeText(text);
     if (onSuccess) onSuccess();
@@ -295,8 +295,10 @@ export async function copyToClipboard(
         onReset();
       }, timeout);
     }
+    return true;
   } catch (err) {
     console.warn("Failed to copy to clipboard", err);
+    return false;
   }
 }
 

--- a/src/client/components/CopyButton.ts
+++ b/src/client/components/CopyButton.ts
@@ -3,7 +3,7 @@ import { customElement, property, state } from "lit/decorators.js";
 import { ClientEnv } from "src/client/ClientEnv";
 import { UserSettings } from "../../core/game/UserSettings";
 import { crazyGamesSDK } from "../CrazyGamesSDK";
-import { copyToClipboard, translateText } from "../Utils";
+import { copyToClipboard, showToast, translateText } from "../Utils";
 
 @customElement("copy-button")
 export class CopyButton extends LitElement {
@@ -24,7 +24,6 @@ export class CopyButton extends LitElement {
   showCopyIcon = true;
   @property({ type: Boolean }) compact = false;
 
-  @state() private copySuccess = false;
   @state() private lobbyIdVisible = true;
 
   private userSettings: UserSettings = new UserSettings();
@@ -39,10 +38,6 @@ export class CopyButton extends LitElement {
   ) {
     if (changedProperties.has("lobbyId")) {
       this.lobbyIdVisible = this.userSettings.lobbyIdVisibility();
-      this.copySuccess = false;
-    }
-    if (changedProperties.has("copyText")) {
-      this.copySuccess = false;
     }
     if (
       changedProperties.has("showVisibilityToggle") ||
@@ -90,10 +85,10 @@ export class CopyButton extends LitElement {
       alert("Error copying game id");
       return;
     }
-    await copyToClipboard(
-      text,
-      () => (this.copySuccess = true),
-      () => (this.copySuccess = false),
+    const copied = await copyToClipboard(text);
+    showToast(
+      translateText(copied ? "common.copied" : "error_modal.failed_copy"),
+      copied ? "green" : "red",
     );
   }
 
@@ -107,11 +102,7 @@ export class CopyButton extends LitElement {
     const rawLabel =
       this.displayContent ??
       (this.displayText || this.lobbyId || this.copyText);
-    const label = this.copySuccess
-      ? translateText("common.copied")
-      : allowMask && !this.lobbyIdVisible
-        ? this.maskLabel
-        : rawLabel;
+    const label = allowMask && !this.lobbyIdVisible ? this.maskLabel : rawLabel;
     const disabledClass = canCopy ? "" : "opacity-60 cursor-not-allowed";
     const toggleDisabled = !this.lobbyId;
     const toggleClass = toggleDisabled ? "opacity-60 cursor-not-allowed" : "";

--- a/tests/client/GameStatsModal.test.ts
+++ b/tests/client/GameStatsModal.test.ts
@@ -9,13 +9,13 @@ import {
   vi,
 } from "vitest";
 
-const copyToClipboardMock = vi.hoisted(() =>
-  vi.fn(async (_text: string, onSuccess?: () => void) => onSuccess?.()),
-);
+const copyToClipboardMock = vi.hoisted(() => vi.fn(async () => true));
+const showToastMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/client/Utils", () => ({
   translateText: vi.fn((key: string) => key),
   copyToClipboard: copyToClipboardMock,
+  showToast: showToastMock,
 }));
 
 vi.mock("../../src/client/components/baseComponents/stats/GameInfoView", () => {
@@ -49,7 +49,9 @@ describe("public game stats route", () => {
   });
 
   beforeEach(async () => {
-    copyToClipboardMock.mockClear();
+    copyToClipboardMock.mockReset();
+    copyToClipboardMock.mockResolvedValue(true);
+    showToastMock.mockClear();
     vi.stubGlobal("localStorage", { getItem: vi.fn(() => null) });
     history.replaceState(null, "", "/");
     modalRouter.register("stats", {
@@ -106,14 +108,12 @@ describe("public game stats route", () => {
     );
     copyActions[0].click();
     await vi.waitFor(() =>
-      expect(copyToClipboardMock).toHaveBeenCalledWith(
-        "public-game",
-        expect.any(Function),
-        expect.any(Function),
-      ),
+      expect(copyToClipboardMock).toHaveBeenCalledWith("public-game"),
     );
     await copyButton.updateComplete;
-    expect(copyButton.textContent).toContain("common.copied");
+    expect(copyButton.textContent).toContain("public-game");
+    expect(copyButton.textContent).not.toContain("common.copied");
+    expect(showToastMock).toHaveBeenCalledWith("common.copied", "green");
 
     expect(document.querySelector("account-modal")).toBeNull();
     expect(window.location.hash).toBe("#modal=stats&gameID=public-game");
@@ -125,5 +125,29 @@ describe("public game stats route", () => {
 
     expect(modal.isOpen()).toBe(false);
     expect(window.location.hash).toBe("");
+  });
+
+  it("shows an error toast and keeps the game ID when copying fails", async () => {
+    copyToClipboardMock.mockResolvedValueOnce(false);
+    history.replaceState(null, "", "/#modal=stats&gameID=public-game");
+
+    expect(modalRouter.routeFromHash()).toBe(true);
+    await vi.waitFor(async () => {
+      await modal.updateComplete;
+      expect(modal.querySelector("copy-button")).not.toBeNull();
+    });
+
+    const copyButton = modal.querySelector<CopyButton>("copy-button")!;
+    await copyButton.updateComplete;
+    copyButton.querySelector("button")!.click();
+
+    await vi.waitFor(() =>
+      expect(showToastMock).toHaveBeenCalledWith(
+        "error_modal.failed_copy",
+        "red",
+      ),
+    );
+    expect(copyButton.textContent).toContain("public-game");
+    expect(copyButton.textContent).not.toContain("common.copied");
   });
 });


### PR DESCRIPTION
## Description:

Replaces the inline “Copied!” state with toast notifications while keeping the original ID or label visible. Success and failure are shown with green and red toasts respectively.

after

https://github.com/user-attachments/assets/ad6540ac-c234-4978-91f4-c163c2461acc



## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri