### PR TITLE
feat(net): binary protocol for every websocket frame

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,8 @@ The game simulation runs **on each client**, not the server. The server only rel
 6. Core sends **GameUpdates** back to client → client renders
 
 Intents and all wire messages are Zod-validated schemas defined in `src/core/Schemas.ts`.
+Every WebSocket frame is a compact binary encoding of those schemas
+(`src/core/ZbinWire.ts`, library docs in `zbin/README.md`). HTTP stays JSON.
 
 ### CDN / Static Assets
 

--- a/src/client/LobbySocket.ts
+++ b/src/client/LobbySocket.ts
@@ -1,5 +1,6 @@
 import { ClientEnv } from "src/client/ClientEnv";
-import { PublicGames, PublicLobbyMessageSchema } from "../core/Schemas";
+import { PublicGames } from "../core/Schemas";
+import { decodeLobbyMessage } from "../core/ZbinWire";
 
 interface LobbySocketOptions {
   reconnectDelay?: number;
@@ -63,6 +64,8 @@ export class PublicLobbySocket {
       const wsUrl = `${ClientEnv.serverWsBase()}${this.workerPath}/lobbies`;
 
       this.ws = new WebSocket(wsUrl);
+      // Frames are zbin payloads; without this they would arrive as Blobs.
+      this.ws.binaryType = "arraybuffer";
       this.wsAttemptCounted = false;
 
       this.ws.addEventListener("open", () => this.handleOpen());
@@ -85,8 +88,8 @@ export class PublicLobbySocket {
 
   private handleMessage(event: MessageEvent) {
     try {
-      const message = PublicLobbyMessageSchema.parse(
-        JSON.parse(event.data as string),
+      const message = decodeLobbyMessage(
+        new Uint8Array(event.data as ArrayBuffer),
       );
       if (message.type === "full") {
         this.lastFull = {

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -1,5 +1,5 @@
 import { ClientEnv } from "src/client/ClientEnv";
-import { z } from "zod";
+import { ZbContext } from "../../zbin";
 import { EventBus, GameEvent } from "../core/EventBus";
 import {
   AllPlayers,
@@ -25,10 +25,13 @@ import {
   Intent,
   LiveStats,
   ServerMessage,
-  ServerMessageSchema,
   Winner,
 } from "../core/Schemas";
-import { replacer } from "../core/Util";
+import {
+  createGameWireContext,
+  decodeServerMessage,
+  encodeClientMessage,
+} from "../core/ZbinWire";
 import { getPlayToken } from "./Auth";
 import { LobbyConfig } from "./ClientGameRunner";
 import { showInGameAlert } from "./InGameModal";
@@ -204,13 +207,18 @@ export class Transport {
 
   private localServer: LocalServer;
 
-  private buffer: string[] = [];
+  private buffer: ClientMessage[] = [];
 
   private onconnect: () => void;
   private onmessage: (msg: ServerMessage) => void;
 
   private pingInterval: number | null = null;
   public readonly isLocal: boolean;
+
+  // clientID dictionary for the binary wire (see ZbinWire.ts), seeded from
+  // the roster in the start message. Null until the game starts, which is
+  // also the last moment a peer can send a dictionary-encoded field.
+  private zbinCtx: ZbContext | null = null;
 
   constructor(
     private lobbyConfig: LobbyConfig,
@@ -365,6 +373,8 @@ export class Transport {
     // the desktop app://openfront origin), not window.location.host.
     const workerPath = ClientEnv.workerPath(this.lobbyConfig.gameID);
     this.socket = new WebSocket(`${ClientEnv.serverWsBase()}/${workerPath}`);
+    // Every frame is a zbin payload; without this they would arrive as Blobs.
+    this.socket.binaryType = "arraybuffer";
     this.onconnect = onconnect;
     this.onmessage = onmessage;
     this.socket.onopen = () => {
@@ -380,20 +390,24 @@ export class Transport {
           console.warn("msg is undefined");
           continue;
         }
-        this.socket.send(msg);
+        // Encoded at flush time, not at buffer time: the dictionary may have
+        // been seeded (or reseeded) while the message sat in the buffer.
+        this.socket.send(encodeClientMessage(msg, this.zbinCtx ?? undefined));
       }
       onconnect();
     };
     this.socket.onmessage = (event: MessageEvent) => {
       try {
-        const parsed = JSON.parse(event.data);
-        const result = ServerMessageSchema.safeParse(parsed);
-        if (!result.success) {
-          const error = z.prettifyError(result.error);
-          console.error("Error parsing server message", error);
-          return;
+        const msg = decodeServerMessage(
+          new Uint8Array(event.data as ArrayBuffer),
+          this.zbinCtx ?? undefined,
+        );
+        if (msg.type === "start") {
+          // Seed the dictionary from the same players array, in the same
+          // order, that the server seeded its own from.
+          this.zbinCtx = createGameWireContext(msg.gameStartInfo.players);
         }
-        this.onmessage(result.data);
+        this.onmessage(msg);
       } catch (e) {
         console.error("Error in onmessage handler:", e, event.data);
         return;
@@ -723,17 +737,16 @@ export class Transport {
       // Socket missing, do nothing
       return;
     }
-    const str = JSON.stringify(msg, replacer);
     if (this.socket.readyState === WebSocket.CLOSED) {
       // Buffer message
       console.warn("socket not ready, closing and trying later");
       this.socket.close();
       this.socket = null;
       this.connectRemote(this.onconnect, this.onmessage);
-      this.buffer.push(str);
+      this.buffer.push(msg);
     } else {
       // Send the message directly
-      this.socket.send(str);
+      this.socket.send(encodeClientMessage(msg, this.zbinCtx ?? undefined));
     }
   }
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -353,13 +353,27 @@ export enum LogSeverity {
 // Utility types
 //
 
-const TeamCountConfigSchema = z.union([
-  zb.uint(),
-  z.literal(Duos),
-  z.literal(Trios),
-  z.literal(Quads),
-  z.literal(HumansVsNations),
-]);
+// select: encoding an untagged union without one costs a zod safeParse per
+// rejected candidate (~10 µs each) — real money on schemas embedded in every
+// GameConfig on the wire. The candidate ORDER is the wire layout; only the
+// picking got cheaper.
+const TEAM_COUNT_PRESETS = [Duos, Trios, Quads, HumansVsNations] as const;
+const TeamCountConfigSchema = zb.union(
+  [
+    zb.uint(),
+    z.literal(Duos),
+    z.literal(Trios),
+    z.literal(Quads),
+    z.literal(HumansVsNations),
+  ],
+  {
+    select: (v) =>
+      typeof v === "number"
+        ? 0
+        : TEAM_COUNT_PRESETS.indexOf(v as (typeof TEAM_COUNT_PRESETS)[number]) +
+          1,
+  },
+);
 export type TeamCountConfig = z.infer<typeof TeamCountConfigSchema>;
 
 // Doomsday Clock (anti-stall). Below a rising share of the map a player (or, in
@@ -410,7 +424,12 @@ export const GameConfigSchema = z.object({
       isDoomsdayClock: z.boolean().optional(),
     })
     .optional(),
-  nations: zb.uint({ min: 1, max: 400 }).or(z.enum(["default", "disabled"])),
+  nations: zb.union(
+    [zb.uint({ min: 1, max: 400 }), z.enum(["default", "disabled"])],
+    {
+      select: (v) => (typeof v === "number" ? 0 : 1),
+    },
+  ),
   bots: zb.uint({ max: 400 }),
   infiniteGold: z.boolean(),
   infiniteTroops: z.boolean(),
@@ -550,7 +569,9 @@ export const TargetPlayerIntentSchema = z.object({
 
 export const EmojiIntentSchema = z.object({
   type: z.literal("emoji"),
-  recipient: z.union([MappedID, z.literal(AllPlayers)]),
+  recipient: zb.union([MappedID, z.literal(AllPlayers)], {
+    select: (v) => (v === AllPlayers ? 1 : 0),
+  }),
   emoji: EmojiSchema,
 });
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -1,5 +1,6 @@
 import quickChatData from "resources/QuickChat.json";
 import { z } from "zod";
+import { zb } from "../../zbin";
 import {
   ColorPaletteSchema,
   CosmeticNameSchema,
@@ -247,15 +248,15 @@ const ClientInfoSchema = z.object({
   // Server-pinned team slot for matchmade team games, so the lobby's team
   // preview can honour the pins instead of re-deriving teams that the server
   // will overrule at start. Absent when the game isn't matchmade.
-  teamIndex: z.number().int().nonnegative().optional(),
+  teamIndex: zb.uint().optional(),
 });
 
 export const GameInfoSchema = z.object({
   gameID: z.string(),
   clients: z.array(ClientInfoSchema).optional(),
   lobbyCreatorClientID: z.string().optional(),
-  startsAt: z.number().optional(),
-  serverTime: z.number(),
+  startsAt: zb.uint().optional(),
+  serverTime: zb.uint(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema.optional(),
   // Private lobbies only: whether the lobby is publicly listed. Server-owned
@@ -265,7 +266,7 @@ export const GameInfoSchema = z.object({
   listed: z.boolean().optional(),
   // Listed lobbies only: server timestamp when the lobby starts
   // automatically (hosts can't sit on a public listing indefinitely).
-  autoStartAt: z.number().optional(),
+  autoStartAt: zb.uint().optional(),
   // Featured lobbies only (admin bot). Echoed back so the creating bot can
   // confirm the request took effect, the same way it checks `listed`.
   label: LobbyLabelSchema.optional(),
@@ -279,8 +280,8 @@ export const GameInfoSchema = z.object({
 // carry them by construction.
 export const PublicGameInfoSchema = z.object({
   gameID: z.string(),
-  numClients: z.number(),
-  startsAt: z.number().optional(),
+  numClients: zb.uint(),
+  startsAt: zb.uint().optional(),
   gameConfig: z.lazy(() => GameConfigSchema).optional(),
   publicGameType: PublicGameTypeSchema,
   // Featured lobbies only. Both optional so a client on an older build simply
@@ -291,7 +292,7 @@ export const PublicGameInfoSchema = z.object({
 });
 
 export const PublicGamesSchema = z.object({
-  serverTime: z.number(),
+  serverTime: zb.uint(),
   // partialRecord: every consumer already treats buckets as optional, and it
   // lets clients tolerate servers that don't send every lobby type.
   games: z.partialRecord(PublicGameTypeSchema, z.array(PublicGameInfoSchema)),
@@ -302,17 +303,17 @@ export const PublicGamesSchema = z.object({
 // per-lobby player counts, which change far more often than the rest.
 export const PublicLobbyFullSchema = z.object({
   type: z.literal("full"),
-  serverTime: z.number(),
+  serverTime: zb.uint(),
   games: z.partialRecord(PublicGameTypeSchema, z.array(PublicGameInfoSchema)),
 });
 
 export const PublicLobbyCountsSchema = z.object({
   type: z.literal("counts"),
-  serverTime: z.number(),
-  counts: z.record(z.string(), z.number()),
+  serverTime: zb.uint(),
+  counts: z.record(z.string(), zb.uint()),
 });
 
-export const PublicLobbyMessageSchema = z.discriminatedUnion("type", [
+export const PublicLobbyMessageSchema = zb.discriminatedUnion("type", [
   PublicLobbyFullSchema,
   PublicLobbyCountsSchema,
 ]);
@@ -353,7 +354,7 @@ export enum LogSeverity {
 //
 
 const TeamCountConfigSchema = z.union([
-  z.number(),
+  zb.uint(),
   z.literal(Duos),
   z.literal(Trios),
   z.literal(Quads),
@@ -378,7 +379,7 @@ export const DoomsdayClockConfigSchema = z.object({
 // `enabled` and `startMinutes` are wire-configurable.
 export const OvertimeConfigSchema = z.object({
   enabled: z.boolean().optional(),
-  startMinutes: z.number().int().min(1).max(120).optional(),
+  startMinutes: zb.uint({ min: 1, max: 120 }).optional(),
 });
 
 export const GameConfigSchema = z.object({
@@ -398,8 +399,8 @@ export const GameConfigSchema = z.object({
       isRandomSpawn: z.boolean().optional(),
       isCrowded: z.boolean().optional(),
       isHardNations: z.boolean().optional(),
-      startingGold: z.number().int().min(0).optional(),
-      goldMultiplier: z.number().min(0.1).max(1000).optional(),
+      startingGold: zb.uint().optional(),
+      goldMultiplier: zb.float({ min: 0.1, max: 1000 }).optional(),
       isAlliancesDisabled: z.boolean().optional(),
       isPortsDisabled: z.boolean().optional(),
       isNukesDisabled: z.boolean().optional(),
@@ -409,13 +410,8 @@ export const GameConfigSchema = z.object({
       isDoomsdayClock: z.boolean().optional(),
     })
     .optional(),
-  nations: z
-    .number()
-    .int()
-    .min(1)
-    .max(400)
-    .or(z.enum(["default", "disabled"])),
-  bots: z.number().int().min(0).max(400),
+  nations: zb.uint({ min: 1, max: 400 }).or(z.enum(["default", "disabled"])),
+  bots: zb.uint({ max: 400 }),
   infiniteGold: z.boolean(),
   infiniteTroops: z.boolean(),
   instantBuild: z.boolean(),
@@ -435,29 +431,23 @@ export const GameConfigSchema = z.object({
   nameRevealPublicIds: z.string().array().max(200).optional(),
   waterNukes: z.boolean().nullable().optional(),
   randomSpawn: z.boolean(),
-  maxPlayers: z.number().optional(),
+  maxPlayers: zb.uint().optional(),
   // OFM: allowlist of publicIds allowed to join (admin-only, see create_game).
   allowedPublicIds: z.array(z.string()).max(200).optional(),
-  maxTimerValue: z.number().int().min(1).max(120).nullable().optional(), // In minutes
-  customAllianceDuration: z.number().int().min(0).max(15).nullable().optional(), // In minutes; 0 disables alliances
-  startDelay: z.number().int().min(0).max(600).nullable().optional(), // In seconds
-  spawnImmunityDuration: z.number().int().min(0).nullable().optional(), // In ticks
+  maxTimerValue: zb.uint({ min: 1, max: 120 }).nullable().optional(), // In minutes
+  customAllianceDuration: zb.uint({ max: 15 }).nullable().optional(), // In minutes; 0 disables alliances
+  startDelay: zb.uint({ max: 600 }).nullable().optional(), // In seconds
+  spawnImmunityDuration: zb.uint().nullable().optional(), // In ticks
   disabledUnits: z.enum(UnitType).array().optional(),
   playerTeams: TeamCountConfigSchema.optional(),
-  goldMultiplier: z.number().min(0.1).max(1000).nullable().optional(),
-  startingGold: z.number().int().min(0).max(1000000000).nullable().optional(),
+  goldMultiplier: zb.float({ min: 0.1, max: 1000 }).nullable().optional(),
+  startingGold: zb.uint({ max: 1000000000 }).nullable().optional(),
   hostCheats: z
     .object({
       infiniteGold: z.boolean().optional(),
       infiniteTroops: z.boolean().optional(),
-      goldMultiplier: z.number().min(0.1).max(1000).nullable().optional(),
-      startingGold: z
-        .number()
-        .int()
-        .min(0)
-        .max(1000000000)
-        .nullable()
-        .optional(),
+      goldMultiplier: zb.float({ min: 0.1, max: 1000 }).nullable().optional(),
+      startingGold: zb.uint({ max: 1000000000 }).nullable().optional(),
     })
     .optional(),
 });
@@ -484,10 +474,7 @@ const TokenSchema = z
     },
   );
 
-const EmojiSchema = z
-  .number()
-  .nonnegative()
-  .max(flattenedEmojiTable.length - 1);
+const EmojiSchema = zb.uint({ max: flattenedEmojiTable.length - 1 });
 
 export const GAME_ID_REGEX = /^[A-Za-z0-9]{8}$/;
 
@@ -495,6 +482,13 @@ export const isValidGameID = (value: string): boolean =>
   GAME_ID_REGEX.test(value);
 
 export const ID = z.string().regex(GAME_ID_REGEX);
+
+// zbin dictionary for player clientIDs (see ZbinWire.ts): both peers seed it
+// from GameStartInfo.players, so an in-game player id costs one byte on the
+// binary wire. Validates exactly like ID; ids outside the roster (e.g.
+// ADMIN_BOT_CLIENT_ID) encode inline via the escape byte.
+export const CLIENT_ID_MAPPING = "clientId";
+const MappedID = zb.mapped(CLIENT_ID_MAPPING, { regex: GAME_ID_REGEX });
 
 export const AllPlayersStatsSchema = z.record(ID, PlayerStatsSchema);
 
@@ -510,59 +504,59 @@ export const QuickChatKeySchema = z.enum(
 
 export const AllianceExtensionIntentSchema = z.object({
   type: z.literal("allianceExtension"),
-  recipient: ID,
+  recipient: MappedID,
 });
 
 export const AttackIntentSchema = z.object({
   type: z.literal("attack"),
-  targetID: ID.nullable(),
-  troops: z.number().nonnegative().nullable(),
+  targetID: MappedID.nullable(),
+  troops: zb.float({ min: 0 }).nullable(),
 });
 
 export const SpawnIntentSchema = z.object({
   type: z.literal("spawn"),
   // A TileRef indexes the typed-array terrain buffers, so it must be a
   // non-negative integer. Fractional refs silently corrupt those lookups.
-  tile: z.number().int().nonnegative(),
+  tile: zb.uint(),
 });
 
 export const BoatAttackIntentSchema = z.object({
   type: z.literal("boat"),
-  // Not .int(): troops are fractional throughout the sim (attackRatio *
+  // Not an int: troops are fractional throughout the sim (attackRatio *
   // troops(), combat attrition), and the client sends the raw float.
-  troops: z.number().nonnegative(),
-  dst: z.number().int().nonnegative(),
+  troops: zb.float({ min: 0 }),
+  dst: zb.uint(),
 });
 
 export const AllianceRequestIntentSchema = z.object({
   type: z.literal("allianceRequest"),
-  recipient: ID,
+  recipient: MappedID,
 });
 
 export const AllianceRejectIntentSchema = z.object({
   type: z.literal("allianceReject"),
-  requestor: ID,
+  requestor: MappedID,
 });
 
 export const BreakAllianceIntentSchema = z.object({
   type: z.literal("breakAlliance"),
-  recipient: ID,
+  recipient: MappedID,
 });
 
 export const TargetPlayerIntentSchema = z.object({
   type: z.literal("targetPlayer"),
-  target: ID,
+  target: MappedID,
 });
 
 export const EmojiIntentSchema = z.object({
   type: z.literal("emoji"),
-  recipient: z.union([ID, z.literal(AllPlayers)]),
+  recipient: z.union([MappedID, z.literal(AllPlayers)]),
   emoji: EmojiSchema,
 });
 
 export const EmbargoIntentSchema = z.object({
   type: z.literal("embargo"),
-  targetID: ID,
+  targetID: MappedID,
   action: z.union([z.literal("start"), z.literal("stop")]),
 });
 
@@ -573,29 +567,29 @@ export const EmbargoAllIntentSchema = z.object({
 
 export const DonateGoldIntentSchema = z.object({
   type: z.literal("donate_gold"),
-  recipient: ID,
-  gold: z.number().nonnegative().nullable(),
+  recipient: MappedID,
+  gold: zb.float({ min: 0 }).nullable(),
 });
 
 export const DonateTroopIntentSchema = z.object({
   type: z.literal("donate_troops"),
-  recipient: ID,
-  troops: z.number().nonnegative().nullable(),
+  recipient: MappedID,
+  troops: zb.float({ min: 0 }).nullable(),
 });
 
 export const BuildUnitIntentSchema = z.object({
   type: z.literal("build_unit"),
   unit: z.enum(UnitType),
-  tile: z.number().int().nonnegative(),
+  tile: zb.uint(),
   rocketDirectionUp: z.boolean().optional(),
-  amount: z.number().int().min(1).max(MAX_UPGRADE_AMOUNT).optional(),
+  amount: zb.uint({ min: 1, max: MAX_UPGRADE_AMOUNT }).optional(),
 });
 
 export const UpgradeStructureIntentSchema = z.object({
   type: z.literal("upgrade_structure"),
   unit: z.enum(UnitType),
-  unitId: z.number().int().nonnegative(),
-  amount: z.number().int().min(1).max(MAX_UPGRADE_AMOUNT).optional(),
+  unitId: zb.uint(),
+  amount: zb.uint({ min: 1, max: MAX_UPGRADE_AMOUNT }).optional(),
 });
 
 export const CancelAttackIntentSchema = z.object({
@@ -605,30 +599,33 @@ export const CancelAttackIntentSchema = z.object({
 
 export const CancelBoatIntentSchema = z.object({
   type: z.literal("cancel_boat"),
-  unitID: z.number().int().nonnegative(),
+  unitID: zb.uint(),
 });
 
 export const MoveWarshipIntentSchema = z.object({
   type: z.literal("move_warship"),
-  unitIds: z.array(z.number().int()).nonempty(),
-  tile: z.number().int().nonnegative(),
+  unitIds: z.array(zb.int()).nonempty(),
+  tile: zb.uint(),
 });
 
 export const DeleteUnitIntentSchema = z.object({
   type: z.literal("delete_unit"),
-  unitId: z.number().int().nonnegative(),
+  unitId: zb.uint(),
 });
 
 export const QuickChatIntentSchema = z.object({
   type: z.literal("quick_chat"),
-  recipient: ID,
+  recipient: MappedID,
   quickChatKey: QuickChatKeySchema,
-  target: ID.optional(),
+  target: MappedID.optional(),
 });
 
+// Server-internal (rejected from clients). The player being marked is the
+// intent's own sender, so the target rides the stamped `clientID` that
+// StampedIntentSchema adds to every intent — declaring it here too would
+// write the same key twice on the binary wire.
 export const MarkDisconnectedIntentSchema = z.object({
   type: z.literal("mark_disconnected"),
-  clientID: ID,
   isDisconnected: z.boolean(),
 });
 
@@ -637,8 +634,8 @@ export const KickPlayerIntentSchema = z.object({
   // Either a live clientID (lobby / in-game kick) OR an account publicID, for
   // callers that identify a player by account rather than per-session clientID;
   // the server resolves the publicID to the live clientID. Exactly one is set.
-  targetClientID: ID.optional(),
-  targetPublicID: ID.optional(),
+  targetClientID: MappedID.optional(),
+  targetPublicID: MappedID.optional(),
 });
 
 export const TogglePauseIntentSchema = z.object({
@@ -648,7 +645,9 @@ export const TogglePauseIntentSchema = z.object({
 
 export const UpdateGameConfigIntentSchema = z.object({
   type: z.literal("update_game_config"),
-  config: GameConfigSchema.partial(),
+  // zb.json: too rare and too config-shaped to deserve a binary layout —
+  // rides the binary wire as length-prefixed JSON.
+  config: zb.json(GameConfigSchema.partial()),
 });
 
 export const ToggleGameStartTimerIntentSchema = z.object({
@@ -684,7 +683,9 @@ export const IntentSchema = z.discriminatedUnion("type", [
 ]);
 
 // StampedIntent = Intent with server-stamped clientID (used in turns and execution)
-export const StampedIntentSchema = IntentSchema.and(z.object({ clientID: ID }));
+export const StampedIntentSchema = zb.stamped(IntentSchema, {
+  clientID: MappedID,
+});
 export type StampedIntent = Intent & { clientID: ClientID };
 
 // Placeholder clientID stamped onto admin-bot intents (HTTP admin API). The bot
@@ -698,10 +699,10 @@ export const ADMIN_BOT_CLIENT_ID: ClientID = "ADMINBOT";
 //
 
 export const TurnSchema = z.object({
-  turnNumber: z.number(),
+  turnNumber: zb.uint(),
   intents: StampedIntentSchema.array(),
   // The hash of the game state at the end of the turn.
-  hash: z.number().nullable().optional(),
+  hash: zb.float().nullable().optional(),
 });
 
 export const FlagName = z
@@ -791,7 +792,7 @@ export const PlayerSchema = z.object({
   // Server-stamped team slot for matchmade team games (index into the
   // game's team list). Feeds deterministic team assignment, so it must be
   // identical for every client (like clanTag/friends).
-  teamIndex: z.number().int().nonnegative().optional(),
+  teamIndex: zb.uint().optional(),
 });
 
 // A purchased bot tribe name in use this game (active names are globally
@@ -807,14 +808,16 @@ export type Tribe = z.infer<typeof TribeSchema>;
 
 export const GameStartInfoSchema = z.object({
   gameID: ID,
-  lobbyCreatedAt: z.number(),
-  visibleAt: z.number().optional(),
+  lobbyCreatedAt: zb.uint(),
+  visibleAt: zb.uint().optional(),
   listed: z.boolean().optional(),
   config: GameConfigSchema,
   players: PlayerSchema.array(),
   // Purchased bot tribe names in use this game (public games only). Rides
   // the analytics record to infra at game end for owner appearance stats.
-  tribes: z.array(TribeSchema).max(100).optional(),
+  // zb.json: TribeSchema is `.loose()`, and a positional binary layout would
+  // silently drop the passthrough keys that looseness exists to preserve.
+  tribes: z.array(zb.json(TribeSchema)).max(100).optional(),
 });
 
 export const WinnerSchema = z
@@ -850,7 +853,7 @@ export const ServerStartGameMessageSchema = z.object({
   // Turns the client missed if they are late to the game.
   turns: TurnSchema.array(),
   gameStartInfo: GameStartInfoSchema,
-  lobbyCreatedAt: z.number(),
+  lobbyCreatedAt: zb.uint(),
   // The clientID assigned to this connection by the server.
   // Absent for replays where the viewer has no player identity.
   myClientID: ID.optional(),
@@ -858,11 +861,13 @@ export const ServerStartGameMessageSchema = z.object({
 
 export const ServerDesyncSchema = z.object({
   type: z.literal("desync"),
-  turn: z.number(),
-  correctHash: z.number().nullable(),
-  clientsWithCorrectHash: z.number(),
-  totalActiveClients: z.number(),
-  yourHash: z.number().optional(),
+  turn: zb.uint(),
+  // Hashes are fractional (PlayerImpl.hash multiplies by troops), so they
+  // ride as bit-exact float64 rather than a varint.
+  correctHash: zb.float().nullable(),
+  clientsWithCorrectHash: zb.uint(),
+  totalActiveClients: zb.uint(),
+  yourHash: zb.float().optional(),
 });
 
 export const ServerErrorSchema = z.object({
@@ -886,7 +891,7 @@ export const ServerNewLobbyMessageSchema = z.object({
   gameID: ID,
 });
 
-export const ServerMessageSchema = z.discriminatedUnion("type", [
+export const ServerMessageSchema = zb.discriminatedUnion("type", [
   ServerTurnMessageSchema,
   ServerPrestartMessageSchema,
   ServerStartGameMessageSchema,
@@ -912,24 +917,24 @@ export const ClientSendWinnerSchema = z.object({
 // be agreed on by majority vote. gold is a decimal string because it is a
 // bigint in the engine.
 export const PlayerLiveStatsSchema = z.object({
-  clientID: ID,
-  tilesOwned: z.number().int().nonnegative(),
-  troops: z.number(),
+  clientID: MappedID,
+  tilesOwned: zb.uint(),
+  troops: zb.float(),
   gold: z.string(),
   isAlive: z.boolean(),
   team: z.string().nullable(),
   // OFM live standings: the eliminator's clientID and the finishing place at
   // elimination, both null while the player is still alive. Deterministic sim
   // values, so clients agree on them for the majority vote.
-  killedBy: ID.nullable(),
-  deathPosition: z.number().int().positive().nullable(),
+  killedBy: MappedID.nullable(),
+  deathPosition: zb.uint({ min: 1 }).nullable(),
 });
 
 // A full live snapshot of a running game at a given turn. Reported by clients
 // (which run the sim) so the server can answer "what's happening" queries for
 // the admin bot.
 export const LiveStatsSchema = z.object({
-  turn: z.number().int().nonnegative(),
+  turn: zb.uint(),
   players: PlayerLiveStatsSchema.array(),
 });
 
@@ -940,8 +945,8 @@ export const ClientSendLiveStatsSchema = z.object({
 
 export const ClientHashSchema = z.object({
   type: z.literal("hash"),
-  hash: z.number(),
-  turnNumber: z.number(),
+  hash: zb.float(),
+  turnNumber: zb.uint(),
 });
 
 export const ClientLogMessageSchema = z.object({
@@ -978,7 +983,7 @@ export const ClientRejoinMessageSchema = z.object({
   type: z.literal("rejoin"),
   gameID: ID,
   // Note: clientID is NOT sent - server looks it up from persistentID in token
-  lastTurn: z.number(),
+  lastTurn: zb.uint(),
   token: TokenSchema,
 });
 
@@ -990,7 +995,7 @@ export const ClientSpectateMessageSchema = z.object({
   spectator: z.boolean(),
 });
 
-export const ClientMessageSchema = z.discriminatedUnion("type", [
+export const ClientMessageSchema = zb.discriminatedUnion("type", [
   ClientSendWinnerSchema,
   ClientSendLiveStatsSchema,
   ClientPingMessageSchema,

--- a/src/core/StatsSchemas.ts
+++ b/src/core/StatsSchemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { zb, ZbEncodeError } from "../../zbin";
 import { UnitType } from "./game/Game";
 
 export const bombUnits = ["abomb", "hbomb", "mirv", "mirvw"] as const;
@@ -93,12 +94,30 @@ export const OTHER_INDEX_CAPTURE = 2; // Structures captured
 export const OTHER_INDEX_LOST = 3; // Structures/warships destroyed/captured by others
 export const OTHER_INDEX_UPGRADE = 4; // Structures upgraded
 
-export const BigIntStringSchema = z.preprocess((val) => {
-  if (val === null) return 0n;
-  if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
-  if (typeof val === "bigint") return val;
-  return val;
-}, z.bigint());
+// Stats are bigints in the engine but ride HTTP/JSON as decimal strings (see
+// `replacer`), so the schema accepts either. On the binary wire they encode as
+// a bigint varint; the codec applies the same coercion as the preprocess so
+// both in-memory shapes serialize identically.
+export const BigIntStringSchema = zb.custom(
+  z.preprocess((val) => {
+    if (val === null) return 0n;
+    if (typeof val === "string" && /^-?\d+$/.test(val)) return BigInt(val);
+    if (typeof val === "bigint") return val;
+    return val;
+  }, z.bigint()),
+  {
+    enc: (w, v) => w.bigint(toBigInt(v)),
+    dec: (r) => r.bigint(),
+    minBytes: 1,
+  },
+);
+
+function toBigInt(v: unknown): bigint {
+  if (typeof v === "bigint") return v;
+  if (v === null || v === undefined) return 0n;
+  if (typeof v === "string" && /^-?\d+$/.test(v)) return BigInt(v);
+  throw new ZbEncodeError(`not a bigint-valued stat: ${String(v)}`);
+}
 
 const AtLeastOneNumberSchema = BigIntStringSchema.array().min(1);
 export type AtLeastOneNumber = z.infer<typeof AtLeastOneNumberSchema>;
@@ -112,7 +131,7 @@ export const PlayerStatsSchema = z
     // non-client, e.g. a bot/nation) and finishing place at elimination. Both
     // first-write-wins. Surfaced live on the PlayerUpdate (not just at game end).
     killedBy: z.string().nullable().optional(),
-    deathPosition: z.number().optional(),
+    deathPosition: zb.uint().optional(),
     // Tiles owned at game end, for OFM standings (set on setWinner).
     finalTiles: BigIntStringSchema.optional(),
     // Humans this player eliminated (victim clientID + tick), for OFM kill scoring.

--- a/src/core/ZbinWire.ts
+++ b/src/core/ZbinWire.ts
@@ -30,16 +30,16 @@ import {
   ServerMessageSchema,
 } from "./Schemas";
 
-// One byte per id needs the table to stay under the escape byte; a game holds
-// far fewer players than this.
-const MAX_MAPPED_CLIENTS = 250;
-
+// Indexes are varints: the first 127 roster entries cost one byte per id,
+// the rest two. Large events (1000+ clients) fit comfortably; if a roster
+// ever exceeds the table cap, assign() ignores the overflow identically on
+// both sides and those ids ride the inline escape path — bigger, never wrong.
 export function createGameWireContext(
   players: ReadonlyArray<{ clientID: string }>,
 ): ZbContext {
   const ctx = new ZbContext();
-  ctx.mapping(CLIENT_ID_MAPPING, { max: MAX_MAPPED_CLIENTS });
-  for (const p of players.slice(0, MAX_MAPPED_CLIENTS)) {
+  ctx.mapping(CLIENT_ID_MAPPING);
+  for (const p of players) {
     ctx.assign(CLIENT_ID_MAPPING, p.clientID);
   }
   return ctx;

--- a/src/core/ZbinWire.ts
+++ b/src/core/ZbinWire.ts
@@ -79,6 +79,18 @@ export function decodeClientMessage(
   return ClientMessageSchema.parseBytes(bytes, ctx);
 }
 
+// Structural decode only, NO zod validation — throws ZbDecodeError on corrupt
+// bytes but happily returns schema-violating values (out-of-range numbers,
+// regex-breaking strings). For callers that validate separately because they
+// want the raw value when validation fails (GameServer's rejected-intent
+// telemetry); everyone else uses decodeClientMessage.
+export function decodeClientMessageUnvalidated(
+  bytes: Uint8Array,
+  ctx: ZbContext | undefined,
+): ClientMessage {
+  return ClientMessageSchema.decodeBytesUnvalidated(bytes, ctx);
+}
+
 // The lobby list socket is broadcast-only and carries no player ids, so it
 // needs no dictionary context.
 export function encodeLobbyMessage(

--- a/src/core/ZbinWire.ts
+++ b/src/core/ZbinWire.ts
@@ -1,0 +1,92 @@
+// Binary framing for the game and lobby WebSockets, built on the zbin library
+// (/zbin). Every frame on both sockets is a zbin payload — there is no JSON
+// fallback, no negotiation, and no version byte.
+//
+// That is only safe because OpenFront ships the client and the server from one
+// build: a zbin payload is a bare positional byte stream, so peers built from
+// different commits mis-decode each other (see zbin/README.md, "Compatibility").
+// If the client and the server ever stop being pinned together, a version has
+// to be negotiated before the first frame.
+//
+// HTTP stays JSON everywhere — the API worker is closed-source and the
+// archived game records are read by tools that expect JSON.
+//
+// The clientID dictionary is seeded identically on both sides from
+// GameStartInfo.players (array order matters — it IS the wire contract). The
+// roster is fixed at game start and the start message always precedes the
+// first dictionary-encoded frame, so the tables cannot diverge. The start
+// message itself is encoded WITHOUT a context, because it is what seeds the
+// receiver's table; ids outside the roster (e.g. ADMIN_BOT_CLIENT_ID) ride the
+// escape path inline.
+
+import { ZbContext } from "../../zbin";
+import {
+  CLIENT_ID_MAPPING,
+  ClientMessage,
+  ClientMessageSchema,
+  PublicLobbyMessage,
+  PublicLobbyMessageSchema,
+  ServerMessage,
+  ServerMessageSchema,
+} from "./Schemas";
+
+// One byte per id needs the table to stay under the escape byte; a game holds
+// far fewer players than this.
+const MAX_MAPPED_CLIENTS = 250;
+
+export function createGameWireContext(
+  players: ReadonlyArray<{ clientID: string }>,
+): ZbContext {
+  const ctx = new ZbContext();
+  ctx.mapping(CLIENT_ID_MAPPING, { max: MAX_MAPPED_CLIENTS });
+  for (const p of players.slice(0, MAX_MAPPED_CLIENTS)) {
+    ctx.assign(CLIENT_ID_MAPPING, p.clientID);
+  }
+  return ctx;
+}
+
+export function encodeServerMessage(
+  msg: ServerMessage,
+  ctx: ZbContext | undefined,
+): Uint8Array<ArrayBuffer> {
+  // The start message carries the roster the receiver seeds its table from, so
+  // it cannot itself be dictionary-encoded.
+  return ServerMessageSchema.serialize(
+    msg,
+    msg.type === "start" ? undefined : ctx,
+  );
+}
+
+// Decode + full zod validation; throws ZbDecodeError / ZodError on bad input.
+export function decodeServerMessage(
+  bytes: Uint8Array,
+  ctx: ZbContext | undefined,
+): ServerMessage {
+  return ServerMessageSchema.parseBytes(bytes, ctx);
+}
+
+export function encodeClientMessage(
+  msg: ClientMessage,
+  ctx: ZbContext | undefined,
+): Uint8Array<ArrayBuffer> {
+  return ClientMessageSchema.serialize(msg, ctx);
+}
+
+export function decodeClientMessage(
+  bytes: Uint8Array,
+  ctx: ZbContext | undefined,
+): ClientMessage {
+  return ClientMessageSchema.parseBytes(bytes, ctx);
+}
+
+// The lobby list socket is broadcast-only and carries no player ids, so it
+// needs no dictionary context.
+export function encodeLobbyMessage(
+  msg: PublicLobbyMessage,
+): Uint8Array<ArrayBuffer> {
+  return PublicLobbyMessageSchema.serialize(msg);
+}
+
+export function decodeLobbyMessage(bytes: Uint8Array): PublicLobbyMessage {
+  return PublicLobbyMessageSchema.parseBytes(bytes);
+}

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -11,6 +11,7 @@ import { GameMode, GameType, RankedType } from "../core/game/Game";
 import {
   ClientID,
   ClientMessage,
+  ClientMessageSchema,
   ClientSendLiveStatsMessage,
   ClientSendWinnerMessage,
   FEATURED_LOBBY_AUTO_START_MS,
@@ -44,7 +45,7 @@ import {
 } from "../core/Util";
 import {
   createGameWireContext,
-  decodeClientMessage,
+  decodeClientMessageUnvalidated,
   encodeServerMessage,
 } from "../core/ZbinWire";
 import { archive, finalizeGameRecord } from "./Archive";
@@ -950,24 +951,45 @@ export class GameServer {
     client.ws.removeAllListeners("message");
     client.ws.on("message", async (message: Buffer) => {
       try {
-        let clientMsg: ClientMessage;
+        // Decode and validate in two steps (instead of one parseBytes) so a
+        // message that is structurally sound but fails validation — the
+        // signature of a buggy or cheating client — can still be attributed
+        // to its intent in telemetry, exactly like the JSON path did.
+        let raw: ClientMessage;
         try {
-          // A Buffer is a Uint8Array and zbin honours its byteOffset. Decoding
-          // runs full zod validation, so this is exactly as strict as the JSON
-          // path it replaced.
-          clientMsg = decodeClientMessage(message, this.zbinCtx);
+          // A Buffer is a Uint8Array and zbin honours its byteOffset.
+          raw = decodeClientMessageUnvalidated(message, this.zbinCtx);
         } catch (e) {
-          const reasonDetail = String(e);
-          // No intent_observed telemetry here: a frame that fails to decode
-          // has no readable type, so it can't be attributed to an intent the
-          // way a schema-invalid JSON message could.
+          // Corrupt bytes: no readable type, nothing to attribute.
           this.log.warn(`Failed to decode client message, kicking`, {
+            clientID: client.clientID,
+            error: String(e),
+          });
+          this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
+          return;
+        }
+        const parsed = ClientMessageSchema.safeParse(raw);
+        if (!parsed.success) {
+          const reasonDetail = z.prettifyError(parsed.error);
+          if (raw.type === "intent") {
+            this.emitIntentObserved(
+              client,
+              raw.intent,
+              typeof raw.intent?.type === "string" ? raw.intent.type : null,
+              "rejected",
+              this.turns.length,
+              KICK_REASON_INVALID_MESSAGE,
+              reasonDetail,
+            );
+          }
+          this.log.warn(`Failed to parse client message, kicking`, {
             clientID: client.clientID,
             error: reasonDetail,
           });
           this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
           return;
         }
+        const clientMsg = parsed.data;
         const bytes = message.length;
         const rateResult = this.intentRateLimiter.check(
           client.clientID,

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -3,13 +3,14 @@ import ipAnonymize from "ip-anonymize";
 import { Logger } from "winston";
 import WebSocket from "ws";
 import { z } from "zod";
+import { ZbContext } from "../../zbin";
 import { anonWordName } from "../core/AnonNames";
 import { isAdminRole } from "../core/ApiSchemas";
 import { GameEnv } from "../core/configuration/Config";
 import { GameMode, GameType, RankedType } from "../core/game/Game";
 import {
   ClientID,
-  ClientMessageSchema,
+  ClientMessage,
   ClientSendLiveStatsMessage,
   ClientSendWinnerMessage,
   FEATURED_LOBBY_AUTO_START_MS,
@@ -41,6 +42,11 @@ import {
   sanitizeLobbyLabel,
   simpleHash,
 } from "../core/Util";
+import {
+  createGameWireContext,
+  decodeClientMessage,
+  encodeServerMessage,
+} from "../core/ZbinWire";
 import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
 import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";
@@ -149,6 +155,12 @@ export class GameServer {
   // gameStartInfo unless disableClanTags is set, in which case clan tags
   // are stripped from players. Archive uses the original gameStartInfo.
   private wireGameStartInfo!: GameStartInfo;
+
+  // clientID dictionary for the binary wire, seeded from gameStartInfo.players
+  // at start (clients seed theirs from the same array in the start message).
+  // Undefined until the game starts, which is also the last moment either peer
+  // can send a dictionary-encoded field.
+  private zbinCtx: ZbContext | undefined;
 
   private log: Logger;
 
@@ -794,10 +806,13 @@ export class GameServer {
       });
 
       client.ws.send(
-        JSON.stringify({
-          type: "error",
-          error: "full-lobby",
-        } satisfies ServerErrorMessage),
+        encodeServerMessage(
+          {
+            type: "error",
+            error: "full-lobby",
+          } satisfies ServerErrorMessage,
+          this.zbinCtx,
+        ),
       );
       return "rejected";
     }
@@ -933,56 +948,27 @@ export class GameServer {
 
   private addListeners(client: Client) {
     client.ws.removeAllListeners("message");
-    client.ws.on("message", async (message: string) => {
+    client.ws.on("message", async (message: Buffer) => {
       try {
-        let json: unknown;
+        let clientMsg: ClientMessage;
         try {
-          json = JSON.parse(message);
+          // A Buffer is a Uint8Array and zbin honours its byteOffset. Decoding
+          // runs full zod validation, so this is exactly as strict as the JSON
+          // path it replaced.
+          clientMsg = decodeClientMessage(message, this.zbinCtx);
         } catch (e) {
-          this.log.warn(`Failed to parse client message JSON, kicking`, {
-            clientID: client.clientID,
-            error: String(e),
-          });
-          this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
-          return;
-        }
-        const parsed = ClientMessageSchema.safeParse(json);
-        if (!parsed.success) {
-          const reasonDetail = z.prettifyError(parsed.error);
-          if (
-            typeof json === "object" &&
-            json !== null &&
-            "type" in json &&
-            json.type === "intent" &&
-            "intent" in json
-          ) {
-            const rawIntent = json.intent;
-            const intentType =
-              typeof rawIntent === "object" &&
-              rawIntent !== null &&
-              "type" in rawIntent &&
-              typeof rawIntent.type === "string"
-                ? rawIntent.type
-                : null;
-            this.emitIntentObserved(
-              client,
-              rawIntent,
-              intentType,
-              "rejected",
-              this.turns.length,
-              KICK_REASON_INVALID_MESSAGE,
-              reasonDetail,
-            );
-          }
-          this.log.warn(`Failed to parse client message, kicking`, {
+          const reasonDetail = String(e);
+          // No intent_observed telemetry here: a frame that fails to decode
+          // has no readable type, so it can't be attributed to an intent the
+          // way a schema-invalid JSON message could.
+          this.log.warn(`Failed to decode client message, kicking`, {
             clientID: client.clientID,
             error: reasonDetail,
           });
           this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
           return;
         }
-        const clientMsg = parsed.data;
-        const bytes = Buffer.byteLength(message, "utf8");
+        const bytes = message.length;
         const rateResult = this.intentRateLimiter.check(
           client.clientID,
           clientMsg.type,
@@ -1221,7 +1207,7 @@ export class GameServer {
       return;
     }
 
-    const msg = JSON.stringify(prestartMsg.data);
+    const msg = encodeServerMessage(prestartMsg.data, this.zbinCtx);
     this.activeClients.forEach((c) => {
       this.log.info("sending prestart message", {
         clientID: c.clientID,
@@ -1295,11 +1281,14 @@ export class GameServer {
     const shared = this.gameConfig.anonymizeNames ? null : this.gameInfo();
     this.activeClients.forEach((c) => {
       if (c.ws.readyState === WebSocket.OPEN) {
-        const msg = JSON.stringify({
-          type: "lobby_info",
-          lobby: shared ?? this.gameInfo(c.clientID),
-          myClientID: c.clientID,
-        } satisfies ServerLobbyInfoMessage);
+        const msg = encodeServerMessage(
+          {
+            type: "lobby_info",
+            lobby: shared ?? this.gameInfo(c.clientID),
+            myClientID: c.clientID,
+          } satisfies ServerLobbyInfoMessage,
+          this.zbinCtx,
+        );
         c.ws.send(msg);
       }
     });
@@ -1323,10 +1312,13 @@ export class GameServer {
   }
 
   private broadcastNewLobby(gameID: GameID) {
-    const msg = JSON.stringify({
-      type: "new_lobby",
-      gameID,
-    } satisfies ServerNewLobbyMessage);
+    const msg = encodeServerMessage(
+      {
+        type: "new_lobby",
+        gameID,
+      } satisfies ServerNewLobbyMessage,
+      this.zbinCtx,
+    );
     this.activeClients.forEach((c) => {
       if (c.ws.readyState === WebSocket.OPEN) {
         c.ws.send(msg);
@@ -1397,6 +1389,9 @@ export class GameServer {
           })),
         }
       : wireGameStartInfo;
+    // Seed the dictionary from the same players array, in the same order,
+    // every client receives in the start message.
+    this.zbinCtx = createGameWireContext(this.gameStartInfo.players);
 
     this.endTurnIntervalID = setInterval(
       () => this.endTurn(),
@@ -1572,16 +1567,19 @@ export class GameServer {
         return;
       }
       ws.send(
-        JSON.stringify({
-          type: "start",
-          turns: this.turns.slice(lastTurn),
-          gameStartInfo: this.startInfoFor(
-            client.clientID,
-            isAdminRole(client.role),
-          ),
-          lobbyCreatedAt: this.createdAt,
-          myClientID: client.clientID,
-        } satisfies ServerStartGameMessage),
+        encodeServerMessage(
+          {
+            type: "start",
+            turns: this.turns.slice(lastTurn),
+            gameStartInfo: this.startInfoFor(
+              client.clientID,
+              isAdminRole(client.role),
+            ),
+            lobbyCreatedAt: this.createdAt,
+            myClientID: client.clientID,
+          } satisfies ServerStartGameMessage,
+          this.zbinCtx,
+        ),
       );
     } catch (error) {
       this.log.error(`error sending start message for game ${this.id}`, {
@@ -1622,10 +1620,13 @@ export class GameServer {
     this.handleSynchronization();
     this.checkDisconnectedStatus();
 
-    const msg = JSON.stringify({
-      type: "turn",
-      turn: pastTurn,
-    } satisfies ServerTurnMessage);
+    const msg = encodeServerMessage(
+      {
+        type: "turn",
+        turn: pastTurn,
+      } satisfies ServerTurnMessage,
+      this.zbinCtx,
+    );
     this.activeClients.forEach((c) => {
       if (c.ws.readyState === c.ws.OPEN) {
         c.ws.send(msg);
@@ -1972,10 +1973,13 @@ export class GameServer {
       });
       if (client.ws.readyState === WebSocket.OPEN) {
         client.ws.send(
-          JSON.stringify({
-            type: "error",
-            error: reasonKey,
-          } satisfies ServerErrorMessage),
+          encodeServerMessage(
+            {
+              type: "error",
+              error: reasonKey,
+            } satisfies ServerErrorMessage,
+            this.zbinCtx,
+          ),
         );
         client.ws.close(1000, reasonKey);
       }
@@ -2112,7 +2116,7 @@ export class GameServer {
       return;
     }
 
-    const desyncMsg = JSON.stringify(serverDesync.data);
+    const desyncMsg = encodeServerMessage(serverDesync.data, this.zbinCtx);
     for (const c of outOfSyncClients) {
       this.outOfSyncClients.add(c.clientID);
       if (this.sentDesyncMessageClients.has(c.clientID)) {

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -10,13 +10,14 @@ import { z } from "zod";
 import { GameEnv } from "../core/configuration/Config";
 import { GameType } from "../core/game/Game";
 import {
-  ClientMessageSchema,
+  ClientMessage,
   ID,
   MAX_HOSTED_LOBBIES,
   ServerErrorMessage,
 } from "../core/Schemas";
 import { generateID, replacer } from "../core/Util";
 import { CreateGameInputSchema } from "../core/WorkerSchemas";
+import { decodeClientMessage, encodeServerMessage } from "../core/ZbinWire";
 import { registerAdminBotRoutes } from "./AdminBotRoutes";
 import { censorPlayer } from "./Censor";
 import { Client } from "./Client";
@@ -374,27 +375,30 @@ export async function startWorker() {
 
   // WebSocket handling
   wss.on("connection", (ws: WebSocket, req) => {
-    ws.on("message", async (message: string) => {
+    ws.on("message", async (message: Buffer) => {
       const ip = getClientIp(req);
 
       try {
-        // Parse and handle client messages
-        const parsed = ClientMessageSchema.safeParse(
-          JSON.parse(message.toString()),
-        );
-        if (!parsed.success) {
-          const error = z.prettifyError(parsed.error);
-          log.warn("Error parsing client message", error);
+        // Every frame is zbin (see ZbinWire.ts). Nothing before join carries a
+        // dictionary-mapped id, so this decodes without a context.
+        let clientMsg: ClientMessage;
+        try {
+          clientMsg = decodeClientMessage(message, undefined);
+        } catch (e) {
+          const error = String(e);
+          log.warn("Error decoding client message", error);
           ws.send(
-            JSON.stringify({
-              type: "error",
-              error: error.toString(),
-            } satisfies ServerErrorMessage),
+            encodeServerMessage(
+              {
+                type: "error",
+                error,
+              } satisfies ServerErrorMessage,
+              undefined,
+            ),
           );
           ws.close(1002, "ClientJoinMessageSchema");
           return;
         }
-        const clientMsg = parsed.data;
 
         if (clientMsg.type === "ping") {
           // Ignore ping

--- a/src/server/WorkerLobbyService.ts
+++ b/src/server/WorkerLobbyService.ts
@@ -6,6 +6,7 @@ import {
   PublicGames,
   PublicLobbyMessage,
 } from "../core/Schemas";
+import { encodeLobbyMessage } from "../core/ZbinWire";
 import { GameManager } from "./GameManager";
 import {
   InternalGameInfo,
@@ -264,12 +265,13 @@ export class WorkerLobbyService {
       // would only see counts-only deltas (which it can't apply without a
       // base) until the next structural change.
       if (this.lastPublicGames !== null) {
-        const fullJson = JSON.stringify({
-          type: "full",
-          serverTime: this.lastPublicGames.serverTime,
-          games: this.sanitizeGames(this.lastPublicGames.games),
-        } satisfies PublicLobbyMessage);
-        ws.send(fullJson);
+        ws.send(
+          encodeLobbyMessage({
+            type: "full",
+            serverTime: this.lastPublicGames.serverTime,
+            games: this.sanitizeGames(this.lastPublicGames.games),
+          } satisfies PublicLobbyMessage),
+        );
       }
       ws.on("message", () => {
         ws.terminate();
@@ -334,12 +336,12 @@ export class WorkerLobbyService {
         counts,
       };
     }
-    const json = JSON.stringify(payload);
+    const frame = encodeLobbyMessage(payload);
 
     const clientsToRemove: WebSocket[] = [];
     this.lobbyClients.forEach((client) => {
       if (client.readyState === WebSocket.OPEN) {
-        client.send(json);
+        client.send(frame);
       } else {
         clientsToRemove.push(client);
       }

--- a/tests/LobbySocket.test.ts
+++ b/tests/LobbySocket.test.ts
@@ -5,6 +5,7 @@ import {
   PublicGames,
   PublicGameType,
 } from "../src/core/Schemas";
+import { lobbyFrame } from "./util/Wire";
 
 function lobby(
   gameID: string,
@@ -18,7 +19,7 @@ function fullMessage(
   serverTime: number,
   games: Partial<Record<PublicGameType, PublicGameInfo[]>>,
 ) {
-  return JSON.stringify({
+  return lobbyFrame({
     type: "full",
     serverTime,
     games: { ffa: [], team: [], special: [], ...games },
@@ -26,13 +27,19 @@ function fullMessage(
 }
 
 function countsMessage(serverTime: number, counts: Record<string, number>) {
-  return JSON.stringify({ type: "counts", serverTime, counts });
+  return lobbyFrame({ type: "counts", serverTime, counts });
 }
 
 function makeSocket() {
   const callback = vi.fn<(g: PublicGames) => void>();
   const socket = new PublicLobbySocket(callback);
-  const dispatch = (data: string) => {
+  const dispatch = (frame: Uint8Array) => {
+    // The real socket is in arraybuffer mode, so handleMessage sees an
+    // ArrayBuffer, not a Uint8Array.
+    const data = frame.buffer.slice(
+      frame.byteOffset,
+      frame.byteOffset + frame.byteLength,
+    );
     (socket as any).handleMessage({ data } as MessageEvent);
   };
   return { socket, callback, dispatch };
@@ -112,15 +119,16 @@ describe("PublicLobbySocket.handleMessage", () => {
     expect(arg.serverTime).toBe(2000);
   });
 
-  it("does not call the callback on malformed JSON", () => {
+  it("does not call the callback on a corrupt frame", () => {
     const { callback, dispatch } = makeSocket();
-    dispatch("not json");
+    dispatch(new Uint8Array([0xff, 0xff, 0xff]));
     expect(callback).not.toHaveBeenCalled();
   });
 
-  it("does not call the callback on schema-invalid messages", () => {
+  it("does not call the callback on a truncated frame", () => {
     const { callback, dispatch } = makeSocket();
-    dispatch(JSON.stringify({ type: "bogus", serverTime: 1 }));
+    const frame = countsMessage(1, { g1: 2 });
+    dispatch(frame.subarray(0, frame.length - 1));
     expect(callback).not.toHaveBeenCalled();
   });
 

--- a/tests/server/AdminBotRoster.test.ts
+++ b/tests/server/AdminBotRoster.test.ts
@@ -4,6 +4,7 @@ import { registerAdminBotRoutes } from "../../src/server/AdminBotRoutes";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
 import { ServerEnv } from "../../src/server/ServerEnv";
+import { testGameConfig } from "../util/Wire";
 
 // The roster endpoint is the ONE place a per-game clientID can be tied back to an
 // account: the public record is PII-stripped, so without it a host sees that 96
@@ -115,9 +116,12 @@ describe("GameServer.roster() — the real projection", () => {
   it("maps every joiner — including one who already disconnected", () => {
     vi.useFakeTimers();
     try {
-      const game = new GameServer("g1", logger, Date.now(), {
-        gameType: GameType.Private,
-      } as any);
+      const game = new GameServer(
+        "g1",
+        logger,
+        Date.now(),
+        testGameConfig({ gameType: GameType.Private }),
+      );
       const stays = makeClient("c1", "pub1");
       const leaves = makeClient("c2", "pub2");
       const anon = makeClient("c3"); // no account — publicId stays undefined

--- a/tests/server/AllowlistJoin.test.ts
+++ b/tests/server/AllowlistJoin.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/core/Schemas", async () => {
 import { GameType } from "../../src/core/game/Game";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
   return {
@@ -72,10 +73,15 @@ describe("GameServer - allowlist (allowedPublicIds)", () => {
   });
 
   function makeGame(allowedPublicIds?: string[]) {
-    return new GameServer("test-game", mockLogger, Date.now(), {
-      gameType: GameType.Private,
-      ...(allowedPublicIds ? { allowedPublicIds } : {}),
-    } as any);
+    return new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Private,
+        ...(allowedPublicIds ? { allowedPublicIds } : {}),
+      }),
+    );
   }
 
   it("admits only listed publicIds and rejects others", () => {
@@ -149,11 +155,16 @@ describe("GameServer - allowlist (allowedPublicIds)", () => {
   });
 
   it("keeps publicId lists out of the start info (wire + archived record)", () => {
-    const game = new GameServer("test-game", mockLogger, Date.now(), {
-      gameType: GameType.Private,
-      allowedPublicIds: ["pub-ok"],
-      nameRevealPublicIds: ["pub-reveal"],
-    } as any);
+    const game = new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Private,
+        allowedPublicIds: ["pub-ok"],
+        nameRevealPublicIds: ["pub-reveal"],
+      }),
+    );
     expect(game.joinClient(makeClient("c1", "p1", "pub-ok"))).toBe("joined");
     game.start();
 

--- a/tests/server/AnonymizeNames.test.ts
+++ b/tests/server/AnonymizeNames.test.ts
@@ -2,6 +2,7 @@ import { GameType } from "../../src/core/game/Game";
 import { UsernameSchema } from "../../src/core/Schemas";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
   return {
@@ -56,13 +57,13 @@ function makeGame(
     "g1",
     logger,
     Date.now(),
-    {
+    testGameConfig({
       gameType: GameType.Private,
       anonymizeNames,
       disableClanTags,
       nameReveals,
       nameRevealPublicIds,
-    } as any,
+    }),
     "creator-pid",
   );
   [

--- a/tests/server/AnonymizeNamesTeammates.test.ts
+++ b/tests/server/AnonymizeNamesTeammates.test.ts
@@ -1,6 +1,7 @@
 import { GameType } from "../../src/core/game/Game";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
   return {
@@ -52,7 +53,7 @@ function makeGame(matchmakingTeams?: string[][]) {
     "g1",
     logger,
     Date.now(),
-    { gameType: GameType.Private, anonymizeNames: true } as any,
+    testGameConfig({ gameType: GameType.Private, anonymizeNames: true }),
     "creator-pid",
     undefined,
     undefined,

--- a/tests/server/CreateNextLobby.test.ts
+++ b/tests/server/CreateNextLobby.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameType } from "../../src/core/game/Game";
+import { ServerNewLobbyMessage } from "../../src/core/Schemas";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { sentServerMessages, testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
   const handlers: Record<string, (...args: any[]) => any> = {};
@@ -42,12 +44,12 @@ function makeClient(
 // The successor id the broadcast should carry (8-char id shape).
 const SUCCESSOR_ID = "SUCCES01";
 
-function newLobbyBroadcasts(ws: ReturnType<typeof makeMockWs>): string[] {
-  return ws.send.mock.calls
-    .map((c: any[]) => c[0])
-    .filter(
-      (m: unknown) => typeof m === "string" && m.includes('"type":"new_lobby"'),
-    );
+function newLobbyBroadcasts(
+  ws: ReturnType<typeof makeMockWs>,
+): ServerNewLobbyMessage[] {
+  return sentServerMessages(ws).filter(
+    (m): m is ServerNewLobbyMessage => m.type === "new_lobby",
+  );
 }
 
 // The worker's create_game?previous= flow calls setSuccessorLobby on the
@@ -76,7 +78,7 @@ describe("GameServer - successor lobby", () => {
       "test-game",
       mockLogger,
       Date.now(),
-      { gameType: GameType.Private } as any,
+      testGameConfig({ gameType: GameType.Private }),
       creatorPersistentID,
     );
   }
@@ -95,7 +97,7 @@ describe("GameServer - successor lobby", () => {
 
     expect(newLobbyBroadcasts(creatorWs)).toHaveLength(1);
     expect(newLobbyBroadcasts(otherWs)).toHaveLength(1);
-    expect(newLobbyBroadcasts(otherWs)[0]).toContain(SUCCESSOR_ID);
+    expect(newLobbyBroadcasts(otherWs)[0].gameID).toBe(SUCCESSOR_ID);
   });
 
   it("remembers the successor id so repeat requests can reuse it", () => {

--- a/tests/server/GameLifecycle.test.ts
+++ b/tests/server/GameLifecycle.test.ts
@@ -15,6 +15,7 @@ vi.mock("../../src/core/Schemas", async () => {
 
 import { GameType } from "../../src/core/game/Game";
 import { GameServer } from "../../src/server/GameServer";
+import { testGameConfig } from "../util/Wire";
 
 describe("GameLifecycle", () => {
   let mockLogger: any;
@@ -35,9 +36,12 @@ describe("GameLifecycle", () => {
   });
 
   it("should not start turn interval if game has ended", async () => {
-    const game = new GameServer("test-game", mockLogger, Date.now(), {
-      gameType: GameType.Private,
-    } as any);
+    const game = new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      testGameConfig({ gameType: GameType.Private }),
+    );
 
     // Call end() first - this should set _hasEnded
     await game.end();
@@ -54,11 +58,12 @@ describe("GameLifecycle", () => {
 
   it("should clear turn interval and set _hasEnded on end()", async () => {
     // We need to initialize the game such that start() can succeed
-    const game = new GameServer("test-game", mockLogger, Date.now(), {
-      gameType: GameType.Private,
-      gameMap: "plains",
-      gameMapSize: 100,
-    } as any);
+    const game = new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      testGameConfig({ gameType: GameType.Private }),
+    );
 
     // Manually trigger prestart to fulfill some internal checks if necessary
     game.prestart();
@@ -74,9 +79,12 @@ describe("GameLifecycle", () => {
   });
 
   it("should be resilient to multiple end() calls", async () => {
-    const game = new GameServer("test-game", mockLogger, Date.now(), {
-      gameType: GameType.Private,
-    } as any);
+    const game = new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      testGameConfig({ gameType: GameType.Private }),
+    );
 
     await game.end();
     expect((game as any)._hasEnded).toBe(true);

--- a/tests/server/GameServerTribes.test.ts
+++ b/tests/server/GameServerTribes.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../src/server/CustomTribes", () => ({
 import { GameType } from "../../src/core/game/Game";
 import { fetchCustomTribes } from "../../src/server/CustomTribes";
 import { GameServer } from "../../src/server/GameServer";
+import { testGameConfig } from "../util/Wire";
 
 function fakeClient(clientID: string, publicId?: string) {
   return {
@@ -63,13 +64,16 @@ describe("GameServer custom tribes", () => {
   });
 
   function makeGame(config: Record<string, unknown> = {}) {
-    return new GameServer("testgame", mockLogger, Date.now(), {
-      gameType: GameType.Public,
-      gameMap: "plains",
-      gameMapSize: 100,
-      bots: 400,
-      ...config,
-    } as any);
+    return new GameServer(
+      "testgame",
+      mockLogger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Public,
+        bots: 400,
+        ...config,
+      }),
+    );
   }
 
   it("fetches the pool at prestart and embeds the tribes in the start info", async () => {

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -29,6 +29,7 @@ import {
 import { MasterLobbyService } from "../../src/server/MasterLobbyService";
 import { ServerEnv } from "../../src/server/ServerEnv";
 import { WorkerLobbyService } from "../../src/server/WorkerLobbyService";
+import { decodeSentLobbyMessage, testGameConfig } from "../util/Wire";
 
 vi.mock("../../src/server/Logger", () => ({
   logger: {
@@ -63,7 +64,7 @@ function makeGame(
     id,
     mockLogger,
     Date.now(),
-    { gameType: GameType.Private, ...config } as any,
+    testGameConfig({ gameType: GameType.Private, ...config }),
     creatorPersistentID,
   );
 }
@@ -174,7 +175,7 @@ describe("GameManager.listedLobbies", () => {
     const gm = new GameManager(mockLogger);
     const pub = gm.createGame(
       "g-public",
-      { gameType: GameType.Public } as any,
+      testGameConfig({ gameType: GameType.Public }),
       undefined,
     )!;
     pub.setListed(true);
@@ -742,7 +743,7 @@ describe("WorkerLobbyService hosted lobbies", () => {
   }
 
   function sentPayloads(ws: { send: ReturnType<typeof vi.fn> }): any[] {
-    return ws.send.mock.calls.map((c) => JSON.parse(c[0]));
+    return ws.send.mock.calls.map((c) => decodeSentLobbyMessage(c[0]));
   }
 
   it("reports listed lobbies to master as hosted, with creatorID and without host-only config", () => {
@@ -775,7 +776,10 @@ describe("WorkerLobbyService hosted lobbies", () => {
       "ranked-g1",
       mockLogger,
       Date.now(),
-      { gameType: GameType.Public, allowedPublicIds: ["p1", "p2"] } as any,
+      testGameConfig({
+        gameType: GameType.Public,
+        allowedPublicIds: ["p1", "p2"],
+      }),
       undefined,
       Date.now() + 7000,
       undefined, // matchmaking games are created without a publicGameType

--- a/tests/server/KickPlayerAuthorization.test.ts
+++ b/tests/server/KickPlayerAuthorization.test.ts
@@ -10,15 +10,13 @@ vi.mock("../../src/core/Schemas", async () => {
     ServerPrestartMessageSchema: {
       safeParse: (data: any) => ({ success: true, data: data }),
     },
-    ClientMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
   };
 });
 
 import { GameType } from "../../src/core/game/Game";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { clientFrame, testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
   const handlers: Record<string, (...args: any[]) => any> = {};
@@ -80,7 +78,7 @@ describe("GameServer - kick_player authorization", () => {
       "test-game",
       mockLogger,
       Date.now(),
-      { gameType: GameType.Private } as any,
+      testGameConfig({ gameType: GameType.Private }),
       creatorPersistentID,
     );
   }
@@ -91,7 +89,7 @@ describe("GameServer - kick_player authorization", () => {
   ) {
     await ws.trigger(
       "message",
-      JSON.stringify({
+      clientFrame({
         type: "intent",
         intent: { type: "kick_player", targetClientID: target },
       }),
@@ -103,19 +101,19 @@ describe("GameServer - kick_player authorization", () => {
     const kickSpy = vi.spyOn(game, "kickClient");
 
     const { client: creator, ws: creatorWs } = makeClient(
-      "creator-cid",
+      "creator1",
       "creator-pid",
     );
-    const { client: target } = makeClient("target-cid", "target-pid");
+    const { client: target } = makeClient("target01", "target-pid");
 
     game.joinClient(creator);
     game.joinClient(target);
 
-    await sendKickMessage(creatorWs, "target-cid");
+    await sendKickMessage(creatorWs, "target01");
 
     expect(kickSpy).toHaveBeenCalledOnce();
     expect(kickSpy).toHaveBeenCalledWith(
-      "target-cid",
+      "target01",
       "kick_reason.lobby_creator",
     );
   });
@@ -125,34 +123,34 @@ describe("GameServer - kick_player authorization", () => {
     const kickSpy = vi.spyOn(game, "kickClient");
 
     const { client: admin, ws: adminWs } = makeClient(
-      "admin-cid",
+      "admin001",
       "admin-pid",
       "admin",
     );
-    const { client: target } = makeClient("target-cid", "target-pid");
+    const { client: target } = makeClient("target01", "target-pid");
 
     game.joinClient(admin);
     game.joinClient(target);
 
-    await sendKickMessage(adminWs, "target-cid");
+    await sendKickMessage(adminWs, "target01");
 
     expect(kickSpy).toHaveBeenCalledOnce();
-    expect(kickSpy).toHaveBeenCalledWith("target-cid", "kick_reason.admin");
+    expect(kickSpy).toHaveBeenCalledWith("target01", "kick_reason.admin");
   });
 
   it("non-creator non-admin cannot kick", async () => {
     const game = makeGame("creator-pid");
     const kickSpy = vi.spyOn(game, "kickClient");
 
-    const { client: creator } = makeClient("creator-cid", "creator-pid");
-    const { client: rando, ws: randoWs } = makeClient("rando-cid", "rando-pid");
-    const { client: target } = makeClient("target-cid", "target-pid");
+    const { client: creator } = makeClient("creator1", "creator-pid");
+    const { client: rando, ws: randoWs } = makeClient("rando001", "rando-pid");
+    const { client: target } = makeClient("target01", "target-pid");
 
     game.joinClient(creator);
     game.joinClient(rando);
     game.joinClient(target);
 
-    await sendKickMessage(randoWs, "target-cid");
+    await sendKickMessage(randoWs, "target01");
 
     expect(kickSpy).not.toHaveBeenCalled();
   });
@@ -162,12 +160,12 @@ describe("GameServer - kick_player authorization", () => {
     const kickSpy = vi.spyOn(game, "kickClient");
 
     const { client: creator, ws: creatorWs } = makeClient(
-      "creator-cid",
+      "creator1",
       "creator-pid",
     );
     game.joinClient(creator);
 
-    await sendKickMessage(creatorWs, "creator-cid");
+    await sendKickMessage(creatorWs, "creator1");
 
     expect(kickSpy).not.toHaveBeenCalled();
   });

--- a/tests/server/MatchTelemetryIntegration.test.ts
+++ b/tests/server/MatchTelemetryIntegration.test.ts
@@ -219,11 +219,11 @@ describe("GameServer match telemetry", () => {
     expect((game as any).intents).toEqual(intentsBefore);
   });
 
-  it("kicks on a schema-invalid intent without attributing it to an intent", async () => {
-    // The frame decodes structurally (the recipient is a plain string on the
-    // wire) but fails zod validation, so the server kicks. It emits no
-    // intent_observed: a rejected frame has no trustworthy intent to report,
-    // and the raw bytes are not a JSON object it could echo back.
+  it("captures the raw intent from a schema-invalid intent message", async () => {
+    // The frame decodes structurally (the target is a plain string on the
+    // wire) but fails zod validation — the signature of a buggy or cheating
+    // client, which is exactly what this telemetry exists to observe. The
+    // rejected intent is attributed with its raw payload before the kick.
     const game = makeGame();
     const { client, ws } = makeClient();
     game.joinClient(client);
@@ -235,6 +235,28 @@ describe("GameServer match telemetry", () => {
         intent: { type: "targetPlayer", target: "not a client id" },
       }),
     );
+    const observed = telemetry.events.find(
+      (event) => event.type === "intent_observed",
+    );
+    expect(observed).toMatchObject({
+      payload: {
+        outcome: "rejected",
+        reasonCode: "kick_reason.invalid_message",
+        intentType: "targetPlayer",
+        intent: { type: "targetPlayer", target: "not a client id" },
+      },
+    });
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it("emits nothing for a structurally corrupt frame", async () => {
+    // Garbage bytes decode to no readable type, so there is no intent to
+    // attribute — the client is just kicked.
+    const game = makeGame();
+    const { client, ws } = makeClient();
+    game.joinClient(client);
+    telemetry.events.length = 0;
+    await ws.trigger("message", Buffer.from([0xff, 0xff, 0xff, 0xff]));
     expect(
       telemetry.events.filter((event) => event.type === "intent_observed"),
     ).toHaveLength(0);

--- a/tests/server/MatchTelemetryIntegration.test.ts
+++ b/tests/server/MatchTelemetryIntegration.test.ts
@@ -20,6 +20,7 @@ import type {
   MatchTelemetryEmitter,
   MatchTelemetryEvent,
 } from "../../src/server/telemetry/MatchTelemetry";
+import { clientFrame, testGameConfig } from "../util/Wire";
 
 class RecordingEmitter implements MatchTelemetryEmitter {
   events: MatchTelemetryEvent[] = [];
@@ -150,7 +151,7 @@ describe("GameServer match telemetry", () => {
     game.joinClient(client);
     await ws.trigger(
       "message",
-      JSON.stringify({ type: "intent", intent: { type: "spawn", tile: 1 } }),
+      clientFrame({ type: "intent", intent: { type: "spawn", tile: 1 } }),
     );
     const observed = telemetry.events.find(
       (event) => event.type === "intent_observed",
@@ -179,7 +180,7 @@ describe("GameServer match telemetry", () => {
     const intentsBefore = [...(game as any).intents];
     await ws.trigger(
       "message",
-      JSON.stringify({ type: "intent", intent: { type: "spawn", tile: 1 } }),
+      clientFrame({ type: "intent", intent: { type: "spawn", tile: 1 } }),
     );
     expect(
       telemetry.events.find((event) => event.type === "intent_observed"),
@@ -201,7 +202,7 @@ describe("GameServer match telemetry", () => {
     const intentsBefore = [...(game as any).intents];
     await ws.trigger(
       "message",
-      JSON.stringify({
+      clientFrame({
         type: "intent",
         intent: { type: "kick_player", targetClientID: "targetAB" },
       }),
@@ -218,39 +219,25 @@ describe("GameServer match telemetry", () => {
     expect((game as any).intents).toEqual(intentsBefore);
   });
 
-  it("captures only the raw intent property from a schema-invalid intent envelope", async () => {
+  it("kicks on a schema-invalid intent without attributing it to an intent", async () => {
+    // The frame decodes structurally (the recipient is a plain string on the
+    // wire) but fails zod validation, so the server kicks. It emits no
+    // intent_observed: a rejected frame has no trustworthy intent to report,
+    // and the raw bytes are not a JSON object it could echo back.
     const game = makeGame();
     const { client, ws } = makeClient();
     game.joinClient(client);
-    const authCanary = "schema-invalid-auth-canary-7f3d91";
+    telemetry.events.length = 0;
     await ws.trigger(
       "message",
-      JSON.stringify({
+      clientFrame({
         type: "intent",
-        intent: { type: "spawn", tile: "invalid", extra: "raw" },
-        token: authCanary,
+        intent: { type: "targetPlayer", target: "not a client id" },
       }),
     );
-    const observed = telemetry.events.find(
-      (event) => event.type === "intent_observed",
-    );
-    expect(observed?.type).toBe("intent_observed");
-    if (observed?.type !== "intent_observed") {
-      throw new Error("expected intent_observed telemetry");
-    }
-    expect(observed).toMatchObject({
-      payload: {
-        outcome: "rejected",
-        reasonCode: "kick_reason.invalid_message",
-        intentType: "spawn",
-      },
-    });
-    expect(observed.payload.intent).toEqual({
-      type: "spawn",
-      tile: "invalid",
-      extra: "raw",
-    });
-    expect(JSON.stringify(observed)).not.toContain(authCanary);
+    expect(
+      telemetry.events.filter((event) => event.type === "intent_observed"),
+    ).toHaveLength(0);
     expect(ws.close).toHaveBeenCalled();
   });
 
@@ -261,7 +248,12 @@ describe("GameServer match telemetry", () => {
     telemetry.events.length = 0;
     await ws.trigger(
       "message",
-      JSON.stringify({ type: "rejoin", token: "secret" }),
+      clientFrame({
+        type: "rejoin",
+        gameID: "not a game id",
+        lastTurn: 0,
+        token: "secret",
+      }),
     );
     expect(
       telemetry.events.filter((event) => event.type === "intent_observed"),
@@ -288,7 +280,7 @@ describe("GameServer match telemetry", () => {
       ]);
       await ws.trigger(
         "message",
-        JSON.stringify({ type: "intent", intent: { type: "spawn", tile: 1 } }),
+        clientFrame({ type: "intent", intent: { type: "spawn", tile: 1 } }),
       );
       const observed = telemetry.events.find(
         (event) => event.type === "intent_observed",
@@ -335,7 +327,7 @@ describe("GameServer match telemetry", () => {
     ]);
     await ws.trigger(
       "message",
-      JSON.stringify({ type: "intent", intent: { type: "spawn", tile: 1 } }),
+      clientFrame({ type: "intent", intent: { type: "spawn", tile: 1 } }),
     );
     (game as any).endTurn();
     const intentIndex = telemetry.events.findIndex(
@@ -359,9 +351,10 @@ describe("GameServer match telemetry", () => {
 
   it("GameManager forwards the worker emitter and build hash to each game", () => {
     const manager = new GameManager(log, telemetry, "build-hash");
-    const game = manager.createGame("managerMatch", {
-      gameType: GameType.Private,
-    } as any);
+    const game = manager.createGame(
+      "managerMatch",
+      testGameConfig({ gameType: GameType.Private }),
+    );
     expect(game).not.toBeNull();
     expect(
       telemetry.events.find((event) => event.type === "match_opened"),

--- a/tests/server/MatchmakingCancel.test.ts
+++ b/tests/server/MatchmakingCancel.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameType, RankedType } from "../../src/core/game/Game";
 import { Client } from "../../src/server/Client";
 import { GamePhase, GameServer } from "../../src/server/GameServer";
+import { sentServerMessages, testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
   return {
@@ -55,7 +56,7 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
       "test-game",
       mockLogger,
       Date.now(),
-      { gameType: GameType.Public, rankedType, maxPlayers } as any,
+      testGameConfig({ gameType: GameType.Public, rankedType, maxPlayers }),
       undefined,
       Date.now() + 15000,
     );
@@ -73,12 +74,10 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
     expect(game.cancelShortHandedMatch()).toBe(true);
 
     for (const c of clients) {
-      expect(c.ws.send).toHaveBeenCalledWith(
-        JSON.stringify({
-          type: "error",
-          error: "kick_reason.match_cancelled",
-        }),
-      );
+      expect(sentServerMessages(c.ws as any)).toContainEqual({
+        type: "error",
+        error: "kick_reason.match_cancelled",
+      });
       expect(c.ws.close).toHaveBeenCalled();
     }
     expect(game.phase()).toBe(GamePhase.Finished);
@@ -106,11 +105,19 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
       "test-game",
       mockLogger,
       Date.now(),
-      { gameType: GameType.Public, rankedType: "3v3", maxPlayers: 6 } as any,
+      testGameConfig({
+        gameType: GameType.Public,
+        rankedType: RankedType.TwoVTwo,
+        maxPlayers: 6,
+      }),
       undefined,
       Date.now() + 15000,
     );
     expect(game.joinClient(makeClient("c1", "p1"))).toBe("joined");
+    // Swapped in after the join: an unknown ranked type can never reach a real
+    // server (CreateGameInput validates it, and the binary wire only encodes
+    // declared enum members), so this pokes the guard directly.
+    (game as any).gameConfig.rankedType = "3v3";
 
     expect(game.cancelShortHandedMatch()).toBe(false);
   });
@@ -120,7 +127,7 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
       "test-game",
       mockLogger,
       Date.now(),
-      { gameType: GameType.Public, maxPlayers: 4 } as any,
+      testGameConfig({ gameType: GameType.Public, maxPlayers: 4 }),
       undefined,
       Date.now() + 15000,
     );

--- a/tests/server/SpectatorJoin.test.ts
+++ b/tests/server/SpectatorJoin.test.ts
@@ -10,26 +10,25 @@ vi.mock("../../src/core/Schemas", async () => {
     ServerPrestartMessageSchema: {
       safeParse: (data: any) => ({ success: true, data }),
     },
-    ClientMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
   };
 });
 
 import { GameType, RankedType } from "../../src/core/game/Game";
+import { ClientMessage } from "../../src/core/Schemas";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { clientFrame, testGameConfig } from "../util/Wire";
 
 function makeMockWs() {
-  const handlers = new Map<string, (msg: string) => void>();
+  const handlers = new Map<string, (msg: Buffer) => void>();
   return {
-    on: (event: string, fn: (msg: string) => void) => handlers.set(event, fn),
+    on: (event: string, fn: (msg: Buffer) => void) => handlers.set(event, fn),
     removeAllListeners: () => handlers.clear(),
     send: vi.fn(),
     close: vi.fn(),
     readyState: 1,
     /** Drive the socket the way a connected client would. */
-    emit: (msg: unknown) => handlers.get("message")?.(JSON.stringify(msg)),
+    emit: (msg: ClientMessage) => handlers.get("message")?.(clientFrame(msg)),
   };
 }
 
@@ -78,10 +77,12 @@ describe("GameServer - spectators", () => {
   });
 
   const makeGame = (maxPlayers?: number) =>
-    new GameServer("g1", logger, Date.now(), {
-      gameType: GameType.Private,
-      maxPlayers,
-    } as any);
+    new GameServer(
+      "g1",
+      logger,
+      Date.now(),
+      testGameConfig({ gameType: GameType.Private, maxPlayers }),
+    );
 
   it("takes no lobby slot, so a full game is still watchable", () => {
     const game = makeGame(2);
@@ -112,10 +113,15 @@ describe("GameServer - spectators", () => {
 
   it("still has to be on the allowlist when the lobby sets one", () => {
     // Taking no slot must not become a way around the allowlist.
-    const game = new GameServer("g1", logger, Date.now(), {
-      gameType: GameType.Private,
-      allowedPublicIds: ["p1-pub"],
-    } as any);
+    const game = new GameServer(
+      "g1",
+      logger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Private,
+        allowedPublicIds: ["p1-pub"],
+      }),
+    );
     expect(game.joinClient(makeClient("cast", true))).toBe("not_allowlisted");
     expect(game.joinClient(makeClient("p1", true))).toBe("joined");
   });
@@ -123,11 +129,16 @@ describe("GameServer - spectators", () => {
   it("does not keep a ranked match alive on its own", () => {
     // 1v1 with one player and one spectator is a one-player game, so the
     // short-handed cancel has to see through the spectator.
-    const game = new GameServer("g1", logger, Date.now(), {
-      gameType: GameType.Private,
-      maxPlayers: 2,
-      rankedType: RankedType.OneVOne,
-    } as any);
+    const game = new GameServer(
+      "g1",
+      logger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Private,
+        maxPlayers: 2,
+        rankedType: RankedType.OneVOne,
+      }),
+    );
     game.joinClient(makeClient("p1"));
     game.joinClient(makeClient("cast", true));
     expect((game as any).cancelShortHandedMatch()).toBe(true);
@@ -145,12 +156,13 @@ describe("GameServer - spectators", () => {
       };
       const spectator = makeClient("cast", true);
       game.joinClient(spectator);
-      await (spectator.ws as any).emit({
-        type,
-        intent: { type: "spawn" },
-        turnNumber: 1,
-        hash: 42,
-      });
+      const byType: Record<string, ClientMessage> = {
+        intent: { type: "intent", intent: { type: "spawn", tile: 1 } },
+        winner: { type: "winner", winner: undefined, allPlayersStats: {} },
+        live_stats: { type: "live_stats", stats: { turn: 1, players: [] } },
+        hash: { type: "hash", hash: 42, turnNumber: 1 },
+      };
+      await (spectator.ws as any).emit(byType[type]);
       if (type === "hash") {
         // hash has no handler spy — it writes client.hashes, which feeds the
         // desync agreement a spectator must not vote in.
@@ -168,7 +180,7 @@ describe("GameServer - spectators", () => {
     game.joinClient(player);
     await (player.ws as any).emit({
       type: "intent",
-      intent: { type: "spawn" },
+      intent: { type: "spawn", tile: 1 },
     });
     expect(handleIntent).toHaveBeenCalled();
   });
@@ -275,17 +287,25 @@ describe("GameServer - spectators", () => {
       // (update_game_config replaces it), so being inside is not proof of a
       // seat. Without this, the toggle is a way past the allowlist the moment
       // anything admits a non-listed spectator.
-      const game = new GameServer("g1", logger, Date.now(), {
-        gameType: GameType.Private,
-        allowedPublicIds: ["p1-pub"],
-      } as any);
+      const game = new GameServer(
+        "g1",
+        logger,
+        Date.now(),
+        testGameConfig({
+          gameType: GameType.Private,
+          allowedPublicIds: ["p1-pub"],
+        }),
+      );
       const listed = makeClient("p1", true);
       const unlisted = makeClient("cast", true);
       // Admit both while... the unlisted one cannot join an allowlisted lobby
       // today, so simulate the post-join list change: join first, then set it.
-      const open = new GameServer("g2", logger, Date.now(), {
-        gameType: GameType.Private,
-      } as any);
+      const open = new GameServer(
+        "g2",
+        logger,
+        Date.now(),
+        testGameConfig({ gameType: GameType.Private }),
+      );
       open.joinClient(unlisted);
       (open as any).gameConfig.allowedPublicIds = ["someone-else-pub"];
       setSpectator(open, unlisted, false);

--- a/tests/server/TurnstileReadmit.test.ts
+++ b/tests/server/TurnstileReadmit.test.ts
@@ -19,6 +19,7 @@ vi.mock("../../src/core/Schemas", async () => {
 import { GameType } from "../../src/core/game/Game";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import { testGameConfig } from "../util/Wire";
 
 // Stateful mock that records listeners so a test can fire the "close" event,
 // exercising GameServer's real ws.on("close") handler.
@@ -81,9 +82,12 @@ describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
   });
 
   function makeGame() {
-    return new GameServer("test-game", mockLogger, Date.now(), {
-      gameType: GameType.Private,
-    } as any);
+    return new GameServer(
+      "test-game",
+      mockLogger,
+      Date.now(),
+      testGameConfig({ gameType: GameType.Private }),
+    );
   }
 
   it("reports unknown players as not admitted", () => {

--- a/tests/util/Wire.ts
+++ b/tests/util/Wire.ts
@@ -1,0 +1,79 @@
+// Helpers for tests that drive the game WebSocket, which carries zbin binary
+// frames rather than JSON (see src/core/ZbinWire.ts).
+
+import {
+  Difficulty,
+  GameMapSize,
+  GameMapType,
+  GameMode,
+  GameType,
+} from "../../src/core/game/Game";
+import {
+  ClientMessage,
+  GameConfig,
+  PublicLobbyMessage,
+  PublicLobbyMessageSchema,
+  ServerMessage,
+  ServerMessageSchema,
+} from "../../src/core/Schemas";
+import {
+  encodeClientMessage,
+  encodeLobbyMessage,
+} from "../../src/core/ZbinWire";
+
+// A frame as a client would put it on the wire. Tests hand these to the
+// server's "message" listener.
+export function clientFrame(msg: ClientMessage): Buffer {
+  return Buffer.from(encodeClientMessage(msg, undefined));
+}
+
+// Every server message a mocked `ws.send` captured, decoded back to objects.
+//
+// Frames are decoded without a dictionary context, which is what a peer that
+// has not yet seen the start message does; ids then ride inline. Validation is
+// skipped: the question these helpers answer is "what did the server put on
+// the wire", and server-test fixtures routinely use placeholder clientIDs
+// ("creator-cid") that were never ID-schema-valid. Structural corruption still
+// throws — that is the decoder, not the validator.
+export function sentServerMessages(ws: {
+  send: { mock: { calls: unknown[][] } };
+}): ServerMessage[] {
+  return ws.send.mock.calls.map(([frame]) => decodeSentServerMessage(frame));
+}
+
+export function decodeSentServerMessage(frame: unknown): ServerMessage {
+  return ServerMessageSchema.decodeBytesUnvalidated(frame as Uint8Array);
+}
+
+export function lobbyFrame(msg: PublicLobbyMessage): Uint8Array {
+  return encodeLobbyMessage(msg);
+}
+
+export function decodeSentLobbyMessage(frame: unknown): PublicLobbyMessage {
+  return PublicLobbyMessageSchema.decodeBytesUnvalidated(frame as Uint8Array);
+}
+
+// A complete, schema-valid GameConfig. Server tests used to get away with
+// `{ gameType } as any` because JSON.stringify happily serialized a partial
+// config; the binary encoder rejects a missing required field, so fixtures now
+// have to be whole.
+export function testGameConfig(
+  overrides: Partial<GameConfig> = {},
+): GameConfig {
+  return {
+    gameMap: GameMapType.World,
+    gameMapSize: GameMapSize.Normal,
+    difficulty: Difficulty.Medium,
+    gameType: GameType.Private,
+    gameMode: GameMode.FFA,
+    donateGold: true,
+    donateTroops: true,
+    nations: "default",
+    bots: 0,
+    infiniteGold: false,
+    infiniteTroops: false,
+    instantBuild: false,
+    randomSpawn: false,
+    ...overrides,
+  };
+}

--- a/tests/zbin/golden.test.ts
+++ b/tests/zbin/golden.test.ts
@@ -96,12 +96,12 @@ describe("golden wire vectors", () => {
     expect(hex(S.serialize({ s: "🎉" }))).toBe("04f09f8e89");
   });
 
-  it("mapped ids are one byte, with an escape for strangers", () => {
+  it("mapped ids are varint(index+1), with varint 0 escaping inline", () => {
     const S = zb.object({ id: zb.mapped("ids") });
     const ctx = zb.context().mapping("ids").assignAll("ids", ["aa", "bb"]);
-    expect(hex(S.serialize({ id: "aa" }, ctx))).toBe("00");
-    expect(hex(S.serialize({ id: "bb" }, ctx))).toBe("01");
-    expect(hex(S.serialize({ id: "zz" }, ctx))).toBe("ff027a7a");
+    expect(hex(S.serialize({ id: "aa" }, ctx))).toBe("01");
+    expect(hex(S.serialize({ id: "bb" }, ctx))).toBe("02");
+    expect(hex(S.serialize({ id: "zz" }, ctx))).toBe("00027a7a");
   });
 
   it("zb.stamped writes tag, then extras, then variant fields", () => {

--- a/tests/zbin/wire.test.ts
+++ b/tests/zbin/wire.test.ts
@@ -387,6 +387,35 @@ describe("zbin wire: server messages", () => {
     );
   });
 
+  it("handles a 1000-client roster without losing the dictionary", () => {
+    // Big events exceed the old one-byte table; indexes are varints now, so
+    // every roster entry stays mapped (1 byte for the first 127, 2 after).
+    const roster = Array.from({ length: 1000 }, (_, i) => ({
+      clientID: `c${String(i).padStart(7, "0")}`,
+    }));
+    const sctx = createGameWireContext(roster);
+    const cctx = createGameWireContext(roster);
+    const turnOf = (clientID: string): ServerMessage => ({
+      type: "turn",
+      turn: {
+        turnNumber: 1,
+        intents: [{ type: "targetPlayer", clientID, target: clientID }],
+      },
+    });
+    const early = encodeServerMessage(turnOf(roster[50].clientID), sctx);
+    const late = encodeServerMessage(turnOf(roster[999].clientID), sctx);
+    // Two mapped ids in the intent: 1 byte each early, 2 bytes each late.
+    expect(late.length).toBe(early.length + 2);
+    for (const p of [roster[0], roster[126], roster[127], roster[999]]) {
+      expect(
+        decodeServerMessage(
+          encodeServerMessage(turnOf(p.clientID), sctx),
+          cctx,
+        ),
+      ).toEqual(turnOf(p.clientID));
+    }
+  });
+
   it("fails loudly when the peers seeded different rosters", () => {
     const sctx = createGameWireContext(PLAYERS);
     const cctx = createGameWireContext(PLAYERS.slice(0, 1));

--- a/tests/zbin/wire.test.ts
+++ b/tests/zbin/wire.test.ts
@@ -1,0 +1,539 @@
+import { describe, expect, it } from "vitest";
+import {
+  Difficulty,
+  GameMapSize,
+  GameMapType,
+  GameMode,
+  GameType,
+  UnitType,
+} from "../../src/core/game/Game";
+import {
+  ADMIN_BOT_CLIENT_ID,
+  ClientMessage,
+  ClientMessageSchema,
+  GameConfig,
+  LogSeverity,
+  PublicLobbyMessage,
+  PublicLobbyMessageSchema,
+  ServerMessage,
+  ServerMessageSchema,
+  StampedIntent,
+  Turn,
+} from "../../src/core/Schemas";
+import { replacer } from "../../src/core/Util";
+import {
+  createGameWireContext,
+  decodeClientMessage,
+  decodeLobbyMessage,
+  decodeServerMessage,
+  encodeClientMessage,
+  encodeLobbyMessage,
+  encodeServerMessage,
+} from "../../src/core/ZbinWire";
+import { ZbDecodeError } from "../../zbin";
+
+const PLAYERS = [
+  { clientID: "aB3dEf7h" },
+  { clientID: "Xk9mNp2q" },
+  { clientID: "Zz8wVu5t" },
+];
+
+const [P1, P2, P3] = PLAYERS.map((p) => p.clientID);
+
+// Server and client each build their own context from the same roster, the way
+// GameServer.start() and Transport's start handler do.
+function ctxPair() {
+  return [createGameWireContext(PLAYERS), createGameWireContext(PLAYERS)];
+}
+
+const CONFIG: GameConfig = {
+  gameMap: GameMapType.World,
+  difficulty: Difficulty.Medium,
+  donateGold: true,
+  donateTroops: true,
+  gameType: GameType.Public,
+  gameMode: GameMode.FFA,
+  gameMapSize: GameMapSize.Normal,
+  nations: "default",
+  bots: 200,
+  infiniteGold: false,
+  infiniteTroops: false,
+  instantBuild: false,
+  randomSpawn: false,
+};
+
+// One of every intent type, as stamped intents inside a turn.
+const SAMPLE_INTENTS: StampedIntent[] = [
+  { type: "spawn", clientID: P1, tile: 123456 },
+  { type: "attack", clientID: P1, targetID: P2, troops: 5123.75 },
+  { type: "attack", clientID: P2, targetID: null, troops: null },
+  { type: "cancel_attack", clientID: P1, attackID: "a1b2c3d4" },
+  { type: "boat", clientID: P2, troops: 100.5, dst: 998877 },
+  { type: "cancel_boat", clientID: P2, unitID: 42 },
+  { type: "allianceRequest", clientID: P1, recipient: P3 },
+  { type: "allianceReject", clientID: P3, requestor: P1 },
+  { type: "allianceExtension", clientID: P1, recipient: P3 },
+  { type: "breakAlliance", clientID: P1, recipient: P3 },
+  { type: "targetPlayer", clientID: P2, target: P1 },
+  { type: "emoji", clientID: P1, recipient: "AllPlayers", emoji: 3 },
+  { type: "emoji", clientID: P1, recipient: P2, emoji: 0 },
+  { type: "donate_gold", clientID: P1, recipient: P2, gold: 1000000 },
+  { type: "donate_troops", clientID: P1, recipient: P2, troops: null },
+  {
+    type: "build_unit",
+    clientID: P2,
+    unit: UnitType.Port,
+    tile: 7,
+    amount: 3,
+  },
+  {
+    type: "upgrade_structure",
+    clientID: P2,
+    unit: UnitType.City,
+    unitId: 88,
+  },
+  { type: "embargo", clientID: P1, targetID: P2, action: "start" },
+  { type: "embargo_all", clientID: P1, action: "stop" },
+  { type: "move_warship", clientID: P3, unitIds: [1, 2, 3], tile: 555 },
+  { type: "delete_unit", clientID: P3, unitId: 9 },
+  { type: "mark_disconnected", clientID: P1, isDisconnected: true },
+  { type: "kick_player", clientID: P1, targetClientID: P2 },
+  {
+    type: "quick_chat",
+    clientID: P1,
+    recipient: P2,
+    quickChatKey: "help.troops",
+    target: P3,
+  },
+  { type: "toggle_pause", clientID: ADMIN_BOT_CLIENT_ID, paused: true },
+  {
+    type: "update_game_config",
+    clientID: P1,
+    config: { bots: 5, instantBuild: true },
+  },
+  { type: "toggle_game_start_timer", clientID: P1 },
+];
+
+const SERVER_MESSAGES: ServerMessage[] = [
+  { type: "ping" },
+  { type: "turn", turn: { turnNumber: 12345, intents: [] } },
+  { type: "turn", turn: { turnNumber: 999, intents: SAMPLE_INTENTS } },
+  {
+    type: "turn",
+    turn: { turnNumber: 4, intents: [], hash: 1234.5 },
+  },
+  {
+    type: "prestart",
+    gameMap: GameMapType.Europe,
+    gameMapSize: GameMapSize.Compact,
+  },
+  {
+    type: "start",
+    turns: [{ turnNumber: 0, intents: SAMPLE_INTENTS.slice(0, 2) }],
+    lobbyCreatedAt: 1_700_000_000_000,
+    myClientID: P1,
+    gameStartInfo: {
+      gameID: "gM3xQ1zR",
+      lobbyCreatedAt: 1_700_000_000_000,
+      config: CONFIG,
+      players: [
+        { clientID: P1, username: "alpha", clanTag: "ABC" },
+        {
+          clientID: P2,
+          username: "bravo",
+          clanTag: null,
+          isLobbyCreator: true,
+          teamIndex: 1,
+          friends: [P1],
+          cosmetics: { flag: "flag:mars", verified: true },
+        },
+        { clientID: P3, username: "charlie", clanTag: null },
+      ],
+      tribes: [{ name: "Wolves" }],
+    },
+  },
+  {
+    type: "desync",
+    turn: 77,
+    correctHash: 12345.5,
+    clientsWithCorrectHash: 3,
+    totalActiveClients: 5,
+    yourHash: 999.25,
+  },
+  { type: "error", error: "full-lobby" },
+  { type: "error", error: "kicked", message: "by host" },
+  {
+    type: "lobby_info",
+    myClientID: P1,
+    lobby: {
+      gameID: "gM3xQ1zR",
+      serverTime: 1_700_000_000_000,
+      startsAt: 1_700_000_030_000,
+      gameConfig: CONFIG,
+      clients: [
+        { clientID: P1, username: "alpha", clanTag: null, teamIndex: 0 },
+        { clientID: P2, username: "bravo", clanTag: "XY", verified: true },
+      ],
+      lobbyCreatorClientID: P1,
+    },
+  },
+  { type: "new_lobby", gameID: "nEwL0bby" },
+];
+
+const TOKEN = "3f1b8c8e-4a2f-4a0e-9d5e-6f2a1b3c4d5e";
+
+const CLIENT_MESSAGES: ClientMessage[] = [
+  { type: "ping" },
+  { type: "hash", hash: 3735928559.5, turnNumber: 120 },
+  {
+    type: "intent",
+    intent: { type: "attack", targetID: P3, troops: 17.25 },
+  },
+  {
+    type: "join",
+    token: TOKEN,
+    gameID: "gM3xQ1zR",
+    username: "alpha",
+    clanTag: "ABC",
+    turnstileToken: null,
+    cosmetics: {
+      flag: "country:us",
+      patternName: "stripes_01",
+      effects: { nukeTrail: "sparkle" },
+      verified: true,
+    },
+  },
+  {
+    type: "rejoin",
+    gameID: "gM3xQ1zR",
+    lastTurn: 4321,
+    token: TOKEN,
+  },
+  { type: "log", severity: LogSeverity.Warn, log: "abcd1234" },
+  {
+    type: "winner",
+    winner: ["player", P1, P2],
+    allPlayersStats: {
+      [P1]: {
+        attacks: [10n, 20n, 0n],
+        gold: [1n, 2n, 3n, 4n, 5n, 6n],
+        killedBy: null,
+        deathPosition: 2,
+        kills: [{ victim: P2, tick: 400n }],
+        units: { city: [3n, 0n, 0n, 0n, 1n] },
+      },
+      [P2]: { betrayals: 1n, finalTiles: 5000n },
+    },
+  },
+  {
+    type: "live_stats",
+    stats: {
+      turn: 900,
+      players: [
+        {
+          clientID: P1,
+          tilesOwned: 1234,
+          troops: 5000.5,
+          gold: "123456789012345678901234567890",
+          isAlive: true,
+          team: null,
+          killedBy: null,
+          deathPosition: null,
+        },
+        {
+          clientID: P2,
+          tilesOwned: 0,
+          troops: 0,
+          gold: "0",
+          isAlive: false,
+          team: "Red",
+          killedBy: P1,
+          deathPosition: 3,
+        },
+      ],
+    },
+  },
+];
+
+const LOBBY_MESSAGES: PublicLobbyMessage[] = [
+  {
+    type: "full",
+    serverTime: 1_700_000_000_000,
+    games: {
+      ffa: [
+        {
+          gameID: "gM3xQ1zR",
+          numClients: 42,
+          startsAt: 1_700_000_030_000,
+          gameConfig: CONFIG,
+          publicGameType: "ffa",
+        },
+      ],
+      hosted: [
+        {
+          gameID: "hOsT3d01",
+          numClients: 3,
+          publicGameType: "hosted",
+          label: "Tournament finals 🏆",
+          accent: "gold",
+          featured: true,
+        },
+      ],
+    },
+  },
+  {
+    type: "counts",
+    serverTime: 1_700_000_000_000,
+    counts: { gM3xQ1zR: 42, hOsT3d01: 3 },
+  },
+];
+
+// The JSON path a message would have taken before zbin, so binary decoding can
+// be checked against it rather than against the in-memory literal alone.
+function viaJson<T>(schema: { parse: (v: unknown) => T }, msg: unknown): T {
+  return schema.parse(JSON.parse(JSON.stringify(msg, replacer)));
+}
+
+describe("zbin wire: server messages", () => {
+  it.each(SERVER_MESSAGES.map((m) => [m.type, m] as const))(
+    "round-trips a %s message",
+    (_type, msg) => {
+      const [sctx, cctx] = ctxPair();
+      const decoded = decodeServerMessage(encodeServerMessage(msg, sctx), cctx);
+      expect(decoded).toEqual(viaJson(ServerMessageSchema, msg));
+    },
+  );
+
+  it("encodes the start message without the dictionary", () => {
+    // The start message carries the roster the receiver seeds its table from,
+    // so a client that has no table yet must still be able to read it.
+    const [sctx] = ctxPair();
+    const start = SERVER_MESSAGES.find((m) => m.type === "start")!;
+    const bytes = encodeServerMessage(start, sctx);
+    expect(decodeServerMessage(bytes, undefined)).toEqual(
+      viaJson(ServerMessageSchema, start),
+    );
+  });
+
+  it("keeps an empty turn under 8 bytes", () => {
+    const [sctx] = ctxPair();
+    const bytes = encodeServerMessage(
+      { type: "turn", turn: { turnNumber: 12345, intents: [] } },
+      sctx,
+    );
+    expect(bytes.length).toBeLessThanOrEqual(8);
+  });
+
+  it("is much smaller than JSON for a realistic turn", () => {
+    const [sctx] = ctxPair();
+    const turn: Turn = {
+      turnNumber: 12345,
+      intents: [
+        { type: "attack", clientID: P1, targetID: P2, troops: 5123.75 },
+        {
+          type: "build_unit",
+          clientID: P2,
+          unit: UnitType.Port,
+          tile: 998877,
+        },
+      ],
+    };
+    const msg: ServerMessage = { type: "turn", turn };
+    const jsonSize = JSON.stringify(msg).length;
+    expect(encodeServerMessage(msg, sctx).length).toBeLessThan(jsonSize / 5);
+  });
+
+  it("rejects truncated frames", () => {
+    const [sctx, cctx] = ctxPair();
+    const bytes = encodeServerMessage(
+      {
+        type: "turn",
+        turn: { turnNumber: 1, intents: SAMPLE_INTENTS.slice(0, 3) },
+      },
+      sctx,
+    );
+    for (let cut = 1; cut < bytes.length; cut++) {
+      expect(() => decodeServerMessage(bytes.subarray(0, cut), cctx)).toThrow(
+        ZbDecodeError,
+      );
+    }
+  });
+
+  it("rejects trailing bytes", () => {
+    const [sctx, cctx] = ctxPair();
+    const bytes = encodeServerMessage({ type: "ping" }, sctx);
+    const padded = new Uint8Array(bytes.length + 1);
+    padded.set(bytes);
+    expect(() => decodeServerMessage(padded, cctx)).toThrow(ZbDecodeError);
+  });
+
+  it("unmapped ids (admin bot) survive via the inline escape", () => {
+    const [sctx, cctx] = ctxPair();
+    const msg: ServerMessage = {
+      type: "turn",
+      turn: {
+        turnNumber: 5,
+        intents: [
+          {
+            type: "toggle_pause",
+            clientID: ADMIN_BOT_CLIENT_ID,
+            paused: false,
+          },
+        ],
+      },
+    };
+    expect(decodeServerMessage(encodeServerMessage(msg, sctx), cctx)).toEqual(
+      msg,
+    );
+  });
+
+  it("fails loudly when the peers seeded different rosters", () => {
+    const sctx = createGameWireContext(PLAYERS);
+    const cctx = createGameWireContext(PLAYERS.slice(0, 1));
+    const bytes = encodeServerMessage(
+      {
+        type: "turn",
+        turn: {
+          turnNumber: 1,
+          intents: [{ type: "targetPlayer", clientID: P1, target: P3 }],
+        },
+      },
+      sctx,
+    );
+    expect(() => decodeServerMessage(bytes, cctx)).toThrow(ZbDecodeError);
+  });
+});
+
+describe("zbin wire: client messages", () => {
+  it.each(CLIENT_MESSAGES.map((m) => [m.type, m] as const))(
+    "round-trips a %s message",
+    (_type, msg) => {
+      const [cctx, sctx] = ctxPair();
+      const decoded = decodeClientMessage(encodeClientMessage(msg, cctx), sctx);
+      expect(decoded).toEqual(viaJson(ClientMessageSchema, msg));
+    },
+  );
+
+  it("round-trips join and rejoin with no dictionary yet", () => {
+    // Both are sent before the game starts, when neither peer has a table.
+    for (const msg of CLIENT_MESSAGES.filter(
+      (m) => m.type === "join" || m.type === "rejoin",
+    )) {
+      const decoded = decodeClientMessage(
+        encodeClientMessage(msg, undefined),
+        undefined,
+      );
+      expect(decoded).toEqual(viaJson(ClientMessageSchema, msg));
+    }
+  });
+
+  it("keeps an attack intent to about a dozen bytes", () => {
+    const [cctx] = ctxPair();
+    const bytes = encodeClientMessage(
+      { type: "intent", intent: { type: "attack", targetID: P2, troops: 500 } },
+      cctx,
+    );
+    expect(bytes.length).toBeLessThanOrEqual(14);
+  });
+
+  it("preserves bigint stats exactly", () => {
+    const [cctx, sctx] = ctxPair();
+    const huge = 2n ** 200n + 12345n;
+    const msg: ClientMessage = {
+      type: "winner",
+      winner: ["team", "Red", P1],
+      allPlayersStats: { [P1]: { gold: [huge], betrayals: -7n } },
+    };
+    const decoded = decodeClientMessage(encodeClientMessage(msg, cctx), sctx);
+    expect(decoded).toEqual(msg);
+  });
+
+  it("accepts stats that arrive as decimal strings", () => {
+    // Engine values are bigints, but the same schema also reads archived JSON
+    // where they are strings; both must encode to the same bytes.
+    const [cctx, sctx] = ctxPair();
+    const asBigint: ClientMessage = {
+      type: "winner",
+      winner: undefined,
+      allPlayersStats: { [P1]: { betrayals: 42n } },
+    };
+    const asString = {
+      ...asBigint,
+      allPlayersStats: { [P1]: { betrayals: "42" } },
+    };
+    expect(
+      encodeClientMessage(asString as unknown as ClientMessage, cctx),
+    ).toEqual(encodeClientMessage(asBigint, cctx));
+    expect(
+      decodeClientMessage(encodeClientMessage(asBigint, cctx), sctx),
+    ).toEqual(asBigint);
+  });
+
+  it("rejects truncated frames", () => {
+    const [cctx, sctx] = ctxPair();
+    const bytes = encodeClientMessage(
+      { type: "hash", hash: 1.5, turnNumber: 300 },
+      cctx,
+    );
+    for (let cut = 1; cut < bytes.length; cut++) {
+      expect(() => decodeClientMessage(bytes.subarray(0, cut), sctx)).toThrow(
+        ZbDecodeError,
+      );
+    }
+  });
+
+  it("rejects a payload that decodes but violates the schema", () => {
+    // parseBytes runs full zod validation, so a structurally valid frame with
+    // an out-of-range value is still rejected.
+    const [cctx, sctx] = ctxPair();
+    const bytes = encodeClientMessage(
+      {
+        type: "rejoin",
+        gameID: "not a game id!" as never,
+        lastTurn: 1,
+        token: TOKEN,
+      },
+      cctx,
+    );
+    expect(() => decodeClientMessage(bytes, sctx)).toThrow();
+  });
+});
+
+describe("zbin wire: lobby list messages", () => {
+  it.each(LOBBY_MESSAGES.map((m) => [m.type, m] as const))(
+    "round-trips a %s message",
+    (_type, msg) => {
+      const decoded = decodeLobbyMessage(encodeLobbyMessage(msg));
+      expect(decoded).toEqual(viaJson(PublicLobbyMessageSchema, msg));
+    },
+  );
+
+  // The lobby socket carries no player ids, so it gets no dictionary: the
+  // saving here is structural (varints, no keys, no punctuation) only.
+  it("shrinks the counts broadcast below JSON", () => {
+    const counts: Record<string, number> = {};
+    for (let i = 0; i < 20; i++) {
+      counts[`g${String(i).padStart(7, "0")}`] = i * 3;
+    }
+    const msg: PublicLobbyMessage = {
+      type: "counts",
+      serverTime: 1_700_000_000_000,
+      counts,
+    };
+    const jsonSize = JSON.stringify(msg).length;
+    expect(encodeLobbyMessage(msg).length).toBeLessThan(jsonSize * 0.7);
+  });
+
+  it("shrinks the full snapshot well below JSON", () => {
+    const msg = LOBBY_MESSAGES[0];
+    const jsonSize = JSON.stringify(msg).length;
+    expect(encodeLobbyMessage(msg).length).toBeLessThan(jsonSize / 3);
+  });
+
+  it("rejects corrupt frames", () => {
+    const bytes = encodeLobbyMessage(LOBBY_MESSAGES[1]);
+    expect(() => decodeLobbyMessage(bytes.subarray(0, 2))).toThrow(
+      ZbDecodeError,
+    );
+  });
+});

--- a/tests/zbin/zbin.test.ts
+++ b/tests/zbin/zbin.test.ts
@@ -520,23 +520,26 @@ describe("edge cases", () => {
 });
 
 describe("context contract", () => {
-  it("handles a full 255-entry table and escapes the 256th value", () => {
+  it("handles a full table, varint growth, and escapes the overflow value", () => {
     const S = zb.object({ id: zb.mapped("m") });
     const values = Array.from(
-      { length: 256 },
+      { length: 301 },
       (_, i) => `v${String(i).padStart(6, "0")}`,
     );
     const ctx = zb.context();
-    ctx.mapping("m"); // default max = 255
-    for (let i = 0; i < 255; i++) expect(ctx.assign("m", values[i])).toBe(i);
-    expect(ctx.assign("m", values[255])).toBe(-1); // full -> unmapped
-    // Boundary index 254 encodes as one byte; overflow value goes inline.
-    expect(S.serialize({ id: values[254] }, ctx).length).toBe(1);
-    expect(S.serialize({ id: values[255] }, ctx).length).toBeGreaterThan(1);
+    ctx.mapping("m", { max: 300 });
+    for (let i = 0; i < 300; i++) expect(ctx.assign("m", values[i])).toBe(i);
+    expect(ctx.assign("m", values[300])).toBe(-1); // full -> unmapped
+    // varint(index+1): index 126 is the last one-byte id, 127+ cost two;
+    // the overflow value goes inline via the escape.
+    expect(S.serialize({ id: values[126] }, ctx).length).toBe(1);
+    expect(S.serialize({ id: values[127] }, ctx).length).toBe(2);
+    expect(S.serialize({ id: values[299] }, ctx).length).toBe(2);
+    expect(S.serialize({ id: values[300] }, ctx).length).toBeGreaterThan(2);
     const rctx = zb.context();
-    rctx.mapping("m");
+    rctx.mapping("m", { max: 300 });
     rctx.assignAll("m", values);
-    for (const id of [values[0], values[254], values[255]]) {
+    for (const id of [values[0], values[126], values[127], values[300]]) {
       expect(S.parseBytes(S.serialize({ id }, ctx), rctx)).toEqual({ id });
     }
   });
@@ -544,7 +547,7 @@ describe("context contract", () => {
   it("rejects invalid mapping declarations", () => {
     const ctx = zb.context();
     expect(() => ctx.mapping("m", { max: 0 })).toThrow(RangeError);
-    expect(() => ctx.mapping("m", { max: 256 })).toThrow(RangeError);
+    expect(() => ctx.mapping("m", { max: 65536 })).toThrow(RangeError);
     expect(() => ctx.mapping("m", { max: 1.5 })).toThrow(RangeError);
     ctx.mapping("m", { max: 10 });
     expect(() => ctx.mapping("m", { max: 10 })).toThrow(/already declared/);

--- a/zbin/README.md
+++ b/zbin/README.md
@@ -60,15 +60,15 @@ records/partialRecords, tuples (incl. `.rest`), discriminated and untagged
 unions, `z.lazy`, and `optional`/`nullable`/`default` wrappers. Only genuinely
 ambiguous or exotic spots need an explicit builder:
 
-| Builder                     | Why                                                            | Wire encoding                            |
-| --------------------------- | -------------------------------------------------------------- | ---------------------------------------- |
-| `zb.uint()` / `zb.int()`    | JSON can't say int vs float                                    | LEB128 / zigzag varint                   |
-| `zb.float()`                | ″                                                              | float64 LE (bit-exact)                   |
-| `zb.string(opts)`           | to attach `min`/`max`/`regex` safely                           | varint length + UTF-8                    |
-| `zb.mapped(name)`           | dictionary compression                                         | 1 byte via context, escape + inline else |
-| `zb.json(schema)`           | cold, complex subtrees                                         | varint length + JSON                     |
-| `zb.stamped(union, extras)` | intersections over a discriminated union can't be introspected | tag + extras + variant                   |
-| `zb.custom(schema, codec)`  | full control                                                   | yours                                    |
+| Builder                     | Why                                                            | Wire encoding                               |
+| --------------------------- | -------------------------------------------------------------- | ------------------------------------------- |
+| `zb.uint()` / `zb.int()`    | JSON can't say int vs float                                    | LEB128 / zigzag varint                      |
+| `zb.float()`                | ″                                                              | float64 LE (bit-exact)                      |
+| `zb.string(opts)`           | to attach `min`/`max`/`regex` safely                           | varint length + UTF-8                       |
+| `zb.mapped(name)`           | dictionary compression                                         | 1-2 byte varint index, escape + inline else |
+| `zb.json(schema)`           | cold, complex subtrees                                         | varint length + JSON                        |
+| `zb.stamped(union, extras)` | intersections over a discriminated union can't be introspected | tag + extras + variant                      |
+| `zb.custom(schema, codec)`  | full control                                                   | yours                                       |
 
 `zb.bigint()`, `zb.literal`, and `zb.enum` are plain aliases kept for symmetry —
 the underlying zod types auto-derive, so `z.bigint()` etc. work identically.
@@ -80,7 +80,7 @@ Chaining zod methods clones the schema, and the clone has no codec:
 ```ts
 zb.uint({ max: 400 }); // correct
 zb.uint().max(400); // throws: "plain z.number() is ambiguous on the wire"
-zb.mapped("cid").min(1); // SILENT: falls back to plain strings, 1 byte -> 9
+zb.mapped("cid").min(1); // SILENT: falls back to plain strings, ~1 byte -> 9
 zb.mapped("cid").describe("…"); // SILENT: same
 ```
 
@@ -155,7 +155,7 @@ and nesting past the depth limit.
 | `zb.bigint` width            | 1024 bits (`MAX_BIGINT_BITS`) |
 | Decoded elements per message | 2^20 (`MAX_DECODE_ITEMS`)     |
 | Nesting depth                | 64 (`MAX_DECODE_DEPTH`)       |
-| Mapping table entries        | 255 (`MAX_MAPPING_SIZE`)      |
+| Mapping table entries        | 65,535 (`MAX_MAPPING_SIZE`)   |
 
 The element budget is per message and shared across every collection in it.
 It exists because elements can encode to zero bytes (single-value literals,
@@ -166,13 +166,14 @@ bound on its own — without it, four bytes could drive 16M allocations.
 
 ```ts
 const ctx = zb.context();
-ctx.mapping("clientId", { max: 125 });
+ctx.mapping("clientId");
 ctx.assign("clientId", "aB3dEf7h"); // → index 0
 ctx.assignAll("clientId", roster); // or seed in bulk
 ```
 
-A `zb.mapped("clientId")` field encodes as one byte when the value is in the
-table, or an escape byte plus the inline string when it isn't. There is no
+A `zb.mapped("clientId")` field encodes as `varint(index + 1)` when the value
+is in the table — one byte for the first 127 entries, two up to 16k — or as
+varint 0 plus the inline string when it isn't. There is no
 on-wire learning: both peers must build identical tables from shared data
 (assign order is part of the wire contract). This keeps decoding stateless per
 message — no stream-position coupling, nothing to break on reconnect.

--- a/zbin/context.ts
+++ b/zbin/context.ts
@@ -1,5 +1,5 @@
 // zbin serialization context: named dictionaries that map frequently repeated
-// strings (e.g. player ids) to single-byte indexes on the wire.
+// strings (e.g. player ids) to small varint indexes on the wire.
 //
 // Sync model: both peers must build identical tables from data they already
 // share (e.g. the player roster in the game-start message) — there is no
@@ -11,10 +11,10 @@
 // orders decode every index to the wrong value with no error, so peers should
 // compare `fingerprint(name)` out-of-band before relying on a table.
 
-// Index 255 is the inline-escape marker, so tables hold at most 255 entries
-// (indexes 0..254).
-export const ESCAPE_BYTE = 0xff;
-export const MAX_MAPPING_SIZE = 255;
+// On the wire an index rides as varint(index + 1); varint 0 is the
+// inline-escape marker. Indexes 0..126 cost one byte, 127..16382 cost two.
+// The size cap is not a wire constant — it just bounds table memory.
+export const MAX_MAPPING_SIZE = 65535;
 
 export interface ZbTable {
   max: number;

--- a/zbin/index.ts
+++ b/zbin/index.ts
@@ -7,7 +7,7 @@ export {
   ZbDecodeError,
   ZbEncodeError,
 } from "./bytes";
-export { ESCAPE_BYTE, MAX_MAPPING_SIZE, ZbContext } from "./context";
+export { MAX_MAPPING_SIZE, ZbContext } from "./context";
 export type { ZbTable } from "./context";
 export * as zb from "./zb";
 export type { Codec, ZbMethods, ZbSchema } from "./zb";

--- a/zbin/zb.ts
+++ b/zbin/zb.ts
@@ -33,7 +33,7 @@ import {
   ZbDecodeError,
   ZbEncodeError,
 } from "./bytes";
-import { ESCAPE_BYTE, ZbContext, type ZbTable } from "./context";
+import { ZbContext, type ZbTable } from "./context";
 
 export {
   ByteReader,
@@ -44,7 +44,7 @@ export {
   ZbDecodeError,
   ZbEncodeError,
 } from "./bytes";
-export { ESCAPE_BYTE, MAX_MAPPING_SIZE, ZbContext } from "./context";
+export { MAX_MAPPING_SIZE, ZbContext } from "./context";
 export { bigint_ as bigint };
 
 export interface Codec<T = any> {
@@ -203,20 +203,21 @@ function mappedCodec(name: string): Codec<string> {
           `zb.mapped("${name}"): no such mapping declared on this context`,
         );
       }
+      // varint(index + 1); varint 0 escapes to an inline string.
       const idx = tableFor(ctx)?.toIndex.get(v);
-      if (idx !== undefined && idx < ESCAPE_BYTE) {
-        w.u8(idx);
+      if (idx !== undefined) {
+        w.uint(idx + 1);
       } else {
-        w.u8(ESCAPE_BYTE);
+        w.u8(0);
         w.str(v);
       }
     },
     dec: (r, ctx) => {
-      const b = r.u8();
-      if (b === ESCAPE_BYTE) return r.str();
-      const value = tableFor(ctx)?.values[b];
+      const n = r.uint();
+      if (n === 0) return r.str();
+      const value = tableFor(ctx)?.values[n - 1];
       if (value === undefined) {
-        throw new ZbDecodeError(`unknown "${name}" dictionary index ${b}`);
+        throw new ZbDecodeError(`unknown "${name}" dictionary index ${n - 1}`);
       }
       return value;
     },


### PR DESCRIPTION
## Summary

Stacked on #5063 (the `zbin` library). **Every frame on OpenFront's own WebSockets is now binary** — the game socket and the `/lobbies` socket, in both directions, all message types. HTTP stays JSON: the closed-source API, archived game records, the admin-bot routes, and the matchmaking socket (which belongs to the API worker, not us) are untouched.

Zod stays the single source of truth. Every `zb.*` builder returns a *real* zod schema, so `z.infer` types, `.extend()` composition, `.safeParse`, and every JSON path keep working. `Schemas.ts` only needed annotations where JSON is genuinely ambiguous:

| Spot | Builder |
| --- | --- |
| every number (JSON can't say int vs float) | `zb.uint` / `zb.int` / `zb.float` |
| player ids that repeat every turn | `zb.mapped("clientId")` |
| `update_game_config`'s partial config | `zb.json` |
| `tribes` (a `.loose()` passthrough) | `zb.json` |
| bigint stats that also read as decimal strings | `zb.custom` (`StatsSchemas.ts`) |
| intent union × server-stamped `clientID` | `zb.stamped` |

Everything else auto-derives. `ClientMessageSchema`, `ServerMessageSchema` and `PublicLobbyMessageSchema` became `zb.discriminatedUnion` roots, which is what gives them `serialize` / `parseBytes`.

The library's contract (encoding, error handling, the list of schema edits that move the wire layout) is in `zbin/README.md`.

## Measured on the wire

70-player game, 12 public lobbies:

| message | JSON | zbin | saved |
| --- | ---: | ---: | ---: |
| turn (empty) | 56 | 5 | 91.1% |
| turn (1 attack intent) | 134 | 17 | 87.3% |
| turn (5 intents) | 397 | 47 | 88.2% |
| client intent (attack) | 83 | 12 | 85.5% |
| client hash | 52 | 11 | 78.8% |
| ping | 15 | 1 | 93.3% |
| start (70 players) | 4,721 | 1,466 | 68.9% |
| lobby_info (70 players) | 4,677 | 1,369 | 70.7% |
| lobby list: full (12 lobbies) | 4,293 | 372 | 91.3% |
| lobby list: counts | 219 | 128 | 41.6% |

The turn broadcast dominates the bill — 10 Hz to every client whether or not anything happened. Applying this to the turn stream of a real 30-minute 70-player game (`P8XsSiP8`: 18,242 turns, 1.54 MB/client of JSON) takes it from ~108 MB of egress to ~15 MB.

`counts` is the weakest case: its record keys are 8-char gameIDs sent as plain strings. A gameID dictionary seeded from the last `full` would take it to ~35 B, and `lobby_info`'s real fix is delta encoding rather than serialization — both deliberate follow-ups, not part of this PR.

## No compatibility window

There is **no JSON fallback, no version byte, and no negotiation**. A zbin payload is a bare positional byte stream — the schema *is* the format — so this is only safe because the client and the server ship from one build. `zbin/README.md` lists the schema edits that move the layout (field order, optionality, enum/variant order, …) and `tests/zbin/golden.test.ts` pins it as hex vectors so an accidental change fails a test instead of corrupting a game. **A deploy must roll the client and the server together.**

## Safety

Both sides decode with `parseBytes` = decode + full zod parse, so every regex, range and refinement still runs — exactly as strict as the JSON path it replaced. An undecodable frame kicks with the existing `kick_reason.invalid_message`. Floats are bit-exact float64, which the desync hash depends on. Singleplayer and replays go through `LocalServer`, which passes plain objects and never touches the wire.

Two behaviour changes worth calling out:

- **`MarkDisconnectedIntent` no longer declares its own `clientID`.** It's server-internal, and the player being marked *is* the intent's sender, so it already rode the stamped `clientID` — writing the same key twice isn't representable on a positional wire. Archived records still parse identically (the intersection supplies the field).
- **Only a structurally corrupt frame skips `intent_observed` telemetry** — garbage bytes have no readable type to attribute. A message that decodes but fails validation (out-of-range values, regex-breaking ids — the buggy/cheating-client signature) is still attributed with its raw intent, exactly like the JSON path: the server decodes unvalidated first, then validates separately.

## Test plan

- [x] `npm test` — 3,743 tests pass (3,382 + the 361 server re-run)
- [x] `npx tsc --noEmit`, `npm run lint`, `npx prettier --check`
- [x] **New `tests/zbin/wire.test.ts` (37 tests)** — round-trips every server, client and lobby message variant against the JSON path; the dictionary escape path (`ADMINBOT`); `start` decoding with no table yet; a mis-seeded roster failing loudly; truncation at *every* byte boundary; trailing bytes; bigint stats as both bigints and decimal strings.
- [x] **Live two-client multiplayer game in headless Chromium.** Two real browser clients joined a private lobby, saw each other in the lobby list, the game started, and both ran the sim (72 and 75 ticks, 475 players) with the map rendering correctly. **386 / 385 binary frames received, 0 text frames.**
- [x] **Real-socket harness against a live server** — `join` → `lobby_info` → `prestart` → `start` → turn stream → dictionary-encoded intents relayed back → `hash` → `ping`, with both peers seeding identical rosters. 27 turns plus the start message came to 526 bytes total.

Server tests that fed the socket JSON strings, read `ws.send` payloads with `JSON.parse`, or built partial `{...} as any` game configs now go through `tests/util/Wire.ts`. The binary encoder rejects a missing required field, so those fixtures had to become whole — which is a fair trade: they were passing structurally invalid start messages that only survived because `JSON.stringify` doesn't care.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


