### PR TITLE
feat(adminbot): read the roster of a lobby the bot created

### DIFF
--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -202,6 +202,8 @@ export function registerAdminBotRoutes(opts: {
     if (game === null) {
       return res.status(409).json({ error: "Game ID already exists" });
     }
+    // Marks the lobby as this bot's, which is what /roster is gated on.
+    game.markBotHosted();
     if (listed) {
       game.setListed(true);
     }
@@ -219,6 +221,27 @@ export function registerAdminBotRoutes(opts: {
       workerIndex: workerId,
       workerPath: ServerEnv.workerPath(id),
     });
+  });
+
+  // Who joined this lobby, and the account behind each one. The public game
+  // record carries no account id, so a host can otherwise see that 96 people
+  // played and identify none of them.
+  //
+  // Bot-hosted lobbies only: this is the one place a clientID can be tied to an
+  // account, and it must not become a way to read the roster of a public or
+  // matchmade game.
+  app.get("/api/adminbot/game/:id/roster", requireAdminBotKey, (req, res) => {
+    const id = req.params.id as string;
+    if (!ownsGame(id, res)) return;
+
+    const game = gm.game(id);
+    if (game === null) {
+      return res.status(404).json({ error: "Game not found" });
+    }
+    if (!game.isBotHosted()) {
+      return res.status(403).json({ error: "not_bot_hosted" });
+    }
+    res.json({ gameID: id, players: game.roster() });
   });
 
   // Read what's happening in a running game. The sim runs on the clients, so

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1684,6 +1684,37 @@ export class GameServer {
     return this.listed;
   }
 
