### PR TITLE
fix(adminbot): refuse team pins the lobby has no slots for

### DIFF
--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -166,15 +166,19 @@ export function registerAdminBotRoutes(opts: {
       // rather than accept a request whose outcome depends on attendance.
       const playerTeams = config.playerTeams;
       if (teams.length > 0) {
-        if (typeof playerTeams === "number") {
-          if (teams.length > playerTeams) {
-            return res.status(400).json({
-              error: `playerTeams (${playerTeams}) is fewer than the ${teams.length} teams being pinned`,
-            });
-          }
-        } else if (playerTeams !== undefined) {
+        // Omitted resolves to 0 teams, which throws "Too few teams" at start, so
+        // there is no slot for a pin either way. Duos/Trios/Quads resolve to
+        // ceil(players / size) at START, from whoever actually turned up, and
+        // that can land below the number of teams being pinned — there is no
+        // count to validate against now, so the request cannot be honoured.
+        if (typeof playerTeams !== "number") {
           return res.status(400).json({
-            error: `teams require a numeric playerTeams, got ${playerTeams}`,
+            error: `teams require a numeric playerTeams, got ${playerTeams ?? "none"}`,
+          });
+        }
+        if (teams.length > playerTeams) {
+          return res.status(400).json({
+            error: `playerTeams (${playerTeams}) is fewer than the ${teams.length} teams being pinned`,
           });
         }
       }

--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -171,14 +171,18 @@ export function registerAdminBotRoutes(opts: {
         // ceil(players / size) at START, from whoever actually turned up, and
         // that can land below the number of teams being pinned — there is no
         // count to validate against now, so the request cannot be honoured.
+        // Stable codes, like the listing/featured refusals above: the caller is
+        // a bot, and these are not presentation strings.
         if (typeof playerTeams !== "number") {
-          return res.status(400).json({
-            error: `teams require a numeric playerTeams, got ${playerTeams ?? "none"}`,
-          });
+          return res
+            .status(400)
+            .json({ error: "teams_require_numeric_player_teams" });
         }
         if (teams.length > playerTeams) {
           return res.status(400).json({
-            error: `playerTeams (${playerTeams}) is fewer than the ${teams.length} teams being pinned`,
+            error: "teams_exceed_player_teams",
+            playerTeams,
+            teams: teams.length,
           });
         }
       }

--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -154,25 +154,12 @@ export function registerAdminBotRoutes(opts: {
           seen.add(publicId);
         }
       }
-      // The lobby must have a slot for every pinned team. A pin is an index into
-      // the game's team list, so one past the end resolves to no team at all and
-      // the player is quietly treated as unpinned — the single worst outcome,
-      // because a partly-pinned lobby looks correct to everyone who reads it.
-      //
-      // Duos/Trios/Quads resolve their team count from the player count at START
-      // (ceil(players / size)), which is not known now and can land below the
-      // number of teams being pinned when fewer players turn up than were
-      // seeded. There is no count to validate against, so refuse the pairing
-      // rather than accept a request whose outcome depends on attendance.
+      // A pin is an index into the team list, so one past the end resolves to
+      // no team and the player is silently unpinned. Duos/Trios/Quads resolve
+      // their count at START from who turned up, and omitting it resolves to 0
+      // (GameImpl throws "Too few teams"), so neither can be checked here.
       const playerTeams = config.playerTeams;
       if (teams.length > 0) {
-        // Omitted resolves to 0 teams, which throws "Too few teams" at start, so
-        // there is no slot for a pin either way. Duos/Trios/Quads resolve to
-        // ceil(players / size) at START, from whoever actually turned up, and
-        // that can land below the number of teams being pinned — there is no
-        // count to validate against now, so the request cannot be honoured.
-        // Stable codes, like the listing/featured refusals above: the caller is
-        // a bot, and these are not presentation strings.
         if (typeof playerTeams !== "number") {
           return res
             .status(400)

--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -154,6 +154,30 @@ export function registerAdminBotRoutes(opts: {
           seen.add(publicId);
         }
       }
+      // The lobby must have a slot for every pinned team. A pin is an index into
+      // the game's team list, so one past the end resolves to no team at all and
+      // the player is quietly treated as unpinned — the single worst outcome,
+      // because a partly-pinned lobby looks correct to everyone who reads it.
+      //
+      // Duos/Trios/Quads resolve their team count from the player count at START
+      // (ceil(players / size)), which is not known now and can land below the
+      // number of teams being pinned when fewer players turn up than were
+      // seeded. There is no count to validate against, so refuse the pairing
+      // rather than accept a request whose outcome depends on attendance.
+      const playerTeams = config.playerTeams;
+      if (teams.length > 0) {
+        if (typeof playerTeams === "number") {
+          if (teams.length > playerTeams) {
+            return res.status(400).json({
+              error: `playerTeams (${playerTeams}) is fewer than the ${teams.length} teams being pinned`,
+            });
+          }
+        } else if (playerTeams !== undefined) {
+          return res.status(400).json({
+            error: `teams require a numeric playerTeams, got ${playerTeams}`,
+          });
+        }
+      }
     }
     // Private only: reject Public and Singleplayer. An omitted gameType defaults
     // to Private in createGame, so it's allowed through.

--- a/tests/server/AdminBotCreateTeams.test.ts
+++ b/tests/server/AdminBotCreateTeams.test.ts
@@ -68,7 +68,7 @@ describe("admin bot create_game team pinning", () => {
       ["pubA", "pubB"],
       ["pubC", "pubD"],
     ];
-    handler({ body: { ...TEAM, teams } }, res);
+    handler({ body: { ...TEAM, playerTeams: 2, teams } }, res);
     expect(res.statusCode).toBe(200);
     expect(created.teams).toEqual(teams);
   });
@@ -77,7 +77,10 @@ describe("admin bot create_game team pinning", () => {
     // Same rule as `listed`: not a GameConfig field, so update_game_config can
     // never set it after the lobby exists.
     const { handler, created } = captureCreateHandler();
-    handler({ body: { ...TEAM, teams: [["pubA", "pubB"]] } }, mockRes());
+    handler(
+      { body: { ...TEAM, playerTeams: 2, teams: [["pubA", "pubB"]] } },
+      mockRes(),
+    );
     expect(created.config).not.toHaveProperty("teams");
     expect(created.config).not.toHaveProperty("matchmakingTeams");
   });
@@ -151,13 +154,15 @@ describe("admin bot create_game team pinning", () => {
     },
   );
 
-  it("still pins when playerTeams is omitted", () => {
-    // Unchanged behaviour: no declared count, nothing to contradict.
+  it("refuses pins with no team count at all", () => {
+    // An omitted playerTeams resolves to 0 teams, which throws "Too few teams"
+    // at start — so the pins could never land and the lobby could never run.
     const { handler, created } = captureCreateHandler();
     const res = mockRes();
     handler({ body: { ...TEAM, teams: [["a"], ["b"]] } }, res);
-    expect(res.statusCode).toBe(200);
-    expect(created.teams).toHaveLength(2);
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toContain("numeric playerTeams");
+    expect(created.teams).toBeUndefined();
   });
 
   it("rejects a malformed teams payload", () => {

--- a/tests/server/AdminBotCreateTeams.test.ts
+++ b/tests/server/AdminBotCreateTeams.test.ts
@@ -122,7 +122,7 @@ describe("admin bot create_game team pinning", () => {
       res,
     );
     expect(res.statusCode).toBe(400);
-    expect(String(res.body.error)).toContain("playerTeams");
+    expect(res.body.error).toBe("teams_exceed_player_teams");
     expect(created.teams).toBeUndefined();
   });
 
@@ -149,7 +149,7 @@ describe("admin bot create_game team pinning", () => {
         res,
       );
       expect(res.statusCode).toBe(400);
-      expect(String(res.body.error)).toContain("numeric playerTeams");
+      expect(res.body.error).toBe("teams_require_numeric_player_teams");
       expect(created.teams).toBeUndefined();
     },
   );
@@ -161,7 +161,7 @@ describe("admin bot create_game team pinning", () => {
     const res = mockRes();
     handler({ body: { ...TEAM, teams: [["a"], ["b"]] } }, res);
     expect(res.statusCode).toBe(400);
-    expect(String(res.body.error)).toContain("numeric playerTeams");
+    expect(res.body.error).toBe("teams_require_numeric_player_teams");
     expect(created.teams).toBeUndefined();
   });
 

--- a/tests/server/AdminBotCreateTeams.test.ts
+++ b/tests/server/AdminBotCreateTeams.test.ts
@@ -109,6 +109,57 @@ describe("admin bot create_game team pinning", () => {
     expect(created.teams).toBeUndefined();
   });
 
+  it("refuses more pinned teams than the lobby has slots", () => {
+    // A pin is an index into the team list, so one past the end resolves to no
+    // team and the player is silently unpinned.
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler(
+      { body: { ...TEAM, playerTeams: 2, teams: [["a"], ["b"], ["c"]] } },
+      res,
+    );
+    expect(res.statusCode).toBe(400);
+    expect(String(res.body.error)).toContain("playerTeams");
+    expect(created.teams).toBeUndefined();
+  });
+
+  it("accepts exactly as many teams as there are slots", () => {
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler(
+      { body: { ...TEAM, playerTeams: 3, teams: [["a"], ["b"], ["c"]] } },
+      res,
+    );
+    expect(res.statusCode).toBe(200);
+    expect(created.teams).toHaveLength(3);
+  });
+
+  it.each(["Duos", "Trios", "Quads"])(
+    "refuses pins alongside %s, whose team count depends on attendance",
+    (mode) => {
+      // Duos/Trios/Quads resolve to ceil(players / size) at START, which can land
+      // below the number of teams pinned if fewer players turn up than seeded.
+      const { handler, created } = captureCreateHandler();
+      const res = mockRes();
+      handler(
+        { body: { ...TEAM, playerTeams: mode, teams: [["a"], ["b"]] } },
+        res,
+      );
+      expect(res.statusCode).toBe(400);
+      expect(String(res.body.error)).toContain("numeric playerTeams");
+      expect(created.teams).toBeUndefined();
+    },
+  );
+
+  it("still pins when playerTeams is omitted", () => {
+    // Unchanged behaviour: no declared count, nothing to contradict.
+    const { handler, created } = captureCreateHandler();
+    const res = mockRes();
+    handler({ body: { ...TEAM, teams: [["a"], ["b"]] } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(created.teams).toHaveLength(2);
+  });
+
   it("rejects a malformed teams payload", () => {
     const { handler } = captureCreateHandler();
     const res = mockRes();


### PR DESCRIPTION
A pin is an index into the game's team list, so one past the end resolves to no team and the player is silently unpinned — a partly-pinned lobby looks correct until the game starts.

`create_game` already refuses pins it can't honour (FFA, duplicate publicIds). It didn't check the count that decides whether a pin can land:

- numeric `playerTeams` — refuse when there are more pinned teams than slots
- `Duos`/`Trios`/`Quads` — resolve to `ceil(players / size)` at start, from who turned up, so there's no count to validate against
- omitted — resolves to 0, and `GameImpl` throws `Too few teams`

Errors are stable codes, matching the `listing_whitelist_enabled` guards above them.
