### PR TITLE
feat(doomsday): rotted territory is wasteland

### DIFF
--- a/src/core/execution/DoomsdayClockExecution.ts
+++ b/src/core/execution/DoomsdayClockExecution.ts
@@ -346,12 +346,9 @@ export class DoomsdayClockExecution implements Execution {
     const tiles = player.tiles();
     if (!tiles.has(tile)) return false;
     player.relinquish(tile);
-    // Rotted ground is WASTELAND, not a prize. Plain relinquish leaves neutral
-    // land, and the biggest adjacent side is best placed to absorb it — so the
-    // clock that exists to pressure the doomed was quietly feeding the leader.
-    // Fallout already has exactly the wanted semantics: passive expansion skips
-    // it, bots avoid it, and conquering it carries the fallout penalty. Order
-    // matters: setFallout throws while the tile has an owner.
+    // Wasteland, not a prize: plain relinquish left neutral land the biggest
+    // neighbour absorbed for free — rot was feeding the one side it never
+    // presses. Must run after relinquish: setFallout throws on owned tiles.
     mg.setFallout(tile, true);
     // Stamp it so the client can paint the red "Decaying" skull off authoritative
     // state instead of re-deriving the (knife-edge) troops-vs-floor test.

--- a/src/core/execution/DoomsdayClockExecution.ts
+++ b/src/core/execution/DoomsdayClockExecution.ts
@@ -346,6 +346,13 @@ export class DoomsdayClockExecution implements Execution {
     const tiles = player.tiles();
     if (!tiles.has(tile)) return false;
     player.relinquish(tile);
+    // Rotted ground is WASTELAND, not a prize. Plain relinquish leaves neutral
+    // land, and the biggest adjacent side is best placed to absorb it — so the
+    // clock that exists to pressure the doomed was quietly feeding the leader.
+    // Fallout already has exactly the wanted semantics: passive expansion skips
+    // it, bots avoid it, and conquering it carries the fallout penalty. Order
+    // matters: setFallout throws while the tile has an owner.
+    mg.setFallout(tile, true);
     // Stamp it so the client can paint the red "Decaying" skull off authoritative
     // state instead of re-deriving the (knife-edge) troops-vs-floor test.
     player.markRotted();

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -242,7 +242,9 @@ class FakeGame {
     return out;
   }
   numTilesWithFallout(): number {
-    return 0;
+    // Kept in sync with setFallout: the execution subtracts this from land when
+    // sizing the bar and the rot quota, so a stale 0 would diverge from prod.
+    return this.falloutTiles.size;
   }
   config() {
     return {

--- a/tests/DoomsdayClockExecution.test.ts
+++ b/tests/DoomsdayClockExecution.test.ts
@@ -195,6 +195,12 @@ class FakeGame {
   now = 0;
   gameMode: GameMode = GameMode.FFA;
   winnerPlayer: FakePlayer | null = null;
+  // Rot marks what it consumes as wasteland; recorded so tests can assert on it.
+  falloutTiles = new Set<TileRef>();
+  setFallout(tile: TileRef, value: boolean): void {
+    if (value) this.falloutTiles.add(tile);
+    else this.falloutTiles.delete(tile);
+  }
   constructor(
     public land: number,
     public sd: SDConfig,
@@ -1378,6 +1384,11 @@ describe("DoomsdayClockExecution (territory rot, real simulation)", () => {
     // leader gained nothing (relinquish takes no conqueror: no kill, no gold).
     for (const tile of held) expect(game.owner(tile).isPlayer()).toBe(false);
     expect(big.numTilesOwned()).toBe(bigTilesBefore);
+    // …and it is WASTELAND, not a prize: every rotted tile carries fallout, so
+    // passive expansion skips it and taking it costs the fallout penalty —
+    // without this, rot converts the doomed into free land for whoever is
+    // biggest next door, and the clock feeds the exact player it never presses.
+    for (const tile of held) expect(game.hasFallout(tile)).toBe(true);
   }, 30_000);
 });
 


### PR DESCRIPTION
Doomsday rot removes a doomed side's land with plain `relinquish`, which leaves ordinary neutral land — and the biggest adjacent side is best placed to absorb it. So the clock that exists to pressure the doomed was quietly feeding the leader: the one player it never presses collected the ground of everyone it killed, for free.

Rotted tiles now carry **fallout**, which already has exactly the wanted semantics, all pre-existing:

- passive expansion skips unowned fallout (`PlayerImpl`)
- bots refuse to path into it (`AiAttackBehavior`)
- conquering it pays the fallout defense penalty, scaling with how much of the map is fallout (`Config.falloutDefenseModifier`)

So the land is still takeable — wanting it back means *fighting* for it — and the client renders it with the existing wasteland visuals for free.

One line of behaviour (`mg.setFallout(tile, true)` after the relinquish — order matters, `setFallout` throws on owned tiles), a comment saying why, and tests: the end-to-end rot test asserts every rotted tile carries fallout (verified by reverting the line: exactly that assertion fails), and the unit-test fake records fallout and feeds it back through `numTilesWithFallout()`, since the execution subtracts that from land when sizing the bar and rot quota.

Balance note: the bar's denominator already excludes fallout (`DoomsdayClockExecution` computes `land = numLandTiles() - numTilesWithFallout()`), so as rot converts territory to wasteland the requirement is measured against the land that can actually be held — survivors' shares are not squeezed by ground nobody can passively take. The change the leader feels is only the intended one: the rotted land is no longer a free meal.