### PR TITLE
fix(server): re-tally winner votes when the electorate shrinks

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1078,6 +1078,7 @@ export class GameServer {
     this.activeClients = this.activeClients.filter(
       (c) => c.clientID !== client.clientID,
     );
+    this.checkWinnerAfterElectorateShrink();
 
     // hasStarted() includes prestart: during the lobby -> game transition
     // clients reconnect, and a host socket closing then must not tear the
@@ -1576,7 +1577,13 @@ export class GameServer {
         alive.push(client);
       }
     }
+    // On an abrupt network drop the ws 'close' event can lag far behind this
+    // ping prune, so re-check the winner vote here too.
+    const pruned = alive.length < this.activeClients.length;
     this.activeClients = alive;
+    if (pruned) {
+      this.checkWinnerAfterElectorateShrink();
+    }
     if (now > this.createdAt + this.maxGameDuration) {
       this.log.warn("game past max duration", {
         gameID: this.id,
@@ -2035,6 +2042,29 @@ export class GameServer {
       {
         winnerKey,
       },
+    );
+    this.archiveGame();
+  }
+
+  // Votes are otherwise only tallied when one arrives (handleWinner), so a
+  // vote stuck short of a majority would never resolve once the rest of the
+  // electorate is gone. In a 1v1 the loser often disconnects within a second
+  // of being eliminated — before their own client simulates the win tick and
+  // votes — leaving the winner's vote wedged at 1 of 2 and the game archived
+  // winnerless (e.g. game s5bcKtj8). Re-tally whenever the electorate
+  // shrinks, counting only votes from still-active IPs (see resultAmong).
+  private checkWinnerAfterElectorateShrink() {
+    if (this.winner !== null || this._hasEnded) {
+      return;
+    }
+    const activeIPs = new Set(this.activeClients.map((c) => c.ip));
+    const result = this.winnerVotes.resultAmong(activeIPs);
+    if (result === null) {
+      return;
+    }
+    this.winner = result.value;
+    this.log.info(
+      `Winner determined by ${result.votes}/${activeIPs.size} active IPs after electorate shrank`,
     );
     this.archiveGame();
   }

--- a/src/server/VoteTally.ts
+++ b/src/server/VoteTally.ts
@@ -34,4 +34,24 @@ export class VoteRound<T> {
     }
     return null;
   }
+
+  // Re-tally against a shrunken electorate: like result(), but both the
+  // electorate and the counted votes are restricted to `activeIPs`. Votes
+  // from departed IPs must not count here — otherwise a player could vote
+  // for themselves and disconnect, and the re-tally triggered by their own
+  // departure would crown them (#4136 again, one step removed).
+  resultAmong(activeIPs: Set<string>): { value: T; votes: number } | null {
+    for (const candidate of this.candidates.values()) {
+      let votes = 0;
+      for (const ip of candidate.ips) {
+        if (activeIPs.has(ip)) {
+          votes++;
+        }
+      }
+      if (votes * 2 > activeIPs.size) {
+        return { value: candidate.value, votes };
+      }
+    }
+    return null;
+  }
 }

--- a/tests/server/VoteTally.test.ts
+++ b/tests/server/VoteTally.test.ts
@@ -52,3 +52,32 @@ describe("VoteRound", () => {
     expect(round.result(1)).toEqual({ value: "a", votes: 1 });
   });
 });
+
+describe("VoteRound.resultAmong", () => {
+  it("resolves once the remaining electorate unanimously backs a candidate", () => {
+    const round = new VoteRound<string>();
+    round.add("a", "a", "1.1.1.1");
+    // Both electors still active: 1 of 2 is not a strict majority.
+    expect(round.resultAmong(new Set(["1.1.1.1", "2.2.2.2"]))).toBeNull();
+    // The non-voting elector departed: 1 of 1 resolves.
+    expect(round.resultAmong(new Set(["1.1.1.1"]))).toEqual({
+      value: "a",
+      votes: 1,
+    });
+  });
+
+  it("ignores votes cast from departed IPs", () => {
+    const round = new VoteRound<string>();
+    round.add("a", "a", "1.1.1.1");
+    // The voter departed: their vote must not count against the remaining
+    // 1-IP electorate, or a player could vote for themselves and disconnect
+    // to claim the win (#4136).
+    expect(round.resultAmong(new Set(["2.2.2.2"]))).toBeNull();
+  });
+
+  it("returns null for an empty electorate", () => {
+    const round = new VoteRound<string>();
+    round.add("a", "a", "1.1.1.1");
+    expect(round.resultAmong(new Set())).toBeNull();
+  });
+});

