### PR TITLE
Fix visual nuke interception indicator when targetable within sam range

### DIFF
--- a/src/client/render/gl/utils/NukeTrajectory.ts
+++ b/src/client/render/gl/utils/NukeTrajectory.ts
@@ -211,23 +211,28 @@ export function computeTrajectoryThresholds(
         continue;
       }
 
+      // Check exact boundary when crossing into the targetable terminal phase
+      if (
+        tUntargetableEnd >= 0 &&
+        tPrev < tUntargetableEnd &&
+        t >= tUntargetableEnd
+      ) {
+        const xe = bezier(tUntargetableEnd, cp.p0x, cp.p1x, cp.p2x, cp.p3x);
+        const ye = bezier(tUntargetableEnd, cp.p0y, cp.p1y, cp.p2y, cp.p3y);
+        for (let s = 0; s < sams.length; s++) {
+          if (distSq(xe, ye, sams[s].x, sams[s].y) <= sams[s].rangeSq) {
+            tSamIntercept = tUntargetableEnd;
+            break;
+          }
+        }
+        if (tSamIntercept < 1.0) break;
+      }
+
       const x = bezier(t, cp.p0x, cp.p1x, cp.p2x, cp.p3x);
       const y = bezier(t, cp.p0y, cp.p1y, cp.p2y, cp.p3y);
 
       for (let s = 0; s < sams.length; s++) {
         if (distSq(x, y, sams[s].x, sams[s].y) <= sams[s].rangeSq) {
-          if (
-            tUntargetableEnd >= 0 &&
-            tPrev < tUntargetableEnd &&
-            t >= tUntargetableEnd
-          ) {
-            const xe = bezier(tUntargetableEnd, cp.p0x, cp.p1x, cp.p2x, cp.p3x);
-            const ye = bezier(tUntargetableEnd, cp.p0y, cp.p1y, cp.p2y, cp.p3y);
-            if (distSq(xe, ye, sams[s].x, sams[s].y) <= sams[s].rangeSq) {
-              tSamIntercept = tUntargetableEnd;
-              break;
-            }
-          }
           const lo =
             tUntargetableEnd >= 0 && tPrev < tUntargetableEnd
               ? tUntargetableEnd

--- a/src/client/render/gl/utils/NukeTrajectory.ts
+++ b/src/client/render/gl/utils/NukeTrajectory.ts
@@ -201,12 +201,12 @@ export function computeTrajectoryThresholds(
   if (sams.length > 0) {
     for (let i = 1; i <= THRESHOLD_SAMPLES; i++) {
       const t = i * dt;
+      const tPrev = t - dt;
 
-      // Skip untargetable segment
       if (
         tUntargetableStart >= 0 &&
-        t >= tUntargetableStart &&
-        t <= tUntargetableEnd
+        t > tUntargetableStart &&
+        t < tUntargetableEnd
       ) {
         continue;
       }
@@ -214,14 +214,30 @@ export function computeTrajectoryThresholds(
       const x = bezier(t, cp.p0x, cp.p1x, cp.p2x, cp.p3x);
       const y = bezier(t, cp.p0y, cp.p1y, cp.p2y, cp.p3y);
 
-      for (const sam of sams) {
-        if (distSq(x, y, sam.x, sam.y) <= sam.rangeSq) {
+      for (let s = 0; s < sams.length; s++) {
+        if (distSq(x, y, sams[s].x, sams[s].y) <= sams[s].rangeSq) {
+          if (
+            tUntargetableEnd >= 0 &&
+            tPrev < tUntargetableEnd &&
+            t >= tUntargetableEnd
+          ) {
+            const xe = bezier(tUntargetableEnd, cp.p0x, cp.p1x, cp.p2x, cp.p3x);
+            const ye = bezier(tUntargetableEnd, cp.p0y, cp.p1y, cp.p2y, cp.p3y);
+            if (distSq(xe, ye, sams[s].x, sams[s].y) <= sams[s].rangeSq) {
+              tSamIntercept = tUntargetableEnd;
+              break;
+            }
+          }
+          const lo =
+            tUntargetableEnd >= 0 && tPrev < tUntargetableEnd
+              ? tUntargetableEnd
+              : tPrev;
           tSamIntercept = refineCrossing(
             cp,
-            sam.x,
-            sam.y,
-            sam.rangeSq,
-            t - dt,
+            sams[s].x,
+            sams[s].y,
+            sams[s].rangeSq,
+            lo,
             t,
             false,
           );

--- a/tests/NukeTrajectory.test.ts
+++ b/tests/NukeTrajectory.test.ts
@@ -33,12 +33,20 @@ describe("NukeTrajectory thresholds", () => {
     expect(data.p3x).toBe(800);
   });
 
-  test("intercepts nuke when targetable range begins inside SAM radius", () => {
+  test("intercepts nuke when SAM covers tUntargetableEnd but excludes next sample", () => {
     const cp = horizontalCp(100, 800);
     const thBase = computeTrajectoryThresholds(cp, 100, 500, 800, 500, []);
+    const t = thBase.tUntargetableEnd,
+      T = 1 - t;
+    const x =
+      T * (T * (T * cp.p0x + 3 * t * cp.p1x) + 3 * t * t * cp.p2x) +
+      t * t * t * cp.p3x;
+    const y =
+      T * (T * (T * cp.p0y + 3 * t * cp.p1y) + 3 * t * t * cp.p2y) +
+      t * t * t * cp.p3y;
     const th = computeTrajectoryThresholds(cp, 100, 500, 800, 500, [
-      { x: cp.p2x, y: cp.p2y, rangeSq: 200 * 200 },
+      { x, y, rangeSq: 25 },
     ]);
-    expect(th.tSamIntercept).toBeCloseTo(thBase.tUntargetableEnd, 2);
+    expect(th.tSamIntercept).toBe(t);
   });
 });

--- a/tests/NukeTrajectory.test.ts
+++ b/tests/NukeTrajectory.test.ts
@@ -32,4 +32,13 @@ describe("NukeTrajectory thresholds", () => {
     expect(data.p0x).toBe(100);
     expect(data.p3x).toBe(800);
   });
+
+  test("intercepts nuke when targetable range begins inside SAM radius", () => {
+    const cp = horizontalCp(100, 800);
+    const thBase = computeTrajectoryThresholds(cp, 100, 500, 800, 500, []);
+    const th = computeTrajectoryThresholds(cp, 100, 500, 800, 500, [
+      { x: cp.p2x, y: cp.p2y, rangeSq: 200 * 200 },
+    ]);
+    expect(th.tSamIntercept).toBeCloseTo(thBase.tUntargetableEnd, 2);
+  });
 });


### PR DESCRIPTION


> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

None: small fix.

## Description:

Fixes the visual display of nuke interception when the trajectory becomes targetable within SAM range + small perf improvement

1. Skips untargetable steps: Drops all bezier math and distance checks while the missile is in mid-air (continue), eliminating calculations for ~40% of the path.
2. Instant exit on intercept: Checks the boundary point tUntargetableEnd directly in distance checks. If inside SAM range, it records the hit and breaks, avoiding a 10-iteration binary search.
3. Zero Allocations: Replaces for-of iterator with indexed sams[i] loops

Performance:
#### Comparison 10 repeated tests

| Scenario | Candidate | Average Time (100k iters) | Min Time | Max Time | Throughput |
| :--- | :--- | :--- | :--- | :--- | :--- |
|no SAMs | New | 74.24 ms | 70.92 ms | 85.14 ms | 1,346,982 ops/sec |
| | Main | 76.49 ms | 73.11 ms | 84.79 ms | 1,307,360 ops/sec |
| Dense (20 SAMs) | New | 91.08 ms | 89.23 ms | 95.55 ms | 1,097,935 ops/sec |
| | Main | 93.11 ms | 91.68 ms | 94.92 ms | 1,073,998 ops/sec |
| Sparse (5 SAMs) | New | 141.69 ms | 134.94 ms | 159.38 ms | 705,766 ops/sec |
| | Main | 145.54 ms | 138.43 ms | 182.41 ms | 687,096 ops/sec |

Before:
<img width="640" height="338" alt="image" src="https://github.com/user-attachments/assets/5c458e11-d47d-4151-9f2c-d7ec54dbc9cf" />
After:
<img width="464" height="601" alt="image" src="https://github.com/user-attachments/assets/d991a253-1193-480b-8850-5a45612d03d6" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
