### PR TITLE
feat(desktop): move the full version string to the footer

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -29,11 +29,7 @@ import {
 } from "./Cosmetics";
 import { updateCrazyGamesNavButton } from "./CrazyGamesAccountButton";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
-import {
-  composeVersionDisplay,
-  desktopVersion,
-  isDesktopShell,
-} from "./DesktopShell";
+import { isDesktopShell } from "./DesktopShell";
 import "./FeaturedStream";
 import "./GameModeSelector";
 import { GameModeSelector } from "./GameModeSelector";
@@ -284,15 +280,13 @@ class Client {
     if (versionElements.length === 0) {
       console.warn("Game version element not found");
     } else {
+      // Game version only, so a player's version reads the same across web and
+      // Steam. The full string, shell version included, is in page-footer.
       const trimmed = version.trim();
       const displayVersion = trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
-      const label = composeVersionDisplay(
-        displayVersion,
-        await desktopVersion(),
-      );
       versionElements.forEach((el) => {
         (el as HTMLElement).style.fontFamily = '"OpenFront", Inter, sans-serif';
-        el.textContent = label;
+        el.textContent = displayVersion;
       });
     }
 

--- a/src/client/components/Footer.ts
+++ b/src/client/components/Footer.ts
@@ -1,12 +1,32 @@
 import { LitElement, html } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
+import version from "resources/version.txt?raw";
 import { assetUrl } from "../../core/AssetUrls";
+import { composeVersionDisplay, desktopVersion } from "../DesktopShell";
 import "./SteamWishlistButton";
+
+const gameVersion = (() => {
+  const trimmed = version.trim();
+  return trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+})();
 
 @customElement("page-footer")
 export class Footer extends LitElement {
+  // Starts as the game version alone and gains the shell version once the
+  // bridge answers, so the line is never blank while that call is in flight.
+  @state() private versionLabel = gameVersion;
+
   createRenderRoot() {
     return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    // desktopVersion() resolves null off the desktop shell and on its own
+    // timeout, so this can only ever leave the label as-is or extend it.
+    void desktopVersion().then((shellVersion) => {
+      this.versionLabel = composeVersionDisplay(gameVersion, shellVersion);
+    });
   }
 
   render() {
@@ -82,6 +102,12 @@ export class Footer extends LitElement {
                 draggable="false"
               />
             </a>
+          </div>
+          <!-- The nav bar shows the game version alone so it reads the same
+               across web and Steam; the full string, shell version included,
+               lives down here where a player can quote it in a bug report. -->
+          <div class="footer-version text-xs mt-1 lg:mt-2 text-center px-4">
+            ${this.versionLabel}
           </div>
           <div
             class="text-xs mt-1 lg:mt-2 flex items-center justify-center gap-4 px-4"

--- a/tests/client/components/Footer.test.ts
+++ b/tests/client/components/Footer.test.ts
@@ -1,0 +1,65 @@
+import version from "resources/version.txt?raw";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Footer } from "../../../src/client/components/Footer";
+
+// version.txt is a build-time placeholder in the repo, so derive the expected
+// label from the same source the component reads rather than hardcoding it.
+const gameVersion = `v${version.trim().replace(/^v/, "")}`;
+
+describe("page-footer version line", () => {
+  let footer: Footer;
+
+  beforeEach(() => {
+    if (!customElements.get("page-footer")) {
+      customElements.define("page-footer", Footer);
+    }
+  });
+
+  afterEach(() => {
+    footer?.remove();
+    window.openfrontDesktop = undefined;
+  });
+
+  async function mount(): Promise<Footer> {
+    footer = document.createElement("page-footer") as Footer;
+    document.body.appendChild(footer);
+    await footer.updateComplete;
+    return footer;
+  }
+
+  it("renders the game version on the web, with no Steam subtext", async () => {
+    window.openfrontDesktop = undefined;
+    await mount();
+
+    const line = footer.querySelector(".footer-version");
+    expect(line?.textContent?.trim()).toBe(gameVersion);
+  });
+
+  it("appends the shell version inside the desktop shell", async () => {
+    window.openfrontDesktop = {
+      version: () => Promise.resolve("0.2.0"),
+    };
+    await mount();
+
+    await vi.waitFor(async () => {
+      await footer.updateComplete;
+      const line = footer.querySelector(".footer-version");
+      expect(line?.textContent?.trim()).toBe(`${gameVersion} (Steam v0.2.0)`);
+    });
+  });
+
+  // The bridge lives in a separate private repo, so the footer must degrade to
+  // the game version alone rather than render a broken label.
+  it("falls back to the game version when the bridge rejects", async () => {
+    window.openfrontDesktop = {
+      version: () => Promise.reject(new Error("boom")),
+    };
+    await mount();
+
+    await vi.waitFor(async () => {
+      await footer.updateComplete;
+      const line = footer.querySelector(".footer-version");
+      expect(line?.textContent?.trim()).toBe(gameVersion);
+    });
+  });
+});


### PR DESCRIPTION
Follow-up to #4898 — no separate issue; this adjusts the presentation of that PR's feature.

## Description:

#4898 appended the Steam shell version to the nav-bar version label. Having both versions in the header reads badly, so this moves the full string down to the footer and gives the header its old label back.

**Header** — the game version alone, `vx.xx.xx`, on web and Steam alike, so a player's version reads the same in both.

**Footer** — a small centred line between the social icons and the legal links:

```
        [gh] [rd] [dc] [wiki]
       vx.xx.xx (Steam v0.2.0)      <- new
  Terms of Service · © OpenFront™ · Privacy Policy
```

It renders on the web too, as just `vx.xx.xx` — a footer version line is where a player would look when filing a bug report either way.

## How

- `Footer.ts` now owns its own version: it imports `version.txt` and reuses `composeVersionDisplay` / `desktopVersion` from `DesktopShell.ts` (unchanged), resolving the shell version in `connectedCallback` into a `@state()` field. It starts at the game version, so the line is never blank while the bridge call is in flight and degrades to the game version if the bridge is absent, rejects, or hits its 500 ms timeout.
- `Main.ts` writes `displayVersion` to `#game-version` / `.game-version-display` as it did before #4898.

Because the footer resolves its own version, this also removes the `await desktopVersion()` that #4898 introduced into the fire-and-forget `initialize()` path ahead of the `join-lobby` / `leave-lobby` / `kick-player` listener registrations — the one risk that PR called out for reviewers.

## Verification

Driven in a real browser against `npm run dev`: the web page renders `vx.xx.xx` in both header and footer; with the Electron bridge injected, the header stays `vx.xx.xx` and the footer reads `vx.xx.xx (Steam v0.2.0)`.

Full suite passes (266 files / 3056 tests), `tsc --noEmit` clean, prettier clean.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — n/a: the line is a version number, and "Steam" is a brand name, so there is no translatable text
- [x] I have added relevant tests to the test directory — `tests/client/components/Footer.test.ts` (web, Steam suffix, bridge-rejects fallback); the existing `tests/DesktopShell.test.ts` still covers the two helpers unchanged

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish
