### PR TITLE
feat(doomsday): team modes climb a higher ladder to the same ceiling

### DIFF
--- a/src/client/components/DoomsdayClockPanel.ts
+++ b/src/client/components/DoomsdayClockPanel.ts
@@ -47,11 +47,16 @@ export class DoomsdayClockPanel extends LitElement {
   // The player's "side" (matching the sim): themselves in FFA, their whole team
   // otherwise. The sim judges a side on its combined territory against the same
   // bar as a solo player, so the HUD only needs the tile sum.
+  // A side is one player in FFA and a whole team otherwise — the same split the
+  // sim uses, and what decides which level ladder the bar climbs.
+  private isTeamGame(): boolean {
+    return this.game.config().gameConfig().gameMode !== GameMode.FFA;
+  }
+
   private sideTiles(me: ReturnType<GameView["myPlayer"]>): number {
     if (!me) return 0;
-    const ffa = this.game.config().gameConfig().gameMode === GameMode.FFA;
     const myTeam = me.team();
-    if (ffa || myTeam === null) return me.numTilesOwned();
+    if (!this.isTeamGame() || myTeam === null) return me.numTilesOwned();
     return this.game
       .playerViews()
       .filter(
@@ -91,8 +96,15 @@ export class DoomsdayClockPanel extends LitElement {
     const yourTiles = this.sideTiles(me);
     // Same bar for every side, solo or team (same as the sim) — so the zone
     // readout is one universal, monotonic number for every player.
-    const requiredTiles = doomsdayClockRequiredTiles(sd.speed, land, elapsed);
-    const wave = doomsdayClockWaveState(sd.speed, elapsed);
+    const requiredTiles = doomsdayClockRequiredTiles(
+      { ...sd, teamGame: this.isTeamGame() },
+      land,
+      elapsed,
+    );
+    const wave = doomsdayClockWaveState(
+      { ...sd, teamGame: this.isTeamGame() },
+      elapsed,
+    );
     // Match the sim: no land -> no bar, no percentages (avoid div-by-zero / >100%).
     const requiredPct = land > 0 ? (requiredTiles / land) * 100 : 0;
     const yourPct = land > 0 ? (yourTiles / land) * 100 : 0;

--- a/src/client/components/DoomsdayClockPanel.ts
+++ b/src/client/components/DoomsdayClockPanel.ts
@@ -47,8 +47,7 @@ export class DoomsdayClockPanel extends LitElement {
   // The player's "side" (matching the sim): themselves in FFA, their whole team
   // otherwise. The sim judges a side on its combined territory against the same
   // bar as a solo player, so the HUD only needs the tile sum.
-  // A side is one player in FFA and a whole team otherwise — the same split the
-  // sim uses, and what decides which level ladder the bar climbs.
+  // A side is one player in FFA and a whole team otherwise — same split as the sim.
   private isTeamGame(): boolean {
     return this.game.config().gameConfig().gameMode !== GameMode.FFA;
   }

--- a/src/core/execution/DoomsdayClockExecution.ts
+++ b/src/core/execution/DoomsdayClockExecution.ts
@@ -127,7 +127,11 @@ export class DoomsdayClockExecution implements Execution {
 
     const land = mg.numLandTiles() - mg.numTilesWithFallout();
     // One bar for every side this tick (solo or team — headcount never scales it).
-    const required = doomsdayClockRequiredTiles(cfg.speed, land, elapsed);
+    const required = doomsdayClockRequiredTiles(
+      { ...cfg, teamGame: !ffa },
+      land,
+      elapsed,
+    );
 
     // The leading side (the crown holder in FFA, the top team otherwise) is
     // never doomed. Doomsday Clock culls the challengers toward the leader, so the

--- a/src/core/game/DoomsdayClock.ts
+++ b/src/core/game/DoomsdayClock.ts
@@ -12,11 +12,10 @@
  */
 
 export type DoomsdayClockSpeed = "slow" | "normal" | "fast" | "veryfast";
-/** Speed sets the PACE; whether sides can hold more than one player sets the
- *  BAR. Passed together because both call sites already resolve both. */
+/** Speed sets the pace; team mode sets the bar. */
 export interface DoomsdayClockProfile {
   speed: DoomsdayClockSpeed;
-  /** True when a side is a TEAM rather than one player — see LEVELS_TEAM. */
+  /** True when a side is a team rather than one player — see LEVELS_TEAM. */
   teamGame?: boolean;
 }
 
@@ -53,22 +52,12 @@ interface WaveSchedule {
 // a higher one climbs past the leader's own share. Steps stay small because half
 // the players alive at the end hold under 0.4% of the map.
 const LEVELS = [200, 400, 700, 1100, 1700, 2500, 3500]; // 2/4/7/11/17/25/35%
-// TEAM modes climb the same ladder with the rungs raised. The bar is one share
-// per SIDE regardless of headcount — deliberately, since elimination happens at
-// side granularity — but that makes the same percentage mean different things: a
-// duo sitting on 2% combined is two players averaging 1% each, against a solo
-// FFA player holding the whole 2%. The FFA levels track the ofstats territory
-// median for ONE player, so applied to a team they under-ask by roughly the
-// team's size.
-//
-// Only the rungs move. Grace, ramp and pause timings are the speed's job, so the
-// final bar still lands exactly where the chosen speed puts it — no team game
-// reaches its endgame sooner than an FFA one on the same preset.
-//
-// The ceiling is deliberately unchanged. 35% already sits well above the 21.6%
-// the runner-up has ever held at game end, so it narrows the field without
-// climbing past the leader's own share; raising it would start dooming whoever
-// is winning, which inverts what the clock is for.
+// TEAM modes climb the same ladder with the rungs raised. A side survives while
+// either member does, so equal pressure collapses the field more slowly —
+// measured, team games plateau at four sides where FFA keeps shedding. Only the
+// rungs move; grace and ramp timings are the speed's job. The ceiling is
+// unchanged: 35% is already above any runner-up share observed at game end, and
+// raising it would start dooming the leader.
 const LEVELS_TEAM = [300, 600, 1000, 1500, 2100, 2800, 3500]; // 3/6/10/15/21/28/35%
 const SCHEDULES: Record<DoomsdayClockSpeed, WaveSchedule> = {
   // grace 10:00, then seven 168s ramps + 54s pauses -> 35% at 35:00.

--- a/src/core/game/DoomsdayClock.ts
+++ b/src/core/game/DoomsdayClock.ts
@@ -12,6 +12,13 @@
  */
 
 export type DoomsdayClockSpeed = "slow" | "normal" | "fast" | "veryfast";
+/** Speed sets the PACE; whether sides can hold more than one player sets the
+ *  BAR. Passed together because both call sites already resolve both. */
+export interface DoomsdayClockProfile {
+  speed: DoomsdayClockSpeed;
+  /** True when a side is a TEAM rather than one player — see LEVELS_TEAM. */
+  teamGame?: boolean;
+}
 
 /** In selector order. */
 export const DOOMSDAY_CLOCK_SPEEDS: DoomsdayClockSpeed[] = [
@@ -46,6 +53,23 @@ interface WaveSchedule {
 // a higher one climbs past the leader's own share. Steps stay small because half
 // the players alive at the end hold under 0.4% of the map.
 const LEVELS = [200, 400, 700, 1100, 1700, 2500, 3500]; // 2/4/7/11/17/25/35%
+// TEAM modes climb the same ladder with the rungs raised. The bar is one share
+// per SIDE regardless of headcount — deliberately, since elimination happens at
+// side granularity — but that makes the same percentage mean different things: a
+// duo sitting on 2% combined is two players averaging 1% each, against a solo
+// FFA player holding the whole 2%. The FFA levels track the ofstats territory
+// median for ONE player, so applied to a team they under-ask by roughly the
+// team's size.
+//
+// Only the rungs move. Grace, ramp and pause timings are the speed's job, so the
+// final bar still lands exactly where the chosen speed puts it — no team game
+// reaches its endgame sooner than an FFA one on the same preset.
+//
+// The ceiling is deliberately unchanged. 35% already sits well above the 21.6%
+// the runner-up has ever held at game end, so it narrows the field without
+// climbing past the leader's own share; raising it would start dooming whoever
+// is winning, which inverts what the clock is for.
+const LEVELS_TEAM = [300, 600, 1000, 1500, 2100, 2800, 3500]; // 3/6/10/15/21/28/35%
 const SCHEDULES: Record<DoomsdayClockSpeed, WaveSchedule> = {
   // grace 10:00, then seven 168s ramps + 54s pauses -> 35% at 35:00.
   normal: {
@@ -80,8 +104,9 @@ const SCHEDULES: Record<DoomsdayClockSpeed, WaveSchedule> = {
   },
 };
 
-function schedule(speed: DoomsdayClockSpeed): WaveSchedule {
-  return SCHEDULES[speed] ?? SCHEDULES.normal;
+function schedule(profile: DoomsdayClockProfile): WaveSchedule {
+  const base = SCHEDULES[profile.speed] ?? SCHEDULES.normal;
+  return profile.teamGame === true ? { ...base, levels: LEVELS_TEAM } : base;
 }
 
 /**
@@ -90,10 +115,10 @@ function schedule(speed: DoomsdayClockSpeed): WaveSchedule {
  * each. Integer-only (floored) so every client agrees.
  */
 function requiredBasisPoints(
-  speed: DoomsdayClockSpeed,
+  profile: DoomsdayClockProfile,
   elapsed: number,
 ): number {
-  const s = schedule(speed);
+  const s = schedule(profile);
   if (elapsed <= s.graceSeconds) return 0;
   let t = elapsed - s.graceSeconds;
   let prev = 0;
@@ -123,12 +148,12 @@ function requiredBasisPoints(
  * ratio, so every client agrees.
  */
 export function doomsdayClockRequiredTiles(
-  speed: DoomsdayClockSpeed,
+  profile: DoomsdayClockProfile,
   land: number,
   elapsed: number,
 ): number {
   if (land <= 0) return 0;
-  return Math.floor((requiredBasisPoints(speed, elapsed) * land) / 10000);
+  return Math.floor((requiredBasisPoints(profile, elapsed) * land) / 10000);
 }
 
 export interface DoomsdayClockWaveState {
@@ -153,11 +178,11 @@ export interface DoomsdayClockWaveState {
  * holding, and the cue window. Lives here so the schedule is defined once.
  */
 export function doomsdayClockWaveState(
-  speed: DoomsdayClockSpeed,
+  profile: DoomsdayClockProfile,
   elapsed: number,
 ): DoomsdayClockWaveState {
-  const s = schedule(speed);
-  const currentPercent = requiredBasisPoints(speed, elapsed) / 100;
+  const s = schedule(profile);
+  const currentPercent = requiredBasisPoints(profile, elapsed) / 100;
   const n = s.levels.length;
   const last = s.levels[n - 1] / 100;
 

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -633,10 +633,16 @@ describe("doomsdayClockRequiredTiles (ramping waves)", () => {
     // Only the rungs move; grace and wave timings belong to the speed preset.
     const team = { speed: "normal" as const, teamGame: true };
     expect(doomsdayClockRequiredTiles(team, land, 600)).toBe(0); // grace unchanged
-    const ffa = doomsdayClockWaveState({ speed: "normal" }, 700);
-    const t = doomsdayClockWaveState(team, 700);
+    // Sampled inside a PAUSE, not the first ramp: during the opening ramp both
+    // profiles report growing with 0s to go, so the comparison would hold even
+    // if the team schedule had been shifted. The targets confirm the two are on
+    // different ladders at the same instant.
+    const ffa = doomsdayClockWaveState({ speed: "normal" }, 1000);
+    const t = doomsdayClockWaveState(team, 1000);
     expect(t.secondsToNextGrowth).toBe(ffa.secondsToNextGrowth);
     expect(t.growing).toBe(ffa.growing);
+    expect(ffa.targetPercent).toBe(7);
+    expect(t.targetPercent).toBe(10);
   });
 
   it("treats an omitted teamGame as FFA", () => {

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -617,15 +617,53 @@ describe("DoomsdayClockExecution (teams)", () => {
 describe("doomsdayClockRequiredTiles (ramping waves)", () => {
   const land = 10000;
 
+  it("a TEAM game climbs higher rungs to the same ceiling", () => {
+    // The bar is one share per SIDE regardless of headcount, so the same
+    // percentage asks less of a team than of a solo player: a duo on 2%
+    // combined is two players averaging 1% each.
+    const ffa = { speed: "normal" as const };
+    const team = { speed: "normal" as const, teamGame: true };
+    expect(doomsdayClockRequiredTiles(team, land, 768)).toBe(300); // 3%, was 2%
+    expect(doomsdayClockRequiredTiles(ffa, land, 768)).toBe(200);
+    expect(doomsdayClockRequiredTiles(team, land, 9999)).toBe(3500); // same ceiling
+    expect(doomsdayClockRequiredTiles(ffa, land, 9999)).toBe(3500);
+  });
+
+  it("does not make a team game reach its endgame any sooner", () => {
+    // Only the rungs move; grace and wave timings belong to the speed preset.
+    const team = { speed: "normal" as const, teamGame: true };
+    expect(doomsdayClockRequiredTiles(team, land, 600)).toBe(0); // grace unchanged
+    const ffa = doomsdayClockWaveState({ speed: "normal" }, 700);
+    const t = doomsdayClockWaveState(team, 700);
+    expect(t.secondsToNextGrowth).toBe(ffa.secondsToNextGrowth);
+    expect(t.growing).toBe(ffa.growing);
+  });
+
+  it("treats an omitted teamGame as FFA", () => {
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 768)).toBe(
+      200,
+    );
+  });
+
   it("is 0 through the grace, ramps linearly, then holds during the pause", () => {
     // normal: grace 600s, then a 168s ramp 0->2%, then a 54s hold, ...
-    expect(doomsdayClockRequiredTiles("normal", land, 300)).toBe(0); // in the grace
-    expect(doomsdayClockRequiredTiles("normal", land, 600)).toBe(0); // grace ends
-    expect(doomsdayClockRequiredTiles("normal", land, 684)).toBe(100); // halfway up -> 1%
-    expect(doomsdayClockRequiredTiles("normal", land, 768)).toBe(200); // ramp done -> 2%
-    expect(doomsdayClockRequiredTiles("normal", land, 800)).toBe(200); // pause holds 2%
-    expect(doomsdayClockRequiredTiles("normal", land, 822)).toBe(200); // next ramp starts at 2%
-    expect(doomsdayClockRequiredTiles("normal", land, 9999)).toBe(3500); // final 35%
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 300)).toBe(0); // in the grace
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 600)).toBe(0); // grace ends
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 684)).toBe(
+      100,
+    ); // halfway up -> 1%
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 768)).toBe(
+      200,
+    ); // ramp done -> 2%
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 800)).toBe(
+      200,
+    ); // pause holds 2%
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 822)).toBe(
+      200,
+    ); // next ramp starts at 2%
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 9999)).toBe(
+      3500,
+    ); // final 35%
   });
 
   it("tops out at 35% exactly on each preset's cap", () => {
@@ -633,13 +671,25 @@ describe("doomsdayClockRequiredTiles (ramping waves)", () => {
     // endgame to act. 35% -- not the old 55% -- because no runner-up in 85
     // tournament games ever held more than 21.6%, so a higher ceiling only ever
     // climbed past the leader's own share.
-    expect(doomsdayClockRequiredTiles("normal", land, 1878)).toBe(2500); // 25% wave
-    expect(doomsdayClockRequiredTiles("normal", land, 2100)).toBe(3500); // 35% @ 35:00
-    expect(doomsdayClockRequiredTiles("fast", land, 1500)).toBe(3500); // 35% @ 25:00
-    expect(doomsdayClockRequiredTiles("veryfast", land, 900)).toBe(3500); // 35% @ 15:00
-    expect(doomsdayClockRequiredTiles("slow", land, 2700)).toBe(3500); // 35% @ 45:00
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 1878)).toBe(
+      2500,
+    ); // 25% wave
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, land, 2100)).toBe(
+      3500,
+    ); // 35% @ 35:00
+    expect(doomsdayClockRequiredTiles({ speed: "fast" }, land, 1500)).toBe(
+      3500,
+    ); // 35% @ 25:00
+    expect(doomsdayClockRequiredTiles({ speed: "veryfast" }, land, 900)).toBe(
+      3500,
+    ); // 35% @ 15:00
+    expect(doomsdayClockRequiredTiles({ speed: "slow" }, land, 2700)).toBe(
+      3500,
+    ); // 35% @ 45:00
     // And never beyond it, however long the game runs.
-    expect(doomsdayClockRequiredTiles("fast", land, 5000)).toBe(3500);
+    expect(doomsdayClockRequiredTiles({ speed: "fast" }, land, 5000)).toBe(
+      3500,
+    );
   });
 
   it("steps gently and never jumps more than 10 points at once", () => {
@@ -659,17 +709,17 @@ describe("doomsdayClockRequiredTiles (ramping waves)", () => {
   it("never decreases, and is zero for no land", () => {
     let prev = 0;
     for (let t = 0; t <= 2400; t += 5) {
-      const r = doomsdayClockRequiredTiles("normal", land, t);
+      const r = doomsdayClockRequiredTiles({ speed: "normal" }, land, t);
       expect(r).toBeGreaterThanOrEqual(prev);
       prev = r;
     }
-    expect(doomsdayClockRequiredTiles("normal", 0, 1800)).toBe(0);
+    expect(doomsdayClockRequiredTiles({ speed: "normal" }, 0, 1800)).toBe(0);
   });
 });
 
 describe("doomsdayClockWaveState", () => {
   it("reports the live share and target while ramping", () => {
-    const s = doomsdayClockWaveState("normal", 684); // mid the first ramp (0->2%)
+    const s = doomsdayClockWaveState({ speed: "normal" }, 684); // mid the first ramp (0->2%)
     expect(s.currentPercent).toBe(1);
     expect(s.targetPercent).toBe(2);
     expect(s.growing).toBe(true);
@@ -679,7 +729,7 @@ describe("doomsdayClockWaveState", () => {
   });
 
   it("counts down to the next ramp during a pause", () => {
-    const s = doomsdayClockWaveState("normal", 800); // in the first pause (768-822)
+    const s = doomsdayClockWaveState({ speed: "normal" }, 800); // in the first pause (768-822)
     expect(s.growing).toBe(false);
     expect(s.currentPercent).toBe(2); // held at the level just reached
     expect(s.targetPercent).toBe(4); // next ramp climbs to 4%
@@ -688,7 +738,7 @@ describe("doomsdayClockWaveState", () => {
   });
 
   it("counts down through the grace", () => {
-    const s = doomsdayClockWaveState("normal", 200);
+    const s = doomsdayClockWaveState({ speed: "normal" }, 200);
     expect(s.currentPercent).toBe(0);
     expect(s.targetPercent).toBe(2);
     expect(s.secondsToNextGrowth).toBe(400); // first ramp at 600
@@ -696,13 +746,19 @@ describe("doomsdayClockWaveState", () => {
 
   it("flags the 10s window (5s each side) around a ramp starting", () => {
     // veryfast first ramp starts at 600s.
-    expect(doomsdayClockWaveState("veryfast", 596).waveFlash).toBe(true); // 4s before
-    expect(doomsdayClockWaveState("veryfast", 604).waveFlash).toBe(true); // 4s after
-    expect(doomsdayClockWaveState("veryfast", 620).waveFlash).toBe(false); // mid-ramp
+    expect(doomsdayClockWaveState({ speed: "veryfast" }, 596).waveFlash).toBe(
+      true,
+    ); // 4s before
+    expect(doomsdayClockWaveState({ speed: "veryfast" }, 604).waveFlash).toBe(
+      true,
+    ); // 4s after
+    expect(doomsdayClockWaveState({ speed: "veryfast" }, 620).waveFlash).toBe(
+      false,
+    ); // mid-ramp
   });
 
   it("marks done after the last ramp", () => {
-    const s = doomsdayClockWaveState("veryfast", 1100); // past the final ramp (@900) = 35%
+    const s = doomsdayClockWaveState({ speed: "veryfast" }, 1100); // past the final ramp (@900) = 35%
     expect(s.done).toBe(true);
     expect(s.currentPercent).toBe(35);
     expect(s.secondsToNextGrowth).toBe(0);
@@ -811,7 +867,7 @@ describe("DoomsdayClockExecution (integration)", () => {
     const small = game.player("small");
     // Size the slices to the bar at the point we stop.
     const bar = doomsdayClockRequiredTiles(
-      "veryfast",
+      { speed: "veryfast" },
       game.numLandTiles(),
       TICKS / 10,
     );


### PR DESCRIPTION
Team modes climb the same ladder with the rungs raised, to the same ceiling:

```
FFA     2 / 4 / 7 / 11 / 17 / 25 / 35%
team    3 / 6 / 10 / 15 / 21 / 28 / 35%
```

**Why.** A side survives while either member does, so equal pressure collapses the field more slowly. Replaying the semifinal and final of two tournaments run the same night, team games plateau at four sides for the last 4–9 minutes while the FFA games keep shedding to the end.

Fraction of sides under the bar, per minute:

```
FFA games, FFA ladder        0.230
team games, FFA ladder       0.215
team games, this ladder      0.250
team games, a uniform 1.5x   0.303
```

A uniform 1.5× is a third harsher than FFA and puts the ceiling at 53%, where two sides can't both sit above it — that forces a single winner by arithmetic instead of leaving it to rot. This curve sits just above parity without changing what the endgame is.

Only the rungs move; grace and ramp timings belong to the speed preset, so no team game finishes sooner than an FFA one. No wire config — the mode already decides what a side is.

<sub>The two team replays diverge from their recorded hashes at turn 0 (known balancer-kick difference), so their territory series is representative, not bit-exact; both FFA replays are faithful.</sub>
