### PR TITLE
Fix loading screen copyright translation

### DIFF
--- a/src/client/GameStartingModal.ts
+++ b/src/client/GameStartingModal.ts
@@ -27,7 +27,7 @@ export class GameStartingModal extends LitElement {
         <div
           class="text-base font-medium tracking-wider uppercase text-white/40 mb-3"
         >
-          © OpenFront and Contributors
+          ${translateText("main.copyright")}
         </div>
         <a
           href="https://github.com/openfrontio/OpenFrontIO/blob/main/CREDITS.md"


### PR DESCRIPTION
Resolves https://discord.com/channels/1359544954044551290/1359544954803847210/1537419895535566878
## Description:

Use the existing `main.copyright` translation in the loading screen

<img width="587" height="458" alt="スクリーンショット 2026-08-15 8 45 40" src="https://github.com/user-attachments/assets/79a75e84-e562-4be2-9360-511f06b71e09" />

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri