### PR TITLE
Update ToS Section 8: refunds, chargebacks and fraudulent refund claims

### DIFF
--- a/resources/terms-of-service.html
+++ b/resources/terms-of-service.html
@@ -56,7 +56,7 @@
   </head>
   <body>
     <h1>Terms of Service</h1>
-    <p class="updated-date"><strong>Last Updated: 8/10/2026</strong></p>
+    <p class="updated-date"><strong>Last Updated: 8/20/2026</strong></p>
 
     <h2>1. Introduction</h2>
     <p>
@@ -381,20 +381,32 @@
     <ul>
       <li>
         <strong>Direct purchases.</strong> Where you purchase directly from us
-        through the Website, your contract of sale is with OpenFront Inc. and
-        this Section 8 applies in full. Payments are processed by our payment
-        provider; we do not store your full payment card details.
+        through the Website, your contract of sale is with OpenFront Inc., which
+        is the seller of record, and this Section 8 applies in full. Payments
+        are processed by our payment provider; we do not receive or store your
+        full payment card details.
       </li>
       <li>
         <strong>Platform purchases.</strong> Where you purchase through Steam,
         Crazy Games, or another Platform, your contract of sale is with that
         Platform, and that Platform's own purchase, billing, and refund terms
-        apply to the transaction. We do not control and cannot process refunds
-        for Platform purchases. This Section 8 continues to govern your use of
+        apply to the transaction. We do not control and cannot grant, refuse, or
+        vary a refund on that Platform's behalf, and refund requests should be
+        directed to the Platform. This Section 8 continues to govern your use of
         what you have purchased within the Service, including Sections 8.8 and
         8.9.
       </li>
     </ul>
+    <p>
+      Where a Purchase made through a Platform grants entitlements within the
+      Service — including Subscription periods, Virtual Items, or account status
+      — those entitlements are granted on the basis that the Purchase is
+      completed and retained. If the Purchase is subsequently refunded,
+      reversed, revoked, or charged back, we may remove the corresponding
+      entitlements from your account, including any portion of a granted
+      Subscription period that remains unused. This applies whether or not the
+      entitlement has been used.
+    </p>
 
     <h3>8.3 Prices and taxes</h3>
     <p>
@@ -415,9 +427,15 @@
       through your account settings or, for Platform purchases, through the
       relevant Platform. Cancellation takes effect at the end of the current
       billing period; you retain access to Subscription benefits until then, and
-      you will not be charged again. We do not provide partial refunds for the
-      unused remainder of a billing period except where required by law or under
-      Section 8.7 or 8.10.
+      you will not be charged again. We do not provide refunds or credits for
+      partial billing periods, for unused time, or for periods during which you
+      did not use the Service, except where required by law or under Section 8.7
+      or 8.12.
+    </p>
+    <p>
+      If a renewal payment fails, we may retry the payment and may suspend
+      Subscription benefits until payment succeeds. Repeated failure may result
+      in cancellation of the Subscription.
     </p>
 
     <h3>8.5 Virtual Items</h3>
@@ -428,7 +446,7 @@
       a mechanism to do so. We may modify, replace, or discontinue Virtual Items
       where reasonably necessary to operate or balance the Service. Where a
       discontinuation materially deprives you of something you paid for, Section
-      8.10 applies.
+      8.12 applies.
     </p>
 
     <h3>8.6 Right to cancel — UK and EEA consumers (direct purchases only)</h3>
@@ -466,6 +484,21 @@
       satisfactory quality, not fit for a purpose you made known to us, or not
       as described.
     </p>
+    <p>
+      Where we consider a discretionary refund request, we will generally
+      decline it where the Purchase has been substantially used, where the
+      request is made a significant period after purchase, where the account has
+      been subject to an enforcement action under Section 6, or where the
+      account has a history of prior refund or chargeback activity. Granting a
+      refund on one occasion does not oblige us to grant one on any other
+      occasion.
+    </p>
+    <p>
+      Refund requests for direct purchases should be sent to
+      support@openfront.io and must be made from, or verifiably linked to, the
+      account that made the Purchase. Refunds for Platform purchases must be
+      requested through the relevant Platform, as set out in Section 8.2.
+    </p>
 
     <h3>8.8 No refund following enforcement action</h3>
     <p>
@@ -495,18 +528,112 @@
       or where restoration is not possible, refund the affected amount.
     </p>
 
-    <h3>8.9 Chargebacks</h3>
+    <h3>8.9 Chargebacks and fraudulent refund claims</h3>
     <p>
-      If you initiate a chargeback or payment dispute in respect of a Purchase
-      or Subscription, we may suspend the associated account while the dispute
-      is resolved. Initiating a chargeback in bad faith, or in respect of a
-      purchase you did in fact authorise and receive, is a breach of these Terms
-      and may result in permanent termination under Section 6.8. This does not
-      restrict your right to dispute a payment you did not authorise, or to seek
-      a refund you are legally entitled to.
+      We operate a zero-tolerance policy in respect of fraudulent refund and
+      chargeback activity.
+    </p>
+    <p>
+      If you believe you have been charged in error, you must contact us first
+      at support@openfront.io. We will investigate in good faith and, where we
+      agree the charge was made in error, we will refund it. Initiating a
+      chargeback, payment dispute, or payment reversal with your bank or payment
+      provider without first contacting us is a breach of these Terms. Where you
+      initiate a chargeback or payment dispute, we may suspend the associated
+      account while the dispute is resolved.
+    </p>
+    <p>
+      The following constitute fraudulent refund activity for the purposes of
+      these Terms:
+    </p>
+    <ul>
+      <li>
+        initiating a chargeback, payment dispute, or payment reversal in respect
+        of a Purchase you authorised and received;
+      </li>
+      <li>
+        making any false or misleading statement in order to obtain a refund,
+        including falsely stating that a product was not delivered, not
+        received, or not as described;
+      </li>
+      <li>
+        obtaining a refund and continuing to use, or attempting to retain, the
+        product or entitlement refunded;
+      </li>
+      <li>
+        requesting a refund for a product after substantial use of that product;
+      </li>
+      <li>
+        making repeated refund requests or chargebacks across one or more
+        accounts in a pattern indicating misuse of refund processes; or
+      </li>
+      <li>using a payment method you are not authorised to use.</li>
+    </ul>
+    <p>
+      Where we determine, acting reasonably, that you have engaged in fraudulent
+      refund activity, we may take any or all of the following actions
+      immediately and without prior notice:
+    </p>
+    <ul>
+      <li>permanently ban the account from the Service;</li>
+      <li>
+        revoke all entitlements associated with the account, including purchased
+        and granted Virtual Items, Subscription periods, account status, and
+        competitive standing;
+      </li>
+      <li>
+        remove statistics, ratings, and leaderboard entries associated with the
+        account;
+      </li>
+      <li>refuse to accept any future Purchase from you;</li>
+      <li>
+        extend any of the above to all accounts and platforms that we reasonably
+        believe are controlled by, or operated on behalf of, you, in accordance
+        with Section 6.8; and
+      </li>
+      <li>
+        recover from you any amount charged back, together with any fee levied
+        on us by our payment provider in connection with the chargeback.
+      </li>
+    </ul>
+    <p>
+      An account permanently banned under this section will not be reinstated.
+      Where an account is banned under this section and an amount remains
+      outstanding, we may require that amount and any associated fees to be
+      settled in full before we will consider permitting you to use the Service
+      again, and we are under no obligation to do so.
+    </p>
+    <p>
+      Enforcement action taken under this section is subject to the appeals
+      process in Section 6.9. Nothing in this section restricts your right to
+      seek a refund you are legally entitled to.
     </p>
 
-    <h3>8.10 If we discontinue a paid feature</h3>
+    <h3>8.10 Unauthorised use of your payment method</h3>
+    <p>
+      Section 8.9 does not apply where a payment was made using your payment
+      method by a third party without your authorisation, and you report this to
+      us promptly at support@openfront.io on becoming aware of it. In that case
+      we will work with you and, where appropriate, with our payment provider to
+      resolve the matter, and we will not treat you as having engaged in
+      fraudulent refund activity.
+    </p>
+    <p>
+      You remain responsible for keeping your account credentials and payment
+      method secure, and for Purchases made by a person you have permitted to
+      access your account or payment method.
+    </p>
+
+    <h3>8.11 Records</h3>
+    <p>
+      Where we take action under Section 8.9, we may retain a record of the
+      account identifiers concerned for the purpose of preventing evasion of
+      that action and preventing further fraudulent refund activity. That record
+      is retained in accordance with our Privacy Policy and is limited to what
+      is necessary for those purposes.
+    </p>
+
+    <h3>8.12 If we discontinue a paid feature</h3>
     <p>
       If we permanently discontinue the Service, or a paid feature or
       Subscription tier, other than following termination of your account for
@@ -514,7 +641,7 @@
       the unused portion of any prepaid Subscription on a pro-rata basis.
     </p>
 
-    <h3>8.11 Creator and referral programmes</h3>
+    <h3>8.13 Creator and referral programmes</h3>
     <p>
       Where you participate in a creator, referral, or affiliate programme, that
       programme's terms apply in addition to these Terms. We may withhold or
@@ -562,7 +689,7 @@
       any part thereof) at any time, with or without notice. We will not be
       liable to you or to any third party for any modification, suspension, or
       discontinuance of the Service. Where you have paid for a Subscription or
-      feature that we discontinue, Section 8.10 applies.
+      feature that we discontinue, Section 8.12 applies.
     </p>
     <p>
       We do not guarantee that our Service will be available at all times. We
@@ -713,17 +840,14 @@
 
     <h2>21. Contact Us</h2>
     <p class="contact">
-      If you have any questions about these Terms, please contact us at:
+      If you have any questions about these Terms, or about a purchase,
+      subscription, or refund, please contact us at:
       <br />
       support@openfront.io
       <br /><br />
       To appeal an enforcement action, please contact:
       <br />
       appeals@openfront.io
-      <br /><br />
-      For questions about a purchase, subscription, or refund, please contact:
-      <br />
-      billing@openfront.io
       <br /><br />
       OpenFront Inc.<br />
       c/o Paracorp Incorporated<br />


### PR DESCRIPTION
Extends the existing Section 8 (Purchases, Subscriptions and Virtual Items) with refund, chargeback and payment-fraud provisions. The draft this came from proposed a standalone new section, but main already has a Section 8 covering overlapping ground — adding a second one would have duplicated it and dropped clauses the draft doesn't cover (licence grant, Virtual Items, discontinuation refunds, creator programmes). So the material is merged in instead.

## What changed

| Subsection | Change |
| --- | --- |
| 8.2 | OpenFront Inc. named as seller of record. New paragraph: entitlements granted by a Platform purchase may be revoked if that purchase is refunded, reversed or charged back, including unused subscription time. |
| 8.4 | Failed renewal payments — retry, suspend benefits, cancel on repeated failure. |
| 8.7 | Criteria for declining a discretionary refund; how and from where to request one. |
| 8.9 | Expanded from a single paragraph on chargebacks to cover fraudulent refund activity: contact-us-first requirement, what counts as fraudulent, and the enforcement response. |
| **8.10** (new) | Carve-out where a third party used your payment method without authorisation. |
| **8.11** (new) | Retention of account identifiers to prevent evasion of a ban issued under 8.9. |
| 8.12 / 8.13 | Previously 8.10 / 8.11. Cross-references in 8.4, 8.5 and Section 12 updated. |

Billing contact routed to `support@openfront.io` throughout; the duplicate contact line in Section 21 was merged into one. `Last Updated` bumped to 8/20/2026.

## Notes for review

- **VAT wording not imported.** The source draft stated prices exclusive of VAT. Existing 8.3 states UK/EEA prices *include* VAT, which was a deliberate fix in a9d17e3 and is what the UK Price Marking Order requires for consumers. Left as-is.
- **8.10 is deliberate.** A clause treating every chargeback as fraud with no exception will eventually catch a customer whose card was genuinely stolen, and in the UK a term penalising a consumer for exercising a right where they were not at fault is exposed as unfair under Part 2 of the Consumer Rights Act 2015. The carve-out is narrow: prompt reporting required, and it does not cover purchases made by someone the account holder let in.
- **Ban and revoke, not delete.** 8.9 permanently bans and strips the account rather than deleting the record — deleting it destroys the ban evidence and conflicts with the retention already in Section 7. 8.11 keeps the minimum identifiers needed to make the ban stick.
- **OPE-70 dependency.** The second paragraph of 8.2 is the contractual basis for revoking subscription grants when a Steam purchase is refunded. Publishing this without that build gives the right without the ability to exercise it.
- **Timing.** Section 17 promises 30 days' notice for material changes, putting the effective date around 19 September — after launch.
- **Counsel sign-off.** The source draft is marked as requiring external legal review before publication. That has not happened.
- Not covered, deliberately: gifting, key resale, regional pricing arbitrage, and the AGPL position on the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
