### PR TITLE
fix(desktop): gate Detailed View's join path while a Steam update is pending

### DIFF
--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -3,6 +3,8 @@ import { customElement, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../../core/Schemas";
+import { type DesktopUpdateState } from "../DesktopShell";
+import { shouldBlockMultiplayerAction } from "../GameModeSelector";
 import { JoinLobbyModal } from "../JoinLobbyModal";
 import { PublicLobbySocket } from "../LobbySocket";
 import { JoinLobbyEvent } from "../Main";
@@ -97,6 +99,7 @@ export class DetailedGameViewModal extends BaseModal {
   @state() private profiles: Record<string, LobbyFilters> = {};
   @state() private selectedProfile = "";
   @state() private profileName = "";
+  @state() private desktopUpdateState: DesktopUpdateState | null = null;
 
   private serverTimeOffset = 0;
   private countdownTimer: number | null = null;
@@ -150,10 +153,26 @@ export class DetailedGameViewModal extends BaseModal {
     }
   }
 
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener(
+      "desktop-update-state",
+      this.onDesktopUpdateState,
+    );
+  }
+
   disconnectedCallback() {
+    document.removeEventListener(
+      "desktop-update-state",
+      this.onDesktopUpdateState,
+    );
     this.onClose();
     super.disconnectedCallback();
   }
+
+  private onDesktopUpdateState = (e: Event) => {
+    this.desktopUpdateState = (e as CustomEvent<DesktopUpdateState>).detail;
+  };
 
   // ---- Slot animation ----
   //
@@ -372,6 +391,10 @@ export class DetailedGameViewModal extends BaseModal {
       timeDisplay: this.timeDisplay(lobby),
       timeDisplayUppercase: lobby.startsAt === undefined,
       heightClass: "h-full",
+      // Gated, not disabled: `disabled` also sets pointer-events-none and would
+      // swallow the click that's supposed to make the update bar wiggle. join()
+      // does the actual refusing.
+      blocked: shouldBlockMultiplayerAction(this.desktopUpdateState),
       onClick: () => this.join(lobby),
     });
   }
@@ -683,8 +706,31 @@ export class DetailedGameViewModal extends BaseModal {
     return usernameInput ? usernameInput.canPlay() : true;
   }
 
