### PR TITLE
refactor(store): remove dead USD purchase path for cosmetics

### DIFF
--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -10,7 +10,6 @@ import {
   Flag,
   Pack,
   Pattern,
-  Product,
   Skin,
   Subscription,
 } from "../core/CosmeticSchemas";
@@ -276,9 +275,7 @@ export async function fetchCosmetics(): Promise<Cosmetics | null> {
         return null;
       }
       const patternKeys = Object.keys(result.data.patterns).sort();
-      const hashInput = patternKeys
-        .map((k) => k + (result.data.patterns[k].product ? "sale" : ""))
-        .join(",");
+      const hashInput = patternKeys.join(",");
       __cosmeticsHash = simpleHash(hashInput);
       __cosmeticsCache = result.data;
       return result.data;
@@ -321,7 +318,6 @@ export function cosmeticRelationship(
   opts: {
     wildcardFlare: string;
     requiredFlare: string;
-    product: Product | null;
     priceSoft?: number;
     priceHard?: number;
     affiliateCode: string | null;
@@ -344,16 +340,12 @@ export function cosmeticRelationship(
     return "blocked";
   }
 
-  // Purchasable if any purchase method is available
+  // Cosmetics are sold for currency only (USD checkout was removed).
   if (opts.priceSoft !== undefined || opts.priceHard !== undefined) {
     return "purchasable";
   }
 
-  if (opts.product === null) {
-    return "blocked";
-  }
-
-  return "purchasable";
+  return "blocked";
 }
 
 export function patternRelationship(
@@ -392,7 +384,6 @@ export function patternRelationship(
     {
       wildcardFlare: "pattern:*",
       requiredFlare: `pattern:${pattern.name}:${colorPalette.name}`,
-      product: pattern.product,
       priceSoft: pattern.priceSoft,
       priceHard: pattern.priceHard,
       affiliateCode,
@@ -411,7 +402,6 @@ export function flagRelationship(
     {
       wildcardFlare: "flag:*",
       requiredFlare: `flag:${flag.name}`,
-      product: flag.product,
       priceSoft: flag.priceSoft,
       priceHard: flag.priceHard,
       affiliateCode,
@@ -430,7 +420,6 @@ export function crownRelationship(
     {
       wildcardFlare: "crown:*",
       requiredFlare: `crown:${crown.name}`,
-      product: crown.product,
       priceSoft: crown.priceSoft,
       priceHard: crown.priceHard,
       affiliateCode,
@@ -449,7 +438,6 @@ export function skinRelationship(
     {
       wildcardFlare: "skin:*",
       requiredFlare: `skin:${skin.name}`,
-      product: skin.product,
       priceSoft: skin.priceSoft,
       priceHard: skin.priceHard,
       affiliateCode,
@@ -468,7 +456,6 @@ export function effectRelationship(
     {
       wildcardFlare: "effect:*",
       requiredFlare: `effect:${effect.name}`,
-      product: effect.product,
       priceSoft: effect.priceSoft,
       priceHard: effect.priceHard,
       affiliateCode,

--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -283,7 +283,14 @@ export class StoreModal extends BaseModal {
       rarity?: string;
     } | null;
     const isPurchasable = resolved.relationship === "purchasable";
-    const product = isPurchasable ? (priced?.product ?? null) : null;
+    // Only packs and subscriptions still check out in USD; cosmetics are
+    // currency-only (their catalog product is always null now, but a cached
+    // cosmetics.json may still carry one — never render a dollar button).
+    const product =
+      isPurchasable &&
+      (resolved.type === "pack" || resolved.type === "subscription")
+        ? (priced?.product ?? null)
+        : null;
     const priceHard = isPurchasable ? priced?.priceHard : undefined;
     const priceSoft = isPurchasable ? priced?.priceSoft : undefined;
     const purchase = (method: "dollar" | "hard" | "soft") =>

--- a/src/client/components/CosmeticCard.ts
+++ b/src/client/components/CosmeticCard.ts
@@ -380,14 +380,10 @@ export class CosmeticCard extends LitElement {
     } ${this.rarityHoverClass(rarity)}`;
     const priced = active.cosmetic as {
       artist?: string;
-      product?: unknown;
       priceHard?: number;
     } | null;
     const usdValue =
-      (priced?.product === null || priced?.product === undefined) &&
-      priced?.priceHard !== undefined
-        ? priced.priceHard / 20
-        : undefined;
+      priced?.priceHard !== undefined ? priced.priceHard / 20 : undefined;
     // A subscription lists its perks as text, which wraps to more lines than a
     // square box holds once cards are phone-width — let it take the height it
     // needs rather than clipping the last perk.

--- a/src/client/hud/layers/WinModal.ts
+++ b/src/client/hud/layers/WinModal.ts
@@ -199,12 +199,10 @@ export class WinModal extends LitElement implements Controller {
                 .interactive=${false}
               ></cosmetic-card>
               <purchase-button
-                .product=${resolved.cosmetic?.product ?? null}
                 .priceHard=${resolved.cosmetic?.priceHard ?? null}
                 .priceSoft=${resolved.cosmetic?.priceSoft ?? null}
                 .rarity=${resolved.cosmetic?.rarity ?? "common"}
                 .itemName=${cosmeticSelectionLabel(resolved)}
-                .onPurchaseDollar=${() => purchaseCosmetic(resolved, "dollar")}
                 .onPurchaseHard=${() => purchaseCosmetic(resolved, "hard")}
                 .onPurchaseSoft=${() => purchaseCosmetic(resolved, "soft")}
               ></purchase-button>

--- a/tests/CosmeticRelationship.test.ts
+++ b/tests/CosmeticRelationship.test.ts
@@ -1,8 +1,6 @@
 import { cosmeticRelationship } from "../src/client/Cosmetics";
 import { UserMeResponse } from "../src/core/ApiSchemas";
 
-const product = { productId: "prod_123", priceId: "price_123", price: "$4.99" };
-
 function makeUserMe(flares: string[]): UserMeResponse {
   return {
     player: { flares },
@@ -16,7 +14,6 @@ describe("cosmeticRelationship", () => {
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product,
           priceSoft: undefined,
           priceHard: undefined,
           affiliateCode: null,
@@ -33,7 +30,6 @@ describe("cosmeticRelationship", () => {
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product,
           priceSoft: undefined,
           priceHard: undefined,
           affiliateCode: null,
@@ -44,13 +40,12 @@ describe("cosmeticRelationship", () => {
     ).toBe("owned");
   });
 
-  it("returns blocked when no product and user does not own it", () => {
+  it("returns blocked when no currency price and user does not own it", () => {
     expect(
       cosmeticRelationship(
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product: null,
           priceSoft: undefined,
           priceHard: undefined,
           affiliateCode: null,
@@ -67,9 +62,8 @@ describe("cosmeticRelationship", () => {
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product,
           priceSoft: undefined,
-          priceHard: undefined,
+          priceHard: 50,
           affiliateCode: "storeA",
           itemAffiliateCode: "storeB",
         },
@@ -78,15 +72,14 @@ describe("cosmeticRelationship", () => {
     ).toBe("blocked");
   });
 
-  it("returns purchasable when product exists and affiliate matches", () => {
+  it("returns purchasable when currency price exists and affiliate matches", () => {
     expect(
       cosmeticRelationship(
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product,
           priceSoft: undefined,
-          priceHard: undefined,
+          priceHard: 50,
           affiliateCode: null,
           itemAffiliateCode: null,
         },
@@ -101,9 +94,8 @@ describe("cosmeticRelationship", () => {
         {
           wildcardFlare: "pattern:*",
           requiredFlare: "pattern:stripes:red",
-          product,
           priceSoft: undefined,
-          priceHard: undefined,
+          priceHard: 50,
           affiliateCode: "storeA",
           itemAffiliateCode: "storeA",
         },
@@ -112,13 +104,12 @@ describe("cosmeticRelationship", () => {
     ).toBe("purchasable");
   });
 
-  it("returns blocked when user is not logged in and no product", () => {
+  it("returns blocked when user is not logged in and no currency price", () => {
     expect(
       cosmeticRelationship(
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product: null,
           priceSoft: undefined,
           priceHard: undefined,
           affiliateCode: null,
@@ -129,15 +120,14 @@ describe("cosmeticRelationship", () => {
     ).toBe("blocked");
   });
 
-  it("returns purchasable when user is not logged in but product exists", () => {
+  it("returns purchasable when user is not logged in but currency price exists", () => {
     expect(
       cosmeticRelationship(
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product,
           priceSoft: undefined,
-          priceHard: undefined,
+          priceHard: 50,
           affiliateCode: null,
           itemAffiliateCode: null,
         },
@@ -146,13 +136,12 @@ describe("cosmeticRelationship", () => {
     ).toBe("purchasable");
   });
 
-  it("returns purchasable when item has currency price and no product", () => {
+  it("returns purchasable when item has soft currency price", () => {
     expect(
       cosmeticRelationship(
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product: null,
           priceSoft: 100,
           affiliateCode: null,
           itemAffiliateCode: null,
@@ -168,7 +157,6 @@ describe("cosmeticRelationship", () => {
         {
           wildcardFlare: "flag:*",
           requiredFlare: "flag:cool",
-          product: null,
           priceSoft: 100,
           priceHard: 50,
           affiliateCode: "storeA",
@@ -185,7 +173,6 @@ describe("cosmeticRelationship", () => {
         {
           wildcardFlare: "pattern:*",
           requiredFlare: "pattern:stripes:red",
-          product,
           priceSoft: undefined,
           priceHard: undefined,
           affiliateCode: null,

--- a/tests/ResolveCosmetics.test.ts
+++ b/tests/ResolveCosmetics.test.ts
@@ -6,8 +6,6 @@ import {
 import { UserMeResponse } from "../src/core/ApiSchemas";
 import { Cosmetics } from "../src/core/CosmeticSchemas";
 
-const product = { productId: "prod_1", priceId: "price_1", price: "$4.99" };
-
 function makeCosmetics(overrides: Partial<Cosmetics> = {}): Cosmetics {
   return {
     patterns: {},
@@ -55,9 +53,9 @@ describe("resolveCosmetics", () => {
       name: "stripes",
       pattern: "AAAAAA",
       affiliateCode: null,
-      product,
+      product: null,
       priceSoft: undefined,
-      priceHard: undefined,
+      priceHard: 100,
       rarity: "common",
       colorPalettes: [
         { name: "red", isArchived: false },
@@ -125,7 +123,7 @@ describe("resolveCosmetics", () => {
       expect(patternItems[0].key).toBe("pattern:stripes");
     });
 
-    test("purchasable when user has no flares and product exists", () => {
+    test("purchasable when user has no flares and currency price exists", () => {
       const cosmetics = makeCosmetics({
         patterns: { stripes: pattern as any },
         colorPalettes,
@@ -236,9 +234,9 @@ describe("resolveCosmetics", () => {
       name: "cool_flag",
       url: "https://example.com/cool.png",
       affiliateCode: null,
-      product,
+      product: null,
       priceSoft: undefined,
-      priceHard: undefined,
+      priceHard: 50,
       rarity: "rare",
     };
 
@@ -253,7 +251,7 @@ describe("resolveCosmetics", () => {
       expect(flagItem?.colorPalette).toBeNull();
     });
 
-    test("purchasable when not logged in and product exists", () => {
+    test("purchasable when not logged in and currency price exists", () => {
       const cosmetics = makeCosmetics({
         flags: { cool_flag: flag as any },
       });
@@ -284,8 +282,8 @@ describe("resolveCosmetics", () => {
       expect(flagItem?.relationship).toBe("owned");
     });
 
-    test("blocked with no product", () => {
-      const freeFlag = { ...flag, product: null };
+    test("blocked with no currency price", () => {
+      const freeFlag = { ...flag, priceHard: undefined };
       const cosmetics = makeCosmetics({
         flags: { cool_flag: freeFlag as any },
       });
@@ -300,7 +298,7 @@ describe("resolveCosmetics", () => {
       name: "gold_crown",
       url: "http://localhost:8787/public/cosmetics/crown/gold",
       affiliateCode: null,
-      product,
+      product: null,
       priceSoft: undefined,
       priceHard: 5,
       artist: "sadfas",
@@ -349,10 +347,9 @@ describe("resolveCosmetics", () => {
       expect(crownItem?.relationship).toBe("owned");
     });
 
-    test("blocked with no product and no price", () => {
+    test("blocked with no currency price", () => {
       const freeCrown = {
         ...crown,
-        product: null,
         priceHard: undefined,
       };
       const cosmetics = makeCosmetics({
@@ -436,7 +433,7 @@ describe("resolveCosmetics", () => {
             name: "stripes",
             pattern: "AAAAAA",
             affiliateCode: null,
-            product,
+            product: null,
             priceSoft: null,
             priceHard: null,
             rarity: "common",
@@ -448,7 +445,7 @@ describe("resolveCosmetics", () => {
             name: "heart",
             url: "/flags/heart.svg",
             affiliateCode: null,
-            product,
+            product: null,
             priceSoft: null,
             priceHard: null,
             rarity: "common",

--- a/tests/client/EffectsGrid.test.ts
+++ b/tests/client/EffectsGrid.test.ts
@@ -88,7 +88,7 @@ const effectCatalog = {
         ...common,
         name: "locked_hydro",
         effectType: "nukeExplosion",
-        product: { priceId: "locked-hydro" },
+        priceHard: 100,
         attributes: {
           type: "shockwave",
           nukeType: "hydro",
@@ -103,7 +103,7 @@ const effectCatalog = {
         ...common,
         name: "locked_hydro_alt",
         effectType: "nukeExplosion",
-        product: { priceId: "locked-hydro-alt" },
+        priceHard: 100,
         attributes: {
           type: "shockwave",
           nukeType: "hydro",

--- a/tests/client/StoreModal.test.ts
+++ b/tests/client/StoreModal.test.ts
@@ -194,11 +194,6 @@ const affiliatePattern: ResolvedCosmetic = {
   cosmetic: {
     ...pattern,
     affiliateCode: "creator",
-    product: {
-      productId: "affiliate-pattern",
-      priceId: "affiliate-pattern-price",
-      price: "$3",
-    },
   } as never,
   key: "pattern:affiliate:red",
 };
@@ -650,7 +645,7 @@ describe("StoreModal cosmetic browser", () => {
       modal.querySelector(`[data-cosmetic-key="${affiliatePattern.key}"]`),
     ).toBeTruthy();
 
-    await purchaseButton(modal, affiliatePattern.key).onPurchaseDollar!();
-    expect(purchaseCosmetic).toHaveBeenCalledWith(affiliatePattern, "dollar");
+    await purchaseButton(modal, affiliatePattern.key).onPurchaseHard!();
+    expect(purchaseCosmetic).toHaveBeenCalledWith(affiliatePattern, "hard");
   });
 });


### PR DESCRIPTION
## Summary

Direct real-money (Stripe/USD) cosmetic purchases were removed server-side (infra#530): `cosmetics.json` now always serves `product: null` for cosmetics, and `POST /stripe/create-checkout-session` rejects cosmetic price ids with `400 {reason: "cosmetic_checkout_removed"}`. This removes the now-dead USD purchase path from the client. Cosmetics are sold for soft/hard currency only; **currency packs and subscriptions keep their Stripe checkout unchanged.**

## Changes

- **`Cosmetics.ts`** — `cosmeticRelationship()` no longer accepts or checks `product`: a cosmetic is purchasable only when `priceSoft`/`priceHard` is present. The pattern/flag/crown/skin/effect relationship helpers stop passing `product` through, and the cosmetics-hash input drops its dead `"sale"` suffix. Pack/sub `product` checks in `resolveCosmetics` are untouched.
- **`Store.ts`** — `renderPurchaseAction()` wires `product`/`onPurchaseDollar` only for `pack` and `subscription` items. A cached `cosmetics.json` that still carries a cosmetic product (≤60s tail after the API deploy) can no longer render a USD buy button that would 400.
- **`WinModal.ts`** — the post-game pattern promo drops its `.product`/`.onPurchaseDollar` bindings; hard/soft buttons remain.
- **`CosmeticCard.ts`** — the USD-value hint derives from `priceHard` alone instead of branching on `product` (behavior-identical: only packs/subs can carry a product, and they have no `priceHard`).

## Deliberately kept

- `purchaseCosmetic`'s `"dollar"` branch and `PurchaseButton`'s dollar path — they are the live Stripe path for packs (`CustomCurrencyCard`) and subscriptions, which route through the same code. No cosmetic can reach them anymore.
- `CosmeticSchemas.ts` keeps `product: ProductSchema.nullable()` on cosmetics for one release to cover the cached-response tail; it can drop to a removed field afterwards.

## Testing

- Full suite passes (36 files, 357 tests), `tsc --noEmit` clean, oxlint + eslint clean.
- Purchasability fixtures updated to currency prices; the affiliate-store purchase assertion moved from the dollar to the hard-currency path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)