### PR TITLE
fix(game): recalculate trade ship spawn rate on each level roll in PortExecution

### DIFF
--- a/src/core/execution/PortExecution.ts
+++ b/src/core/execution/PortExecution.ts
@@ -70,10 +70,10 @@ export class PortExecution implements Execution {
 
   shouldSpawnTradeShip(): boolean {
     const numTradeShips = this.mg.unitCount(UnitType.TradeShip);
-    const spawnRate = this.mg
-      .config()
-      .tradeShipSpawnRate(this.tradeShipSpawnRejections, numTradeShips);
     for (let i = 0; i < this.port!.level(); i++) {
+      const spawnRate = this.mg
+        .config()
+        .tradeShipSpawnRate(this.tradeShipSpawnRejections, numTradeShips);
       if (this.random.chance(spawnRate)) {
         this.tradeShipSpawnRejections = 0;
         return true;

--- a/tests/PortExecution.test.ts
+++ b/tests/PortExecution.test.ts
@@ -94,4 +94,62 @@ describe("PortExecution", () => {
 
     expect(ports.length).toBe(1);
   });
+
+  test("shouldSpawnTradeShip recomputes spawn rate per level with updated rejection count", () => {
+    player.conquer(game.ref(7, 10));
+    const spawn = player.canBuild(UnitType.Port, game.ref(7, 10));
+    if (spawn === false) {
+      throw new Error("Unable to build port for test");
+    }
+    const port = player.buildUnit(UnitType.Port, spawn, {});
+    port.increaseLevel();
+    port.increaseLevel(); // level is 3
+
+    const execution = new PortExecution(port);
+    execution.init(game, 0);
+
+    const rejectionsReceived: number[] = [];
+    game.config().tradeShipSpawnRate = (
+      rejections: number,
+      numTradeShips: number,
+    ) => {
+      rejectionsReceived.push(rejections);
+      return 1000000;
+    };
+
+    const spawned = execution.shouldSpawnTradeShip();
+    expect(spawned).toBe(false);
+    // For a level 3 port, 3 failed rolls query spawn rate with rejections 0, 1, 2
+    expect(rejectionsReceived).toEqual([0, 1, 2]);
+
+    // Next call should start from 3
+    rejectionsReceived.length = 0;
+    execution.shouldSpawnTradeShip();
+    expect(rejectionsReceived).toEqual([3, 4, 5]);
+
+    // If a roll succeeds (spawnRate = 1 guarantees success)
+    game.config().tradeShipSpawnRate = (
+      rejections: number,
+      numTradeShips: number,
+    ) => {
+      rejectionsReceived.push(rejections);
+      return 1;
+    };
+    rejectionsReceived.length = 0;
+    const success = execution.shouldSpawnTradeShip();
+    expect(success).toBe(true);
+    expect(rejectionsReceived).toEqual([6]);
+
+    // Rejections are reset to 0 after success
+    game.config().tradeShipSpawnRate = (
+      rejections: number,
+      numTradeShips: number,
+    ) => {
+      rejectionsReceived.push(rejections);
+      return 1000000;
+    };
+    rejectionsReceived.length = 0;
+    execution.shouldSpawnTradeShip();
+    expect(rejectionsReceived).toEqual([0, 1, 2]);
+  });
 });


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #5013

## Description:

In `PortExecution.ts`, `shouldSpawnTradeShip()` rolls for trade ship spawns for each level of the port (`for (let i = 0; i < this.port!.level(); i++)`). When a roll fails, `this.tradeShipSpawnRejections` is incremented to track consecutive rejections.

Previously, `spawnRate` was computed once before the loop:
```ts
const spawnRate = this.mg
  .config()
  .tradeShipSpawnRate(this.tradeShipSpawnRejections, numTradeShips);
for (let i = 0; i < this.port!.level(); i++) {
  if (this.random.chance(spawnRate)) {
    this.tradeShipSpawnRejections = 0;
    return true;
  }
  this.tradeShipSpawnRejections++;
}
```

Because `Config.tradeShipSpawnRate()` implements a pity modifier (`1 / (tradeShipSpawnRejections + 1)`) that increases spawn chances as rejections accumulate, computing `spawnRate` once before the loop prevented higher-level ports (levels 2–5) from benefiting from the updated pity rate across consecutive failed rolls within the same tick.

This PR moves the `tradeShipSpawnRate` calculation inside the loop so that each roll evaluates against the up-to-date rejection count.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

berkelmali
