### PR TITLE
feat(homepage): the lobby cards carry their own expand control

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -112,6 +112,7 @@ Stats icon by [Meko](https://thenounproject.com/mekoda/) – https://thenounproj
 Pay Per Click icon by [Fauzan Adiima](https://thenounproject.com/creator/fauzan94/) – https://thenounproject.com/icon/pay-per-click-2586454/
 Medal icon by [Snow](https://thenounproject.com/snowdoll/) – https://thenounproject.com/icon/medal-4567887/
 Guild icon by Trimanggolo Mulyo – https://thenounproject.com/icon/guild-8266144/
+Expand icon by [Proicon](https://thenounproject.com/creator/proicon/) – https://thenounproject.com/icon/expand-8462947/
 
 ### Flags
 

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -10,6 +10,7 @@ import {
   Trios,
 } from "../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
+import type { BaseModal } from "./components/BaseModal";
 import "./components/IOSAddToHomeScreenBanner";
 import { lobbyCard, mapAspectRatios } from "./components/LobbyCard";
 import { multiplayerAllowed, type DesktopUpdateState } from "./DesktopShell";
@@ -26,7 +27,15 @@ import {
   translateText,
 } from "./Utils";
 
+/**
+ * The scheduled lobby buckets the homepage shows one card each for. The keys
+ * double as the lobby browser's tab keys, so a card can open its own tab.
+ */
+type LobbyBucket = "ffa" | "team" | "special";
+
 const CARD_BG = "bg-surface";
+const SECONDARY_CARD_BG =
+  "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:shadow-[var(--shadow-action-card-hover)]";
 
 /**
  * Whether a multiplayer entry point should refuse to act. Exported for tests
@@ -135,46 +144,6 @@ export class GameModeSelector extends LitElement {
 
     return html`
       <div class="flex flex-col gap-4 w-full px-4 sm:px-0 mx-auto pb-4 sm:pb-0">
-        <!-- Solo + detailed view: mobile only, top. The lobby browser is one
-             column wide, matching Join Lobby below it. -->
-        <div class="sm:hidden grid grid-cols-3 gap-4 h-14">
-          <div class="col-span-2">
-            ${this.renderSmallActionCard(
-              translateText("main.solo"),
-              this.openSinglePlayerModal,
-              "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 hover:scale-y-105 hover:scale-x-[1.01]",
-            )}
-          </div>
-          ${this.renderSmallActionCard(
-            translateText("main.detailed_view"),
-            this.openDetailedView,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-          )}
-        </div>
-        <!-- Create/ranked/join: mobile only, below solo -->
-        <div class="sm:hidden grid grid-cols-3 gap-4 h-14">
-          ${this.renderSmallActionCard(
-            translateText("main.create"),
-            this.openHostLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            undefined,
-            true,
-          )}
-          ${this.renderSmallActionCard(
-            translateText("mode_selector.ranked_title"),
-            this.openRankedMenu,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            undefined,
-            true,
-          )}
-          ${this.renderSmallActionCard(
-            translateText("main.join"),
-            this.openJoinLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            this.hostedLobbyCount(),
-            true,
-          )}
-        </div>
         <!-- iOS Add to Home Screen banner -->
         <ios-add-to-home-screen-banner
           class="no-crazygames"
@@ -195,7 +164,7 @@ export class GameModeSelector extends LitElement {
               <!-- Left col: main card (desktop only) -->
               ${ffa
                 ? html`<div class="hidden sm:block">
-                    ${this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))}
+                    ${this.renderLobbyCard(ffa, this.getLobbyTitle(ffa), "ffa")}
                   </div>`
                 : nothing}
 
@@ -208,7 +177,11 @@ export class GameModeSelector extends LitElement {
                   : nothing}
                 ${teams
                   ? html`<div class="flex-1 min-h-0">
-                      ${this.renderLobbyCard(teams, this.getLobbyTitle(teams))}
+                      ${this.renderLobbyCard(
+                        teams,
+                        this.getLobbyTitle(teams),
+                        "team",
+                      )}
                     </div>`
                   : nothing}
               </div>
@@ -219,62 +192,61 @@ export class GameModeSelector extends LitElement {
               </div>
               <div class="sm:hidden">
                 ${ffa
-                  ? this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))
+                  ? this.renderLobbyCard(ffa, this.getLobbyTitle(ffa), "ffa")
                   : nothing}
               </div>
               <div class="sm:hidden">
                 ${teams
-                  ? this.renderLobbyCard(teams, this.getLobbyTitle(teams))
+                  ? this.renderLobbyCard(
+                      teams,
+                      this.getLobbyTitle(teams),
+                      "team",
+                    )
                   : nothing}
               </div>
             </div>`}
 
-        <!-- Solo + detailed view, desktop only. Solo spans two columns; the
-             lobby browser is one, the same width as Join Lobby below it. -->
-        <div class="hidden sm:grid grid-cols-3 gap-4 h-14">
-          <div class="col-span-2">
+        <!-- Solo takes a full row as the primary call to action, with Create,
+             Ranked and Join below it. The block keeps its old placement: above
+             the lobby grid on mobile, below it on desktop. -->
+        <div class="flex flex-col gap-4 order-first sm:order-none">
+          <div class="h-14">
             ${this.renderSmallActionCard(
               translateText("main.solo"),
               this.openSinglePlayerModal,
-              "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 hover:scale-y-105 hover:scale-x-[1.01]",
+              "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80",
             )}
           </div>
-          ${this.renderSmallActionCard(
-            translateText("main.detailed_view"),
-            this.openDetailedView,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-          )}
-        </div>
-        <!-- Bottom row: create + ranked + join (desktop only) -->
-        <div class="hidden sm:grid grid-cols-3 gap-4 h-14">
-          ${this.renderSmallActionCard(
-            translateText("main.create"),
-            this.openHostLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            undefined,
-            true,
-          )}
-          ${this.renderSmallActionCard(
-            translateText("mode_selector.ranked_title"),
-            this.openRankedMenu,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            undefined,
-            true,
-          )}
-          ${this.renderSmallActionCard(
-            translateText("main.join"),
-            this.openJoinLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            this.hostedLobbyCount(),
-            true,
-          )}
+          <div class="grid grid-cols-3 gap-4 h-14">
+            ${this.renderSmallActionCard(
+              translateText("main.create"),
+              this.openHostLobby,
+              SECONDARY_CARD_BG,
+              undefined,
+              true,
+            )}
+            ${this.renderSmallActionCard(
+              translateText("mode_selector.ranked_title"),
+              this.openRankedMenu,
+              SECONDARY_CARD_BG,
+              undefined,
+              true,
+            )}
+            ${this.renderSmallActionCard(
+              translateText("main.join"),
+              this.openJoinLobby,
+              SECONDARY_CARD_BG,
+              this.hostedLobbyCount(),
+              true,
+            )}
+          </div>
         </div>
       </div>
     `;
   }
 
   private renderSpecialLobbyCard(lobby: PublicGameInfo) {
-    return this.renderLobbyCard(lobby, this.getLobbyTitle(lobby));
+    return this.renderLobbyCard(lobby, this.getLobbyTitle(lobby), "special");
   }
 
   /**
@@ -307,9 +279,24 @@ export class GameModeSelector extends LitElement {
     window.showPage?.("page-ranked");
   };
 
-  private openDetailedView = () => {
+  // Opens the lobby browser on the tab matching the card that was expanded, so
+  // expanding the teams card lands on teams rather than the overview.
+  private openDetailedView = (tab?: LobbyBucket) => {
     if (!this.validateUsername()) return;
-    window.showPage?.("page-detailed-view");
+    const modal = document.querySelector("detailed-view-modal") as
+      | (Partial<BaseModal> & HTMLElement)
+      | null;
+    if (typeof modal?.open === "function") {
+      modal.open(tab === undefined ? undefined : { tab });
+      return;
+    }
+    // The tag lives in index.html, so we only land here if the element hasn't
+    // upgraded yet. Route through the hash rather than showPage: ModalRouter
+    // waits for the upgrade and forwards the tab, which showPage would drop.
+    window.location.hash =
+      tab === undefined
+        ? "#modal=detailed-view"
+        : `#modal=detailed-view&tab=${tab}`;
   };
 
   private openSinglePlayerModal = () => {
@@ -375,6 +362,7 @@ export class GameModeSelector extends LitElement {
   private renderLobbyCard(
     lobby: PublicGameInfo,
     titleContent: string | TemplateResult,
+    bucket: LobbyBucket,
   ) {
     const timeRemaining = lobby.startsAt
       ? getSecondsUntilServerTimestamp(lobby.startsAt, this.serverTimeOffset)
@@ -403,6 +391,8 @@ export class GameModeSelector extends LitElement {
       disabled: !this.inputValid,
       blocked: shouldBlockMultiplayerAction(this.desktopUpdateState),
       onClick: () => this.validateAndJoin(lobby),
+      onExpand: () => this.openDetailedView(bucket),
+      expandLabel: translateText("main.detailed_view"),
     });
   }
 

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -84,7 +84,7 @@ const BUTTON_CLASS =
   "hover:text-white transition-colors";
 
 /**
- * The full lobby browser behind the homepage "More Games" button: every lobby
+ * The full lobby browser behind each homepage lobby card's expand control: every lobby
  * the server advertises (not just the one card per bucket the homepage shows),
  * rendered as the same map cards, with filtering, sorting and saved filter
  * profiles.

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -5,7 +5,7 @@ import { terrainMapFileLoader } from "../TerrainMapFileLoader";
 import { getMapName, getModifierLabels } from "../Utils";
 
 /**
- * The map-image lobby card used on the homepage and in the More Games lobby
+ * The map-image lobby card used on the homepage and in the detailed lobby
  * browser: map art behind modifier pills, a countdown pill, the player count
  * and a bottom bar naming the map and mode.
  */
@@ -65,6 +65,14 @@ export interface LobbyCardOptions {
   blocked?: boolean;
   /** Card height; defaults to the homepage's fill-the-grid-cell sizing. */
   heightClass?: string;
+  /**
+   * When set, a corner expand control is drawn over the card's bottom-right.
+   * It sits outside the card button (buttons can't nest) and swallows the
+   * click so expanding never joins the lobby.
+   */
+  onExpand?: () => void;
+  /** Accessible name for the expand control; required alongside `onExpand`. */
+  expandLabel?: string;
 }
 
 export function lobbyCard({
@@ -76,6 +84,8 @@ export function lobbyCard({
   disabled = false,
   blocked = false,
   heightClass = "h-44 sm:h-full",
+  onExpand,
+  expandLabel,
 }: LobbyCardOptions): TemplateResult {
   const mapType = lobby.gameConfig!.gameMap as GameMapType;
   const mapImageSrc = terrainMapFileLoader.getMapData(mapType).webpPath;
@@ -111,88 +121,122 @@ export function lobbyCard({
   }
 
   return html`
-    <button
-      @click=${onClick}
-      ?disabled=${disabled}
-      aria-disabled=${blocked}
-      class="group relative w-full ${heightClass} text-white uppercase rounded-2xl transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] bg-surface hover:shadow-[var(--shadow-lobby-card-hover)] ${disabled
-        ? "opacity-50 cursor-not-allowed pointer-events-none"
-        : blocked
-          ? "opacity-50 cursor-not-allowed"
-          : ""}"
-    >
-      <!-- Image clipped separately so overflow-hidden doesn't block absolute children -->
-      <div
-        class="absolute inset-0 rounded-2xl overflow-hidden pointer-events-none"
+    <div class="relative w-full ${heightClass}">
+      <button
+        @click=${onClick}
+        ?disabled=${disabled}
+        aria-disabled=${blocked}
+        class="group relative w-full h-full text-white uppercase rounded-2xl transition-shadow duration-200 bg-surface hover:shadow-[var(--shadow-lobby-card-hover)] ${disabled
+          ? "opacity-50 cursor-not-allowed pointer-events-none"
+          : blocked
+            ? "opacity-50 cursor-not-allowed"
+            : ""}"
       >
-        ${mapImageSrc
-          ? html`<img
-              src="${mapImageSrc}"
-              alt="${mapName ?? lobby.gameConfig?.gameMap ?? "map"}"
-              draggable="false"
-              class="absolute inset-0 w-full h-full ${useContain
-                ? "object-contain"
-                : "object-cover object-center scale-[1.05]"} [image-rendering:auto]"
-            />`
-          : null}
-      </div>
-      <!-- Top row: modifiers + timer -->
-      <div
-        class="absolute inset-x-2 top-2 flex items-start justify-between gap-2"
-      >
-        ${modifierLabels.length > 0
-          ? html`<div
-              class="flex flex-col items-start gap-1 mt-[2px] min-w-0 max-w-[65%]"
-            >
-              ${modifierLabels.map(
-                (label) =>
-                  html`<span
-                    class="px-2 py-1 rounded text-xs font-bold uppercase tracking-widest bg-malibu-blue text-white shadow-[var(--shadow-malibu-blue-pill)]"
-                    >${label}</span
-                  >`,
-              )}
-            </div>`
-          : html`<div></div>`}
-        <div class="shrink-0">
-          <span
-            class="text-xs font-bold tracking-widest ${timeDisplayUppercase
-              ? "uppercase"
-              : "normal-case"} bg-malibu-blue text-white px-2 py-1 rounded"
-            >${timeDisplay}</span
-          >
-        </div>
-      </div>
-      <!-- Bottom bar: map name + mode, with player count floating above -->
-      <div
-        class="absolute bottom-0 left-0 right-0 flex flex-col px-3 py-2 bg-black/55 backdrop-blur-sm rounded-b-2xl"
-        style="overflow: visible;"
-      >
-        <span
-          class="absolute bottom-full right-2 mb-1 flex items-center gap-1 text-xs font-bold tracking-widest bg-black/70 backdrop-blur-sm px-2 py-0.5 rounded"
+        <!-- Image clipped separately so overflow-hidden doesn't block absolute children -->
+        <div
+          class="absolute inset-0 rounded-2xl overflow-hidden pointer-events-none"
         >
-          ${playerCount}
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            class="h-4 w-4 inline-block"
-            viewBox="0 0 20 20"
-            fill="currentColor"
-          >
-            <path
-              d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"
-            ></path>
-          </svg>
-        </span>
-        ${title
-          ? html`<p
-              class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"
+          ${mapImageSrc
+            ? html`<img
+                src="${mapImageSrc}"
+                alt="${mapName ?? lobby.gameConfig?.gameMap ?? "map"}"
+                draggable="false"
+                class="absolute inset-0 w-full h-full transition-transform duration-200 ${useContain
+                  ? "object-contain group-hover:scale-105"
+                  : "object-cover object-center scale-[1.05] group-hover:scale-[1.12]"} [image-rendering:auto]"
+              />`
+            : null}
+        </div>
+        <!-- Top row: modifiers + timer -->
+        <div
+          class="absolute inset-x-2 top-2 flex items-start justify-between gap-2"
+        >
+          ${modifierLabels.length > 0
+            ? html`<div
+                class="flex flex-col items-start gap-1 mt-[2px] min-w-0 max-w-[65%]"
+              >
+                ${modifierLabels.map(
+                  (label) =>
+                    html`<span
+                      class="px-2 py-1 rounded text-xs font-bold uppercase tracking-widest bg-malibu-blue text-white shadow-[var(--shadow-malibu-blue-pill)]"
+                      >${label}</span
+                    >`,
+                )}
+              </div>`
+            : html`<div></div>`}
+          <div class="shrink-0">
+            <span
+              class="text-xs font-bold tracking-widest ${timeDisplayUppercase
+                ? "uppercase"
+                : "normal-case"} bg-malibu-blue text-white px-2 py-1 rounded"
+              >${timeDisplay}</span
             >
-              ${title}
-            </p>`
-          : ""}
-        <h3 class="text-xs text-white/70 uppercase tracking-wider text-left">
-          ${subtitleLine}
-        </h3>
-      </div>
-    </button>
+          </div>
+        </div>
+        <!-- Bottom bar: map name + mode, with player count floating above -->
+        <div
+          class="absolute bottom-0 left-0 right-0 flex flex-col px-3 py-2 bg-black/55 backdrop-blur-sm rounded-b-2xl"
+          style="overflow: visible;"
+        >
+          <span
+            class="absolute bottom-full right-2 mb-1 flex items-center gap-1 text-xs font-bold tracking-widest bg-black/70 backdrop-blur-sm px-2 py-0.5 rounded"
+          >
+            ${playerCount}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              class="h-4 w-4 inline-block"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path
+                d="M13 6a3 3 0 11-6 0 3 3 0 016 0zM18 8a2 2 0 11-4 0 2 2 0 014 0zM14 15a4 4 0 00-8 0v3h8v-3zM6 8a2 2 0 11-4 0 2 2 0 014 0zM16 18v-3a5.972 5.972 0 00-.75-2.906A3.005 3.005 0 0119 15v3h-3zM4.75 12.094A5.973 5.973 0 004 15v3H1v-3a3 3 0 013.75-2.906z"
+              ></path>
+            </svg>
+          </span>
+          ${title
+            ? html`<p
+                class="text-sm sm:text-base font-bold uppercase tracking-wider text-left leading-tight"
+              >
+                ${title}
+              </p>`
+            : ""}
+          <h3
+            class="text-xs text-white/70 uppercase tracking-wider text-left ${onExpand
+              ? "pr-9"
+              : ""}"
+          >
+            ${subtitleLine}
+          </h3>
+        </div>
+      </button>
+      ${onExpand
+        ? html`<button
+            @click=${(e: Event) => {
+              e.stopPropagation();
+              onExpand();
+            }}
+            ?disabled=${disabled}
+            aria-label=${expandLabel ?? ""}
+            title=${expandLabel ?? ""}
+            class="absolute bottom-2 right-2 z-10 flex items-center justify-center size-8 rounded-lg bg-black/70 backdrop-blur-sm text-white/90 hover:text-white hover:bg-black/85 transition-colors ${disabled
+              ? "opacity-50 cursor-not-allowed pointer-events-none"
+              : ""}"
+          >
+            <!-- Expand icon by Proicon from the Noun Project; see CREDITS.md -->
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 100 100"
+              fill="currentColor"
+              class="size-5"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="m39.199 91.039h51.84v-82.078h-82.078v51.84h-5.7617v-57.602h93.602v93.602h-57.602zm0.84375-35.156 4.0703 4.0703 31.328-31.32v13.445h5.7617l-0.003906-23.277h-23.281v5.7617h13.445zm-31.082 35.156h18.238v-18.238h-18.238zm21.117 5.7617h2.8789l0.003907-29.762h-29.762v29.762z"
+              />
+            </svg>
+          </button>`
+        : null}
+    </div>
   `;
 }


### PR DESCRIPTION
## What

Detailed View had a button of its own on the homepage, taking a third of the row next to Solo. Each lobby card now draws a corner expand control over its bottom-right instead, which opens the lobby browser on that card's own tab, and Solo takes the full row as the primary call to action.

Hovering a homepage button no longer scales the button itself: the lobby cards zoom their map image inside a frame that holds still, and Solo, Create, Ranked and Join keep their brightness and shadow response without growing.

## How

- `lobbyCard` takes optional `onExpand` / `expandLabel`. The control lives outside the card button — buttons cannot nest — and stops the click, so expanding never joins the lobby. It is drawn only when a caller passes `onExpand`, so the cards inside the detailed browser itself stay plain.
- The subtitle line gains right padding when the control is present, so a map's mode text never runs under it.
- Each homepage card knows its bucket (`ffa` / `team` / `special`), and those keys are already the lobby browser's tab keys, so expanding calls `open({ tab })` on the modal. `BaseModal` validates the tab and syncs it to the URL, giving `#modal=detailed-view&tab=team`. If the element is missing, it falls back to the old `showPage` call.
- The glyph is the Noun Project expand icon by Proicon, credited in `CREDITS.md` alongside the other icons from there. Its accessible name reuses the existing `main.detailed_view` string, so there is no new translation entry.
- The card drops `hover:scale`/`active:scale`; the map image gains `group-hover:scale`, clipped by the image wrapper's existing `overflow-hidden`. The small action cards drop their `hover:scale` classes.
- `game-mode-selector` drops the Detailed View button and its row-splitting wrapper; Solo spans the row again. The mobile and desktop copies of that block were identical in content, so they collapse into one block ordered with `order-first sm:order-none` — above the lobby grid on mobile, below it on desktop, exactly as before.

## Testing

Verified in the running dev app at 1440x900 and 420x900:

- Solo spanning the full row with Create/Ranked/Join below it.
- Expanding each of the three cards lands on the matching tab (`activeTab` and the URL read `ffa`, `team` and `special` respectively) without starting a game.
- On hover the card's own scale stays unset while the map image reads `1.12`, and Solo's scale stays unset.

`tsc --noEmit`, oxlint, ESLint and Prettier are clean. No `src/core` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)