### PR TITLE
Fix one-player teams on small public maps

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -146,7 +146,7 @@ export class MapPlaylist {
     const mode = type === "ffa" ? GameMode.FFA : GameMode.Team;
     const map = this.getNextMap(type);
 
-    const playerTeams =
+    let playerTeams =
       mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
     let isCompact: boolean | undefined =
@@ -159,11 +159,21 @@ export class MapPlaylist {
       isCompact = undefined;
     }
 
+    const unadjustedMaxPlayers = await this.lobbyMaxPlayers(
+      map,
+      mode,
+      isCompact,
+    );
+    playerTeams = this.adjustTeamCountForPlayerCapacity(
+      playerTeams,
+      unadjustedMaxPlayers,
+    );
+
     return {
       donateGold: mode === GameMode.Team,
       donateTroops: mode === GameMode.Team,
       gameMap: map,
-      maxPlayers: await this.lobbyMaxPlayers(map, mode, playerTeams, isCompact),
+      maxPlayers: this.adjustForTeams(unadjustedMaxPlayers, playerTeams),
       gameType: GameType.Public,
       gameMapSize: isCompact ? GameMapSize.Compact : GameMapSize.Normal,
       publicGameModifiers: {
@@ -192,7 +202,7 @@ export class MapPlaylist {
   private async getSpecialConfig(): Promise<GameConfig> {
     const mode = Math.random() < 0.5 ? GameMode.FFA : GameMode.Team;
     const map = this.getNextMap("special");
-    const playerTeams =
+    let playerTeams =
       mode === GameMode.Team ? this.getTeamCount(map) : undefined;
 
     const excludedModifiers: ModifierKey[] = [];
@@ -275,9 +285,7 @@ export class MapPlaylist {
     let crowdedMaxPlayers: number | undefined;
     if (isCrowded) {
       crowdedMaxPlayers = await this.getCrowdedMaxPlayers(map, !!isCompact);
-      if (crowdedMaxPlayers !== undefined) {
-        crowdedMaxPlayers = this.adjustForTeams(crowdedMaxPlayers, playerTeams);
-      } else {
+      if (crowdedMaxPlayers === undefined) {
         // Map doesn't support crowded. Drop it and pick one replacement only
         // if it was the sole modifier, so the lobby always has at least one.
         isCrowded = undefined;
@@ -316,10 +324,15 @@ export class MapPlaylist {
       }
     }
 
+    const unadjustedMaxPlayers =
+      crowdedMaxPlayers ?? (await this.lobbyMaxPlayers(map, mode, isCompact));
+    playerTeams = this.adjustTeamCountForPlayerCapacity(
+      playerTeams,
+      unadjustedMaxPlayers,
+    );
     const maxPlayers = Math.max(
       2,
-      crowdedMaxPlayers ??
-        (await this.lobbyMaxPlayers(map, mode, playerTeams, isCompact)),
+      this.adjustForTeams(unadjustedMaxPlayers, playerTeams),
     );
 
     const nations: GameConfig["nations"] =
@@ -629,10 +642,16 @@ export class MapPlaylist {
     p = Math.min(Math.max(3, Math.floor(p * 0.25)), MAX_PLAYER_COUNT);
     // Apply team adjustment
     p = this.adjustForTeams(p, playerTeams);
-    // Check at least 2 players per team AND at least 2 teams
+    return this.supportsTeamPlayerCount(p, playerTeams);
+  }
+
+  private supportsTeamPlayerCount(
+    adjustedPlayerCount: number,
+    playerTeams: TeamCountConfig,
+  ): boolean {
     return (
-      this.playersPerTeam(p, playerTeams) >= 2 &&
-      this.numberOfTeams(p, playerTeams) >= 2
+      this.playersPerTeam(adjustedPlayerCount, playerTeams) >= 2 &&
+      this.numberOfTeams(adjustedPlayerCount, playerTeams) >= 2
     );
   }
 
@@ -707,7 +726,6 @@ export class MapPlaylist {
   private async lobbyMaxPlayers(
     map: GameMapType,
     mode: GameMode,
-    numPlayerTeams: TeamCountConfig | undefined,
     isCompactMap?: boolean,
   ): Promise<number> {
     const landTiles = await getMapLandTiles(map);
@@ -721,7 +739,26 @@ export class MapPlaylist {
     }
     // Cap for performance
     p = Math.min(p, MAX_PLAYER_COUNT);
-    return this.adjustForTeams(p, numPlayerTeams);
+    return p;
+  }
+
+  // Numeric team modes specify a number of teams, so ensure every team can
+  // receive at least two players before rounding the lobby capacity.
+  private adjustTeamCountForPlayerCapacity(
+    playerTeams: TeamCountConfig | undefined,
+    unadjustedMaxPlayers: number,
+  ): TeamCountConfig | undefined {
+    if (
+      typeof playerTeams !== "number" ||
+      this.supportsTeamPlayerCount(
+        this.adjustForTeams(unadjustedMaxPlayers, playerTeams),
+        playerTeams,
+      )
+    ) {
+      return playerTeams;
+    }
+
+    return Math.max(2, Math.floor(unadjustedMaxPlayers / 2));
   }
 
   private adjustForTeams(


### PR DESCRIPTION
Resolves https://discord.com/channels/1284581928254701718/1536175686115532870/1536175686115532870

## Description:

Fixes small public team maps creating one player teams, such as `6 teams of 1`.

Reuses the existing team validity rule: at least two players per team and at least two teams.
This now applies to normal and special public games. When a numeric team count does not fit the selected lobby capacity, it is adjusted to a valid team count.

Example: a 10 player lobby that rolls 6 teams now becomes 5 teams of 2.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri