### PR TITLE
fix(auth): tell users why a duplicate sign-in was rejected (main port of #5047)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -41,6 +41,7 @@
     "linked_account": "Logged in as {account_name}",
     "linked_to_google": "Linked to Google",
     "linked_to_google_email": "Linked to Google ({email})",
+    "login_email_exists": "You already have an account with this email. Sign in to it, then link this account in settings.",
     "manage_subscription": "Manage",
     "marketing_desc": "Occasional news, events, and game updates. Unsubscribe anytime.",
     "marketing_no_email": "Link an email to your account to subscribe to updates.",

--- a/src/client/AccountModal.ts
+++ b/src/client/AccountModal.ts
@@ -30,6 +30,7 @@ import { googleLinkButton } from "./components/ui/GoogleLinkButton";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { crazyGamesSDK, type CrazyGamesUser } from "./CrazyGamesSDK";
 import { consumeGoogleLinkResult } from "./GoogleLinkResult";
+import { consumeLoginResult, LoginResult } from "./LoginResult";
 import { playerProfileUrl } from "./utilities/PlayerProfileUrl";
 import { translateText } from "./Utils";
 
@@ -62,6 +63,9 @@ export class AccountModal extends BaseModal {
   // Set on CrazyGames when a CrazyGames user is signed in. Their identity comes
   // from the SDK, not our backend user object.
   @state() private crazyGamesUser: CrazyGamesUser | null = null;
+  // One-shot outcome of a rejected sign-in, read from the `login=` router
+  // arg on open. Reassigned on every open, so reopening clears it.
+  @state() private loginError: LoginResult | undefined;
 
   private userMeResponse: UserMeResponse | null = null;
   private statsTree: PlayerStatsTree | null = null;
@@ -560,6 +564,32 @@ export class AccountModal extends BaseModal {
     this.restoreGamesScrollAfterOpen = false;
   }
 
+  // Shown when a sign-in was rejected because the provider's verified email
+  // already belongs to an account. We deliberately don't name which provider
+  // that account uses — the visitor has only proven control of the email.
+  private renderLoginError(): TemplateResult {
+    if (this.loginError === undefined) return html``;
+    return html`
+      <div
+        class="mb-6 flex items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/10 p-4"
+      >
+        <span class="text-red-400 text-lg leading-none" aria-hidden="true">
+          &#9888;
+        </span>
+        <p class="flex-1 text-sm text-red-200">
+          ${translateText("account_modal.login_email_exists")}
+        </p>
+        <button
+          class="text-red-200/60 hover:text-red-200 text-lg leading-none"
+          aria-label=${translateText("common.close")}
+          @click=${() => (this.loginError = undefined)}
+        >
+          &times;
+        </button>
+      </div>
+    `;
+  }
+
   private renderLoginOptions() {
     return html`
       <div class="flex items-center justify-center p-6 min-h-full">
@@ -590,6 +620,8 @@ export class AccountModal extends BaseModal {
             </p>
             ${this.renderCurrency()}
           </div>
+
+          ${this.renderLoginError()}
 
           <div class="space-y-6">
             <!-- Discord Login Button -->
@@ -710,6 +742,7 @@ export class AccountModal extends BaseModal {
   protected onOpen(args?: Record<string, unknown>): void {
     this.isLoadingUser = true;
     consumeGoogleLinkResult(args);
+    this.loginError = consumeLoginResult(args);
 
     this.refreshCrazyGamesUser();
 

--- a/src/client/LoginResult.ts
+++ b/src/client/LoginResult.ts
@@ -1,0 +1,39 @@
+/**
+ * One-shot login outcomes the auth callbacks hand back on the URL they
+ * redirect to, as `#login=<result>`.
+ *
+ * `email_exists` means the sign-in was rejected because the provider's
+ * verified email already belongs to an account: we never auto-merge by email,
+ * so the user has to sign into the account they have and link this provider
+ * from settings.
+ *
+ * `cancel` is also sent (the user backed out at the provider) but needs no
+ * feedback, so it is deliberately not a recognised result here.
+ */
+export type LoginResult = "email_exists";
+
+const KNOWN_RESULTS: readonly string[] = ["email_exists"];
+
+/**
+ * Read the one-shot `login=<result>` router arg and strip it from the URL so a
+ * refresh or re-open doesn't replay it. Returns undefined when the param is
+ * absent or isn't a result we surface.
+ */
+export function consumeLoginResult(
+  args?: Record<string, unknown>,
+): LoginResult | undefined {
+  const login = typeof args?.login === "string" ? args.login : undefined;
+  if (login === undefined) return undefined;
+
+  // replaceState doesn't fire hashchange, so removing the param won't re-route.
+  const params = new URLSearchParams(window.location.hash.slice(1));
+  params.delete("login");
+  const rest = params.toString();
+  history.replaceState(
+    null,
+    "",
+    rest ? `#${rest}` : window.location.pathname + window.location.search,
+  );
+
+  return KNOWN_RESULTS.includes(login) ? (login as LoginResult) : undefined;
+}

--- a/tests/client/AccountModal.rendering.test.ts
+++ b/tests/client/AccountModal.rendering.test.ts
@@ -104,6 +104,13 @@ describe("AccountModal — rendering", () => {
     await modal.updateComplete;
   }
 
+  // onOpen kicks off getUserMe(); let the microtasks settle before asserting on
+  // the rendered output.
+  async function flushOpen(): Promise<void> {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await modal.updateComplete;
+  }
+
   it("shows the Steam account (no link/login CTAs) for a Steam-primary user", async () => {
     const userMe = makeUserMe({
       steam: {
@@ -237,5 +244,42 @@ describe("AccountModal — rendering", () => {
 
       expect(findLinkGateButton()).toBeUndefined();
     });
+  });
+  // The duplicate-account rejection: the auth callback bounced us back with
+  // `login=email_exists` rather than creating a second account, and the user
+  // needs to be told why nothing happened and what to do instead.
+  it("shows the duplicate-account error after a rejected sign-in", async () => {
+    modal.open({ login: "email_exists" });
+    await flushOpen();
+
+    // Logged out, so the login options screen is what renders.
+    const text = modal.textContent ?? "";
+    expect(text).toContain("main.login_google");
+    expect(text).toContain("account_modal.login_email_exists");
+  });
+
+  it("shows no login error on an ordinary open", async () => {
+    modal.open();
+    await flushOpen();
+
+    const text = modal.textContent ?? "";
+    expect(text).toContain("main.login_google");
+    expect(text).not.toContain("account_modal.login_email_exists");
+  });
+
+  it("drops the error when the modal is reopened", async () => {
+    modal.open({ login: "email_exists" });
+    await flushOpen();
+    expect(modal.textContent ?? "").toContain(
+      "account_modal.login_email_exists",
+    );
+
+    modal.close();
+    modal.open();
+    await flushOpen();
+
+    expect(modal.textContent ?? "").not.toContain(
+      "account_modal.login_email_exists",
+    );
   });
 });

--- a/tests/client/LoginResult.test.ts
+++ b/tests/client/LoginResult.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { consumeLoginResult } from "../../src/client/LoginResult";
+
+describe("consumeLoginResult", () => {
+  beforeEach(() => {
+    history.replaceState(null, "", "/");
+  });
+
+  it("returns the login result the auth callback sent back", () => {
+    expect(consumeLoginResult({ login: "email_exists" })).toBe("email_exists");
+  });
+
+  it("returns undefined when there is no login param", () => {
+    expect(consumeLoginResult({ tab: "account" })).toBeUndefined();
+    expect(consumeLoginResult(undefined)).toBeUndefined();
+  });
+
+  it("ignores a login value it doesn't recognise", () => {
+    expect(consumeLoginResult({ login: "cancel" })).toBeUndefined();
+    expect(consumeLoginResult({ login: "../../evil" })).toBeUndefined();
+  });
+
+  it("strips the one-shot param so a refresh doesn't replay it", () => {
+    history.replaceState(null, "", "/#modal=account&login=email_exists");
+
+    consumeLoginResult({ login: "email_exists" });
+
+    expect(window.location.hash).toBe("#modal=account");
+  });
+
+  it("clears the hash entirely when login was the only param", () => {
+    history.replaceState(null, "", "/#login=email_exists");
+
+    consumeLoginResult({ login: "email_exists" });
+
+    expect(window.location.hash).toBe("");
+  });
+});


### PR DESCRIPTION
## Context

`main` port of #5047 — same change, resolved against main's refactors. Paired with openfrontio/infra#531.

The API no longer creates a second account when a Google/Discord sign-in carries a verified email that already belongs to a player; it bounces back with `#login=email_exists`. This surfaces that to the user instead of redirecting them home with no feedback.

## Change

- `LoginResult.ts` — `consumeLoginResult()` reads the one-shot `login=` router arg and strips it from the URL so a refresh doesn't replay it. Sits alongside the existing `GoogleLinkResult.ts` and follows the same shape.
- `AccountModal` renders a dismissible banner above the sign-in buttons.
- One new `en.json` key.

## Copy

> You already have an account with this email. Sign in to it, then link this account in settings.

It deliberately **doesn't name which provider** the existing account uses — the visitor has only proven control of the email address, not of the account.

## Port notes

The cherry-pick from `v33` conflicted; resolved toward main's structure rather than forcing it:

- kept main's `consumeGoogleLinkResult(args)`, dropped v33's `handleLinkResult(args)`
- did **not** reintroduce `consentBusy`, `renderLogoutButton`, or `account_modal.log_out` — main has moved those into `AccountSettingsModal`
- import order fixed for main's `./utilities/PlayerProfileUrl` path

Resulting diff is identical in shape to #5047, and `LoginResult.ts` is byte-identical across both branches.

## Testing

Full suite: **278 files / 3227 tests passing**, `tsc --noEmit` and lint clean.

⚠️ Unrelated heads-up: `tests/client/InventoryModal.test.ts` fails intermittently under full-suite load on pristine `origin/main` (verified with none of this branch's code present — 3-4 failures, different subset each run, 21/21 in isolation). It happened not to trip on the final run here, but it's flaky on main independent of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)