### PR TITLE
fix(server): exempt spectators from the allowlist once the game has started

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -781,7 +781,11 @@ export class GameServer {
     // OFM: if an allowlist is set, only those publicIds may join. Re-checked on
     // every join attempt. Admins/root bypass it so moderation can reach any
     // private lobby; a kick still applies (checked above).
-    if (!this.passesAllowlist(client)) {
+    // A spectator is exempt once the game has started: the field is locked and
+    // they take no seat, so the allowlist has nothing left to protect — and
+    // mid-game casters are exactly who it would otherwise shut out.
+    const spectatingStartedGame = client.spectator && this._hasStarted;
+    if (!spectatingStartedGame && !this.passesAllowlist(client)) {
       this.log.warn("client not on allowlist, rejecting", {
         clientID: client.clientID,
       });

--- a/tests/server/SpectatorJoin.test.ts
+++ b/tests/server/SpectatorJoin.test.ts
@@ -126,6 +126,44 @@ describe("GameServer - spectators", () => {
     expect(game.joinClient(makeClient("p1", true))).toBe("joined");
   });
 
+  it("is exempt from the allowlist once the game has started", () => {
+    // The field is locked at start and a spectator takes no seat, so the
+    // allowlist has nothing left to protect; a caster arriving mid-game is
+    // exactly who an allowlisted (tournament) lobby is cast for.
+    const game = new GameServer(
+      "g1",
+      logger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Private,
+        allowedPublicIds: ["p1-pub"],
+      }),
+    );
+    (game as any)._hasStarted = true;
+    const cast = makeClient("cast", true);
+    expect(game.joinClient(cast)).toBe("joined");
+    expect(cast.spectator).toBe(true);
+    // ...and the exemption is not a way into a seat.
+    (game as any).setSpectator(cast, false);
+    expect(cast.spectator).toBe(true);
+  });
+
+  it("does not exempt a non-spectator join after the start", () => {
+    // Someone joining to play stays subject to the allowlist even though a
+    // late join would only demote them to watching anyway.
+    const game = new GameServer(
+      "g1",
+      logger,
+      Date.now(),
+      testGameConfig({
+        gameType: GameType.Private,
+        allowedPublicIds: ["p1-pub"],
+      }),
+    );
+    (game as any)._hasStarted = true;
+    expect(game.joinClient(makeClient("late"))).toBe("not_allowlisted");
+  });
+
   it("does not keep a ranked match alive on its own", () => {
     // 1v1 with one player and one spectator is a one-player game, so the
     // short-handed cancel has to see through the spectator.


### PR DESCRIPTION
An allowlisted lobby runs the allowlist check before the spectator flag is honored, and the check has no spectator exemption — so it rejects every spectator. Tournament games are exactly the lobbies that set an allowlist *and* the ones with casters, so spectating (#5031) doesn't work for the games it was built for.

A spectator joining a **started** allowlisted game is now admitted without being on the list. Once the game has started the field is locked and a spectator takes no seat, so the allowlist has nothing left to protect. Pre-start it stays authoritative — a closed lobby isn't browsable before the field is locked — and the lobby Play/Spectate toggle still refuses a seat the allowlist doesn't name, so the exemption is never a way into a seat. A post-start join that asks to *play* is still rejected.

Tests (extends #5031's `SpectatorJoin.test.ts`): unlisted spectator admitted after start and unable to take a seat; unlisted non-spectator still rejected after start; the existing pre-start rejection test unchanged.