### PR TITLE
fix(core): only annex territory that is actually enclosed

### DIFF
--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -273,6 +273,16 @@ export class PlayerExecution implements Execution {
       return;
     }
 
+    // The checks above only ever looked at this one cluster of border tiles,
+    // but the fill below hands over the whole territory the cluster sits on.
+    // Those are different sets: every hole in a territory — an enemy enclave,
+    // a nuke crater — gives it another border cluster, so a cluster that
+    // passes can be wrapped around a hole in the middle of a wide open
+    // empire. Verify the land actually changing hands is sealed in.
+    if (!this.isEnclosed(firstTile)) {
+      return;
+    }
+
     const tiles = this.floodFillWithGen(
       this.bumpGeneration(),
       this.traversalState().visited,
@@ -288,6 +298,55 @@ export class PlayerExecution implements Execution {
     for (const tile of tiles) {
       capturing.conquer(tile);
     }
+  }
+
+  /**
+   * Whether the player's territory reachable from `start` is walled in by
+   * other players: walking from it through our own tiles and any unclaimed
+   * land can never reach water or the edge of the map, so the only way out
+   * is across someone else's territory.
+   *
+   * Unclaimed land is walked through rather than treated as a way out — a
+   * crater inside our own land is a hole, not an exit — but water and the
+   * map edge end it, matching what the cluster checks already require of the
+   * tiles they inspect.
+   */
+  private isEnclosed(start: TileRef): boolean {
+    const map = this.map;
+    const mySmallID = this.player.smallID();
+    const state = this.traversalState();
+    const gen = bumpTraversalGeneration(state);
+    const visited = state.visited;
+    const stack = state.stack;
+    stack.length = 0;
+    visited[start] = gen;
+    stack.push(start);
+
+    while (stack.length > 0) {
+      const tile = stack.pop()!;
+      if (map.isOnEdgeOfMap(tile)) {
+        return false;
+      }
+      const numNeighbors = map.neighbors4(tile, this.nbuf);
+      for (let i = 0; i < numNeighbors; i++) {
+        const n = this.nbuf[i];
+        if (visited[n] === gen) {
+          continue;
+        }
+        const ownerId = map.ownerID(n);
+        if (ownerId !== 0 && ownerId !== mySmallID) {
+          // Someone else's tile — part of the wall, so stop here.
+          continue;
+        }
+        if (ownerId === 0 && !map.isLand(n)) {
+          // Open water is a way out.
+          return false;
+        }
+        visited[n] = gen;
+        stack.push(n);
+      }
+    }
+    return true;
   }
 
   private getCapturingPlayer(cluster: readonly TileRef[]): Player | null {

--- a/tests/core/executions/AnnexationRequiresEnclosure.test.ts
+++ b/tests/core/executions/AnnexationRequiresEnclosure.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, test } from "vitest";
+import { PlayerExecution } from "../../../src/core/execution/PlayerExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+} from "../../../src/core/game/Game";
+import { TileRef } from "../../../src/core/game/GameMap";
+import { setup } from "../../util/Setup";
+
+// The annexation checks (surroundedBySamePlayer / isSurrounded) run on a
+// cluster of *border* tiles, but removeCluster hands over the whole
+// contiguous territory that cluster sits on. One territory owns a separate
+// border cluster for every hole punched in it — a nuke crater, an enemy
+// enclave — so those two sets are not the same thing, and the defect lives in
+// the gap between them. Drive removeCluster directly to pin the invariant:
+// only land that is genuinely sealed in may change hands.
+type ClusterRemover = { removeCluster(cluster: TileRef[]): void };
+
+function clusterRemoverFor(game: Game, player: Player) {
+  const exec = new PlayerExecution(player);
+  exec.init(game, 0);
+  const internals = exec as unknown as ClusterRemover;
+  return (cluster: TileRef[]) => internals.removeCluster(cluster);
+}
+
+let game: Game;
+let defender: Player;
+let attacker: Player;
+
+describe("annexation only takes territory that is actually enclosed", () => {
+  beforeEach(async () => {
+    game = await setup("big_plains", {}, [
+      new PlayerInfo("defender", PlayerType.Human, "client1", "defender_id"),
+      new PlayerInfo("attacker", PlayerType.Human, "client2", "attacker_id"),
+    ]);
+    defender = game.player("defender_id");
+    attacker = game.player("attacker_id");
+  });
+
+  test("an enemy enclave does not hand over the empire around it", () => {
+    // The attacker holds a small enclave deep inside the defender's empire.
+    // The defender's empire runs to the edge of the map, so it is wide open —
+    // but the ring of tiles around the enclave is a border cluster of its own,
+    // and it is that ring the annexation checks get to look at.
+    const enclave = { min: 60, max: 64 };
+    for (let x = 0; x <= 120; x++) {
+      for (let y = 0; y <= 120; y++) {
+        const inEnclave =
+          x >= enclave.min &&
+          x <= enclave.max &&
+          y >= enclave.min &&
+          y <= enclave.max;
+        (inEnclave ? attacker : defender).conquer(game.ref(x, y));
+      }
+    }
+
+    const ring: TileRef[] = [];
+    for (let i = enclave.min; i <= enclave.max; i++) {
+      ring.push(game.ref(enclave.min - 1, i));
+      ring.push(game.ref(enclave.max + 1, i));
+      ring.push(game.ref(i, enclave.min - 1));
+      ring.push(game.ref(i, enclave.max + 1));
+    }
+    for (const tile of ring) {
+      expect(game.ownerID(tile)).toBe(defender.smallID());
+    }
+
+    const defenderTilesBefore = defender.numTilesOwned();
+    const attackerTilesBefore = attacker.numTilesOwned();
+
+    clusterRemoverFor(game, defender)(ring);
+
+    expect(defender.numTilesOwned()).toBe(defenderTilesBefore);
+    expect(attacker.numTilesOwned()).toBe(attackerTilesBefore);
+  });
+
+  test("a genuinely sealed-in pocket is still annexed", () => {
+    // Same shape inverted: this time the defender is the one walled in, with
+    // no route out to open land, so the mechanic should still fire.
+    const pocket = { min: 60, max: 64 };
+    for (let x = 58; x <= 66; x++) {
+      for (let y = 58; y <= 66; y++) {
+        const inPocket =
+          x >= pocket.min &&
+          x <= pocket.max &&
+          y >= pocket.min &&
+          y <= pocket.max;
+        (inPocket ? defender : attacker).conquer(game.ref(x, y));
+      }
+    }
+
+    const cluster: TileRef[] = [];
+    for (let x = pocket.min; x <= pocket.max; x++) {
+      for (let y = pocket.min; y <= pocket.max; y++) {
+        if (game.map().isBorder(game.ref(x, y))) {
+          cluster.push(game.ref(x, y));
+        }
+      }
+    }
+    expect(cluster.length).toBeGreaterThan(0);
+
+    const attackerTilesBefore = attacker.numTilesOwned();
+    const pocketSize = defender.numTilesOwned();
+
+    clusterRemoverFor(game, defender)(cluster);
+
+    expect(defender.numTilesOwned()).toBe(0);
+    expect(attacker.numTilesOwned()).toBe(attackerTilesBefore + pocketSize);
+  });
+});


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

A player can lose their entire empire to a neighbour in a single tick, with no attack landing, no death event and no notification — enough to hand that neighbour an instant win. Found from a reported FFA game whose record replays 100% in sync on `87f1a5278` (2322/2322 recorded hashes match), so this is simulation behaviour, not a desync.

### Root cause

`PlayerExecution.removeClusters` splits the player's border tiles into 8-connected clusters, checks each one, and calls `removeCluster` on the ones that pass. The checks run on a cluster of *border tiles*, but `removeCluster` flood-fills and hands over the whole contiguous *territory* that cluster sits on.

Those are not the same set. A territory gets a separate border cluster for every hole punched in it — an enemy enclave, a nuke crater — so a cluster wrapped around a hole in the middle of a wide-open empire can pass the check, and then the entire empire around it changes hands. Nothing ever verified that the land being transferred was enclosed; only that one ring of border tiles looked like it was.

`isSurrounded` is what lets such a cluster through. It is a bounding-box test: no tile may be shore or on the map edge, there must be at least one enemy neighbour, and the enemy neighbours' bounding box must contain the cluster's. The observed failure:

```
clusterBox = [157,279 .. 2262,2145]
enemyBox   = [156,278 .. 2263,2145]
shoreTiles = 0   oceanShoreTiles = 0   edgeTiles = 0
unownedNbrs = 7856
```

The enemy tiles reach one tile past the cluster's bounding box on three sides and match it on the fourth, which is all `inscribed()` asks for. That cluster spans 2106×1867 tiles on a 2480×2148 map — not a pocket, but the border web of a whole empire. Note also that `isSurrounded` ignores unowned neighbours entirely, where `surroundedBySamePlayer` bails on the first one.

Heavy nuking makes this far more likely: fallout tiles are unowned, so they punch holes that multiply the border clusters and erase the shore tiles the checks would otherwise bail on. In the observed case 261,175 fallout tiles had shattered one empire's border into **1,334 clusters**, and a non-largest cluster of 6,813 tiles transferred **1,455,433 tiles — 98.2% of that empire** — in one tick. The same bug fired three more times in the same endgame at smaller scale (87,847, 79,414 and 17,751 tiles), all with the same one-tile-margin bounding boxes.

Because a disconnected remnant survived, `numTilesOwned() === tiles.length` was false and `conquerPlayer` never ran, so none of it surfaced as a kill or an event. The land simply changed colour, and `WinCheckExecution` ended the game on the next check.

### The fix

Verify the territory itself is sealed in before any of it changes hands. `isEnclosed` walks from the tile through the player's own tiles and any unclaimed land; if that walk reaches water or the edge of the map, the territory has a way out and nothing is transferred.

Unclaimed land is walked through rather than treated as a way out — a crater inside your own territory is a hole, not a door — which is the distinction the bounding-box checks cannot make. Water and the map edge end the walk, matching what `surroundedBySamePlayer` (`isOceanShore`, unowned neighbours) and `isSurrounded` (`isShore`) already require of the tiles they inspect.

The cheap checks stay as the candidate filter; this runs on the exact set of tiles about to be mutated. It is purely additive, so it can only refuse annexations, never enable new ones, and it costs no more than the flood fill that already ran — in the pathological case it costs less, because it aborts instead of transferring 1.45M tiles.

I deliberately did not tighten `isSurrounded` itself. No amount of tightening turns a bounding-box test over a border cluster into a statement about the territory, and with this guard in place its false positives just cost a wasted fill.

### Verification

- New test reproduces the defect: a 20-tile ring around an enemy enclave took all 14,616 tiles of an empire that runs to the map edge; it now takes 0.
- Second test pins the other direction: a genuinely walled-in pocket is still annexed and its owner still dies.
- `NoInverseAnnexation.test.ts` and the rest of the suite pass (6,988 tests).
- Replaying the reported game with the fix: no mass transfer, no instant win, and legitimate annexations still fire — including one player fully annexed and another losing 10,052 tiles.

### ⚠️ This changes simulation behaviour beyond the one incident

Replaying the reported game with the fix diverges from **tick 400**, not from the tick the mass transfer happened. The old code was mis-annexing constantly at small scale and every one of those is now refused. The first divergence is a 4-tile sliver of a bot's territory, next to open unclaimed land, that would otherwise have gone to a neighbouring player.

Across a full replay the guard refuses 2,985 transfers totalling ~835k tiles. Most are slivers — median 2 tiles, 78% of them under 10 — but the tail is real: 177 refusals over 1,000 tiles, the largest 35,009. (The replay diverges from tick 400, so treat those as indicative of the rate and scale rather than an exact counterfactual.)

So this cannot ship as a hotfix to the released version: replays recorded on the old code will desync against the new code. It needs a version boundary, hence `main` / the next release.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish
