### PR TITLE
perf: reduce water nuke terrain update spikes

### DIFF
--- a/src/client/render/frame/derive/TerrainRowSpans.ts
+++ b/src/client/render/frame/derive/TerrainRowSpans.ts
@@ -5,13 +5,19 @@ export interface TerrainRowSpansResult {
   bytes: Uint8Array;
 }
 
+const MAX_MERGE_OVERDRAW_RATIO = 1.5;
+const MAX_MERGE_EXTRA_TEXELS = 4096;
+
+interface PendingRect extends TerrainRect {
+  sourceArea: number;
+}
+
 /**
- * Group terrain-changed tile refs into one span per map row (min..max x),
- * reading the CURRENT terrain byte for every tile in each span. A massive
- * water nuke changes tens of thousands of tiles in one tick; uploading them
- * as individual 1×1 texSubImage2D calls costs hundreds of ms of driver time,
- * while a few hundred row spans upload in ~1ms. Unchanged tiles inside a span
- * re-upload their current byte — harmless.
+ * Group terrain-changed tile refs into row spans, then merge adjacent spans
+ * into rectangles when the extra unchanged texels stay bounded. A massive
+ * water nuke changes tens of thousands of tiles in one tick; reducing hundreds
+ * of texSubImage2D calls to a handful is much cheaper than uploading each row.
+ * Unchanged tiles inside a rectangle re-upload their current byte — harmless.
  *
  * Spans are returned in ascending row order; `bytes` holds each span's data
  * concatenated in that order.
@@ -35,23 +41,54 @@ export function buildTerrainRowSpans(
   }
 
   const ys = [...rows.keys()].sort((a, b) => a - b);
-  let total = 0;
+  const pendingRects: PendingRect[] = [];
   for (const y of ys) {
     const row = rows.get(y)!;
-    total += row.max - row.min + 1;
+    const rowWidth = row.max - row.min + 1;
+    const previous = pendingRects[pendingRects.length - 1];
+    if (previous && previous.y + previous.h === y) {
+      const minX = Math.min(previous.x, row.min);
+      const maxX = Math.max(previous.x + previous.w - 1, row.max);
+      const mergedArea = (maxX - minX + 1) * (previous.h + 1);
+      const sourceArea = previous.sourceArea + rowWidth;
+      const extraTexels = mergedArea - sourceArea;
+      if (
+        mergedArea <= sourceArea * MAX_MERGE_OVERDRAW_RATIO ||
+        extraTexels <= MAX_MERGE_EXTRA_TEXELS
+      ) {
+        previous.x = minX;
+        previous.w = maxX - minX + 1;
+        previous.h++;
+        previous.sourceArea = sourceArea;
+        continue;
+      }
+    }
+    pendingRects.push({
+      x: row.min,
+      y,
+      w: rowWidth,
+      h: 1,
+      sourceArea: rowWidth,
+    });
+  }
+
+  let total = 0;
+  for (const rect of pendingRects) {
+    total += rect.w * rect.h;
   }
 
   const bytes = new Uint8Array(total);
-  const rects: TerrainRect[] = new Array(ys.length);
+  const rects: TerrainRect[] = new Array(pendingRects.length);
   let offset = 0;
-  for (let i = 0; i < ys.length; i++) {
-    const y = ys[i];
-    const { min, max } = rows.get(y)!;
-    const rowStart = y * mapW;
-    for (let x = min; x <= max; x++) {
-      bytes[offset++] = terrainByteAt(rowStart + x);
+  for (let i = 0; i < pendingRects.length; i++) {
+    const { x, y, w, h } = pendingRects[i];
+    for (let dy = 0; dy < h; dy++) {
+      const rowStart = (y + dy) * mapW;
+      for (let dx = 0; dx < w; dx++) {
+        bytes[offset++] = terrainByteAt(rowStart + x + dx);
+      }
     }
-    rects[i] = { x: min, y, w: max - min + 1, h: 1 };
+    rects[i] = { x, y, w, h };
   }
   return { rects, bytes };
 }

--- a/src/core/game/WaterManager.ts
+++ b/src/core/game/WaterManager.ts
@@ -94,6 +94,7 @@ export class WaterManager {
    */
   tick(currentTick: number): TileRef[] {
     const changedTiles: TileRef[] = [];
+    let convertedThisTick = false;
 
     if (this._pendingWaterTiles.size > 0) {
       const converted: TileRef[] = [];
@@ -113,6 +114,7 @@ export class WaterManager {
       }
       this._pendingWaterTiles.clear();
       if (converted.length > 0) {
+        convertedThisTick = true;
         this.finalizeWaterChanges(converted, changedTiles);
       }
     }
@@ -121,6 +123,10 @@ export class WaterManager {
     if (
       this._waterGraphDirty &&
       !this.disableNavMesh &&
+      // Keep terrain fixup and graph rebuilding out of the same tick. The
+      // graph is already allowed to remain stale between throttled rebuilds,
+      // and a one-tick delay avoids combining both water-nuke CPU spikes.
+      !convertedThisTick &&
       currentTick - this._waterGraphLastRebuildTick >=
         WATER_GRAPH_REBUILD_INTERVAL
     ) {

--- a/tests/client/render/frame/derive/terrain-row-spans.test.ts
+++ b/tests/client/render/frame/derive/terrain-row-spans.test.ts
@@ -1,9 +1,7 @@
 /**
- * buildTerrainRowSpans groups terrain-changed tile refs into one span per map
- * row (min..max x) so the renderer uploads a few hundred row rects instead of
- * one 1×1 texel per changed tile. Bytes come from the provided lookup for
- * EVERY tile in the span — including unchanged gap tiles, which must carry
- * their current value.
+ * buildTerrainRowSpans groups terrain-changed tile refs into bounded-overdraw
+ * rectangles so the renderer uploads a handful of regions instead of one per
+ * tile or row. Bytes include unchanged gap tiles at their current value.
  */
 
 import { describe, expect, it } from "vitest";
@@ -46,18 +44,27 @@ describe("buildTerrainRowSpans", () => {
     expect([...bytes]).toEqual([0, 37, 38]);
   });
 
-  it("covers a blob the way a nuke crater changes tiles", () => {
+  it("merges a compact multi-row blob into one rectangle", () => {
     // 3×3 blob centered at (5,5): every span is exactly the blob's row.
     const refs: number[] = [];
     for (let y = 4; y <= 6; y++) {
       for (let x = 4; x <= 6; x++) refs.push(y * MAP_W + x);
     }
     const { rects, bytes } = buildTerrainRowSpans(refs, MAP_W, byteAt);
-    expect(rects).toEqual([
-      { x: 4, y: 4, w: 3, h: 1 },
-      { x: 4, y: 5, w: 3, h: 1 },
-      { x: 4, y: 6, w: 3, h: 1 },
-    ]);
+    expect(rects).toEqual([{ x: 4, y: 4, w: 3, h: 3 }]);
     expect([...bytes]).toEqual([44, 45, 46, 54, 55, 56, 64, 65, 66]);
+  });
+
+  it("does not merge adjacent sparse rows when overdraw is excessive", () => {
+    const wideMap = 10_000;
+    const { rects } = buildTerrainRowSpans(
+      [wideMap, wideMap * 3 - 1],
+      wideMap,
+      byteAt,
+    );
+    expect(rects).toEqual([
+      { x: 0, y: 1, w: 1, h: 1 },
+      { x: wideMap - 1, y: 2, w: 1, h: 1 },
+    ]);
   });
 });

--- a/tests/nukes/WaterNukes.test.ts
+++ b/tests/nukes/WaterNukes.test.ts
@@ -137,6 +137,30 @@ describe("Water Nukes", () => {
       expect(navGame.waterGraphVersion()).toBeGreaterThan(versionBefore);
     });
 
+    test("water graph rebuild waits until the tick after terrain conversion", async () => {
+      const navGame = await setup(
+        "plains",
+        { waterNukes: true, disableNavMesh: false },
+        [],
+      );
+
+      // Make the rebuild interval already elapsed, matching a nuke during an
+      // established game. Convert a complete minimap cell so the graph dirties.
+      for (let i = 0; i < 21; i++) navGame.executeNextTick();
+      for (let y = 50; y < 52; y++) {
+        for (let x = 50; x < 52; x++) {
+          navGame.queueWaterConversion(navGame.ref(x, y));
+        }
+      }
+
+      const versionBefore = navGame.waterGraphVersion();
+      navGame.executeNextTick();
+      expect(navGame.waterGraphVersion()).toBe(versionBefore);
+
+      navGame.executeNextTick();
+      expect(navGame.waterGraphVersion()).toBe(versionBefore + 1);
+    });
+
     test("minimap tiles get correct magnitude after water nuke", async () => {
       const navGame = await setup(
         "plains",


### PR DESCRIPTION
## Description

Water nukes could cause noticeable frame and simulation spikes when large terrain deltas were applied.

This PR reduces those spikes in two ways:

- Coalesces adjacent terrain row spans into bounded-overdraw rectangles before uploading them to WebGL.
- Prevents terrain finalization and water-path graph rebuilding from running in the same game tick.

Previously, each changed row produced a separate `texSubImage2D` call for each of the three terrain textures. Compact crater-shaped deltas can now be uploaded as a single rectangle. Unchanged texels inside a merged rectangle are uploaded using their current terrain value, so the rendered result remains unchanged.

Rectangles are only merged when the additional upload area is bounded:

- merged area is at most 1.5× the original span area; or
- the merge adds at most 4,096 texels.

## Performance

Synthetic WebGL2 benchmark using Giant World Map-sized textures (`4108×1948`). The benchmark mirrors the production terrain-delta path: RGBA terrain encoding followed by uploads to the terrain, railroad, and shared terrain-byte textures.

Each result is the median of 11 samples, with 50 uploads per sample. Results were reproduced across three browser runs.

| Scenario | GL calls before → after | Upload size before → after | Median before → after | Speedup |
|---|---:|---:|---:|---:|
| Atom bomb | 183 → 3 | 2.8 KB → 3.7 KB | 0.84ms → 0.014–0.016ms | ~56× |
| Hydrogen bomb | 603 → 3 | 31.4 KB → 40.4 KB | 2.76ms → 0.112–0.116ms | ~24× |
| 5× atom barrage | 915 → 15 | 14.1 KB → 18.6 KB | 5.03–5.14ms → 0.088–0.094ms | ~56× |
| 40× MIRV | 555 → 15 | 626.6 KB → 628.4 KB | 2.18–2.19ms → 1.43ms | ~1.53× |

For a hydrogen-bomb-shaped delta, the number of WebGL upload calls is reduced by 99.5%, from 603 to 3.

On Giant World Map, separating terrain finalization from water-graph rebuilding also reduced the measured worst water-nuke simulation tick:

| Before | After | Improvement |
|---:|---:|---:|
| 80.8ms | 47.3ms | ~41% lower peak |

## Correctness

- Merged rectangles contain the current terrain byte for every texel, including unchanged gap tiles.
- Excessively sparse adjacent rows are kept separate to avoid unbounded overdraw.
- Water-graph rebuilding is delayed by only one tick when terrain conversion occurs. The existing rebuild throttle already permits the graph to remain stale between rebuilds.

## Tests

- Added coverage for compact multi-row rectangle merging.
- Added coverage ensuring sparse rows are not merged when overdraw is excessive.
- Added coverage ensuring water-graph rebuilding occurs on the tick after terrain conversion.
- `npx vitest run tests/client/render/frame/derive/terrain-row-spans.test.ts tests/nukes/WaterNukes.test.ts`
- `npx tsc --noEmit`

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

aotumuri