### PR TITLE
fix(net): route the game server's HTTP API through the configured host (v33)

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -823,7 +823,7 @@ export async function openSubscriptionPortal(): Promise<string | false> {
 export async function fetchLobbyListed(gameID: string): Promise<boolean> {
   try {
     const res = await fetch(
-      `/${ClientEnv.workerPath(gameID)}/api/game/${gameID}`,
+      `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(gameID)}/api/game/${gameID}`,
       { headers: { Accept: "application/json" } },
     );
     if (!res.ok) return false;
@@ -847,7 +847,7 @@ export async function setLobbyListed(
   try {
     const token = await getPlayToken();
     const response = await fetch(
-      `/${ClientEnv.workerPath(gameID)}/api/game/${gameID}/listing`,
+      `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(gameID)}/api/game/${gameID}/listing`,
       {
         method: "POST",
         headers: {
@@ -871,6 +871,42 @@ export async function setLobbyListed(
   }
 }
 
+// POST /api/create_game on the game server — mints a fresh private lobby with
+// the caller as creator. Deliberately has no worker prefix and no id: the edge
+// (nginx in prod, the vite dev proxy locally) picks a worker, which mints a
+// self-owned id and returns it.
+export async function createLobby(): Promise<GameInfo> {
+  // Send JWT token for creator identification - server extracts persistentID from it
+  // persistentID should never be exposed to other clients
+  const token = await getPlayToken();
+  try {
+    const response = await fetch(
+      `${ClientEnv.serverHttpBase()}/api/create_game`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error("Server error response:", errorText);
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const data = await response.json();
+    console.log("Success:", data);
+
+    return data as GameInfo;
+  } catch (error) {
+    console.error("Error creating lobby:", error);
+    throw error;
+  }
+}
+
 // POST /wX/api/create_game?previous=<gameID>, targeted at the worker that owns
 // the finished game — mints a successor private lobby (same creator, default
 // settings) and has the old game broadcast the new id to everyone still
@@ -881,7 +917,7 @@ export async function createNextLobby(
 ): Promise<GameInfo> {
   const token = await getPlayToken();
   const response = await fetch(
-    `/${ClientEnv.workerPath(previousGameID)}/api/create_game?previous=${previousGameID}`,
+    `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(previousGameID)}/api/create_game?previous=${previousGameID}`,
     {
       method: "POST",
       headers: {

--- a/src/client/ClientEnv.ts
+++ b/src/client/ClientEnv.ts
@@ -121,34 +121,81 @@ export class ClientEnv {
       window.location.host,
     );
   }
+  // Origin (scheme + host, no trailing slash) of the same game server's HTTP
+  // API — the worker routes under `/api` (create_game, game/:id/exists,
+  // game/:id/listing). Callers append the path, worker prefix included where
+  // the route needs one (e.g. `/w0/api/game/<id>`).
+  //
+  // NOT the account/shop API: that is a separate service on api.<audience>,
+  // reached via getApiBase().
+  static serverHttpBase(): string {
+    return deriveServerHttpBase(
+      ClientEnv.serverHost(),
+      window.location.protocol,
+      window.location.host,
+    );
+  }
 }
 
 /**
- * Resolve the game-server WebSocket origin.
+ * Resolve which host serves the game, and whether to reach it over TLS.
  *
- * When an explicit `serverHost` is configured, target it over TLS (wss). Only
- * the desktop app sets this: it loads the renderer from `app://openfront`,
- * where `window.location.host` is just "openfront" (not a real server), and the
+ * This is the single place that answers "which game server?". Both the
+ * WebSocket base and the HTTP base derive from it so they cannot drift apart:
+ * a lobby created over HTTP on one host is only playable over the socket on
+ * that same host. A future multi-server client (picking a host at load time
+ * from /cluster.json) changes this function and both bases follow.
+ *
+ * When an explicit `serverHost` is configured, target it over TLS. Only the
+ * desktop app sets this: it loads the renderer from `app://openfront`, where
+ * `window.location.host` is just "openfront" (not a real server), and the
  * game-server host is NOT derivable from the API audience — it is the bare
  * audience host in prod (`openfront.io`) but a branch-variable subdomain on
  * dev/staging (default `main.openfront.dev`, or `<branch>.openfront.dev`). So
  * the host is injected explicitly rather than derived.
  *
  * When no `serverHost` is configured — the normal web build — the game server
- * is same-origin as the document, so we keep the historical behaviour exactly:
- * derive scheme + host from `window.location`. This leaves the web build
- * byte-for-byte unchanged.
+ * is same-origin as the document, so we keep the historical behaviour: scheme
+ * and host come from `window.location`, which is what the previously relative
+ * URLs resolved against anyway.
  */
+function resolveServerOrigin(
+  serverHost: string | undefined,
+  locationProtocol: string,
+  locationHost: string,
+): { secure: boolean; host: string } {
+  if (serverHost) {
+    return { secure: true, host: serverHost };
+  }
+  return { secure: locationProtocol === "https:", host: locationHost };
+}
+
+/** Game-server WebSocket origin: see resolveServerOrigin. */
 export function deriveServerWsBase(
   serverHost: string | undefined,
   locationProtocol: string,
   locationHost: string,
 ): string {
-  if (serverHost) {
-    return `wss://${serverHost}`;
-  }
-  const wsProtocol = locationProtocol === "https:" ? "wss:" : "ws:";
-  return `${wsProtocol}//${locationHost}`;
+  const { secure, host } = resolveServerOrigin(
+    serverHost,
+    locationProtocol,
+    locationHost,
+  );
+  return `${secure ? "wss:" : "ws:"}//${host}`;
+}
+
+/** Game-server HTTP origin: see resolveServerOrigin. */
+export function deriveServerHttpBase(
+  serverHost: string | undefined,
+  locationProtocol: string,
+  locationHost: string,
+): string {
+  const { secure, host } = resolveServerOrigin(
+    serverHost,
+    locationProtocol,
+    locationHost,
+  );
+  return `${secure ? "https:" : "http:"}//${host}`;
 }
 /**
  * Values that flow from server → client via index.html. Set on the server from

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -22,13 +22,11 @@ import { UserSettings } from "../core/game/UserSettings";
 import {
   ClientInfo,
   GameConfig,
-  GameInfo,
   LobbyInfoEvent,
   TeamCountConfig,
   isValidGameID,
 } from "../core/Schemas";
-import { getUserMe, setLobbyListed } from "./Api";
-import { getPlayToken } from "./Auth";
+import { createLobby, getUserMe, setLobbyListed } from "./Api";
 import "./components/baseComponents/Modal";
 import { BaseModal } from "./components/BaseModal";
 import "./components/ConfirmDialog";
@@ -1458,36 +1456,5 @@ export class HostLobbyModal extends BaseModal {
       console.warn("Failed to load nation count", error);
       // Leave existing values unchanged so the UI stays consistent
     }
-  }
-}
-
-async function createLobby(): Promise<GameInfo> {
-  // Send JWT token for creator identification - server extracts persistentID from it
-  // persistentID should never be exposed to other clients
-  const token = await getPlayToken();
-  try {
-    // No worker prefix and no id: nginx (prod) / the vite dev proxy randomly
-    // routes to a worker, which mints a self-owned id and returns it.
-    const response = await fetch(`/api/create_game`, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${token}`,
-      },
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      console.error("Server error response:", errorText);
-      throw new Error(`HTTP error! status: ${response.status}`);
-    }
-
-    const data = await response.json();
-    console.log("Success:", data);
-
-    return data as GameInfo;
-  } catch (error) {
-    console.error("Error creating lobby:", error);
-    throw error;
   }
 }

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -1174,7 +1174,7 @@ export class JoinLobbyModal extends BaseModal {
     lobbyId: string,
     spectator = false,
   ): Promise<boolean> {
-    const url = `/${ClientEnv.workerPath(lobbyId)}/api/game/${lobbyId}/exists`;
+    const url = `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(lobbyId)}/api/game/${lobbyId}/exists`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/src/client/Matchmaking.ts
+++ b/src/client/Matchmaking.ts
@@ -431,7 +431,7 @@ export class MatchmakingModal extends BaseModal {
     if (this.gameID === null) {
       return;
     }
-    const url = `/${ClientEnv.workerPath(this.gameID)}/api/game/${this.gameID}/exists`;
+    const url = `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(this.gameID)}/api/game/${this.gameID}/exists`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/tests/client/GameServerApiCallers.test.ts
+++ b/tests/client/GameServerApiCallers.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/client/Auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Auth")>()),
+  getPlayToken: vi.fn(async () => "play-token"),
+  getAuthHeader: vi.fn(async () => "Bearer test"),
+  isSessionActive: vi.fn(() => false),
+}));
+
+import { createLobby } from "../../src/client/Api";
+import { ClientEnv } from "../../src/client/ClientEnv";
+import { JoinLobbyModal } from "../../src/client/JoinLobbyModal";
+import { MatchmakingModal } from "../../src/client/Matchmaking";
+
+// Every remaining caller of the game server's HTTP API, driven through real
+// production code. Each one used to build a relative URL, which silently
+// resolved against the document origin instead of the game server.
+const SERVER_HOST = "main.openfront.dev";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function lastCall(): any[] {
+  const calls = fetchMock.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1];
+}
+
+function lastUrl(): string {
+  return String(lastCall()[0]);
+}
+
+beforeEach(() => {
+  (window as any).BOOTSTRAP_CONFIG = {
+    gameEnv: "prod",
+    numWorkers: 1,
+    turnstileSiteKey: "x",
+    jwtAudience: "openfront.io",
+    instanceId: "test",
+    gitCommit: "test",
+    serverHost: SERVER_HOST,
+  };
+  ClientEnv.reset();
+  fetchMock = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ exists: true, gameID: "game-1" }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete (window as any).BOOTSTRAP_CONFIG;
+  ClientEnv.reset();
+  vi.clearAllMocks();
+});
+
+describe("createLobby", () => {
+  it("creates the lobby on the configured game server", async () => {
+    await createLobby();
+    // No worker prefix: the edge (nginx in prod, the vite proxy in dev) picks
+    // a worker, which mints a self-owned id.
+    expect(lastUrl()).toBe(`https://${SERVER_HOST}/api/create_game`);
+  });
+
+  it("still sends the play token as the creator's identity", async () => {
+    await createLobby();
+    const init = lastCall()[1] as RequestInit;
+    expect(init.method).toBe("POST");
+    expect((init.headers as Record<string, string>).Authorization).toBe(
+      "Bearer play-token",
+    );
+  });
+});
+
+describe("JoinLobbyModal.checkActiveLobby", () => {
+  it("probes the configured game server for the lobby", async () => {
+    const modal = new JoinLobbyModal();
+    await (
+      modal as unknown as {
+        checkActiveLobby(id: string): Promise<boolean>;
+      }
+    ).checkActiveLobby("game-1");
+    expect(lastUrl()).toBe(
+      `https://${SERVER_HOST}/${ClientEnv.workerPath("game-1")}/api/game/game-1/exists`,
+    );
+  });
+});
+
+describe("MatchmakingModal.checkGame", () => {
+  it("polls the configured game server for the matched game", async () => {
+    const modal = new MatchmakingModal();
+    const internals = modal as unknown as {
+      gameID: string | null;
+      checkGame(): Promise<void>;
+    };
+    internals.gameID = "game-1";
+    await internals.checkGame();
+    expect(lastUrl()).toBe(
+      `https://${SERVER_HOST}/${ClientEnv.workerPath("game-1")}/api/game/game-1/exists`,
+    );
+  });
+});

--- a/tests/client/GameServerApiUrls.test.ts
+++ b/tests/client/GameServerApiUrls.test.ts
@@ -1,0 +1,124 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/client/Auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Auth")>()),
+  getPlayToken: vi.fn(async () => "play-token"),
+  getAuthHeader: vi.fn(async () => "Bearer test"),
+  isSessionActive: vi.fn(() => false),
+}));
+
+import {
+  createNextLobby,
+  fetchLobbyListed,
+  setLobbyListed,
+} from "../../src/client/Api";
+import { ClientEnv } from "../../src/client/ClientEnv";
+
+// The game server's HTTP API must be addressed the same way its WebSockets
+// are: against the configured server host. These fetches used to be relative,
+// so they resolved against the document origin — which is correct only when
+// the page happens to be served by the game server itself. It is not on the
+// desktop build (app://openfront, where every /api route 404s against the
+// local file handler) nor on any deployment that serves the client from a
+// different host than the game server.
+function setConfig(serverHost?: string) {
+  (window as any).BOOTSTRAP_CONFIG = {
+    gameEnv: "prod",
+    numWorkers: 1,
+    turnstileSiteKey: "x",
+    jwtAudience: "openfront.io",
+    instanceId: "test",
+    gitCommit: "test",
+    ...(serverHost === undefined ? {} : { serverHost }),
+  };
+  ClientEnv.reset();
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+function lastCall(): any[] {
+  const calls = fetchMock.mock.calls;
+  expect(calls.length).toBeGreaterThan(0);
+  return calls[calls.length - 1];
+}
+
+function lastUrl(): string {
+  return String(lastCall()[0]);
+}
+
+beforeEach(() => {
+  fetchMock = vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({ listed: true, exists: true, gameID: "g1" }),
+        {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        },
+      ),
+  );
+  vi.stubGlobal("fetch", fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete (window as any).BOOTSTRAP_CONFIG;
+  ClientEnv.reset();
+  vi.clearAllMocks();
+});
+
+describe("game-server API URLs with an explicit serverHost", () => {
+  beforeEach(() => setConfig("main.openfront.dev"));
+
+  it("fetchLobbyListed targets the configured game server", async () => {
+    await fetchLobbyListed("game-1");
+    expect(lastUrl()).toBe(
+      `https://main.openfront.dev/${ClientEnv.workerPath("game-1")}/api/game/game-1`,
+    );
+  });
+
+  it("setLobbyListed targets the configured game server", async () => {
+    await setLobbyListed("game-1", true);
+    expect(lastUrl()).toBe(
+      `https://main.openfront.dev/${ClientEnv.workerPath("game-1")}/api/game/game-1/listing`,
+    );
+  });
+
+  it("createNextLobby targets the worker that owns the finished game", async () => {
+    await createNextLobby("game-1");
+    expect(lastUrl()).toBe(
+      `https://main.openfront.dev/${ClientEnv.workerPath("game-1")}/api/create_game?previous=game-1`,
+    );
+  });
+});
+
+describe("game-server API URLs on the web build (no serverHost)", () => {
+  beforeEach(() => setConfig(undefined));
+
+  // jsdom serves the tests from http://localhost:3000 by default; the point is
+  // that the request still lands on the document's own origin, exactly as the
+  // previous relative URLs did.
+  it("fetchLobbyListed stays same-origin", async () => {
+    await fetchLobbyListed("game-1");
+    expect(new URL(lastUrl()).origin).toBe(window.location.origin);
+    expect(new URL(lastUrl()).pathname).toBe(
+      `/${ClientEnv.workerPath("game-1")}/api/game/game-1`,
+    );
+  });
+
+  it("setLobbyListed stays same-origin", async () => {
+    await setLobbyListed("game-1", true);
+    expect(new URL(lastUrl()).origin).toBe(window.location.origin);
+    expect(new URL(lastUrl()).pathname).toBe(
+      `/${ClientEnv.workerPath("game-1")}/api/game/game-1/listing`,
+    );
+  });
+
+  it("createNextLobby stays same-origin", async () => {
+    await createNextLobby("game-1");
+    expect(new URL(lastUrl()).origin).toBe(window.location.origin);
+    expect(new URL(lastUrl()).pathname).toBe(
+      `/${ClientEnv.workerPath("game-1")}/api/create_game`,
+    );
+  });
+});

--- a/tests/client/ServerHttpBase.test.ts
+++ b/tests/client/ServerHttpBase.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveServerHttpBase,
+  deriveServerWsBase,
+} from "../../src/client/ClientEnv";
+
+// deriveServerHttpBase resolves the origin of the game server's *HTTP* API —
+// the worker routes under /api (create_game, game/:id, game/:id/exists,
+// game/:id/listing). It is the sibling of deriveServerWsBase: the two must
+// always name the same server, because a lobby created on one host is only
+// reachable over the socket on that same host.
+//
+// This is deliberately NOT the account/shop API (api.<audience>, see
+// getApiBase) — that one is a separate service and derives from the audience.
+describe("deriveServerHttpBase", () => {
+  describe("web build (no injected serverHost) stays same-origin", () => {
+    it("uses the document origin on https", () => {
+      expect(deriveServerHttpBase(undefined, "https:", "openfront.io")).toBe(
+        "https://openfront.io",
+      );
+    });
+
+    it("uses the document origin on http (local dev keeps the port)", () => {
+      expect(deriveServerHttpBase(undefined, "http:", "localhost:3000")).toBe(
+        "http://localhost:3000",
+      );
+    });
+
+    it("preserves the exact location.host (e.g. www vs apex)", () => {
+      expect(
+        deriveServerHttpBase(undefined, "https:", "www.openfront.io"),
+      ).toBe("https://www.openfront.io");
+    });
+
+    it("treats an empty serverHost as absent (web fallback)", () => {
+      expect(deriveServerHttpBase("", "https:", "openfront.io")).toBe(
+        "https://openfront.io",
+      );
+    });
+  });
+
+  describe("explicit serverHost targets the real game server", () => {
+    it("targets the packaged prod host over https", () => {
+      expect(deriveServerHttpBase("openfront.io", "app:", "openfront")).toBe(
+        "https://openfront.io",
+      );
+    });
+
+    it("targets a branch-specific subdomain over https", () => {
+      expect(
+        deriveServerHttpBase("my-feature.openfront.dev", "app:", "openfront"),
+      ).toBe("https://my-feature.openfront.dev");
+    });
+
+    it("never falls through to the desktop app:// origin", () => {
+      // The bug this fixes: relative /api fetches resolved against
+      // app://openfront, which serves local files and 404s every API route.
+      expect(
+        deriveServerHttpBase("openfront.io", "app:", "openfront"),
+      ).not.toContain("openfront/");
+    });
+
+    it("ignores location entirely when a serverHost is configured", () => {
+      expect(
+        deriveServerHttpBase("openfront.io", "https:", "elsewhere.example"),
+      ).toBe("https://openfront.io");
+    });
+  });
+
+  // The invariant that matters once the client picks a server at runtime (the
+  // planned /cluster.json lookup): whatever decides the host must move both
+  // bases together, or lobbies get created on one server and played on another.
+  describe("stays in lockstep with deriveServerWsBase", () => {
+    it.each([
+      [undefined, "https:", "openfront.io"],
+      [undefined, "http:", "localhost:3000"],
+      ["openfront.io", "app:", "openfront"],
+      ["main.openfront.dev", "app:", "openfront"],
+    ] as const)(
+      "names the same host for (%s, %s, %s)",
+      (serverHost, protocol, host) => {
+        const http = new URL(deriveServerHttpBase(serverHost, protocol, host));
+        const ws = new URL(deriveServerWsBase(serverHost, protocol, host));
+        expect(http.host).toBe(ws.host);
+        // ...and the same transport security, so an https page never talks to
+        // a ws:// game server (mixed content) or vice versa.
+        expect(http.protocol === "https:").toBe(ws.protocol === "wss:");
+      },
+    );
+  });
+});


### PR DESCRIPTION
Cherry-pick of #5072 (merged to main as 1edabacfc) onto `v33`. Applied cleanly,
no conflicts. Opened as a PR only because `v33` rejects direct pushes.

The desktop build ships from this line, and it's where the bug actually bites:
six game-server API calls built relative URLs, which resolve against the
document origin. Under `app://openfront` the protocol handler serves local
files, so every one of them 404s — hosting a private lobby, joining by id, the
matchmaking liveness poll, publishing a lobby to the browser and the win-screen
"next game" flow are all broken in the packaged app today.

See #5072 for the full rationale. No behaviour change on the web: with no
configured host both the WS and HTTP bases resolve to the document's own
origin, which is what the relative URLs resolved against anyway.

## Verified on this branch, not just on main

- Full suite green: 2824 unit + 374 server tests.
- `tsc --noEmit` and `npm run lint` clean.
- Re-grepped `src/client` on this branch for leftover relative `/api` URLs —
  none remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URxNGKBbPtYSybwfR3Uih1