### PR TITLE
fix the loading bar of SAM/Silos when 0 ammo

### DIFF
--- a/src/client/render/gl/passes/BarPass.ts
+++ b/src/client/render/gl/passes/BarPass.ts
@@ -333,7 +333,6 @@ export class BarPass {
     if (reloading === 0) return 1;
 
     const ready = maxMissiles - reloading;
-    if (ready === 0 && maxMissiles > 1) return 0;
 
     const cooldown =
       unit.unitType === UT_SAM_LAUNCHER


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #5007

## Description:
Tiny bug fix - when missiles was 0 but had more than 1 max missile, it'd display as empty. 
shooting 10 nukes at a time would cause ammo = 0, but they all reloaded at the same time. One finishes first, and suddenly it's 95% done reloading.

We should contemplate more visual clarity for reload bars - for example a SAM bar can be 90% full and unable to fire, or 10% full and shooting down a nuke - but that is a separate issue, just noting it down.

## Please complete the following:

- None, this is a visual only thing and an extremely minor and obvious bug fix.

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