--- a/tests/server/WinnerVoteRetally.test.ts
+++ b/tests/server/WinnerVoteRetally.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GameType } from "../../src/core/game/Game";
+import { GameServer } from "../../src/server/GameServer";
+
+// Regression tests for game s5bcKtj8: in a 1v1 the loser disconnected within
+// a second of being eliminated, before their client simulated the win tick
+// and voted. The winner's vote sat at 1 of 2 active IPs and was never
+// re-evaluated, so the game archived winnerless. The electorate shrinking
+// must now trigger a re-tally.
+describe("winner vote re-tally when the electorate shrinks", () => {
+  let mockLogger: any;
+
+  beforeEach(() => {
+    mockLogger = {
+      child: vi.fn().mockReturnThis(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+  });
+
+  function makeClient(clientID: string, ip: string) {
+    return {
+      clientID,
+      ip,
+      persistentID: `pid-${clientID}`,
+      username: clientID,
+      reportedWinner: null,
+      hashes: new Map(),
+      lastPing: Date.now(),
+      ws: { readyState: 3, close: vi.fn(), OPEN: 1 },
+    } as any;
+  }
+
+  function game1v1() {
+    const game = new GameServer("test-game", mockLogger, Date.now(), {
+      gameType: GameType.Public,
+    } as any);
+    const winner = makeClient("client01", "1.1.1.1");
+    const loser = makeClient("client02", "2.2.2.2");
+    (game as any).activeClients = [winner, loser];
+    (game as any).allClients = new Map([
+      ["client01", winner],
+      ["client02", loser],
+    ]);
+    (game as any)._hasStarted = true;
+    (game as any).archiveGame = vi.fn();
+    return { game, winner, loser };
+  }
+
+  const vote = (game: GameServer, client: any, winner: any) =>
+    (game as any).handleWinner(client, {
+      type: "winner",
+      winner,
+      allPlayersStats: {},
+    });
+
+  it("resolves a wedged 1v1 vote when the non-voting loser disconnects", () => {
+    const { game, winner, loser } = game1v1();
+    vote(game, winner, ["player", "client01"]);
+    // 1 of 2 active IPs is not a strict majority: nothing archived yet.
+    expect((game as any).winner).toBeNull();
+    expect((game as any).archiveGame).not.toHaveBeenCalled();
+
+    (game as any).handleClientDisconnect(loser);
+
+    expect((game as any).winner?.winner).toEqual(["player", "client01"]);
+    expect((game as any).archiveGame).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not crown a player who votes for themselves and disconnects", () => {
+    const { game, loser: cheater } = game1v1();
+    vote(game, cheater, ["player", "client02"]);
+    (game as any).handleClientDisconnect(cheater);
+    // The departed cheater's vote must not count against the shrunken
+    // electorate (#4136).
+    expect((game as any).winner).toBeNull();
+    expect((game as any).archiveGame).not.toHaveBeenCalled();
+  });
+
+  it("stays winnerless when everyone leaves without any votes", () => {
+    const { game, winner, loser } = game1v1();
+    (game as any).handleClientDisconnect(loser);
+    (game as any).handleClientDisconnect(winner);
+    expect((game as any).winner).toBeNull();
+    expect((game as any).archiveGame).not.toHaveBeenCalled();
+  });
+
+  it("does not archive again after the game already ended", () => {
+    const { game, winner, loser } = game1v1();
+    vote(game, winner, ["player", "client01"]);
+    (game as any)._hasEnded = true;
+    (game as any).handleClientDisconnect(loser);
+    expect((game as any).winner).toBeNull();
+    expect((game as any).archiveGame).not.toHaveBeenCalled();
+  });
+
+  it("re-tallies when the ping prune in phase() drops a stale client", () => {
+    const { game, winner, loser } = game1v1();
+    vote(game, winner, ["player", "client01"]);
+    // The loser's connection dropped without a ws close event: pings stop,
+    // and only the 60s prune in phase() removes them from activeClients.
+    loser.lastPing = Date.now() - 61_000;
+    game.phase();
+    expect((game as any).winner?.winner).toEqual(["player", "client01"]);
+    expect((game as any).archiveGame).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Problem

Ranked 1v1 game `s5bcKtj8` archived with `winner: null` and no player stats, even though the winner's client showed the win screen and the replay shows the win.

Diagnosis (verified by re-simulating the archived record headlessly at the game's exact commit — all 552 recorded sync hashes reproduce bit-for-bit):

- The win fires in-sim at tick 5530 of 5759 (`WinCheckExecution` ranked-1v1 lone-human rule; the loser is fully eliminated). `WinCheckExecution` is working correctly.
- The loser disconnected within ~1s of being eliminated — **before their own client simulated the win tick and voted**.
- The winner's vote arrived while the loser was still in `activeClients`: 1 of 2 unique IPs, not a strict majority.
- `winnerVotes.result()` was only ever evaluated when a new vote arrived. Nothing re-checked the standing vote when the electorate shrank, so the vote stayed wedged at 1/2 forever and the game archived winnerless (which is also what produces the `Unable to find stats for clientID …` warnings — archive stats ride on the winning vote message).

This race needs no malice and will hit any 1v1 where the loser closes the tab within a second or two of dying — which is the normal way to lose.

## Fix

Re-tally the winner vote whenever `activeClients` shrinks:

- on ws close (`handleClientDisconnect`), and
- on the 60s ping prune in `phase()` (abrupt network drops where the close event can lag far behind).

The re-tally (`VoteRound.resultAmong`) counts **only votes cast from still-active IPs**, with the electorate restricted to the same set. A departed IP's vote never counts in a re-tally, so a player cannot vote for themselves and disconnect to have their own departure crown them — preserving the no-unilateral-self-declare property from #4136.

For `s5bcKtj8` this means: the moment the loser's disconnect lands, the winner's standing vote becomes 1 of 1 → winner recorded, stats populated, ranked result ingested.

## Not addressed (follow-up candidates)

- A malicious loser who **stays connected and never votes** still wedges the vote at 1/2 (ELO-loss dodge). Fixing that needs something like a vote deadline and is a separate design decision.
- Both players leaving near-simultaneously before either client reaches the win tick still archives winnerless (nothing to tally).

## Testing

- `tests/server/WinnerVoteRetally.test.ts`: wedged-1v1 resolution on disconnect, self-vote-then-leave rejection, no-votes case, no re-archive after `end()`, and the `phase()` ping-prune path.
- `tests/server/VoteTally.test.ts`: `resultAmong` unit coverage.
- Full `tests/server` suite passes (35 files, 338 tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)