### PR TITLE
Add "Request Allies to Attack" option to the nation radial menu

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1474,6 +1474,8 @@
   "radial_menu": {
     "delete_unit_description": "Click to delete the nearest unit",
     "delete_unit_title": "Delete Unit",
+    "target_description": "Mark this nation as a target, calling on your allies to attack it",
+    "target_title": "Request Allies to Attack",
     "upgrade_x": "Upgrade x{amount}"
   },
   "relation": {

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -165,7 +165,6 @@ const infoChatElement: MenuElement = {
       })),
 };
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const allyTargetElement: MenuElement = {
   id: "ally_target",
   name: "target",
@@ -175,6 +174,16 @@ const allyTargetElement: MenuElement = {
   },
   color: COLORS.target,
   icon: targetIcon,
+  tooltipKeys: [
+    {
+      key: "radial_menu.target_title",
+      className: "title",
+    },
+    {
+      key: "radial_menu.target_description",
+      className: "description",
+    },
+  ],
   action: (params: MenuElementParams) => {
     params.playerActionHandler.handleTargetPlayer(params.selected!.id());
     params.closeMenu();
@@ -810,6 +819,7 @@ export const rootMenuElement: MenuElement = {
             showDonateInsteadOfAttack
               ? donateGoldRadialElement
               : attackMenuElement,
+            ...(!isAllied ? [allyTargetElement] : []),
           ]),
     ];
 


### PR DESCRIPTION
## Summary
- Wires the existing (but unused) target-marking feature into the double-click/right-click radial menu on enemy nations, so players can mark a nation and call on their allies to attack it directly from the map — previously this required opening the side player panel.
- The underlying mechanism already existed end-to-end (`TargetPlayerIntentSchema`, `TargetPlayerExecution`, AI allies reacting via `transitiveTargets()`, a relation penalty on the target, and an in-game notification to friendly players) — the menu element (`allyTargetElement`) was defined in `RadialMenuElements.ts` but explicitly excluded from the ring, marked `eslint-disable no-unused-vars`.
- Added a hover tooltip ("Request Allies to Attack" / description) using the existing `radial_menu` translation namespace, and only show the option for non-allied targets (allies/teammates can't be targeted — `canTarget` already disables it, but hiding it avoids a dead icon in that slot).

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npx eslint src/client/hud/layers/RadialMenuElements.ts` — clean
- [x] `npx vitest run` — 273 files / 3147 tests passed
- [x] Manually verified in a running dev server: right-clicked an enemy nation, confirmed the new target icon + tooltip appear in the ring, clicked it, and confirmed via `myPlayer.targets()` that the intent was applied end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)