+  // Set once, by the admin-bot create_game route. A lobby with no human creator
+  // is NOT proof of this: public lobbies and matchmade games have none either.
+  private botHosted = false;
+  public markBotHosted(): void {
+    this.botHosted = true;
+  }
+  public isBotHosted(): boolean {
+    return this.botHosted;
+  }
+
+  /** Who joined, and the account behind each one.
+   *
+   *  The public game record is PII-stripped, so a clientID can only be tied back
+   *  to an account by whoever ran the lobby. Without this a host can see that 96
+   *  people played and identify none of them. Restricted to lobbies the admin bot
+   *  created — never a public or matchmade game.
+   *
+   *  allClients, not activeClients: someone who joined and left still appears in
+   *  the record the host has to reconcile against. */
+  public roster(): {
+    clientID: ClientID;
+    publicId: string | undefined;
+    username: string;
+  }[] {
+    return [...this.allClients.values()].map((c) => ({
+      clientID: c.clientID,
+      publicId: c.publicId,
+      username: c.username,
+    }));
+  }
+
   public setListed(listed: boolean): void {
     if (this.listed === listed) {
       // Duplicate toggles must not extend the auto-start deadline.

--- a/tests/server/AdminBotCreateListed.test.ts
+++ b/tests/server/AdminBotCreateListed.test.ts
@@ -17,7 +17,11 @@ function captureCreateHandler(game: { setListed: (v: boolean) => void }) {
   const gm: any = {
     createGame(_id: string, config: Record<string, unknown>) {
       created.config = config;
-      return { ...game, gameInfo: () => ({ gameID: "x" }) };
+      return {
+        markBotHosted: vi.fn(),
+        ...game,
+        gameInfo: () => ({ gameID: "x" }),
+      };
     },
   };
   const log: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/tests/server/AdminBotCreateTeams.test.ts
+++ b/tests/server/AdminBotCreateTeams.test.ts
@@ -28,7 +28,11 @@ function captureCreateHandler() {
     ) {
       created.config = config;
       created.teams = matchmakingTeams;
-      return { setListed: vi.fn(), gameInfo: () => ({ gameID: "x" }) };
+      return {
+        markBotHosted: vi.fn(),
+        setListed: vi.fn(),
+        gameInfo: () => ({ gameID: "x" }),
+      };
     },
   };
   const log: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };

--- a/tests/server/AdminBotRoster.test.ts
+++ b/tests/server/AdminBotRoster.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerAdminBotRoutes } from "../../src/server/AdminBotRoutes";
+import { ServerEnv } from "../../src/server/ServerEnv";
+
+// The roster endpoint is the ONE place a per-game clientID can be tied back to an
+// account: the public record is PII-stripped, so without it a host sees that 96
+// people played and can identify none of them. Which makes the gate the point of
+// the feature — it must never read a lobby the bot did not create.
+function routes(game: unknown) {
+  const table: Record<string, (req: any, res: any) => void> = {};
+  const app: any = {
+    get(path: string, ...h: ((req: any, res: any) => void)[]) {
+      table[path] = h[h.length - 1];
+    },
+    post(path: string, ...h: ((req: any, res: any) => void)[]) {
+      table[path] = h[h.length - 1];
+    },
+  };
+  const gm: any = { game: () => game, createGame: () => game };
+  const log: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+  registerAdminBotRoutes({ app, gm, workerId: 0, log });
+  return table;
+}
+
+function mockRes() {
+  const res: any = {
+    statusCode: 200,
+    body: undefined,
+    status(code: number) {
+      res.statusCode = code;
+      return res;
+    },
+    json(payload: unknown) {
+      res.body = payload;
+      return res;
+    },
+  };
+  return res;
+}
+
+const ROSTER = [
+  { clientID: "c1", publicId: "pub1", username: "ana" },
+  { clientID: "c2", publicId: undefined, username: "anon" },
+];
+
+beforeEach(() => {
+  vi.spyOn(ServerEnv, "workerIndex").mockReturnValue(0);
+});
+
+describe("GET /api/adminbot/game/:id/roster", () => {
+  it("returns the clientID → publicId mapping for a bot-hosted lobby", () => {
+    const table = routes({ isBotHosted: () => true, roster: () => ROSTER });
+    const res = mockRes();
+    table["/api/adminbot/game/:id/roster"]({ params: { id: "aaaaaaaa" } }, res);
+    expect(res.statusCode).toBe(200);
+    expect(res.body.players).toEqual(ROSTER);
+  });
+
+  it("refuses a lobby the bot did not create", () => {
+    // A public or matchmade game has no human creator either, so "no creator"
+    // cannot stand in for "ours" — this is why the flag exists.
+    const table = routes({ isBotHosted: () => false, roster: () => ROSTER });
+    const res = mockRes();
+    table["/api/adminbot/game/:id/roster"]({ params: { id: "aaaaaaaa" } }, res);
+    expect(res.statusCode).toBe(403);
+    expect(res.body).toEqual({ error: "not_bot_hosted" });
+  });
+
+  it("404s an unknown game rather than leaking whether it exists elsewhere", () => {
+    const table = routes(null);
+    const res = mockRes();
+    table["/api/adminbot/game/:id/roster"]({ params: { id: "aaaaaaaa" } }, res);
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("rejects a malformed game id", () => {
+    const table = routes({ isBotHosted: () => true, roster: () => ROSTER });
+    const res = mockRes();
+    table["/api/adminbot/game/:id/roster"]({ params: { id: "nope!" } }, res);
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("marks a lobby it creates as bot-hosted", () => {
+    const markBotHosted = vi.fn();
+    const table = routes({
+      markBotHosted,
+      setListed: vi.fn(),
+      gameInfo: () => ({ gameID: "aaaaaaaa" }),
+    });
+    vi.spyOn(ServerEnv, "generateGameIdForWorker").mockReturnValue("aaaaaaaa");
+    vi.spyOn(ServerEnv, "workerPath").mockReturnValue("w0");
+    table["/api/adminbot/create_game"](
+      { body: { gameMap: "World" } },
+      mockRes(),
+    );
+    expect(markBotHosted).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
The public game record is PII-stripped, so a `clientID` cannot be tied back to an account by anyone. A host running a public lobby sees that 96 people played and can identify none of them — the whole field is uncreditable, which makes per-player stats, scoring and unique-player counts impossible for everyone who is not already on a roster the host knew in advance.

```
GET /api/adminbot/game/:id/roster
→ { gameID, players: [{ clientID, publicId, username }] }
```

`allClients`, not `activeClients`: someone who joined and left still appears in the record the host has to reconcile against.

**Restricted to lobbies created through `create_game`**, which now mark themselves as bot-hosted. A missing human creator cannot stand in for that — public and matchmade games have none either, and this must never read their rosters. A lobby that isn't bot-hosted gets a 403, an unknown id a 404.

This is the only place a per-game `clientID` can be linked to an account, so the gate is the feature. Five tests cover it: the mapping is returned for a bot-hosted lobby, refused for one the bot didn't create, 404 on unknown, 400 on a malformed id, and `create_game` marks what it creates. Two existing `create_game` test fakes gained the new method.
