### PR TITLE
fix(server): rate limit in-socket rejoin messages

### DIFF
--- a/src/server/ClientMsgRateLimiter.ts
+++ b/src/server/ClientMsgRateLimiter.ts
@@ -4,12 +4,18 @@ import { ClientID } from "../core/Schemas";
 const INTENTS_PER_SECOND = 10;
 const INTENTS_PER_MINUTE = 150;
 const MAX_INTENT_SIZE = 2000;
+// A rejoin makes the server serialize and send the turn history since
+// `lastTurn`, which is the full game so far when lastTurn is 0. A real client
+// only sends one per (re)connect, so anything beyond a handful per minute is
+// abuse.
+const REJOINS_PER_MINUTE = 5;
 const TOTAL_BYTES = 5 * 1024 * 1024; // 5MB per client
 export type RateLimitResult = "ok" | "limit" | "kick";
 
 interface ClientBucket {
   perSecond: RateLimiter;
   perMinute: RateLimiter;
+  rejoinPerMinute: RateLimiter;
   totalBytes: number;
 }
 
@@ -37,6 +43,10 @@ export class ClientMsgRateLimiter {
       ) {
         return "limit";
       }
+    } else if (type === "rejoin") {
+      if (!bucket.rejoinPerMinute.tryRemoveTokens(1)) {
+        return "limit";
+      }
     }
 
     return "ok";
@@ -54,6 +64,10 @@ export class ClientMsgRateLimiter {
       }),
       perMinute: new RateLimiter({
         tokensPerInterval: INTENTS_PER_MINUTE,
+        interval: "minute",
+      }),
+      rejoinPerMinute: new RateLimiter({
+        tokensPerInterval: REJOINS_PER_MINUTE,
         interval: "minute",
       }),
       totalBytes: 0,

--- a/tests/server/ClientMsgRateLimiter.test.ts
+++ b/tests/server/ClientMsgRateLimiter.test.ts
@@ -56,6 +56,26 @@ describe("ClientMsgRateLimiter", () => {
     });
   });
 
+  describe("rejoin messages", () => {
+    it("allows a few rejoins then limits", () => {
+      const limiter = new ClientMsgRateLimiter();
+      for (let i = 0; i < 5; i++) {
+        expect(limiter.check(CLIENT_A, "rejoin", SMALL)).toBe("ok");
+      }
+      expect(limiter.check(CLIENT_A, "rejoin", SMALL)).toBe("limit");
+    });
+
+    it("rejoin limit is per client and independent of intents", () => {
+      const limiter = new ClientMsgRateLimiter();
+      for (let i = 0; i < 5; i++) {
+        limiter.check(CLIENT_A, "rejoin", SMALL);
+      }
+      expect(limiter.check(CLIENT_A, "rejoin", SMALL)).toBe("limit");
+      expect(limiter.check(CLIENT_A, "intent", SMALL)).toBe("ok");
+      expect(limiter.check(CLIENT_B, "rejoin", SMALL)).toBe("ok");
+    });
+  });
+
   describe("total bytes limit", () => {
     it("kicks when cumulative bytes reach 5MB", () => {
       const limiter = new ClientMsgRateLimiter();


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #(security report — no public issue)

## Description:

A `rejoin` message sent on an already-open game WebSocket makes the server serialize and send the turn history since `lastTurn` (`GameServer.sendStartGameMsg`) — the entire game so far when `lastTurn` is `0`. `ClientMsgRateLimiter` only applied its per-second/per-minute buckets to `intent` messages, so a `rejoin` frame (~120 bytes) just ticked the 5 MiB byte budget. One admitted client could trigger tens of thousands of full-history `JSON.stringify` + multi-MB sends on a single connection, stalling the worker event loop for every game it hosts. Cloudflare's upgrade rate limit doesn't cover frames on an established socket, so this needs an app-level limit.

This adds a per-client `rejoin` bucket (5/min) in `ClientMsgRateLimiter`; excess rejoins return `"limit"` and are dropped by the existing handling in `GameServer.addListeners`. A real client only sends one rejoin per (re)connect, so legitimate players are unaffected.

## Please complete the following:

- [x] I have added screenshots for all UI updates (n/a — server only)
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file (n/a)
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

evanpelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
