### PR TITLE
fix(auth): tell users why a duplicate sign-in was rejected

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -32,6 +32,7 @@
     "linked_to_google": "Linked to Google",
     "linked_to_google_email": "Linked to Google ({email})",
     "log_out": "Log Out",
+    "login_email_exists": "You already have an account with this email. Sign in to it, then link this account in settings.",
     "manage_subscription": "Manage",
     "marketing_desc": "Occasional news, events, and game updates. Unsubscribe anytime.",
     "marketing_no_email": "Link an email to your account to subscribe to updates.",

--- a/src/client/AccountModal.ts
+++ b/src/client/AccountModal.ts
@@ -37,6 +37,7 @@ import { modalHeader } from "./components/ui/ModalHeader";
 import "./components/UsernamePanel";
 import { fetchCosmetics } from "./Cosmetics";
 import { crazyGamesSDK, type CrazyGamesUser } from "./CrazyGamesSDK";
+import { consumeLoginResult, LoginResult } from "./LoginResult";
 import { playerProfileUrl } from "./PlayerProfileModal";
 import { translateText } from "./Utils";
 
@@ -50,6 +51,9 @@ export class AccountModal extends BaseModal {
   // from the SDK, not our backend user object.
   @state() private crazyGamesUser: CrazyGamesUser | null = null;
   @state() private consentBusy: boolean = false;
+  // One-shot outcome of a rejected sign-in, read from the `login=` router
+  // arg on open. Reassigned on every open, so reopening clears it.
+  @state() private loginError: LoginResult | undefined;
 
   private userMeResponse: UserMeResponse | null = null;
   private statsTree: PlayerStatsTree | null = null;
@@ -666,6 +670,32 @@ export class AccountModal extends BaseModal {
     `;
   }
 
+  // Shown when a sign-in was rejected because the provider's verified email
+  // already belongs to an account. We deliberately don't name which provider
+  // that account uses — the visitor has only proven control of the email.
+  private renderLoginError(): TemplateResult {
+    if (this.loginError === undefined) return html``;
+    return html`
+      <div
+        class="mb-6 flex items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4"
+      >
+        <span class="text-red-400 text-lg leading-none" aria-hidden="true">
+          &#9888;
+        </span>
+        <p class="flex-1 text-sm text-red-200">
+          ${translateText("account_modal.login_email_exists")}
+        </p>
+        <button
+          class="text-red-200/60 hover:text-red-200 text-lg leading-none"
+          aria-label=${translateText("common.close")}
+          @click=${() => (this.loginError = undefined)}
+        >
+          &times;
+        </button>
+      </div>
+    `;
+  }
+
   private renderLoginOptions() {
     return html`
       <div class="flex items-center justify-center p-6 min-h-full">
@@ -696,6 +726,8 @@ export class AccountModal extends BaseModal {
             </p>
             ${this.renderCurrency()}
           </div>
+
+          ${this.renderLoginError()}
 
           <div class="space-y-6">
             <!-- Discord Login Button -->
@@ -853,6 +885,7 @@ export class AccountModal extends BaseModal {
   protected onOpen(args?: Record<string, unknown>): void {
     this.isLoadingUser = true;
     this.handleLinkResult(args);
+    this.loginError = consumeLoginResult(args);
 
     this.refreshCrazyGamesUser();
 

--- a/src/client/LoginResult.ts
+++ b/src/client/LoginResult.ts
@@ -1,0 +1,39 @@
+/**
+ * One-shot login outcomes the auth callbacks hand back on the URL they
+ * redirect to, as `#login=<result>`.
+ *
+ * `email_exists` means the sign-in was rejected because the provider's
+ * verified email already belongs to an account: we never auto-merge by email,
+ * so the user has to sign into the account they have and link this provider
+ * from settings.
+ *
+ * `cancel` is also sent (the user backed out at the provider) but needs no
+ * feedback, so it is deliberately not a recognised result here.
+ */
+export type LoginResult = "email_exists";
+
+const KNOWN_RESULTS: readonly string[] = ["email_exists"];
+
+/**
+ * Read the one-shot `login=<result>` router arg and strip it from the URL so a
+ * refresh or re-open doesn't replay it. Returns undefined when the param is
+ * absent or isn't a result we surface.
+ */
+export function consumeLoginResult(
+  args?: Record<string, unknown>,
+): LoginResult | undefined {
+  const login = typeof args?.login === "string" ? args.login : undefined;
+  if (login === undefined) return undefined;
+
+  // replaceState doesn't fire hashchange, so removing the param won't re-route.
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  params.delete("login");
+  const rest = params.toString();
+  history.replaceState(
+    null,
+    "",
+    rest ? `#${rest}` : window.location.pathname + window.location.search,
+  );
+
+  return KNOWN_RESULTS.includes(login) ? (login as LoginResult) : undefined;
+}

--- a/tests/client/AccountModal.rendering.test.ts
+++ b/tests/client/AccountModal.rendering.test.ts
@@ -103,6 +103,13 @@ describe("AccountModal — rendering", () => {
     await modal.updateComplete;
   }
 
+  // onOpen kicks off getUserMe(); let the microtasks settle before asserting on
+  // the rendered output.
+  async function flushOpen(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await modal.updateComplete;
+  }
+
   it("shows the Steam account (no link/login CTAs) for a Steam-primary user", async () => {
     const userMe = makeUserMe({
       steam: {
@@ -162,5 +169,42 @@ describe("AccountModal — rendering", () => {
     // Still a logged-in view, not the login-options screen.
     expect(modal.querySelector("currency-display")).toBeTruthy();
     expect(text).toContain("account_modal.log_out");
+  });
+  // The duplicate-account rejection: the auth callback bounced us back with
+  // `login=email_exists` rather than creating a second account, and the user
+  // needs to be told why nothing happened and what to do instead.
+  it("shows the duplicate-account error after a rejected sign-in", async () => {
+    modal.open({ login: "email_exists" });
+    await flushOpen();
+
+    // Logged out, so the login options screen is what renders.
+    const text = modal.textContent ?? "";
+    expect(text).toContain("main.login_google");
+    expect(text).toContain("account_modal.login_email_exists");
+  });
+
+  it("shows no login error on an ordinary open", async () => {
+    modal.open();
+    await flushOpen();
+
+    const text = modal.textContent ?? "";
+    expect(text).toContain("main.login_google");
+    expect(text).not.toContain("account_modal.login_email_exists");
+  });
+
+  it("drops the error when the modal is reopened", async () => {
+    modal.open({ login: "email_exists" });
+    await flushOpen();
+    expect(modal.textContent ?? "").toContain(
+      "account_modal.login_email_exists",
+    );
+
+    modal.close();
+    modal.open();
+    await flushOpen();
+
+    expect(modal.textContent ?? "").not.toContain(
+      "account_modal.login_email_exists",
+    );
   });
 });

--- a/tests/client/LoginResult.test.ts
+++ b/tests/client/LoginResult.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { consumeLoginResult } from "../../src/client/LoginResult";
+
+describe("consumeLoginResult", () => {
+  beforeEach(() => {
+    history.replaceState(null, "", "/");
+  });
+
+  it("returns the login result the auth callback sent back", () => {
+    expect(consumeLoginResult({ login: "email_exists" })).toBe("email_exists");
+  });
+
+  it("returns undefined when there is no login param", () => {
+    expect(consumeLoginResult({ tab: "account" })).toBeUndefined();
+    expect(consumeLoginResult(undefined)).toBeUndefined();
+  });
+
+  it("ignores a login value it doesn't recognise", () => {
+    expect(consumeLoginResult({ login: "cancel" })).toBeUndefined();
+    expect(consumeLoginResult({ login: "../../evil" })).toBeUndefined();
+  });
+
+  it("strips the one-shot param so a refresh doesn't replay it", () => {
+    history.replaceState(null, "", "/#modal=account&login=email_exists");
+
+    consumeLoginResult({ login: "email_exists" });
+
+    expect(window.location.hash).toBe("#modal=account");
+  });
+
+  it("clears the hash entirely when login was the only param", () => {
+    history.replaceState(null, "", "/#login=email_exists");
+
+    consumeLoginResult({ login: "email_exists" });
+
+    expect(window.location.hash).toBe("");
+  });
+});


### PR DESCRIPTION
## Context

Paired with openfrontio/infra#531. The API no longer creates a second account when a Google/Discord sign-in carries a verified email that already belongs to a player — it bounces back with `#login=email_exists` instead. Without this PR the user is redirected home with **no feedback at all** and no idea why nothing happened.

## Change

- `LoginResult.ts` — `consumeLoginResult()` reads the one-shot `login=` router arg and strips it from the URL so a refresh doesn't replay it. Mirrors how the existing `link=` results are consumed.
- `AccountModal` renders it as a dismissible banner above the sign-in buttons, so the next action is already on screen.
- One new `en.json` key. No other translation files touched.

## Copy

> You already have an account with this email. Sign in to it, then link this account in settings.

It deliberately **doesn't name which provider** the existing account uses. The visitor has only proven control of the email address, not of the account, so we confirm an account exists and stop there.

## Note on scope

No fallback for a return URL missing `#modal=account`. `BaseModal.open()` always calls `modalRouter.syncOpened()` before the user can reach a login button — including the `showPage("page-account")` paths from Matchmaking/ClanModal/SinglePlayerModal — so the arg always arrives. A fallback would have been untested dead code.

## Testing

TDD: tests written and watched fail first.

- `consumeLoginResult`: returns the result, ignores unrecognised values, strips the param, clears the hash when it was the only param
- `AccountModal` rendering: banner shows after a rejected sign-in, absent on an ordinary open, dropped on reopen

Full suite: **234 files / 2749 tests passing**, `tsc --noEmit` and lint clean.

## Landing on main too

Same change ported to `main` in a separate PR — `AccountModal.ts` has diverged there (`GoogleLinkResult.ts` / `AccountSettingsModal.ts` extracted), so it needed a real resolution rather than a clean pick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)