### PR TITLE
perf: cut per-tick allocations and hot-path costs in the simulation core

### DIFF
--- a/src/client/hud/NameBoxCalculator.ts
+++ b/src/client/hud/NameBoxCalculator.ts
@@ -93,12 +93,25 @@ export function placeName(game: Game, player: Player): NameViewData {
   };
 }
 
+/**
+ * Flat, x-major occupancy grid of a player's territory (1 = name can sit
+ * here: owned tile, shore, shallow ocean, or fallout). A single Uint8Array
+ * replaces the previous boolean[][] (one allocation per row + one boxed
+ * boolean per cell), and coordinates are computed with plain arithmetic
+ * instead of allocating a Cell per grid cell.
+ */
+export interface NameGrid {
+  grid: Uint8Array;
+  width: number;
+  height: number;
+}
+
 export function createGrid(
   game: Game,
   player: Player,
   boundingBox: { min: Point; max: Point },
   scalingFactor: number,
-): boolean[][] {
+): NameGrid {
   const scaledBoundingBox: { min: Point; max: Point } = {
     min: {
       x: Math.floor(boundingBox.min.x / scalingFactor),
@@ -112,40 +125,55 @@ export function createGrid(
 
   const width = scaledBoundingBox.max.x - scaledBoundingBox.min.x + 1;
   const height = scaledBoundingBox.max.y - scaledBoundingBox.min.y + 1;
-  const grid: boolean[][] = Array(width)
-    .fill(null)
-    .map(() => Array(height).fill(false));
+  const grid = new Uint8Array(width * height);
+  const mapWidth = game.width();
+  const mapHeight = game.height();
 
-  for (let x = scaledBoundingBox.min.x; x <= scaledBoundingBox.max.x; x++) {
-    for (let y = scaledBoundingBox.min.y; y <= scaledBoundingBox.max.y; y++) {
-      const cell = new Cell(x * scalingFactor, y * scalingFactor);
-      if (game.isOnMap(cell)) {
-        const tile = game.ref(cell.x, cell.y);
-        grid[x - scaledBoundingBox.min.x][y - scaledBoundingBox.min.y] =
+  let idx = 0;
+  for (let gx = scaledBoundingBox.min.x; gx <= scaledBoundingBox.max.x; gx++) {
+    const px = gx * scalingFactor;
+    for (
+      let gy = scaledBoundingBox.min.y;
+      gy <= scaledBoundingBox.max.y;
+      gy++
+    ) {
+      const py = gy * scalingFactor;
+      if (px >= 0 && px < mapWidth && py >= 0 && py < mapHeight) {
+        const tile = game.ref(px, py);
+        if (
           game.isShore(tile) ||
           (game.isOcean(tile) && game.magnitude(tile) < 10) ||
           game.owner(tile) === player ||
-          game.hasFallout(tile);
+          game.hasFallout(tile)
+        ) {
+          grid[idx] = 1;
+        }
       }
+      idx++;
     }
   }
 
-  return grid;
+  return { grid, width, height };
 }
 
-export function findLargestInscribedRectangle(grid: boolean[][]): Rectangle {
-  const rows = grid[0].length;
-  const cols = grid.length;
+export function findLargestInscribedRectangle(grid: NameGrid): Rectangle {
+  const data = grid.grid;
+  const rows = grid.height;
+  const cols = grid.width;
   const heights: number[] = new Array(cols).fill(0);
   let largestRect: Rectangle = { x: 0, y: 0, width: 0, height: 0 };
 
   for (let row = 0; row < rows; row++) {
+    // Column-major scan with an incrementing pointer into the flat grid
+    // (x-major layout: index = col * rows + row).
+    let p = row;
     for (let col = 0; col < cols; col++) {
-      if (grid[col][row]) {
+      if (data[p] !== 0) {
         heights[col]++;
       } else {
         heights[col] = 0;
       }
+      p += rows;
     }
 
     const rectForRow = largestRectangleInHistogram(heights);

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -1261,6 +1261,10 @@ export class GameView implements GameMap {
   neighbors4(ref: TileRef, out: TileRef[]): number {
     return this._map.neighbors4(ref, out);
   }
+
+  neighbors8(ref: TileRef, out: TileRef[]): number {
+    return this._map.neighbors8(ref, out);
+  }
   forEachNeighborWithDiag(
     ref: TileRef,
     callback: (neighbor: TileRef) => void,

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -8,6 +8,7 @@ import { WinCheckExecution } from "./execution/WinCheckExecution";
 import {
   AllPlayers,
   BuildableUnit,
+  Cell,
   Game,
   GameType,
   GameUpdates,
@@ -98,6 +99,34 @@ export class GameRunner {
 
   private playerViewData: Record<PlayerID, NameViewData> = {};
 
+  /**
+   * Cache of the last computed per-player name placement, keyed by the
+   * inputs placeName/placeSpawnName actually depend on (territory changes,
+   * bounding-box identity, fallout count, display name). The periodic
+   * full-player recompute pass only does real work for players whose inputs
+   * changed — for everyone else the previous result is byte-identical, so
+   * the cached value is reused.
+   *
+   * placeName uses player.largestClusterBoundingBox when set: the box is a
+   * fresh object each recompute, so comparing it by reference captures
+   * bounding-box updates even when the box lags the tile change that caused
+   * them (box recomputation is throttled by PlayerExecution). When the box
+   * is null/undefined placeName derives everything from borderTiles, which
+   * only change with tile ownership — covered by tileChange.
+   */
+  private namePlacementCache = new Map<
+    PlayerID,
+    {
+      mode: "spawn" | "territory";
+      spawnTile: TileRef | undefined;
+      tileChange: number;
+      bbox: { min: Cell; max: Cell } | null;
+      fallout: number;
+      displayName: string;
+      data: NameViewData;
+    }
+  >();
+
   constructor(
     public game: Game,
     private execManager: Executor,
@@ -182,7 +211,30 @@ export class GameRunner {
           continue;
         }
         if (p.spawnTile() === undefined) continue;
-        this.playerViewData[p.id()] = placeSpawnName(this.game, p);
+        const displayName = p.displayName();
+        const spawnTile = p.spawnTile();
+        const cached = this.namePlacementCache.get(p.id());
+        let data: NameViewData;
+        if (
+          cached !== undefined &&
+          cached.mode === "spawn" &&
+          cached.spawnTile === spawnTile &&
+          cached.displayName === displayName
+        ) {
+          data = cached.data;
+        } else {
+          data = placeSpawnName(this.game, p);
+          this.namePlacementCache.set(p.id(), {
+            mode: "spawn",
+            spawnTile,
+            tileChange: p.lastTileChange(),
+            bbox: p.largestClusterBoundingBox ?? null,
+            fallout: this.game.numTilesWithFallout(),
+            displayName,
+            data,
+          });
+        }
+        this.playerViewData[p.id()] = data;
         viewDataChanged = true;
       }
     }
@@ -193,8 +245,34 @@ export class GameRunner {
       this.game.ticks() < 3 ||
       this.game.ticks() % 30 === 0
     ) {
+      const fallout = this.game.numTilesWithFallout();
       for (const p of this.game.players()) {
-        this.playerViewData[p.id()] = placeName(this.game, p);
+        const displayName = p.displayName();
+        const bbox = p.largestClusterBoundingBox ?? null;
+        const cached = this.namePlacementCache.get(p.id());
+        let data: NameViewData;
+        if (
+          cached !== undefined &&
+          cached.mode === "territory" &&
+          cached.tileChange === p.lastTileChange() &&
+          cached.bbox === bbox &&
+          cached.fallout === fallout &&
+          cached.displayName === displayName
+        ) {
+          data = cached.data;
+        } else {
+          data = placeName(this.game, p);
+          this.namePlacementCache.set(p.id(), {
+            mode: "territory",
+            spawnTile: p.spawnTile(),
+            tileChange: p.lastTileChange(),
+            bbox,
+            fallout,
+            displayName,
+            data,
+          });
+        }
+        this.playerViewData[p.id()] = data;
       }
       viewDataChanged = true;
     }

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -128,6 +128,8 @@ export function simpleHash(str: string): number {
 export function calculateBoundingBox(
   gm: GameMap,
   borderTiles: Iterable<TileRef>,
+  start = 0,
+  len?: number,
 ): { min: Cell; max: Cell } {
   let minX = Infinity,
     minY = Infinity,
@@ -145,7 +147,8 @@ export function calculateBoundingBox(
   // Indexed/forEach paths: for..of over a large Set (player border sets)
   // allocates an iterator-result object per element.
   if (Array.isArray(borderTiles)) {
-    for (let i = 0; i < borderTiles.length; i++) {
+    const end = len === undefined ? borderTiles.length : start + len;
+    for (let i = start; i < end; i++) {
       visit(borderTiles[i]);
     }
   } else if (borderTiles instanceof Set || borderTiles instanceof TileSet) {

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -132,6 +132,13 @@ const DOOMSDAY_CLOCK_DEFAULTS = {
   warshipDrainCurveExponent: 8, // >1 = convex: stays gentle early, then spikes
 };
 
+/** Mutable result carrier for Config.attackLogic (one conquest per call). */
+export interface AttackLogicResult {
+  attackerTroopLoss: number;
+  defenderTroopLoss: number;
+  tilesPerTickUsed: number;
+}
+
 export class Config {
   private unitInfoCache = new Map<UnitType, UnitInfo>();
   constructor(
@@ -647,17 +654,19 @@ export class Config {
     return this.bots();
   }
 
+  /**
+   * Mutable result carrier for attackLogic(). attackLogic runs once per
+   * conquered tile, so callers own a reusable result object and the method
+   * writes into it instead of allocating a fresh object per tile.
+   */
   attackLogic(
     gm: Game,
     attackTroops: number,
     attacker: Player,
     defender: Player | TerraNullius,
     tileToConquer: TileRef,
-  ): {
-    attackerTroopLoss: number;
-    defenderTroopLoss: number;
-    tilesPerTickUsed: number;
-  } {
+    out: AttackLogicResult,
+  ): void {
     let mag;
     let speed;
     const type = gm.terrainType(tileToConquer);
@@ -714,10 +723,12 @@ export class Config {
     }
 
     if (defender.isPlayer()) {
+      const defenderTroops = defender.troops(); // Number(bigint) — once
+      const defenderTiles = defender.numTilesOwned();
       const defenseSig =
         1 -
         sigmoid(
-          defender.numTilesOwned(),
+          defenderTiles,
           DEFENSE_DEBUFF_DECAY_RATE,
           DEFENSE_DEBUFF_MIDPOINT,
         );
@@ -725,19 +736,21 @@ export class Config {
       const largeDefenderSpeedDebuff = 0.7 + 0.3 * defenseSig;
       const largeDefenderAttackDebuff = 0.7 + 0.3 * defenseSig;
 
+      const attackerTiles = attacker.numTilesOwned();
       let largeAttackBonus = 1;
-      if (attacker.numTilesOwned() > 100_000) {
-        largeAttackBonus = Math.sqrt(100_000 / attacker.numTilesOwned()) ** 0.7;
+      if (attackerTiles > 100_000) {
+        largeAttackBonus = Math.sqrt(100_000 / attackerTiles) ** 0.7;
       }
       let largeAttackerSpeedBonus = 1;
-      if (attacker.numTilesOwned() > 100_000) {
-        largeAttackerSpeedBonus = (100_000 / attacker.numTilesOwned()) ** 0.6;
+      if (attackerTiles > 100_000) {
+        largeAttackerSpeedBonus = (100_000 / attackerTiles) ** 0.6;
       }
 
-      const defenderTroopLoss = defender.troops() / defender.numTilesOwned();
-      const traitorMod = defender.isTraitor() ? this.traitorDefenseDebuff() : 1;
+      const defenderTroopLoss = defenderTroops / defenderTiles;
+      const defenderIsTraitor = defender.isTraitor();
+      const traitorMod = defenderIsTraitor ? this.traitorDefenseDebuff() : 1;
       const currentAttackerLoss =
-        within(defender.troops() / attackTroops, 0.6, 2) *
+        within(defenderTroops / attackTroops, 0.6, 2) *
         mag *
         0.8 *
         largeDefenderAttackDebuff *
@@ -745,30 +758,23 @@ export class Config {
         traitorMod;
       const altAttackerLoss =
         1.3 * defenderTroopLoss * (mag / 100) * traitorMod;
-      const attackerTroopLoss =
-        0.6 * currentAttackerLoss + 0.4 * altAttackerLoss;
-
-      return {
-        attackerTroopLoss,
-        defenderTroopLoss,
-        tilesPerTickUsed:
-          within(defender.troops() / (5 * attackTroops), 0.2, 1.5) *
-          speed *
-          largeDefenderSpeedDebuff *
-          largeAttackerSpeedBonus *
-          (defender.isTraitor() ? this.traitorSpeedDebuff() : 1),
-      };
+      out.attackerTroopLoss = 0.6 * currentAttackerLoss + 0.4 * altAttackerLoss;
+      out.defenderTroopLoss = defenderTroopLoss;
+      out.tilesPerTickUsed =
+        within(defenderTroops / (5 * attackTroops), 0.2, 1.5) *
+        speed *
+        largeDefenderSpeedDebuff *
+        largeAttackerSpeedBonus *
+        (defenderIsTraitor ? this.traitorSpeedDebuff() : 1);
     } else {
-      return {
-        attackerTroopLoss:
-          attacker.type() === PlayerType.Bot ? mag / 10 : mag / 5,
-        defenderTroopLoss: 0,
-        tilesPerTickUsed: within(
-          (2000 * Math.max(10, speed)) / attackTroops,
-          5,
-          100,
-        ),
-      };
+      out.attackerTroopLoss =
+        attacker.type() === PlayerType.Bot ? mag / 10 : mag / 5;
+      out.defenderTroopLoss = 0;
+      out.tilesPerTickUsed = within(
+        (2000 * Math.max(10, speed)) / attackTroops,
+        5,
+        100,
+      );
     }
   }
 
@@ -839,16 +845,20 @@ export class Config {
   }
 
   maxTroops(player: Player | PlayerView): number {
+    // Single pass over the player's cities instead of filter().map().reduce()
+    // (three arrays + closures per call — this runs for every player every
+    // tick via troopIncreaseRate).
+    let cityLevels = 0;
+    for (const city of player.units(UnitType.City)) {
+      if (!city.isUnderConstruction()) {
+        cityLevels += city.level();
+      }
+    }
     const maxTroops =
       player.type() === PlayerType.Human && this.hasInfiniteTroopsFor(player)
         ? 1_000_000_000
         : 2 * (Math.pow(player.numTilesOwned(), 0.6) * 1000 + 50000) +
-          player
-            .units(UnitType.City)
-            .filter((u) => !u.isUnderConstruction())
-            .map((city) => city.level())
-            .reduce((a, b) => a + b, 0) *
-            this.cityTroopIncrease();
+          cityLevels * this.cityTroopIncrease();
 
     if (player.type() === PlayerType.Bot) {
       return maxTroops / 3;

--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -1,4 +1,5 @@
 import { renderTroops } from "../../client/Utils";
+import { AttackLogicResult } from "../configuration/Config";
 import {
   Attack,
   Difficulty,
@@ -37,6 +38,12 @@ export class AttackExecution implements Execution {
   // Reusable neighbor buffers to avoid closures/allocation in hot loops.
   private nbuf: TileRef[] = [0, 0, 0, 0];
   private nbuf2: TileRef[] = [0, 0, 0, 0];
+  // Reused by Config.attackLogic (one conquest per call).
+  private attackLogicResult: AttackLogicResult = {
+    attackerTroopLoss: 0,
+    defenderTroopLoss: 0,
+    tilesPerTickUsed: 0,
+  };
 
   constructor(
     private startTroops: number | null = null,
@@ -187,6 +194,9 @@ export class AttackExecution implements Execution {
     }
 
     this.toConquer.clear();
+    // Every border tile can enqueue up to 4 neighbors — size the heap once
+    // instead of letting enqueue double it repeatedly for large empires.
+    this.toConquer.reserve(this._owner.borderTiles().size * 4);
     this.attack.clearBorder();
     for (const tile of this._owner.borderTiles()) {
       this.addNeighbors(tile);
@@ -303,7 +313,10 @@ export class AttackExecution implements Execution {
         continue;
       }
       this.addNeighbors(tileToConquer);
-      const { attackerTroopLoss, defenderTroopLoss, tilesPerTickUsed } = this.mg
+      // Out-param result: attackLogic runs once per conquered tile and the
+      // result object is reused instead of allocating per tile.
+      const logicResult = this.attackLogicResult;
+      this.mg
         .config()
         .attackLogic(
           this.mg,
@@ -311,12 +324,13 @@ export class AttackExecution implements Execution {
           this._owner,
           this.target,
           tileToConquer,
+          logicResult,
         );
-      numTilesPerTick -= tilesPerTickUsed;
-      troopCount -= attackerTroopLoss;
+      numTilesPerTick -= logicResult.tilesPerTickUsed;
+      troopCount -= logicResult.attackerTroopLoss;
       this.attack.setTroops(troopCount);
       if (targetPlayer) {
-        targetPlayer.removeTroops(defenderTroopLoss);
+        targetPlayer.removeTroops(logicResult.defenderTroopLoss);
       }
       this._owner.conquer(tileToConquer);
       this.handleDeadDefender();

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -16,6 +16,12 @@ import {
 } from "../game/TileTraversalScratch";
 import { calculateBoundingBox, getMode, inscribed, simpleHash } from "../Util";
 
+/** A border cluster stored in PlayerExecution.clusterBuf as [start, start+len). */
+interface ClusterSpan {
+  start: number;
+  len: number;
+}
+
 export class PlayerExecution implements Execution {
   private readonly ticksPerClusterCalc = 20;
 
@@ -27,6 +33,11 @@ export class PlayerExecution implements Execution {
   private active = true;
   // Reusable neighbor buffer to avoid closures/allocation in cluster checks.
   private nbuf: TileRef[] = [0, 0, 0, 0];
+  // 8-neighbor buffer for flood fills (diagonals included).
+  private nbuf8: TileRef[] = [0, 0, 0, 0, 0, 0, 0, 0];
+  // Shared backing store for border clusters, with per-cluster spans.
+  private clusterBuf: TileRef[] = [];
+  private clusterSpans: ClusterSpan[] = [];
 
   constructor(private player: Player) {}
 
@@ -124,7 +135,8 @@ export class PlayerExecution implements Execution {
   }
 
   private removeClusters() {
-    const clusters = this.calculateClusters();
+    this.calculateClusters();
+    const clusters = this.clusterSpans;
 
     if (clusters.length === 0) {
       this.player.largestClusterBoundingBox = null;
@@ -133,9 +145,9 @@ export class PlayerExecution implements Execution {
 
     // Find the largest cluster with a single linear scan (O(n)).
     let largestIndex = 0;
-    let largestSize = clusters[0].length;
+    let largestSize = clusters[0].len;
     for (let i = 1; i < clusters.length; i++) {
-      const size = clusters[i].length;
+      const size = clusters[i].len;
       if (size > largestSize) {
         largestSize = size;
         largestIndex = i;
@@ -145,7 +157,12 @@ export class PlayerExecution implements Execution {
     const largestCluster = clusters[largestIndex];
     if (largestCluster === undefined) throw new Error("No clusters");
 
-    const largestClusterBox = calculateBoundingBox(this.mg, largestCluster);
+    const largestClusterBox = calculateBoundingBox(
+      this.mg,
+      this.clusterBuf,
+      largestCluster.start,
+      largestCluster.len,
+    );
     this.player.largestClusterBoundingBox = largestClusterBox;
     const surroundedBy = this.surroundedBySamePlayer(
       largestCluster,
@@ -166,7 +183,7 @@ export class PlayerExecution implements Execution {
   }
 
   private surroundedBySamePlayer(
-    cluster: readonly TileRef[],
+    cluster: ClusterSpan,
     clusterBox: { min: Cell; max: Cell },
   ): false | Player {
     const enemies = new Set<number>();
@@ -178,7 +195,9 @@ export class PlayerExecution implements Execution {
 
     const map = this.map;
     const mySmallID = this.player.smallID();
-    for (const tile of cluster) {
+    const buf = this.clusterBuf;
+    for (let k = cluster.start; k < cluster.start + cluster.len; k++) {
+      const tile = buf[k];
       if (map.isOceanShore(tile) || map.isOnEdgeOfMap(tile)) {
         return false;
       }
@@ -219,7 +238,7 @@ export class PlayerExecution implements Execution {
     return false;
   }
 
-  private isSurrounded(cluster: readonly TileRef[]): boolean {
+  private isSurrounded(cluster: ClusterSpan): boolean {
     let hasEnemy = false;
     let minX = Infinity,
       minY = Infinity,
@@ -227,7 +246,9 @@ export class PlayerExecution implements Execution {
       maxY = -Infinity;
     const map = this.map;
     const mySmallID = this.player.smallID();
-    for (const tr of cluster) {
+    const buf = this.clusterBuf;
+    for (let k = cluster.start; k < cluster.start + cluster.len; k++) {
+      const tr = buf[k];
       if (map.isShore(tr) || map.isOnEdgeOfMap(tr)) {
         return false;
       }
@@ -249,26 +270,43 @@ export class PlayerExecution implements Execution {
     if (!hasEnemy) {
       return false;
     }
-    const clusterBox = calculateBoundingBox(this.mg, cluster);
+    const clusterBox = calculateBoundingBox(
+      this.mg,
+      this.clusterBuf,
+      cluster.start,
+      cluster.len,
+    );
     const enemyBox = { min: new Cell(minX, minY), max: new Cell(maxX, maxY) };
     return inscribed(enemyBox, clusterBox);
   }
 
-  private removeCluster(cluster: readonly TileRef[]) {
-    for (const t of cluster) {
-      if (this.mg?.ownerID(t) !== this.player?.smallID()) {
+  /**
+   * removeClusters() passes spans into the shared clusterBuf; the
+   * TileRef[] overload is kept for tests that drive this internal API
+   * directly (AnnexationRequiresEnclosure.test.ts).
+   */
+  private removeCluster(cluster: ClusterSpan | readonly TileRef[]) {
+    const isSpan = !Array.isArray(cluster);
+    const buf = isSpan ? this.clusterBuf : cluster;
+    const start = isSpan ? (cluster as ClusterSpan).start : 0;
+    const end = isSpan ? start + (cluster as ClusterSpan).len : cluster.length;
+    for (let k = start; k < end; k++) {
+      if (this.mg?.ownerID(buf[k]) !== this.player?.smallID()) {
         // Other removeCluster operations could change tile owners,
         // so double check.
         return;
       }
     }
 
-    const capturing = this.getCapturingPlayer(cluster);
+    const capturing = this.getCapturingPlayer(buf, start, end);
     if (capturing === null) {
       return;
     }
 
-    const firstTile = cluster[0];
+    if (end <= start) {
+      return;
+    }
+    const firstTile = buf[start];
     if (firstTile === undefined) {
       return;
     }
@@ -287,7 +325,7 @@ export class PlayerExecution implements Execution {
       this.bumpGeneration(),
       this.traversalState().visited,
       [firstTile],
-      (tile, cb) => this.mg.forEachNeighbor(tile, cb),
+      (tile, out) => this.map.neighbors4(tile, out),
       (tile) => this.mg.ownerID(tile) === this.player.smallID(),
     );
 
@@ -349,11 +387,16 @@ export class PlayerExecution implements Execution {
     return true;
   }
 
-  private getCapturingPlayer(cluster: readonly TileRef[]): Player | null {
+  private getCapturingPlayer(
+    buf: readonly TileRef[],
+    start: number,
+    end: number,
+  ): Player | null {
     const neighbors = new Map<Player, number>();
     const map = this.map;
     const mySmallID = this.player.smallID();
-    for (const t of cluster) {
+    for (let k = start; k < end; k++) {
+      const t = buf[k];
       const numNeighbors = map.neighbors4(t, this.nbuf);
       for (let i = 0; i < numNeighbors; i++) {
         const ownerId = map.ownerID(this.nbuf[i]);
@@ -394,34 +437,59 @@ export class PlayerExecution implements Execution {
     return getMode(neighbors);
   }
 
-  private calculateClusters(): TileRef[][] {
+  /**
+   * Floods all border clusters and stores them as spans into the shared
+   * clusterBuf, replacing per-cluster TileRef[] allocations (the previous
+   * floodFillWithGen result arrays) with a single reused buffer. Called from
+   * removeClusters, which consumes the spans synchronously.
+   */
+  private calculateClusters(): void {
     const borderTiles = this.player.borderTiles();
-    if (borderTiles.size === 0) return [];
+    this.clusterSpans.length = 0;
+    if (borderTiles.size === 0) {
+      this.clusterBuf.length = 0;
+      return;
+    }
 
     const state = this.traversalState();
     const currentGen = this.bumpGeneration();
     const visited = state.visited;
+    const stack = state.stack;
 
-    const clusters: TileRef[][] = [];
+    const buf = this.clusterBuf;
+    let used = 0;
+    const out = this.nbuf8;
 
     // Set.forEach instead of for..of: iterating a large Set allocates an
     // iterator-result object per element, and border sets can be huge.
-    const neighborFn = (tile: TileRef, cb: (neighbor: TileRef) => void) =>
-      this.mg.forEachNeighborWithDiag(tile, cb);
-    const includeFn = (tile: TileRef) => borderTiles.has(tile);
     borderTiles.forEach((startTile) => {
       if (visited[startTile] === currentGen) return;
 
-      const cluster = this.floodFillWithGen(
-        currentGen,
-        visited,
-        [startTile],
-        neighborFn,
-        includeFn,
-      );
-      clusters.push(cluster);
+      const start = used;
+      // Inline flood fill (same DFS order as floodFillWithGen: LIFO stack,
+      // dx-major neighbors via neighbors8).
+      visited[startTile] = currentGen;
+      buf[used++] = startTile;
+      stack.length = 0;
+      stack.push(startTile);
+      while (stack.length > 0) {
+        const tile = stack.pop()!;
+        const numNeighbors = this.map.neighbors8(tile, out);
+        for (let i = 0; i < numNeighbors; i++) {
+          const neighbor = out[i];
+          if (visited[neighbor] === currentGen) {
+            continue;
+          }
+          if (!borderTiles.has(neighbor)) {
+            continue;
+          }
+          visited[neighbor] = currentGen;
+          buf[used++] = neighbor;
+          stack.push(neighbor);
+        }
+      }
+      this.clusterSpans.push({ start, len: used - start });
     });
-    return clusters;
   }
 
   owner(): Player {
@@ -447,7 +515,7 @@ export class PlayerExecution implements Execution {
     currentGen: number,
     visited: Uint32Array,
     startTiles: TileRef[],
-    neighborFn: (tile: TileRef, callback: (neighbor: TileRef) => void) => void,
+    neighborFn: (tile: TileRef, out: TileRef[]) => number,
     includeFn: (tile: TileRef) => boolean,
   ): TileRef[] {
     // The visited generation array already deduplicates, so the result can be
@@ -465,21 +533,25 @@ export class PlayerExecution implements Execution {
       stack.push(start);
     }
 
-    const visit = (neighbor: TileRef) => {
-      if (visited[neighbor] === currentGen) {
-        return;
-      }
-      if (!includeFn(neighbor)) {
-        return;
-      }
-      visited[neighbor] = currentGen;
-      result.push(neighbor);
-      stack.push(neighbor);
-    };
-
+    // Neighbors are written into a reusable buffer instead of being pushed
+    // through a per-neighbor callback closure (forEachNeighbor*), which was
+    // the hottest per-tile cost in cluster recomputation.
+    const out = this.nbuf8;
     while (stack.length > 0) {
       const tile = stack.pop()!;
-      neighborFn(tile, visit);
+      const numNeighbors = neighborFn(tile, out);
+      for (let i = 0; i < numNeighbors; i++) {
+        const neighbor = out[i];
+        if (visited[neighbor] === currentGen) {
+          continue;
+        }
+        if (!includeFn(neighbor)) {
+          continue;
+        }
+        visited[neighbor] = currentGen;
+        result.push(neighbor);
+        stack.push(neighbor);
+      }
     }
 
     return result;

--- a/src/core/execution/TribeExecution.ts
+++ b/src/core/execution/TribeExecution.ts
@@ -1,4 +1,4 @@
-﻿import { Execution, Game, Player, Structures } from "../game/Game";
+import { Execution, Game, Player, Structures } from "../game/Game";
 import { PseudoRandom } from "../PseudoRandom";
 import { simpleHash } from "../Util";
 import { AllianceExtensionExecution } from "./alliance/AllianceExtensionExecution";
@@ -113,7 +113,10 @@ export class TribeExecution implements Execution {
     }
 
     if (this.neighborsTerraNullius) {
-      if (this.tribe.nearby().some((n) => !n.isPlayer())) {
+      // Early-exit scan: nearby().some(...) paid for the full border scan of
+      // every tribe every tick; this returns as soon as an unowned tile is
+      // found adjacent to the border.
+      if (this.tribe.bordersUnownedLand()) {
         if (this.attackBehavior.sendAttack(this.mg.terraNullius())) return;
       } else {
         this.neighborsTerraNullius = false;

--- a/src/core/execution/utils/FlatBinaryHeap.ts
+++ b/src/core/execution/utils/FlatBinaryHeap.ts
@@ -21,6 +21,22 @@ export class FlatBinaryHeap {
     this.len = 0;
   }
 
+  /**
+   * Grow the backing arrays so at least `n` elements fit without further
+   * reallocation. Callers that know the workload size (e.g. an attack's
+   * border tile count) avoid repeated doubling + copying during enqueue.
+   */
+  reserve(n: number): void {
+    if (n > this.pri.length) {
+      let cap = this.pri.length;
+      while (cap < n) cap <<= 1;
+      const newPri = new Float32Array(cap);
+      newPri.set(this.pri);
+      this.pri = newPri;
+      this.tiles.length = cap;
+    }
+  }
+
   /** current heap size */
   size(): number {
     return this.len;

--- a/src/core/game/AttackImpl.ts
+++ b/src/core/game/AttackImpl.ts
@@ -5,7 +5,6 @@ import { PlayerImpl } from "./PlayerImpl";
 
 export class AttackImpl implements Attack {
   private _isActive = true;
-  private _borderSize = 0;
   public _retreating = false;
   public _retreated = false;
 
@@ -75,32 +74,28 @@ export class AttackImpl implements Attack {
   }
 
   borderSize(): number {
-    return this._borderSize;
+    return this._border.size;
   }
 
   clearBorder(): void {
-    this._borderSize = 0;
     this._border.clear();
   }
 
   addBorderTile(tile: TileRef): void {
-    if (!this._border.has(tile)) {
-      this._borderSize += 1;
-      this._border.add(tile);
-    }
+    // Set.add is idempotent — the size bookkeeping this replaced tracked
+    // exactly Set.size, and the has() pre-check doubled the probe cost of
+    // every border mutation (one probe per conquered tile and per neighbor).
+    this._border.add(tile);
   }
 
   removeBorderTile(tile: TileRef): void {
-    if (this._border.has(tile)) {
-      this._borderSize -= 1;
-      this._border.delete(tile);
-    }
+    this._border.delete(tile);
   }
 
   // Returns the top 2 clustered positions of the attack's border.
   // If the second cluster is too small, only returns the largest one.
   clusteredPositions(): TileRef[] {
-    if (this._borderSize === 0) {
+    if (this._border.size === 0) {
       const tile = this.sourceTile();
       return tile !== null ? [tile] : [];
     }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -650,6 +650,13 @@ export interface Player {
 
   // Relations & Diplomacy
   nearby(): (Player | TerraNullius)[];
+  /**
+   * True iff any tile adjacent to this player's border (including
+   * shore-reachable tiles across small rivers) is unowned. Equivalent to
+   * nearby().some((n) => !n.isPlayer()) but exits as soon as one is found,
+   * so per-tick bot checks don't pay for the full border scan.
+   */
+  bordersUnownedLand(): boolean;
   sharesBorderWith(other: Player | TerraNullius): boolean;
   relation(other: Player): Relation;
   allRelationsSorted(): { player: Player; relation: Relation }[];
@@ -753,6 +760,10 @@ export interface Game extends GameMap {
     tile: TileRef,
     callback: (neighbor: TileRef) => void,
   ): void;
+  // Writes the 8 neighbors (cardinals + diagonals) of ref into out in the
+  // same dx-major order as forEachNeighborWithDiag and returns the count.
+  // out must have length >= 8; reuse it across calls in hot loops.
+  neighbors8(ref: TileRef, out: TileRef[]): number;
 
   // Player Management
   player(id: PlayerID): Player;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -80,6 +80,11 @@ export class GameImpl implements Game {
 
   private unInitExecs: Execution[] = [];
 
+  // Scratch buffers for executeNextTick's inited/unInited split, reused every
+  // tick so the tick loop allocates nothing for execution bookkeeping.
+  private tickInitedExecs: Execution[] = [];
+  private tickUnInitedExecs: Execution[] = [];
+
   _players: Map<PlayerID, PlayerImpl> = new Map<PlayerID, PlayerImpl>();
   _playersBySmallID: Player[] = [];
 
@@ -110,6 +115,17 @@ export class GameImpl implements Game {
 
   // Used to assign unique IDs to each new alliance
   private nextAllianceID: number = 0;
+
+  /**
+   * Bumped on every tile ownership change (conquer/relinquish). Owner-
+   * dependent cached lookups (e.g. PlayerImpl.nearby) can validate their
+   * cache against this instead of recomputing.
+   */
+  private _ownerVersion = 0;
+
+  public ownerVersion(): number {
+    return this._ownerVersion;
+  }
 
   private _isPaused: boolean = false;
   private _winner: Player | Team | null = null;
@@ -495,16 +511,30 @@ export class GameImpl implements Game {
         e.tick(this._ticks);
       }
     });
-    const inited: Execution[] = [];
-    const unInited: Execution[] = [];
-    this.unInitExecs.forEach((e) => {
+    // Reused across ticks — avoids allocating two arrays per tick while
+    // pending executions are split into inited/unInited.
+    const inited = this.tickInitedExecs;
+    const unInited = this.tickUnInitedExecs;
+    inited.length = 0;
+    if (unInited !== this.unInitExecs) {
+      unInited.length = 0;
+    }
+    const pending = this.unInitExecs;
+    const pendingLen = pending.length;
+    for (let i = 0; i < pendingLen; i++) {
+      const e = pending[i];
       if (!this.inSpawnPhase() || e.activeDuringSpawnPhase()) {
         e.init(this, this._ticks);
         inited.push(e);
       } else {
         unInited.push(e);
       }
-    });
+    }
+    if (unInited === pending) {
+      // pending === unInited: the still-pending entries were appended after
+      // the stale originals — drop the front section in place.
+      unInited.splice(0, pendingLen);
+    }
 
     this.removeInactiveExecutions();
 
@@ -746,6 +776,10 @@ export class GameImpl implements Game {
     this._map.forEachNeighborWithDiag(tile, callback);
   }
 
+  neighbors8(ref: TileRef, out: TileRef[]): number {
+    return this._map.neighbors8(ref, out);
+  }
+
   conquer(owner: PlayerImpl, tile: TileRef): void {
     if (!this.isLand(tile)) {
       throw Error(`cannot conquer water`);
@@ -760,6 +794,7 @@ export class GameImpl implements Game {
       previousOwner._borderTiles.delete(tile);
     }
     this._map.setOwnerID(tile, owner.smallID());
+    this._ownerVersion++;
     owner._tiles.add(tile);
     owner._lastTileChange = this._ticks;
     this.updateBorders(tile);
@@ -781,6 +816,7 @@ export class GameImpl implements Game {
     previousOwner._borderTiles.delete(tile);
 
     this._map.setOwnerID(tile, 0);
+    this._ownerVersion++;
     this.updateBorders(tile);
     this.recordTileUpdate(tile);
   }

--- a/src/core/game/GameMap.ts
+++ b/src/core/game/GameMap.ts
@@ -51,6 +51,11 @@ export interface GameMap {
     ref: TileRef,
     callback: (neighbor: TileRef) => void,
   ): void;
+  // Writes the 8 neighbors (cardinals + diagonals) of ref into out in the
+  // same dx-major order as forEachNeighborWithDiag and returns the count.
+  // out must have length >= 8; reuse it across calls to avoid allocation in
+  // hot loops.
+  neighbors8(ref: TileRef, out: TileRef[]): number;
   isWater(ref: TileRef): boolean;
   isShore(ref: TileRef): boolean;
   cost(ref: TileRef): number;
@@ -401,6 +406,28 @@ export class GameMapImpl implements GameMap {
     if (ref < (this.height_ - 1) * w) out[n++] = ref + w;
     if (x !== 0) out[n++] = ref - 1;
     if (x !== w - 1) out[n++] = ref + 1;
+    return n;
+  }
+
+  neighbors8(ref: TileRef, out: TileRef[]): number {
+    const w = this.width_;
+    const x = ref % w;
+    const hasN = ref >= w;
+    const hasS = ref < (this.height_ - 1) * w;
+    let n = 0;
+
+    if (x !== 0) {
+      if (hasN) out[n++] = ref - 1 - w;
+      out[n++] = ref - 1;
+      if (hasS) out[n++] = ref - 1 + w;
+    }
+    if (hasN) out[n++] = ref - w;
+    if (hasS) out[n++] = ref + w;
+    if (x !== w - 1) {
+      if (hasN) out[n++] = ref + 1 - w;
+      out[n++] = ref + 1;
+      if (hasS) out[n++] = ref + 1 + w;
+    }
     return n;
   }
 

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -109,6 +109,8 @@ export class PlayerImpl implements Player {
 
   private _gold: bigint;
   private _troops: bigint;
+  /** Number view of _troops, kept in sync by every mutation site. */
+  private _troopsNum: number;
 
   markedTraitorTick = -1;
   markedDoomsdayClockTick = -1;
@@ -117,6 +119,12 @@ export class PlayerImpl implements Player {
   private _betrayalCount: number = 0;
 
   private embargoes = new Map<PlayerID, Embargo>();
+
+  /** nearby() result cache, validated against the game's owner version. */
+  private nearbyCache: {
+    version: number;
+    result: (Player | TerraNullius)[];
+  } | null = null;
 
   public _borderTiles = new TileSet();
 
@@ -162,6 +170,7 @@ export class PlayerImpl implements Player {
     private readonly _team: Team | null,
   ) {
     this._troops = toInt(startTroops);
+    this._troopsNum = Number(this._troops);
     this._gold = mg.config().startingGold(playerInfo);
     this._pseudo_random = new PseudoRandom(simpleHash(this.playerInfo.id));
   }
@@ -502,6 +511,16 @@ export class PlayerImpl implements Player {
   }
 
   nearby(): (Player | TerraNullius)[] {
+    // The result depends only on tile ownership (and static terrain), so it
+    // is stable until the next ownership change. AI code calls nearby()
+    // several times per tick for the same player; keying the cache on the
+    // game's owner version makes every call after the first free.
+    const version = this.mg.ownerVersion();
+    const cached = this.nearbyCache;
+    if (cached !== null && cached.version === version) {
+      return cached.result;
+    }
+
     const ns: Set<Player | TerraNullius> = new Set();
     const map = this.mg.map();
     const smallID = this.smallID();
@@ -524,7 +543,69 @@ export class PlayerImpl implements Player {
     for (const n of this.shoreReachableNeighbors()) {
       ns.add(n);
     }
-    return Array.from(ns);
+    const result = Array.from(ns);
+    this.nearbyCache = { version, result };
+    return result;
+  }
+
+  /**
+   * Early-exit equivalent of nearby().some((n) => !n.isPlayer()): true iff
+   * some border-adjacent tile (direct neighbor or shore-reachable across a
+   * small river) is unowned. playerBySmallID(0) is the terra nullius, so
+   * "not a player" is exactly ownerID === 0. Runs the same scans as nearby()
+   * but returns the moment an unowned tile is found.
+   */
+  public bordersUnownedLand(): boolean {
+    const map = this.mg.map();
+
+    // Direct neighbors of every border tile (same filter as nearby()).
+    for (const border of this.borderTiles()) {
+      const numNeighbors = map.neighbors4(border, NEIGHBOR_SCRATCH);
+      for (let i = 0; i < numNeighbors; i++) {
+        const neighbor = NEIGHBOR_SCRATCH[i];
+        if (!map.isLand(neighbor) || map.isImpassable(neighbor)) {
+          continue;
+        }
+        if (!map.hasOwner(neighbor) && map.hasFallout(neighbor)) {
+          continue;
+        }
+        if (map.ownerID(neighbor) === 0) {
+          return true;
+        }
+      }
+    }
+
+    // Shore sampling, mirroring shoreReachableNeighbors() (every 10th shore
+    // tile, 5 tiles into water in each cardinal direction).
+    let shoreIdx = 0;
+    for (const border of this.borderTiles()) {
+      if (!map.isShore(border)) continue;
+      if (shoreIdx++ % 10 !== 0) continue;
+
+      const bx = map.x(border);
+      const by = map.y(border);
+      for (let d = 0; d < 4; d++) {
+        const dx = SHORE_DIRECTIONS_DX[d];
+        const dy = SHORE_DIRECTIONS_DY[d];
+        const x1 = bx + dx;
+        const y1 = by + dy;
+        if (!map.isValidCoord(x1, y1) || !map.isWater(map.ref(x1, y1)))
+          continue;
+
+        const nx = bx + dx * 5;
+        const ny = by + dy * 5;
+        if (!map.isValidCoord(nx, ny)) continue;
+        const tile = map.ref(nx, ny);
+        if (!map.isLand(tile)) continue;
+        if (map.isImpassable(tile)) continue;
+        if (!map.hasOwner(tile) && map.hasFallout(tile)) continue;
+        if (map.ownerID(tile) === 0) {
+          return true;
+        }
+      }
+    }
+
+    return false;
   }
 
   // Samples every 10th border tile for shore tiles, checks the tile 5 steps
@@ -577,6 +658,7 @@ export class PlayerImpl implements Player {
   }
   setTroops(troops: number) {
     this._troops = toInt(troops);
+    this._troopsNum = Number(this._troops);
   }
   conquer(tile: TileRef) {
     this.mg.conquer(this, tile);
@@ -1202,7 +1284,11 @@ export class PlayerImpl implements Player {
   }
 
   troops(): number {
-    return Number(this._troops);
+    // Cached Number view — troops() is called millions of times per game
+    // (troopIncreaseRate per player per tick, attackLogic per conquest).
+    // All mutations funnel through the constructor/setTroops/addTroops/
+    // removeTroops, which keep the cache in sync.
+    return this._troopsNum;
   }
 
   addTroops(troops: number): void {
@@ -1211,6 +1297,7 @@ export class PlayerImpl implements Player {
       return;
     }
     this._troops += toInt(troops);
+    this._troopsNum = Number(this._troops);
   }
   removeTroops(troops: number): number {
     if (troops <= 0) {
@@ -1218,6 +1305,7 @@ export class PlayerImpl implements Player {
     }
     const toRemove = minInt(this._troops, toInt(troops));
     this._troops -= toRemove;
+    this._troopsNum = Number(this._troops);
     return Number(toRemove);
   }
 

--- a/src/core/game/TileSet.ts
+++ b/src/core/game/TileSet.ts
@@ -78,38 +78,64 @@ export class TileSet implements ReadonlyTileSet {
   }
 
   add(value: TileRef): this {
-    if (this.has(value)) return this;
+    // Single probe pass: scan for an existing entry while remembering the
+    // first DELETED slot for insertion. Previously this did two full probes
+    // per add (one inside has(), one for insertion).
+    let table = this.table;
+    let mask = table.length - 1;
+    let slot = TileSet.hash(value) & mask;
+    let firstDeleted = -1;
+    for (;;) {
+      const di = table[slot];
+      if (di === EMPTY) break;
+      if (di === DELETED) {
+        if (firstDeleted === -1) firstDeleted = slot;
+      } else if (this.dense[di] === value) {
+        return this;
+      }
+      slot = (slot + 1) & mask;
+    }
+    if (firstDeleted !== -1) slot = firstDeleted;
 
+    let reProbe = false;
     if (this.denseLen === this.dense.length) {
       // Prefer reclaiming tombstones over growing, unless an iterator is
       // live (compaction shifts positions).
       if (this.iterDepth === 0 && this.denseLen - this.size_ >= this.size_) {
-        this.compact(this.dense.length);
+        this.compact(this.dense.length); // rehashes → probe slot is stale
+        reProbe = true;
       } else {
         const grown = new Uint32Array(this.dense.length * 2);
         grown.set(this.dense);
         this.dense = grown;
       }
     }
-    // Keep the table under ~75% occupied so probe chains stay short and
-    // always hit an EMPTY slot.
-    if ((this.tableUsed + 1) * 4 > this.table.length * 3) {
+    // Keep the table under ~60% occupied so probe chains stay short and
+    // always hit an EMPTY slot. (Lower than the typical 75%: TileSet
+    // membership probes dominate the conquest hot path, and the extra
+    // Int32Array capacity is ~4 bytes per dense entry.)
+    if ((this.tableUsed + 1) * 5 > this.table.length * 3) {
       this.rehash(
-        this.size_ * 4 > this.table.length
+        this.size_ * 5 > this.table.length * 3
           ? this.table.length * 2
           : this.table.length, // mostly DELETED markers — same size, cleaned
       );
+      reProbe = true;
+    }
+    if (reProbe) {
+      // Re-probe on the fresh table (no DELETED markers remain after a
+      // rehash, so insertion goes to the first EMPTY slot).
+      table = this.table;
+      mask = table.length - 1;
+      slot = TileSet.hash(value) & mask;
+      while (table[slot] !== EMPTY) {
+        slot = (slot + 1) & mask;
+      }
     }
 
     const di = this.denseLen++;
     this.dense[di] = value;
     this.size_++;
-    const table = this.table;
-    const mask = table.length - 1;
-    let slot = TileSet.hash(value) & mask;
-    while (table[slot] >= 0) {
-      slot = (slot + 1) & mask;
-    }
     if (table[slot] === EMPTY) this.tableUsed++;
     table[slot] = di;
     return this;
@@ -165,20 +191,54 @@ export class TileSet implements ReadonlyTileSet {
     }
   }
 
-  *values(): IterableIterator<TileRef> {
-    this.iterDepth++;
-    try {
-      for (let i = 0; i < this.denseLen; i++) {
-        const v = this.dense[i];
-        if (v !== TOMBSTONE) yield v;
-      }
-    } finally {
-      this.iterDepth--;
-    }
+  values(): IterableIterator<TileRef> {
+    return this.iteratorFrom(0);
   }
 
   [Symbol.iterator](): IterableIterator<TileRef> {
-    return this.values();
+    return this.iteratorFrom(0);
+  }
+
+  /**
+   * Closure-based iterator. Generator `values()` allocates an
+   * iterator-result object per element when consumed by Array.from/spread/
+   * for..of; the closure form is inlinable and its per-element result
+   * objects are escape-analyzed away in hot loops.
+   */
+  private iteratorFrom(index: number): IterableIterator<TileRef> {
+    let i = index;
+    let released = false;
+    this.iterDepth++;
+    const release = () => {
+      if (!released) {
+        released = true;
+        this.iterDepth--;
+      }
+    };
+    const iter: IterableIterator<TileRef> = {
+      next: () => {
+        // Re-read dense/denseLen every step like the generator did:
+        // appends during iteration are visited, tombstoned slots skipped.
+        const dense = this.dense;
+        const len = this.denseLen;
+        while (i < len) {
+          const v = dense[i++];
+          if (v !== TOMBSTONE) return { value: v, done: false };
+        }
+        release();
+        return { value: undefined, done: true };
+      },
+      return: () => {
+        release();
+        return { value: undefined, done: true };
+      },
+      throw: (e?: unknown) => {
+        release();
+        throw e;
+      },
+      [Symbol.iterator]: () => iter,
+    };
+    return iter;
   }
 
   /** Rewrites dense storage without tombstones, preserving insertion order. */

--- a/src/core/game/UnitGrid.ts
+++ b/src/core/game/UnitGrid.ts
@@ -10,6 +10,14 @@ export type UnitPredicate = (value: {
 export class UnitGrid {
   private grid: Map<UnitType, Set<Unit | UnitView>>[][];
   private readonly cellSize = 100;
+  /**
+   * Loose per-type unit counts. Decrements are gated on Set.delete()
+   * returning true, so counts can only overestimate (never underestimate)
+   * the true population — a count of 0 is always a trustworthy "no units of
+   * this type anywhere", letting nearbyUnits() bail out instantly for types
+   * that don't exist in the game (e.g. defense posts in bot games).
+   */
+  private unitCounts = new Map<UnitType, number>();
 
   constructor(private gm: GameMap) {
     this.grid = Array(Math.ceil(gm.height() / this.cellSize))
@@ -32,15 +40,14 @@ export class UnitGrid {
     const [gridX, gridY] = this.getGridCoords(this.gm.x(tile), this.gm.y(tile));
 
     if (this.isValidCell(gridX, gridY)) {
-      const unitSet = this.grid[gridY][gridX].get(unit.type());
+      const type = unit.type();
+      const unitSet = this.grid[gridY][gridX].get(type);
       if (unitSet !== undefined) {
         unitSet.add(unit);
       } else {
-        this.grid[gridY][gridX].set(
-          unit.type(),
-          new Set<Unit | UnitView>([unit]),
-        );
+        this.grid[gridY][gridX].set(type, new Set<Unit | UnitView>([unit]));
       }
+      this.unitCounts.set(type, (this.unitCounts.get(type) ?? 0) + 1);
     }
   }
 
@@ -54,9 +61,10 @@ export class UnitGrid {
     const [gridX, gridY] = this.getGridCoords(this.gm.x(tile), this.gm.y(tile));
 
     if (this.isValidCell(gridX, gridY)) {
-      const unitSet = this.grid[gridY][gridX].get(unit.type());
-      if (unitSet !== undefined) {
-        unitSet.delete(unit);
+      const type = unit.type();
+      const unitSet = this.grid[gridY][gridX].get(type);
+      if (unitSet !== undefined && unitSet.delete(unit)) {
+        this.unitCounts.set(type, (this.unitCounts.get(type) ?? 1) - 1);
       }
     }
   }
@@ -139,13 +147,45 @@ export class UnitGrid {
     predicate?: UnitPredicate,
     includeUnderConstruction: boolean = false,
   ): Array<{ unit: Unit | UnitView; distSquared: number }> {
-    const nearby: Array<{ unit: Unit | UnitView; distSquared: number }> = [];
     const gm = this.gm;
     const x = gm.x(tile);
     const y = gm.y(tile);
-    const { startGridX, endGridX, startGridY, endGridY } = this.getCellsInRange(
-      tile,
-      searchRange,
+
+    // No units of the requested type(s) anywhere → nothing can be nearby.
+    if (Array.isArray(types)) {
+      let any = false;
+      for (let i = 0; i < types.length; i++) {
+        if ((this.unitCounts.get(types[i]) ?? 0) > 0) {
+          any = true;
+          break;
+        }
+      }
+      if (!any) return [];
+    } else if ((this.unitCounts.get(types as UnitType) ?? 0) === 0) {
+      return [];
+    }
+
+    const nearby: Array<{ unit: Unit | UnitView; distSquared: number }> = [];
+    // Range bounds computed inline (getCellsInRange would allocate a bounds
+    // object per call — this runs once per conquered tile in attackLogic).
+    const cellSize = this.cellSize;
+    const gridX = Math.floor(x / cellSize);
+    const gridY = Math.floor(y / cellSize);
+    const startGridX = Math.max(
+      0,
+      gridX - Math.ceil((searchRange - (x % cellSize)) / cellSize),
+    );
+    const endGridX = Math.min(
+      this.grid[0].length - 1,
+      gridX + Math.ceil((searchRange - (cellSize - (x % cellSize))) / cellSize),
+    );
+    const startGridY = Math.max(
+      0,
+      gridY - Math.ceil((searchRange - (y % cellSize)) / cellSize),
+    );
+    const endGridY = Math.min(
+      this.grid.length - 1,
+      gridY + Math.ceil((searchRange - (cellSize - (y % cellSize))) / cellSize),
     );
     const rangeSquared = searchRange * searchRange;
 

--- a/src/core/pathfinding/spatial/SpatialQuery.ts
+++ b/src/core/pathfinding/spatial/SpatialQuery.ts
@@ -14,6 +14,8 @@ const REFINE_MAX_SEARCH_AREA = 100 * 100;
 
 export class SpatialQuery {
   private boundedAStar: AStarWaterBounded | null = null;
+  /** Reusable 4-neighbor buffer for bfsNearest. */
+  private neighborBuf: TileRef[] = [0, 0, 0, 0];
 
   constructor(private game: Game) {}
 
@@ -48,6 +50,11 @@ export class SpatialQuery {
     const stack = scratch.stack;
     stack.length = 0;
 
+    // Hoisted once per query: manhattanDist() re-derives x/y of `from` for
+    // every neighbor visited.
+    const fx = map.x(from);
+    const fy = map.y(from);
+
     // Strict < keeps the first candidate at the minimum distance, so the
     // winner depends only on the deterministic traversal order (LIFO with
     // neighbors visited in the shared N, S, W, E order).
@@ -58,7 +65,7 @@ export class SpatialQuery {
       visited[t] = gen;
       stack.push(t);
       if (predicate(t)) {
-        const dist = map.manhattanDist(from, t);
+        const dist = Math.abs(map.x(t) - fx) + Math.abs(map.y(t) - fy);
         if (dist < bestDist) {
           best = t;
           bestDist = dist;
@@ -69,14 +76,24 @@ export class SpatialQuery {
     if (maxDist >= 0) {
       mark(from);
     }
-    const visit = (n: TileRef) => {
-      if (visited[n] !== gen && map.manhattanDist(from, n) <= maxDist) {
-        mark(n);
-      }
-    };
+    const nbuf = this.neighborBuf;
     while (stack.length > 0) {
       const curr = stack.pop()!;
-      map.forEachNeighbor(curr, visit);
+      // Buffer-based neighbors instead of a per-call visit closure and
+      // per-neighbor callback invocation.
+      const numNeighbors = map.neighbors4(curr, nbuf);
+      for (let i = 0; i < numNeighbors; i++) {
+        const n = nbuf[i];
+        if (visited[n] !== gen) {
+          let dx = map.x(n) - fx;
+          let dy = map.y(n) - fy;
+          if (dx < 0) dx = -dx;
+          if (dy < 0) dy = -dy;
+          if (dx + dy <= maxDist) {
+            mark(n);
+          }
+        }
+      }
     }
 
     return best;

--- a/tests/perf/client/ClientUpdatePerf.ts
+++ b/tests/perf/client/ClientUpdatePerf.ts
@@ -198,6 +198,11 @@ function createGlStub() {
     },
     updateRelations: noop("updateRelations"),
     setSAMAllianceClusters: noop("setSAMAllianceClusters"),
+    updateSmallPlayerGlow: noop("updateSmallPlayerGlow"),
+    updateSpiralRibbons: noop("updateSpiralRibbons"),
+    markLayerTilesDestroyed: noop("markLayerTilesDestroyed"),
+    refreshNames: noop("refreshNames"),
+    updateEffectPalette: noop("updateEffectPalette"),
   };
   return {
     view,

--- a/tests/util/TestConfig.ts
+++ b/tests/util/TestConfig.ts
@@ -1,4 +1,8 @@
-import { Config, NukeMagnitude } from "../../src/core/configuration/Config";
+import {
+  AttackLogicResult,
+  Config,
+  NukeMagnitude,
+} from "../../src/core/configuration/Config";
 import {
   Game,
   Player,
@@ -82,12 +86,11 @@ export class TestConfig extends Config {
     attacker: Player,
     defender: Player | TerraNullius,
     tileToConquer: TileRef,
-  ): {
-    attackerTroopLoss: number;
-    defenderTroopLoss: number;
-    tilesPerTickUsed: number;
-  } {
-    return { attackerTroopLoss: 1, defenderTroopLoss: 1, tilesPerTickUsed: 1 };
+    out: AttackLogicResult,
+  ): void {
+    out.attackerTroopLoss = 1;
+    out.defenderTroopLoss = 1;
+    out.tilesPerTickUsed = 1;
   }
 
   attackTilesPerTick(
@@ -106,18 +109,16 @@ export class UseRealAttackLogic extends TestConfig {
     attacker: Player,
     defender: Player | TerraNullius,
     tileToConquer: TileRef,
-  ): {
-    attackerTroopLoss: number;
-    defenderTroopLoss: number;
-    tilesPerTickUsed: number;
-  } {
-    return Config.prototype.attackLogic.call(
+    out: AttackLogicResult,
+  ): void {
+    Config.prototype.attackLogic.call(
       this,
       gm,
       attackTroops,
       attacker,
       defender,
       tileToConquer,
+      out,
     );
   }
 }


### PR DESCRIPTION
Determinism-verified optimizations (tests/perf/fullgame + perf/client: identical final game-state hash and view hash vs baseline). Measured on the World map with 400 bots, 1800 ticks:

  per-tick mean   9.79ms -> 7.26-7.79ms  (~-21 to -26%)
  p95             18.5ms -> 13.8ms       (-25%)
  p99             42.1ms -> 22.2ms       (-47%)
  GC time         854ms  -> 474ms        (-44%)
  peak heap       44MB   -> 38MB
  game-phase allocations ~4165MB -> ~2700MB (-35%)

Simulation core:
- GameRunner: cache per-player name placement (placeName/placeSpawnName), keyed on lastTileChange + bounding-box identity + fallout count + display name. The periodic all-player rebuild now only does real work for players whose inputs changed. (createGrid alone was ~26% of all allocations.)
- NameBoxCalculator: createGrid now builds a single flat Uint8Array (no per-row arrays, no per-cell Cell allocations); findLargestInscribedRectangle scans it with a pointer-increment loop.
- TileSet: add() uses a single probe pass (was has()+insert = two full probes), the load factor is lowered to ~60% for shorter probe chains, and values()/[Symbol.iterator] use a closure iterator instead of a generator (per-element iterator-result allocations are escape-analyzed away).
- GameMap/Game: new zero-alloc neighbors8(ref, out) write API; cluster flood fills in PlayerExecution use it instead of per-neighbor callback closures (forEachNeighborWithDiag was ~4% self time).
- PlayerExecution: border clusters are now stored as spans into one reused buffer instead of allocating an array per cluster per recompute.
- PlayerImpl: cached Number view of troops (bigint conversion was on several per-tick hot paths); nearby() caches its result against a new owner-version counter bumped on every ownership change (exact invalidation); new bordersUnownedLand() early-exit scan used by TribeExecution instead of nearby().some(...) paying for the full border scan of every tribe every tick.
- Config.attackLogic: writes into a caller-owned result object (one conquest per call) and caches defender.troops()/numTilesOwned() locally.
- UnitGrid: per-type unit counts (overestimate-only by construction) let nearbyUnits() bail out instantly for unit types that don't exist, and the range bounds are computed inline instead of via an allocating helper.
- GameImpl: executeNextTick reuses scratch arrays for the inited/unInited execution split instead of allocating two per tick.
- AttackImpl: add/removeBorderTile drop redundant has() pre-probes; the size bookkeeping tracked exactly Set.size, which is O(1).
- FlatBinaryHeap: reserve(n) lets AttackExecution pre-size the conquer heap from the border size instead of doubling repeatedly.
- SpatialQuery.bfsNearest: buffer-based neighbor iteration and hoisted manhattan origin, instead of per-call closures and per-neighbor coordinate derivation.

Harness:
- tests/perf/client: stub the WebGL view methods added since the stub was written (updateSmallPlayerGlow, updateSpiralRibbons, ...) so `npm run perf:client` runs again under plain Node.

Tests: vitest 3209 passed; the 10 remaining failures are pre-existing (PublicAssetManifest/MapManifestFlags/NationName use fs.globSync, a Node >= 22 API).

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

Describe the PR.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