+  /**
+   * Refuses the action and draws attention to the update bar. Returns true
+   * when the caller should stop.
+   *
+   * Mirrors GameModeSelector's blockedByUpdate() (deliberately not shared: it
+   * touches this component's own state field) -- see that file for why this
+   * nudges the bar instead of relying on `disabled`, which would swallow the
+   * click.
+   */
+  private blockedByUpdate(): boolean {
+    if (!shouldBlockMultiplayerAction(this.desktopUpdateState)) return false;
+    (
+      document.querySelector("desktop-update-bar") as
+        | (HTMLElement & { wiggle?: () => void })
+        | null
+    )?.wiggle?.();
+    return true;
+  }
+
   private join(lobby: PublicGameInfo) {
     if (!this.canPlay()) return;
+    // Checked -- and the bar nudged -- before close(): a blocked attempt must
+    // leave the modal open and tell the player why, not vanish silently. This
+    // sits above the hosted/public branch below so both paths are covered.
+    if (this.blockedByUpdate()) return;
     this.close();
 
     // Hosted lobbies are private games a subscriber listed publicly: joining

--- a/tests/DetailedGameViewModalGatingWiring.test.ts
+++ b/tests/DetailedGameViewModalGatingWiring.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { DesktopUpdateState } from "../src/client/DesktopShell";
+import { GameMapType, GameMode } from "../src/core/game/Game";
+import type {
+  GameConfig,
+  PublicGameInfo,
+  PublicGames,
+  PublicGameType,
+} from "../src/core/Schemas";
+
+// DetailedGameViewModal opens a public-lobby WebSocket via a class-field
+// PublicLobbySocket the moment the component is constructed. jsdom has no
+// WebSocket worth talking to and this test is about the join() gate, not the
+// lobby list, so the socket is a no-op -- except for retaining the update
+// callback the real socket would drive off the wire. Without that, `lobbies`
+// never leaves `null`, no lobby card ever renders, and join() goes completely
+// untested by this file.
+const { lobbiesCallbackRef } = vi.hoisted(() => ({
+  lobbiesCallbackRef: { current: null as ((g: PublicGames) => void) | null },
+}));
+
+vi.mock("../src/client/LobbySocket", () => ({
+  PublicLobbySocket: class {
+    constructor(onUpdate: (g: PublicGames) => void) {
+      lobbiesCallbackRef.current = onUpdate;
+    }
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+// Registers <detailed-view-modal> as a side effect and gives us the class
+// directly. This also pulls in GameModeSelector.ts (for
+// shouldBlockMultiplayerAction), which registers <game-mode-selector> too --
+// harmless, nothing in this file instantiates it.
+import { DetailedGameViewModal } from "../src/client/components/DetailedGameViewModal";
+
+function lobby(gameID: string, publicGameType: PublicGameType): PublicGameInfo {
+  return {
+    gameID,
+    numClients: 3,
+    publicGameType,
+    gameConfig: {
+      gameMap: GameMapType.World,
+      gameMode: GameMode.FFA,
+      maxPlayers: 8,
+    } as unknown as GameConfig,
+  };
+}
+
+/**
+ * The pure predicate is covered in GameModeSelectorGating.test.ts and the
+ * homepage entry points are covered in GameModeSelectorGatingWiring.test.ts.
+ * Neither can see whether DetailedGameViewModal's join() -- a separate call
+ * site reached from Solo -> Detailed View -> any lobby card -- actually
+ * consults the gate. So this mounts the real component, drives it into a
+ * gated state through the real `desktop-update-state` event, clicks a real
+ * rendered lobby card, and asserts nothing proceeded.
+ */
+let modal: HTMLElement & { updateComplete: Promise<unknown> };
+let joinModalOpen: ReturnType<typeof vi.fn>;
+let wiggle: ReturnType<typeof vi.fn>;
+let joinLobby: ReturnType<typeof vi.fn>;
+
+function stub(tag: string, methods: Record<string, unknown>): void {
+  const el = document.createElement(tag);
+  Object.assign(el, methods);
+  document.body.appendChild(el);
+}
+
+async function setUpdateState(state: DesktopUpdateState): Promise<void> {
+  document.dispatchEvent(
+    new CustomEvent("desktop-update-state", { detail: state }),
+  );
+  await modal.updateComplete;
+}
+
+/**
+ * Pushes a full lobby snapshot through the (mocked) socket's own update
+ * callback, exactly as the real PublicLobbySocket would on receiving a "full"
+ * message -- the only way `lobbies` leaves `null` and any lobby card renders.
+ */
+async function pushLobbies(games: PublicGames["games"]): Promise<void> {
+  lobbiesCallbackRef.current?.({ serverTime: Date.now(), games });
+  await modal.updateComplete;
+}
+
+/** The rendered card button for a given lobby, or null if none rendered. */
+function cardButton(gameID: string): HTMLButtonElement | null {
+  return modal.querySelector(`[data-lobby-slot="${gameID}"] button.group`);
+}
+
+beforeEach(async () => {
+  joinModalOpen = vi.fn();
+  wiggle = vi.fn();
+  joinLobby = vi.fn();
+  stub("join-lobby-modal", { open: joinModalOpen });
+  stub("desktop-update-bar", { wiggle });
+  // join() dispatches "join-lobby" as a bubbling/composed CustomEvent rather
+  // than calling a modal's open() -- catch it at the document the same way
+  // Main.ts's real listener would.
+  document.addEventListener("join-lobby", joinLobby as EventListener);
+
+  lobbiesCallbackRef.current = null;
+  // `new DetailedGameViewModal()` rather than
+  // `document.createElement("detailed-view-modal")`: the constructor sets
+  // `this.id` (for the page router), and jsdom's spec-strict
+  // document.createElement path rejects a custom element whose constructor
+  // touched its own attributes. Constructing directly takes jsdom's other,
+  // unchecked construction branch -- real browsers tolerate this pattern
+  // either way.
+  modal = new DetailedGameViewModal() as unknown as HTMLElement & {
+    updateComplete: Promise<unknown>;
+  };
+  document.body.appendChild(modal);
+  await modal.updateComplete;
+
+  await pushLobbies({
+    ffa: [lobby("public-1", "ffa")],
+    hosted: [lobby("hosted-1", "hosted")],
+  });
+});
+
+afterEach(() => {
+  document.removeEventListener("join-lobby", joinLobby as EventListener);
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+});
+
+describe("the multiplayer gate at DetailedGameViewModal's join()", () => {
+  it("renders real lobby cards once the socket reports them", () => {
+    expect(cardButton("public-1")).not.toBeNull();
+    expect(cardButton("hosted-1")).not.toBeNull();
+  });
+
+  it("emits join-lobby when ungated (public lobby)", async () => {
+    await setUpdateState({ status: "current", bytes: 0, total: 0 });
+
+    const card = cardButton("public-1");
+    expect(card).not.toBeNull();
+    card!.click();
+
+    expect(joinLobby).toHaveBeenCalled();
+    const detail = joinLobby.mock.calls[0][0].detail;
+    expect(detail.gameID).toBe("public-1");
+    expect(detail.source).toBe("public");
+    expect(wiggle).not.toHaveBeenCalled();
+  });
+
+  it("refuses to emit join-lobby and nudges the bar while an update is downloading", async () => {
+    await setUpdateState({ status: "downloading", bytes: 1, total: 100 });
+
+    const card = cardButton("public-1");
+    expect(card).not.toBeNull();
+    card!.click();
+
+    expect(joinLobby).not.toHaveBeenCalled();
+    expect(wiggle).toHaveBeenCalled();
+  });
+
+  it("does not close the modal (or drop its lobby list) on a blocked attempt", async () => {
+    await setUpdateState({ status: "downloading", bytes: 1, total: 100 });
+
+    const card = cardButton("public-1");
+    card!.click();
+
+    // close() -> onClose() nulls out `lobbies`, which would collapse the
+    // whole body to the loading spinner and remove every card. Still being
+    // able to find the card proves close() did not run.
+    expect(cardButton("public-1")).not.toBeNull();
+  });
+
+  it("marks cards aria-disabled while blocked", async () => {
+    await setUpdateState({ status: "downloading", bytes: 1, total: 100 });
+
+    const card = cardButton("public-1");
+    expect(card?.getAttribute("aria-disabled")).toBe("true");
+    // Deliberately not `disabled`/pointer-events-none -- see LobbyCard.ts.
+    expect(card?.hasAttribute("disabled")).toBe(false);
+  });
+
+  it("opens join-lobby-modal for a hosted lobby when ungated", async () => {
+    await setUpdateState({ status: "current", bytes: 0, total: 0 });
+
+    const card = cardButton("hosted-1");
+    expect(card).not.toBeNull();
+    card!.click();
+
+    expect(joinModalOpen).toHaveBeenCalledWith({ lobbyId: "hosted-1" });
+    expect(joinLobby).not.toHaveBeenCalled();
+  });
+
+  it("refuses to open join-lobby-modal for a hosted lobby while blocked", async () => {
+    await setUpdateState({ status: "downloading", bytes: 1, total: 100 });
+
+    const card = cardButton("hosted-1");
+    expect(card).not.toBeNull();
+    card!.click();
+
+    expect(joinModalOpen).not.toHaveBeenCalled();
+    expect(wiggle).toHaveBeenCalled();
+  });
+
+  it("refuses while an update is staged", async () => {
+    await setUpdateState({ status: "staged", bytes: 100, total: 100 });
+
+    cardButton("public-1")!.click();
+    cardButton("hosted-1")!.click();
+
+    expect(joinLobby).not.toHaveBeenCalled();
+    expect(joinModalOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not refuse on a failure the player cannot retry away", async () => {
+    await setUpdateState({
+      status: "failed",
+      bytes: 0,
+      total: 0,
+      error: { kind: "refused", message: "403 from the WAF" },
+    });
+
+    cardButton("public-1")!.click();
+
+    expect(joinLobby).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Follow-up to #5061, which added runtime asset updating for the Steam desktop shell.

## Why

When the desktop shell has an update downloaded and waiting, or one that failed in a way the player can retry, the client must not let them join a live multiplayer game. A stale client is not cleanly rejected by the server — it connects and then desyncs, because the simulation runs on each client rather than the server.

#5061 gated the four ways into a game: Create, Ranked, Join, and clicking a public lobby card. `DetailedGameViewModal` — the lobby browser reached from the Solo row, added separately in #5022 — is a fifth. Its `join()` dispatches the same `join-lobby` event and, for hosted lobbies, opens `join-lobby-modal` directly. It never consulted the gate.

So a player with a pending update could still reach a live game via Solo row → Detailed View → any lobby. Not a regression from #5061 — a path that existed alongside it.

Single-player remains ungated everywhere, as before: `LocalServer.ts` runs the whole simulation in-client, so a stale client is safe there.

## What's here

- `join()` is gated **before** `close()`, so a blocked attempt leaves the modal open and visibly refuses rather than vanishing silently, and **above** the hosted/public branch so both paths are covered.
- `renderCard()` passes `blocked:` to `lobbyCard()`, not `disabled:`. `disabled` also applies `pointer-events-none`, which swallows the click — and the click is what nudges the update bar. Gated cards stay clickable and merely stop being actionable, matching how `GameModeSelector` handles the same distinction.
- Subscribes to the existing `desktop-update-state` document event, following `GameModeSelector`'s lifecycle pattern exactly.
- `shouldBlockMultiplayerAction` is imported from `GameModeSelector`, not copied. There is already one deliberate cross-repo duplicate of that rule; a second one inside this repo would be indefensible.
- The two `openDetailedView` call sites are deliberately **not** gated. Browsing lobbies is not joining one, and the list is useful while an update downloads.

## Testing

New `tests/DetailedGameViewModalGatingWiring.test.ts` — 9 tests that mount the real component, drive it through the real `desktop-update-state` event, and click real rendered lobby cards. It covers both the public (`join-lobby` event) and hosted (`join-lobby-modal.open`) branches, that the modal stays open on a blocked attempt, and the `aria-disabled` state.

Verified the tests actually reach the guard: removing `if (this.blockedByUpdate()) return;` from `join()` fails exactly 3 of the 9; restoring it passes all 9.

Full suite 3471/3472. The single failure is `tests/client/InventoryNavigation.test.ts`, which asserts on a literal `\n` in `index.html` and fails on Windows checkouts with `core.autocrlf=true` — reproducible on a clean `main` and unaffected by this change.

`build-prod`, `tsc --noEmit`, `lint` and `prettier --check` all clean.

## One note for reviewers

jsdom enforces the Custom Elements rule that a constructor must not touch its own attributes more strictly than real browsers do. This component's pre-existing constructor sets `this.id`, so `document.createElement("detailed-view-modal")` throws under jsdom. The test constructs it directly instead, which still exercises the real constructor, `connectedCallback`, Lit rendering and click handling.

`HostLobbyModal`, `RankedModal` and `Matchmaking` share that constructor pattern and appear never to have been mounted via `createElement` in any existing test, so this looks like a pre-existing jsdom gap rather than anything introduced here — flagging it in case it is worth addressing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JC92Wq1tF8WhDhD9FSGjUB
