### PR TITLE
feat(adminbot): pin a player to a team after the lobby exists

### DIFF
--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -240,14 +240,8 @@ export function registerAdminBotRoutes(opts: {
   });
 
   // Send an intent. Honors the lobby-management intents; everything else 400.
-  // Pin a player to a team after the lobby was created. Team pins are otherwise
-  // fixed at create_game, which makes them useless for a lobby that fills up
-  // over time — every late joiner is left to the balancer, and in a team game
-  // that splits partners onto opposing sides.
-  //
-  // Returns the resulting team list so the caller can assert what landed rather
-  // than assume it: a half-pinned lobby looks correct from the outside, so
-  // "success" alone is not enough to act on.
+  // Returns the resulting team list so the caller can assert what landed: a
+  // half-pinned lobby looks correct from the outside.
   app.post("/api/adminbot/game/:id/pin", requireAdminBotKey, (req, res) => {
     const id = req.params.id as string;
     if (!ownsGame(id, res)) return;

--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -240,6 +240,45 @@ export function registerAdminBotRoutes(opts: {
   });
 
   // Send an intent. Honors the lobby-management intents; everything else 400.
+  // Pin a player to a team after the lobby was created. Team pins are otherwise
+  // fixed at create_game, which makes them useless for a lobby that fills up
+  // over time — every late joiner is left to the balancer, and in a team game
+  // that splits partners onto opposing sides.
+  //
+  // Returns the resulting team list so the caller can assert what landed rather
+  // than assume it: a half-pinned lobby looks correct from the outside, so
+  // "success" alone is not enough to act on.
+  app.post("/api/adminbot/game/:id/pin", requireAdminBotKey, (req, res) => {
+    const id = req.params.id as string;
+    if (!ownsGame(id, res)) return;
+
+    const parsed = z
+      .object({
+        publicId: z.string().min(1),
+        teamIndex: z.number().int().nonnegative(),
+      })
+      .safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: z.prettifyError(parsed.error) });
+    }
+    const game = gm.game(id);
+    if (game === null) {
+      return res.status(404).json({ error: "Game not found" });
+    }
+
+    const result = game.addMatchmakingPin(
+      parsed.data.publicId,
+      parsed.data.teamIndex,
+    );
+    if (!result.ok) {
+      return res.status(result.status).json({ error: result.error });
+    }
+    log.info(`admin bot pinned a player on game ${id}`, {
+      teamIndex: parsed.data.teamIndex,
+    });
+    res.json({ teams: result.teams });
+  });
+
   app.post("/api/adminbot/game/:id/intent", requireAdminBotKey, (req, res) => {
     const id = req.params.id as string;
     if (!ownsGame(id, res)) return;

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1359,18 +1359,10 @@ export class GameServer {
     });
   }
 
