### PR TITLE
feat: add map background color override

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -647,6 +647,8 @@
   "graphics_setting": {
     "advanced_desc": "Fine-tune individual graphics options",
     "advanced_label": "Advanced settings",
+    "background_color_desc": "Color of the area outside the map and impassable terrain.",
+    "background_color_label": "Background color",
     "black": "Black",
     "classic_icons_desc": "Lighter outline with near-black interior",
     "classic_icons_label": "Classic icons",

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -507,6 +507,13 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     this.requestUpdate();
   }
 
+  private currentBackgroundColor(): string {
+    return (
+      this.userSettings.graphicsOverrides().terrain?.backgroundColor ??
+      renderDefaults.terrain.backgroundColor
+    );
+  }
+
   private currentOceanColor(): string {
     return (
       this.userSettings.graphicsOverrides().terrain?.oceanColor ??
@@ -540,6 +547,13 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
       this.userSettings.graphicsOverrides().terrain?.mountainColor ??
       renderDefaults.terrain.mountainColor
     );
+  }
+
+  private onBackgroundColorChange(event: Event) {
+    const value = (event.target as HTMLInputElement).value.trim();
+    const match = HEX_COLOR_RE.exec(value);
+    if (!match) return; // ignore partial/invalid hex while typing
+    this.patchTerrain({ backgroundColor: `#${match[1].toLowerCase()}` });
   }
 
   private onOceanColorChange(event: Event) {
@@ -960,6 +974,7 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     const coordinateGridOpacity = this.currentCoordinateGridOpacity();
     const railDrawDistance = RAIL_ZOOM_MAX - this.currentRailMinZoom();
     const railThickness = this.currentRailThickness();
+    const backgroundColor = this.currentBackgroundColor();
     const oceanColor = this.currentOceanColor();
     const sandColor = this.currentSandColor();
     const plainsColor = this.currentPlainsColor();
@@ -1528,6 +1543,33 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
         class="px-3 py-1 text-xs font-semibold text-slate-400 uppercase tracking-wider mt-2"
       >
         ${translateText("graphics_setting.section_terrain")}
+      </div>
+
+      <div
+        class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
+      >
+        <div class="flex-1">
+          <div class="font-medium">
+            ${translateText("graphics_setting.background_color_label")}
+          </div>
+          <div class="text-sm text-slate-400">
+            ${translateText("graphics_setting.background_color_desc")}
+          </div>
+        </div>
+        <input
+          type="text"
+          .value=${backgroundColor}
+          placeholder=${renderDefaults.terrain.backgroundColor}
+          spellcheck="false"
+          @change=${this.onBackgroundColorChange}
+          class="w-24 px-2 py-1 bg-slate-900 border border-slate-500 rounded-sm text-sm text-white font-mono"
+        />
+        <input
+          type="color"
+          .value=${backgroundColor}
+          @input=${this.onBackgroundColorChange}
+          class="w-10 h-8 bg-transparent border border-slate-500 rounded-sm cursor-pointer"
+        />
       </div>
 
       <div

--- a/src/client/render/gl/GraphicsOverrides.ts
+++ b/src/client/render/gl/GraphicsOverrides.ts
@@ -83,6 +83,9 @@ export const GraphicsOverridesSchema = z
       .partial(),
     terrain: z
       .object({
+        // "#rrggbb" hex string; overrides the map background color (the area
+        // outside the map and impassable terrain, which renders to match).
+        backgroundColor: z.string(),
         // "#rrggbb" hex string; overrides the base ocean (deep water) color.
         oceanColor: z.string(),
         sandColor: z.string(),

--- a/src/client/render/gl/RenderOverrides.ts
+++ b/src/client/render/gl/RenderOverrides.ts
@@ -143,6 +143,9 @@ export function applyGraphicsOverrides(
     settings.passEnabled.falloutBloom = overrides.passEnabled.fallout;
     settings.passEnabled.falloutLight = overrides.passEnabled.fallout;
   }
+  if (overrides.terrain?.backgroundColor !== undefined) {
+    settings.terrain.backgroundColor = overrides.terrain.backgroundColor;
+  }
   if (overrides.terrain?.oceanColor !== undefined) {
     settings.terrain.oceanColor = overrides.terrain.oceanColor;
   }

--- a/src/client/render/gl/RenderSettings.ts
+++ b/src/client/render/gl/RenderSettings.ts
@@ -61,6 +61,12 @@ export interface RenderSettings {
   };
   terrain: {
     /**
+     * Map background color as a "#rrggbb" hex string — the clear color drawn
+     * outside the map quad. Impassable terrain is baked to the same color so
+     * the map keeps its non-rectangular silhouette.
+     */
+    backgroundColor: string;
+    /**
      * Base (shallowest) color of deep water as a "#rrggbb" hex string. The
      * per-depth brightness gradient is preserved relative to this color.
      */

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -273,6 +273,8 @@ export class GPURenderer {
       mapW,
       mapH,
       {
+        backgroundColor:
+          hexToRgb(this.settings.terrain.backgroundColor) ?? undefined,
         oceanColor: hexToRgb(this.settings.terrain.oceanColor) ?? undefined,
         sandColor: hexToRgb(this.settings.terrain.sandColor) ?? undefined,
         plainsColor: hexToRgb(this.settings.terrain.plainsColor) ?? undefined,
@@ -987,6 +989,8 @@ export class GPURenderer {
    */
   rebuildTerrain(): void {
     this.terrainPass.setTerrainColors({
+      backgroundColor:
+        hexToRgb(this.settings.terrain.backgroundColor) ?? undefined,
       oceanColor: hexToRgb(this.settings.terrain.oceanColor) ?? undefined,
       sandColor: hexToRgb(this.settings.terrain.sandColor) ?? undefined,
       plainsColor: hexToRgb(this.settings.terrain.plainsColor) ?? undefined,
@@ -1303,7 +1307,10 @@ export class GPURenderer {
   private drawBaseLayer(cam: Float32Array): void {
     const gl = this.gl;
     const pe = this.settings.passEnabled;
-    gl.clearColor(60 / 255, 60 / 255, 60 / 255, 1.0);
+    const [bgR, bgG, bgB] = hexToRgb(this.settings.terrain.backgroundColor) ?? [
+      60, 60, 60,
+    ];
+    gl.clearColor(bgR / 255, bgG / 255, bgB / 255, 1.0);
     gl.clear(gl.COLOR_BUFFER_BIT);
     gl.disable(gl.BLEND);
     if (pe.terrain) this.terrainPass.draw(cam);

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -17,6 +17,7 @@
     "nameDebug": false
   },
   "terrain": {
+    "backgroundColor": "#3c3c3c",
     "oceanColor": "#4785b5",
     "sandColor": "#CCCB9E",
     "plainsColor": "#BEDC8A",

--- a/src/client/render/gl/utils/ColorUtils.ts
+++ b/src/client/render/gl/utils/ColorUtils.ts
@@ -60,6 +60,14 @@ const DEEP_WATER_BASE: readonly [number, number, number] = hexToRgb(
 )!;
 
 /**
+ * Default map background color, from `terrain.backgroundColor` in
+ * render-settings.json; used as a fallback when no override is supplied.
+ */
+const BACKGROUND_BASE: readonly [number, number, number] = hexToRgb(
+  renderDefaults.terrain.backgroundColor,
+)!;
+
+/**
  * Compute a static RGBA8 texture from raw terrain bytes.
  * The single source of truth for terrain colors.
  *
@@ -76,6 +84,7 @@ const DEEP_WATER_BASE: readonly [number, number, number] = hexToRgb(
  */
 /** Encode one terrain byte → RGBA, writing into `out[offset..offset+3]`. */
 export interface TerrainColorOverrides {
+  backgroundColor?: readonly [number, number, number];
   oceanColor?: readonly [number, number, number];
   sandColor?: readonly [number, number, number];
   plainsColor?: readonly [number, number, number];
@@ -89,6 +98,7 @@ export function encodeTerrainTile(
   offset: number,
   colors?: TerrainColorOverrides,
 ): void {
+  const backgroundColor = colors?.backgroundColor;
   const oceanColor = colors?.oceanColor;
   const sandColor = colors?.sandColor;
   const plainsColor = colors?.plainsColor;
@@ -108,12 +118,12 @@ export function encodeTerrainTile(
     plains: plainsColor ?? [190, 220, 138],
     highland: highlandColor ?? [200, 183, 138],
     mountain: mountainColor ?? [230, 230, 230],
-    peak: [60, 60, 60],
+    peak: backgroundColor ?? BACKGROUND_BASE,
   };
 
   // Impassable terrain: render as the map background colour so it blends
   // with the area outside the map quad. Must match the clear colour in
-  // Renderer.ts drawBaseLayer(): gl.clearColor(60/255, 60/255, 60/255).
+  // Renderer.ts drawBaseLayer() (settings.terrain.backgroundColor).
   if (isLand && magnitude === 31) {
     [r, g, b] = terrainColors.peak;
   } else if (isLand && isShoreline) {

--- a/tests/ImpassableTerrain.test.ts
+++ b/tests/ImpassableTerrain.test.ts
@@ -300,6 +300,15 @@ describe("Impassable Terrain", () => {
     expect(out[3]).toBe(255);
   });
 
+  test("encodeTerrainTile uses the backgroundColor override for impassable tiles", () => {
+    const out = new Uint8Array(4);
+    encodeTerrainTile(IMPASSABLE, out, 0, { backgroundColor: [10, 20, 30] });
+    expect(out[0]).toBe(10);
+    expect(out[1]).toBe(20);
+    expect(out[2]).toBe(30);
+    expect(out[3]).toBe(255);
+  });
+
   test("encodeTerrainTile renders plains normally (not background)", () => {
     const out = new Uint8Array(4);
     encodeTerrainTile(LAND_PLAINS, out, 0);


### PR DESCRIPTION
## Summary

Adds a **background color** override to the graphics settings, alongside the existing terrain color overrides (ocean, shore, plains, highland, mountain).

- New `terrain.backgroundColor` entry in `GraphicsOverridesSchema` / `render-settings.json` (default `#3c3c3c`, the previously hardcoded 60/60/60).
- `drawBaseLayer()` now derives its `gl.clearColor` from the setting instead of the hardcoded value.
- Impassable (peak) terrain is baked with the same color via `TerrainColorOverrides`, so impassable regions still blend with the area outside the map and the map keeps its non-rectangular silhouette. Changes apply live through the existing `rebuildTerrain()` path.
- New color picker row in the Terrain section of the graphics settings modal, with `en.json` strings.

## Testing

- `tsc --noEmit`, `npm run lint`, prettier: clean
- Full test suite passes (316 tests)
- Added a test asserting `encodeTerrainTile` honors the `backgroundColor` override for impassable tiles; the existing test pinning the default to rgb(60,60,60) still passes unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)