### PR TITLE
fix(anon): a matchmade team shares one view of everyone else

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -346,20 +346,11 @@ export class GameServer {
     return anonWordName(slot, this.anonOffsetSeed(viewer));
   }
 
-  // What rotates the animal assignment, so different viewers see different fake
-  // names for the same player — the anti-teaming point of anonymization.
-  //
-  // For a matchmade TEAM the seed is the team, not the viewer. Teammates already
-  // see each other's real names (sameMatchmadeTeam), but every OTHER player was
-  // still named per viewer, so two people on the same team saw the same opponent
-  // under different names and could not call a target between them. A team that
-  // cannot agree on who to attack is not really a team, in any size — duos,
-  // trios, quads or a numeric split.
-  //
-  // Sharing one mapping inside a team costs nothing the team did not already
-  // have: they are permitted to coordinate, and it is the same information each
-  // of them could read out loud. Everyone outside the team keeps their own
-  // rotation, so nothing is shared across the boundary that matters.
+  // Rotates the animal assignment so viewers see different fake names for the
+  // same player. Seeded by TEAM for a matchmade viewer: teammates already see
+  // each other's real names, but were still shown different fake names for the
+  // same opponent, so they could not call a target. Everyone outside the team
+  // keeps their own rotation, so anti-teaming holds across the boundary.
   private anonOffsetSeed(viewer: ClientID | undefined): number {
     if (viewer === undefined) return 0;
     const client = this.allClients.get(viewer);

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -343,7 +343,31 @@ export class GameServer {
       if (id === target) break;
       slot++;
     }
-    return anonWordName(slot, viewer ? simpleHash(viewer) : 0);
+    return anonWordName(slot, this.anonOffsetSeed(viewer));
+  }
+
+  // What rotates the animal assignment, so different viewers see different fake
+  // names for the same player — the anti-teaming point of anonymization.
+  //
+  // For a matchmade TEAM the seed is the team, not the viewer. Teammates already
+  // see each other's real names (sameMatchmadeTeam), but every OTHER player was
+  // still named per viewer, so two people on the same team saw the same opponent
+  // under different names and could not call a target between them. A team that
+  // cannot agree on who to attack is not really a team, in any size — duos,
+  // trios, quads or a numeric split.
+  //
+  // Sharing one mapping inside a team costs nothing the team did not already
+  // have: they are permitted to coordinate, and it is the same information each
+  // of them could read out loud. Everyone outside the team keeps their own
+  // rotation, so nothing is shared across the boundary that matters.
+  private anonOffsetSeed(viewer: ClientID | undefined): number {
+    if (viewer === undefined) return 0;
+    const client = this.allClients.get(viewer);
+    const team =
+      client === undefined ? undefined : this.matchmakingTeamIndex(client);
+    return team === undefined
+      ? simpleHash(viewer)
+      : simpleHash(`${this.id}:team:${team}`);
   }
 
   // Whether `viewer` should see `target`'s real identity: when names aren't

--- a/tests/server/AnonymizeNamesTeammates.test.ts
+++ b/tests/server/AnonymizeNamesTeammates.test.ts
@@ -100,9 +100,19 @@ describe("anonymizeNames: a team shares one view of everyone else", () => {
   it("still shows the OTHER team a different set of names", () => {
     // Anti-teaming holds across the boundary: sharing inside a team must not
     // become one mapping for the whole lobby.
-    const game = makeGame(TEAMS);
+    //
+    // dave gets a team of his own so BOTH viewers anonymize him. Against the
+    // two-team fixture carol would be his teammate and see his real name, and
+    // the comparison would pass even if every team shared one seed.
+    const game = makeGame([
+      ["alice-pub", "bob-pub"],
+      ["carol-pub"],
+      ["dave-pub"],
+    ]);
     const alice = game.gameInfo("alice");
     const carol = game.gameInfo("carol");
+    expect(REAL).not.toContain(byId(alice, "dave").username);
+    expect(REAL).not.toContain(byId(carol, "dave").username);
     expect(byId(alice, "dave").username).not.toBe(byId(carol, "dave").username);
   });
 

--- a/tests/server/AnonymizeNamesTeammates.test.ts
+++ b/tests/server/AnonymizeNamesTeammates.test.ts
@@ -77,6 +77,45 @@ const byId = (info: any, id: string) =>
 const player = (info: any, id: string) =>
   info.players.find((p: any) => p.clientID === id);
 
+describe("anonymizeNames: a team shares one view of everyone else", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("gives teammates the SAME fake name for a given opponent", () => {
+    // The point of the team: they can call a target. Seeding the rotation per
+    // viewer meant alice and bob saw the same opponent under different names,
+    // so neither could tell the other who to attack.
+    const game = makeGame(TEAMS);
+    const alice = game.gameInfo("alice");
+    const bob = game.gameInfo("bob");
+    for (const opponent of ["carol", "dave"]) {
+      expect(byId(alice, opponent).username).toBe(byId(bob, opponent).username);
+      expect(REAL).not.toContain(byId(alice, opponent).username);
+    }
+  });
+
+  it("still shows the OTHER team a different set of names", () => {
+    // Anti-teaming holds across the boundary: sharing inside a team must not
+    // become one mapping for the whole lobby.
+    const game = makeGame(TEAMS);
+    const alice = game.gameInfo("alice");
+    const carol = game.gameInfo("carol");
+    expect(byId(alice, "dave").username).not.toBe(byId(carol, "dave").username);
+  });
+
+  it("keeps per-viewer names when the game is not matchmade", () => {
+    // No pins, no teams — nothing to share a seed with, so the original
+    // per-viewer rotation is unchanged.
+    const game = makeGame();
+    const alice = game.gameInfo("alice");
+    const bob = game.gameInfo("bob");
+    expect(byId(alice, "dave").username).not.toBe(byId(bob, "dave").username);
+  });
+});
+
 describe("anonymizeNames: pinned teammates see each other (lobby)", () => {
   beforeEach(() => vi.useFakeTimers());
   afterEach(() => {


### PR DESCRIPTION
Teammates see each other's real names (#4945), but every other player was still named per viewer — so two people on the same team saw the same opponent under different fake names and couldn't call a target.

The anonymization offset is now seeded from the team when the viewer is on a matchmade one, and from the viewer otherwise. Sharing a mapping inside a team costs nothing they didn't already have; everyone outside keeps their own rotation, so anti-teaming holds across the boundary.

Applies to any team size. Non-matchmade games are unchanged.