-  // Pin a publicId to a team slot after the lobby exists.
-  //
-  // Pins are otherwise fixed at create, which makes them unusable for any lobby
-  // that grows: everyone who arrives later is left to the balancer, and in a
-  // team game that means partners split across opposing sides. Nothing has to be
-  // recomputed to support this — matchmakingTeamIndex resolves against the array
-  // live, and it is only read when gameStartInfo is built at START, so an
-  // amendment any time before then is picked up on its own.
-  //
-  // Refused once the game has started: the stamped teams are already in
-  // gameStartInfo and every client has them, so a late write would change
-  // nothing and report success for work that did not happen.
+  // Pin a publicId to a team slot after the lobby exists, so a lobby that fills
+  // over time can still seat late joiners with their partners.
+  // matchmakingTeamIndex resolves against this array live and is only read when
+  // gameStartInfo is built at start, so nothing needs recomputing.
   public addMatchmakingPin(
     publicId: string,
     teamIndex: number,
@@ -1393,8 +1385,7 @@ export class GameServer {
     const existing = this.matchmakingTeams.findIndex((team) =>
       team.includes(publicId),
     );
-    // Already where it was asked to go: report success rather than an error, so
-    // a caller retrying after a dropped response converges instead of failing.
+    // Idempotent, so a caller retrying after a dropped response converges.
     if (existing === teamIndex) {
       return { ok: true, teams: this.matchmakingTeams };
     }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1378,21 +1378,17 @@ export class GameServer {
     | { ok: true; teams: string[][] }
     | { ok: false; status: number; error: string } {
     if (this.matchmakingTeams === undefined) {
-      return { ok: false, status: 400, error: "game has no matchmade teams" };
+      return { ok: false, status: 400, error: "game_not_matchmade" };
     }
     if (this.hasStarted()) {
-      return { ok: false, status: 409, error: "game already started" };
+      return { ok: false, status: 409, error: "game_already_started" };
     }
     if (
       !Number.isInteger(teamIndex) ||
       teamIndex < 0 ||
       teamIndex >= this.matchmakingTeams.length
     ) {
-      return {
-        ok: false,
-        status: 400,
-        error: `teamIndex ${teamIndex} outside 0..${this.matchmakingTeams.length - 1}`,
-      };
+      return { ok: false, status: 400, error: "team_index_out_of_range" };
     }
     const existing = this.matchmakingTeams.findIndex((team) =>
       team.includes(publicId),
@@ -1403,11 +1399,7 @@ export class GameServer {
       return { ok: true, teams: this.matchmakingTeams };
     }
     if (existing !== -1) {
-      return {
-        ok: false,
-        status: 409,
-        error: `${publicId} is already pinned to team ${existing}`,
-      };
+      return { ok: false, status: 409, error: "player_already_pinned" };
     }
     this.matchmakingTeams[teamIndex].push(publicId);
     return { ok: true, teams: this.matchmakingTeams };

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1359,6 +1359,60 @@ export class GameServer {
     });
   }
 
+  // Pin a publicId to a team slot after the lobby exists.
+  //
+  // Pins are otherwise fixed at create, which makes them unusable for any lobby
+  // that grows: everyone who arrives later is left to the balancer, and in a
+  // team game that means partners split across opposing sides. Nothing has to be
+  // recomputed to support this — matchmakingTeamIndex resolves against the array
+  // live, and it is only read when gameStartInfo is built at START, so an
+  // amendment any time before then is picked up on its own.
+  //
+  // Refused once the game has started: the stamped teams are already in
+  // gameStartInfo and every client has them, so a late write would change
+  // nothing and report success for work that did not happen.
+  public addMatchmakingPin(
+    publicId: string,
+    teamIndex: number,
+  ):
+    | { ok: true; teams: string[][] }
+    | { ok: false; status: number; error: string } {
+    if (this.matchmakingTeams === undefined) {
+      return { ok: false, status: 400, error: "game has no matchmade teams" };
+    }
+    if (this.hasStarted()) {
+      return { ok: false, status: 409, error: "game already started" };
+    }
+    if (
+      !Number.isInteger(teamIndex) ||
+      teamIndex < 0 ||
+      teamIndex >= this.matchmakingTeams.length
+    ) {
+      return {
+        ok: false,
+        status: 400,
+        error: `teamIndex ${teamIndex} outside 0..${this.matchmakingTeams.length - 1}`,
+      };
+    }
+    const existing = this.matchmakingTeams.findIndex((team) =>
+      team.includes(publicId),
+    );
+    // Already where it was asked to go: report success rather than an error, so
+    // a caller retrying after a dropped response converges instead of failing.
+    if (existing === teamIndex) {
+      return { ok: true, teams: this.matchmakingTeams };
+    }
+    if (existing !== -1) {
+      return {
+        ok: false,
+        status: 409,
+        error: `${publicId} is already pinned to team ${existing}`,
+      };
+    }
+    this.matchmakingTeams[teamIndex].push(publicId);
+    return { ok: true, teams: this.matchmakingTeams };
+  }
+
   // Resolves a client to its matchmade team slot (index into
   // matchmakingTeams), or undefined when the game isn't matchmade / the
   // client isn't in the assignment.

--- a/tests/server/AdminBotPin.test.ts
+++ b/tests/server/AdminBotPin.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GameType } from "../../src/core/game/Game";
+import { GameServer } from "../../src/server/GameServer";
+
+// Pins are otherwise fixed at create, which makes them useless for a lobby that
+// fills over time: every late joiner is left to the balancer, and in a team game
+// that splits partners onto opposing sides.
+describe("GameServer.addMatchmakingPin", () => {
+  let logger: any;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    logger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllTimers();
+  });
+
+  const makeGame = (teams?: string[][]) =>
+    new GameServer(
+      "g1",
+      logger,
+      Date.now(),
+      { gameType: GameType.Private } as any,
+      "creator-pid",
+      undefined,
+      undefined,
+      teams,
+    );
+
+  const started = (game: GameServer) => {
+    (game as any)._hasStarted = true;
+  };
+
+  it("adds the player to the requested team", () => {
+    const game = makeGame([["a"], ["b"]]);
+    const result = game.addMatchmakingPin("c", 1);
+    expect(result).toEqual({ ok: true, teams: [["a"], ["b", "c"]] });
+  });
+
+  it("is idempotent — re-pinning to the same team succeeds without duplicating", () => {
+    // A caller retrying after a dropped response has to converge, not fail.
+    const game = makeGame([["a"], ["b"]]);
+    game.addMatchmakingPin("c", 1);
+    const again = game.addMatchmakingPin("c", 1);
+    expect(again).toEqual({ ok: true, teams: [["a"], ["b", "c"]] });
+  });
+
+  it("refuses to move a player already pinned elsewhere", () => {
+    // Silently moving them would contradict a team the caller already acted on.
+    const game = makeGame([["a"], ["b"]]);
+    const result = game.addMatchmakingPin("a", 1);
+    expect(result).toMatchObject({ ok: false, status: 409 });
+    expect(String((result as any).error)).toContain("already pinned to team 0");
+  });
+
+  it("refuses a team index outside the list", () => {
+    const game = makeGame([["a"], ["b"]]);
+    expect(game.addMatchmakingPin("c", 2)).toMatchObject({
+      ok: false,
+      status: 400,
+    });
+    expect(game.addMatchmakingPin("c", -1)).toMatchObject({
+      ok: false,
+      status: 400,
+    });
+  });
+
+  it("refuses once the game has started", () => {
+    // The teams are already stamped into gameStartInfo and every client has
+    // them, so a late write would report success for work that did nothing.
+    const game = makeGame([["a"], ["b"]]);
+    started(game);
+    expect(game.addMatchmakingPin("c", 1)).toMatchObject({
+      ok: false,
+      status: 409,
+    });
+  });
+
+  it("refuses when the game was never matchmade", () => {
+    expect(makeGame().addMatchmakingPin("c", 0)).toMatchObject({
+      ok: false,
+      status: 400,
+    });
+  });
+
+  it("leaves the pin visible to the team lookup the start info uses", () => {
+    // The point of the whole change: matchmakingTeamIndex resolves live, so an
+    // amendment before start is picked up with nothing else recomputed.
+    const game = makeGame([["a"], ["b"]]);
+    game.addMatchmakingPin("c", 1);
+    const idx = (game as any).matchmakingTeamIndex({ publicId: "c" });
+    expect(idx).toBe(1);
+  });
+});

--- a/tests/server/AdminBotPin.test.ts
+++ b/tests/server/AdminBotPin.test.ts
@@ -58,7 +58,7 @@ describe("GameServer.addMatchmakingPin", () => {
     const game = makeGame([["a"], ["b"]]);
     const result = game.addMatchmakingPin("a", 1);
     expect(result).toMatchObject({ ok: false, status: 409 });
-    expect(String((result as any).error)).toContain("already pinned to team 0");
+    expect((result as any).error).toBe("player_already_pinned");
   });
 
   it("refuses a team index outside the list", () => {


### PR DESCRIPTION
Pins are fixed at `create_game`, so any lobby that fills over time leaves late joiners to the balancer — in a team game that splits partners onto opposing sides.

Nothing needs recomputing: `matchmakingTeamIndex` resolves against the array live and is only read when `gameStartInfo` is built at start.

```
POST /api/adminbot/game/:id/pin  { publicId, teamIndex }
```

Refused once started, for a game that was never matchmade, and for an index outside the list. Re-pinning to the same team is idempotent so a retry converges; moving a player pinned elsewhere is refused. Returns the resulting team list so the caller can assert what landed.
