### PR TITLE
fix(core): cancel in-flight MIRVs and warheads on alliance acceptance (#5042)

### DIFF
--- a/src/core/execution/alliance/AllianceRequestExecution.ts
+++ b/src/core/execution/alliance/AllianceRequestExecution.ts
@@ -92,28 +92,48 @@ export class AllianceRequestExecution implements Execution {
     const players = [this.requestor, recipient];
 
     for (const launcher of players) {
-      for (const unit of launcher.units(
+      const other = launcher === this.requestor ? recipient : this.requestor;
+
+      for (const unit of launcher.units([
         UnitType.AtomBomb,
         UnitType.HydrogenBomb,
-      )) {
+        UnitType.MIRV,
+        UnitType.MIRVWarhead,
+      ])) {
         if (!unit.isActive() || unit.reachedTarget()) continue;
 
         const targetTile = unit.targetTile();
         if (!targetTile) continue;
 
-        const other = launcher === this.requestor ? recipient : this.requestor;
-        const magnitude = this.mg.config().nukeMagnitudes(unit.type());
         if (
-          !wouldNukeBreakAlliance({
-            game: this.mg,
-            targetTile,
-            magnitude,
-            allySmallIds: new Set([other.smallID()]),
-            threshold: this.mg.config().nukeAllianceBreakThreshold(),
-          })
+          unit.type() === UnitType.MIRV ||
+          unit.type() === UnitType.MIRVWarhead
         ) {
-          continue;
+          // A MIRV (and each individual warhead it separates into) breaks an
+          // alliance unconditionally when aimed at a current ally - see the
+          // "Betrayal on launch" check in MirvExecution.init() - unlike
+          // AtomBomb/HydrogenBomb, which only break above a tile-count
+          // threshold. An in-flight MIRV has to be cancelled on acceptance
+          // by that same unconditional rule: otherwise it keeps flying,
+          // separates into hundreds of warheads, and devastates the player
+          // you just allied with, with no alliance-break or relation
+          // penalty since MIRVWarhead impacts don't run that check either.
+          if (this.mg.owner(targetTile) !== other) continue;
+        } else {
+          const magnitude = this.mg.config().nukeMagnitudes(unit.type());
+          if (
+            !wouldNukeBreakAlliance({
+              game: this.mg,
+              targetTile,
+              magnitude,
+              allySmallIds: new Set([other.smallID()]),
+              threshold: this.mg.config().nukeAllianceBreakThreshold(),
+            })
+          ) {
+            continue;
+          }
         }
+
         unit.delete(false);
         neutralized.set(launcher, (neutralized.get(launcher) ?? 0) + 1);
       }

--- a/tests/AllianceAcceptNukes.test.ts
+++ b/tests/AllianceAcceptNukes.test.ts
@@ -1,5 +1,6 @@
 import { AllianceRequestExecution } from "src/core/execution/alliance/AllianceRequestExecution";
 import { GameUpdateType } from "src/core/game/GameUpdates";
+import { MirvExecution } from "../src/core/execution/MIRVExecution";
 import { NukeExecution } from "../src/core/execution/NukeExecution";
 import {
   Game,
@@ -146,5 +147,64 @@ describe("Alliance acceptance immediately destroys in-flight nukes", () => {
           m === "events_display.alliance_nukes_destroyed_incoming",
       ),
     ).toBe(true);
+  });
+
+  test("accepting alliance destroys an in-flight MIRV between the newly allied players", () => {
+    game.addExecution(new MirvExecution(player1, game.ref(5, 5)));
+
+    game.executeNextTick(); // init: not allied yet, so no betrayal-on-launch break
+    game.executeNextTick(); // spawn MIRV
+
+    expect(game.units(UnitType.MIRV)).toHaveLength(1);
+
+    expect(player2.isAlliedWith(player1)).toBe(false);
+    expect(player1.isFriendly(player2)).toBe(false);
+
+    game.addExecution(new AllianceRequestExecution(player1, player2.id()));
+    game.executeNextTick(); // creates request
+    game.addExecution(new AllianceRequestExecution(player2, player1.id()));
+    game.executeNextTick(); // counter-request auto-accepts
+
+    expect(player2.isAlliedWith(player1)).toBe(true);
+    expect(player1.isFriendly(player2)).toBe(true);
+
+    // Without the fix this MIRV keeps flying, separates into ~350
+    // MIRVWarheads, and devastates the player you just allied with.
+    expect(game.units(UnitType.MIRV)).toHaveLength(0);
+  });
+
+  test("accepting alliance destroys an in-flight MIRV warhead between the newly allied players", () => {
+    // MIRVWarhead's canBuild() returns the target tile itself (in real play
+    // MirvExecution always supplies an explicit separation point as src), so
+    // an explicit src plus a wait is needed here - otherwise src defaults to
+    // the target (instant detonation) or the warhead's speed covers this
+    // small test map before the alliance can even be requested.
+    game.addExecution(
+      new NukeExecution(
+        UnitType.MIRVWarhead,
+        player1,
+        game.ref(5, 5),
+        game.ref(0, 0),
+        -1,
+        5,
+      ),
+    );
+
+    game.executeNextTick(); // init
+    game.executeNextTick(); // spawn warhead
+
+    expect(game.units(UnitType.MIRVWarhead)).toHaveLength(1);
+
+    game.addExecution(new AllianceRequestExecution(player1, player2.id()));
+    game.executeNextTick();
+    game.addExecution(new AllianceRequestExecution(player2, player1.id()));
+    game.executeNextTick();
+
+    expect(player2.isAlliedWith(player1)).toBe(true);
+
+    // A MIRVWarhead never runs maybeBreakAlliances() on impact (MIRVs only
+    // break alliance at launch), so a warhead that's already separated has
+    // to be caught here too, or it silently lands on the new ally.
+    expect(game.units(UnitType.MIRVWarhead)).toHaveLength(0);
   });
 });


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #5042

## Description:

`cancelNukesBetweenAlliedPlayers()` (executed in `AllianceRequestExecution` when an alliance request is accepted) previously only queried `UnitType.AtomBomb` and `UnitType.HydrogenBomb`, omitting `UnitType.MIRV` and `UnitType.MIRVWarhead`.

This created a severe gameplay exploit: `MirvExecution.init()` strictly enforces an unconditional "Betrayal on launch" rule when a MIRV is aimed at an existing ally. However, if two players allied while a legitimately launched MIRV was mid-flight, nothing cancelled the missile. It would continue flying, separate into ~350 `MIRVWarhead` units, and devastate the newly allied player with zero alliance break or relation penalty (because individual `MIRVWarhead` detonations never trigger alliance break checks).

### Solution:
1. Extended `launcher.units([...])` in `AllianceRequestExecution.ts` to include `UnitType.MIRV` and `UnitType.MIRVWarhead`.
2. For MIRVs and warheads, cancellation verifies target tile ownership (`this.mg.owner(targetTile) === other`), matching `MirvExecution`'s unconditional launch check rather than the tile-count blast threshold applied to single bombs.
3. Added 2 regression tests to `tests/AllianceAcceptNukes.test.ts` (covering both in-flight MIRVs and separated warheads).

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Core simulation logic)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — Reuses existing alliance_nukes_destroyed message keys)
- [x] I have added relevant tests to the test directory (`tests/AllianceAcceptNukes.test.ts`)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
