### PR TITLE
feat(desktop): serve a release descriptor on v33 (server side of #5061)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,12 @@ COPY index.html ./
 COPY resources ./resources
 COPY proprietary ./proprietary
 COPY src ./src
+# build-prod runs scripts/buildAssetHashes.ts after vite, to emit
+# static/asset-hashes.json and static/core-version.txt for the desktop
+# release descriptor. Without this the image build fails at that step with
+# ERR_MODULE_NOT_FOUND -- the unit suite cannot catch it, because only the
+# container build runs build-prod from a copied tree.
+COPY scripts ./scripts
 
 ARG GIT_COMMIT=unknown
 ENV GIT_COMMIT="$GIT_COMMIT"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "openfront-client",
   "scripts": {
     "build-dev": "concurrently \"tsc --noEmit\" \"vite build --mode development\"",
-    "build-prod": "concurrently --kill-others-on-fail \"tsc --noEmit\" \"vite build\"",
+    "build-prod": "concurrently --kill-others-on-fail \"tsc --noEmit\" \"vite build\" && tsx scripts/buildAssetHashes.ts",
     "start:client": "vite",
     "start:server": "tsx src/server/Server.ts",
     "start:server-dev": "cross-env GAME_ENV=dev NUM_WORKERS=2 TURNSTILE_SITE_KEY=1x00000000000000000000AA API_KEY=WARNING_DEV_API_KEY_DO_NOT_USE_IN_PRODUCTION ADMIN_BOT_API_KEY=WARNING_DEV_ADMIN_BOT_KEY_DO_NOT_USE_IN_PRODUCTION DOMAIN=localhost GIT_COMMIT=DEV tsx src/server/Server.ts",

--- a/scripts/buildAssetHashes.ts
+++ b/scripts/buildAssetHashes.ts
@@ -1,0 +1,117 @@
+import { createHash } from "crypto";
+import fs from "fs/promises";
+import path from "path";
+
+export interface AssetHash {
+  sha256: string;
+  bytes: number;
+}
+
+// A POSITIVE allowlist, not an exclusion list, and it MUST stay identical to
+// ALLOWED_ROOTS in the desktop shell's src/main/update/descriptor.ts.
+//
+// The shell's parseDescriptor runs safeOverlayPath over every asset url and
+// THROWS on the first one outside these two roots, aborting the parse of the
+// whole descriptor -- so a single stray entry does not degrade one asset, it
+// takes every desktop client to the `failed` state on every launch.
+//
+// static/ is not only hashed content. The build copies a handful of root files
+// through unhashed (LICENSE, ads.txt, privacy-policy.html, robots.txt,
+// terms-of-service.html, version.txt), plus index.html (an EJS template
+// rendered per-request, not an immutable asset) and asset-manifest.json. An
+// exclusion list has to enumerate all of those correctly forever; an allowlist
+// only has to name the two roots the overlay can actually serve.
+//
+// Note asset-manifest.json is NOT "superseded by the descriptor": the
+// descriptor carries the download SET (keyed by emitted path), while
+// asset-manifest.json carries the semantic MAPPING the client resolves names
+// through (semantic name -> hashed url). The descriptor carries it as its own
+// top-level `assetManifest` field -- see buildDescriptor in
+// src/server/DesktopRelease.ts -- rather than as a hashed asset.
+const ALLOWED_ROOTS = ["assets/", "_assets/"];
+
+function isOverlayServable(rel: string): boolean {
+  return ALLOWED_ROOTS.some((root) => rel.startsWith(root));
+}
+
+async function walk(root: string, rel = ""): Promise<string[]> {
+  const entries = await fs.readdir(path.join(root, rel), {
+    withFileTypes: true,
+  });
+  const files: string[] = [];
+  for (const entry of entries) {
+    const childRel = rel === "" ? entry.name : `${rel}/${entry.name}`;
+    if (entry.isDirectory()) {
+      files.push(...(await walk(root, childRel)));
+    } else if (entry.isFile()) {
+      files.push(childRel);
+    }
+  }
+  return files;
+}
+
+export async function hashDirectory(
+  dir: string,
+): Promise<Record<string, AssetHash>> {
+  const files = await walk(dir);
+  const out: Record<string, AssetHash> = {};
+  for (const rel of files.sort()) {
+    if (!isOverlayServable(rel)) continue;
+    const content = await fs.readFile(path.join(dir, rel));
+    out[rel] = {
+      sha256: createHash("sha256").update(content).digest("hex"),
+      bytes: content.byteLength,
+    };
+  }
+  return out;
+}
+
+// Sorted before hashing so the result depends on content, not on the order the
+// filesystem happens to hand back directory entries. Paths are included so a
+// pure rename changes the hash.
+export async function hashSourceTree(dir: string): Promise<string> {
+  const files = (await walk(dir)).sort();
+  const hash = createHash("sha256");
+  for (const rel of files) {
+    const relBytes = Buffer.from(rel, "utf8");
+    const content = await fs.readFile(path.join(dir, rel));
+    // Length-prefix both fields. Feeding path and content in unseparated makes
+    // the encoding ambiguous: a file "a" holding "bc" hashes identically to a
+    // file "ab" holding "c", so a rename that shifts bytes across the boundary
+    // would leave coreVersion unchanged -- the one thing it exists to detect.
+    hash.update(`${relBytes.length}:`);
+    hash.update(relBytes);
+    hash.update(`${content.length}:`);
+    hash.update(content);
+  }
+  return hash.digest("hex");
+}
+
+async function main(): Promise<void> {
+  const root = path.join(import.meta.dirname, "..");
+  const staticDir = path.join(root, "static");
+
+  const hashes = await hashDirectory(staticDir);
+  await fs.writeFile(
+    path.join(staticDir, "asset-hashes.json"),
+    `${JSON.stringify(hashes, null, 2)}\n`,
+  );
+
+  const coreVersion = await hashSourceTree(path.join(root, "src", "core"));
+  await fs.writeFile(
+    path.join(staticDir, "core-version.txt"),
+    `${coreVersion}\n`,
+  );
+
+  console.log(
+    `asset-hashes.json: ${Object.keys(hashes).length} files; core ${coreVersion.slice(0, 12)}`,
+  );
+}
+
+// Only run as a script, never on import (the tests import the helpers above).
+if (process.argv[1] && process.argv[1].endsWith("buildAssetHashes.ts")) {
+  main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/src/server/DesktopRelease.ts
+++ b/src/server/DesktopRelease.ts
@@ -1,0 +1,310 @@
+import { createHash } from "crypto";
+import fs from "fs/promises";
+import path from "path";
+import { logger } from "./Logger";
+
+const log = logger.child({ comp: "desktop-release" });
+
+// Bump ONLY when a client genuinely cannot run on an older desktop shell.
+// A shell below this refuses to stage the update and tells the player to take
+// a Steam update, so a careless bump strands every installed client.
+const MIN_SHELL_VERSION = "0.1.0";
+
+// ---------------------------------------------------------------------------
+// Mirror of the desktop shell's safeOverlayPath / safeManifestTarget.
+//
+// SOURCE OF TRUTH: openfront-desktop's src/main/update/descriptor.ts. The two
+// repositories cannot import from each other, so this is duplicated on purpose
+// -- the same arrangement as multiplayerAllowed in src/client/DesktopShell.ts.
+// If the shell's rules change, change these to match.
+//
+// This exists because the shell's parseDescriptor THROWS on the first value it
+// refuses and aborts the parse of the entire descriptor. That is not a degraded
+// asset; it is every Steam client landing in `failed` on every launch. A
+// prefix-only check here would be weaker than the rule it is meant to
+// anticipate: parseDescriptor also rejects "%", "?", "#", backslashes, NUL,
+// UNC paths, drive letters and traversal segments, and it validates the assets
+// map's KEYS as well as its urls. Catching all of that at build time is the
+// entire point of asserting here at all.
+const ALLOWED_ROOTS = ["assets/", "_assets/"];
+
+// Same mirror-of-the-shell rationale as ALLOWED_ROOTS above: parseDescriptor
+// in openfront-desktop's src/main/update/descriptor.ts requires `sha256` to be
+// 64 lowercase hex characters and `bytes` a non-negative integer, and throws
+// on the first entry that isn't -- aborting the parse of the WHOLE descriptor.
+// asset-hashes.json is generated, not hand-written, but a bug in
+// scripts/buildAssetHashes.ts (or a corrupted build artifact) would otherwise
+// pass straight through this file and only surface once every Steam client
+// fails to update.
+const SHA256 = /^[0-9a-f]{64}$/;
+
+function shellWouldRefuse(value: string): boolean {
+  if (typeof value !== "string" || value === "") return true;
+  // NUL, written as an escape rather than a raw byte: 171 real flag
+  // filenames contain a literal SPACE, which the shell accepts, and an
+  // embedded NUL renders as one in most editors. A raw NUL here would also
+  // make git treat this file as binary.
+  if (value.includes("\u0000")) return true;
+  if (value.includes("%")) return true;
+  if (value.includes("\\")) return true;
+  if (value.includes("?") || value.includes("#")) return true;
+  if (value.startsWith("//")) return true;
+  if (/^[a-zA-Z]:/.test(value)) return true;
+
+  const rel = value.startsWith("/") ? value.slice(1) : value;
+  if (rel === "") return true;
+  if (rel.split("/").some((seg) => seg === "" || seg === "." || seg === "..")) {
+    return true;
+  }
+  return !ALLOWED_ROOTS.some((root) => rel.startsWith(root));
+}
+
+// asset-manifest.json holds percent-ENCODED hrefs where asset-hashes.json holds
+// literal paths -- 171 flag filenames in the current build contain a space,
+// carried here as %20. The shell decodes before applying its rules, so this
+// must too, or every one of those would look like a violation.
+function shellWouldRefuseManifestValue(value: string): boolean {
+  if (typeof value !== "string" || value === "") return true;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(value);
+  } catch {
+    return true;
+  }
+  return shellWouldRefuse(decoded);
+}
+
+export interface ReleaseAsset {
+  url: string;
+  sha256: string;
+  bytes: number;
+}
+
+export interface ReleaseDescriptor {
+  schemaVersion: 1;
+  clientVersion: string;
+  coreVersion: string;
+  minShellVersion: string;
+  cdnBase: string;
+  template: { html: string; sha256: string };
+  /**
+   * The download set, keyed by emitted path
+   * ("_assets/atlases/emoji-atlas.eb6eeb4f.png").
+   */
+  assets: Record<string, ReleaseAsset>;
+  /**
+   * static/asset-manifest.json verbatim: the SEMANTIC mapping
+   * ("atlases/emoji-atlas.png" -> "/_assets/atlases/emoji-atlas.eb6eeb4f.png")
+   * the client resolves asset names through at runtime.
+   *
+   * A separate field from `assets` because the two key-spaces are different and
+   * overlap in only a handful of entries -- the Vite `assets/**` outputs, where
+   * the semantic name happens to equal the emitted path. Deriving one from the
+   * other yields a manifest whose `_assets/**` lookups all miss, and a client
+   * that boots but cannot start a game.
+   */
+  assetManifest: Record<string, string>;
+}
+
+export interface VersionPointer {
+  clientVersion: string;
+  coreVersion: string;
+}
+
+interface BuildOpts {
+  clientVersion: string;
+  cdnBase: string;
+  /**
+   * Refuse to build a descriptor with an empty cdnBase. True in production,
+   * where an unset CDN_BASE would tell every Steam client to pull ~570MB of
+   * assets from this app server -- contradicting the architecture (the game
+   * server serves index.html and the WebSocket; everything else comes from the
+   * CDN bucket) and risking the app server for web players too, not just Steam
+   * ones. False elsewhere, where there is genuinely no CDN and same-origin is
+   * how the web client already behaves.
+   */
+  requireCdnBase: boolean;
+}
+
+let cached: Promise<ReleaseDescriptor> | null = null;
+
+export function clearDesktopReleaseCache(): void {
+  cached = null;
+}
+
+/**
+ * A parsed JSON value that is genuinely a string-keyed mapping. `as` is a cast,
+ * not a check: an array survives it, and `Object.entries` on one yields index
+ * keys ("0", "1"), which then flow into the descriptor as if they were real
+ * names. The client resolves assets by semantic name, so every lookup would
+ * miss -- silently, and only once a player applied the update.
+ */
+function asMapping(value: unknown, file: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${file} must contain a JSON object.`);
+  }
+  return value as Record<string, unknown>;
+}
+
+export async function buildDescriptor(
+  staticDir: string,
+  opts: BuildOpts,
+): Promise<ReleaseDescriptor> {
+  const [html, hashesRaw, coreRaw, manifestRaw] = await Promise.all([
+    fs.readFile(path.join(staticDir, "index.html"), "utf-8"),
+    fs.readFile(path.join(staticDir, "asset-hashes.json"), "utf-8"),
+    fs.readFile(path.join(staticDir, "core-version.txt"), "utf-8"),
+    fs.readFile(path.join(staticDir, "asset-manifest.json"), "utf-8"),
+  ]);
+
+  const hashes = asMapping(
+    JSON.parse(hashesRaw),
+    "asset-hashes.json",
+  ) as Record<string, { sha256: string; bytes: number }>;
+  if (Object.keys(hashes).length === 0) {
+    throw new Error(
+      "asset-hashes.json is empty — did scripts/buildAssetHashes.ts run after the Vite build?",
+    );
+  }
+
+  const assets: Record<string, ReleaseAsset> = {};
+  for (const [rel, h] of Object.entries(hashes)) {
+    const url = `/${rel}`;
+    // Fail the BUILD rather than every client. Both the KEY and the URL are
+    // checked, because parseDescriptor validates both.
+    if (shellWouldRefuse(rel) || shellWouldRefuse(url)) {
+      throw new Error(
+        `asset-hashes.json contains "${rel}", which the desktop shell's ` +
+          `safeOverlayPath refuses — it must be under assets/ or _assets/ and ` +
+          `free of "%", "?", "#", backslashes, NUL and traversal segments. ` +
+          `The shell rejects the WHOLE descriptor on it, so every Steam client ` +
+          `would fail to update. Fix hashDirectory in ` +
+          `scripts/buildAssetHashes.ts.`,
+      );
+    }
+    // Check the entry is an object before reading its fields. JSON null is
+    // typeof "object", so `h.sha256` on one throws a bare TypeError naming
+    // nothing -- losing the key and the reason, which is the whole point of
+    // failing here rather than in every client.
+    // Check the entry is an object before reading its fields. JSON null is
+    // typeof "object", so `h.sha256` on one throws a bare TypeError naming
+    // nothing -- losing the key and the reason, which is the whole point of
+    // failing here rather than in every client.
+    if (typeof h !== "object" || h === null || Array.isArray(h)) {
+      throw new Error(
+        `asset-hashes.json["${rel}"] is not an object. Expected ` +
+          `{ sha256, bytes } from scripts/buildAssetHashes.ts.`,
+      );
+    }
+    // sha256/bytes are taken from a generated file and used as-is elsewhere,
+    // so a malformed entry here would otherwise reach parseDescriptor
+    // untouched -- same build-time-vs-runtime tradeoff as the path check
+    // above.
+    if (typeof h.sha256 !== "string" || !SHA256.test(h.sha256)) {
+      throw new Error(
+        `asset-hashes.json["${rel}"].sha256 is not 64 lowercase hex ` +
+          `characters, which the desktop shell's parseDescriptor requires. ` +
+          `The shell rejects the WHOLE descriptor on it, so every Steam ` +
+          `client would fail to update.`,
+      );
+    }
+    if (
+      typeof h.bytes !== "number" ||
+      !Number.isInteger(h.bytes) ||
+      h.bytes < 0
+    ) {
+      throw new Error(
+        `asset-hashes.json["${rel}"].bytes is not a non-negative integer, ` +
+          `which the desktop shell's parseDescriptor requires. The shell ` +
+          `rejects the WHOLE descriptor on it, so every Steam client would ` +
+          `fail to update.`,
+      );
+    }
+    assets[rel] = { url, sha256: h.sha256, bytes: h.bytes };
+  }
+
+  const assetManifest = asMapping(
+    JSON.parse(manifestRaw),
+    "asset-manifest.json",
+  ) as Record<string, string>;
+  if (Object.keys(assetManifest).length === 0) {
+    throw new Error(
+      "asset-manifest.json is empty — the desktop client resolves every asset name through it",
+    );
+  }
+  for (const [name, target] of Object.entries(assetManifest)) {
+    // Values only. The keys are semantic names the client looks up by, never
+    // paths, and the shell does not constrain them beyond being strings.
+    if (shellWouldRefuseManifestValue(target)) {
+      throw new Error(
+        `asset-manifest.json maps "${name}" to "${target}", which the desktop ` +
+          `shell's safeManifestTarget refuses once decoded. The shell rejects ` +
+          `the WHOLE descriptor on it, so every Steam client would fail to ` +
+          `update.`,
+      );
+    }
+    // Every manifest target must also be in the download set. The manifest is
+    // what the client resolves a semantic name through; `assets` is what it
+    // actually fetches and hash-verifies. A target with no `assets` entry is
+    // never downloaded, so the client resolves the name to a path that is not
+    // in the overlay and 404s at runtime -- with no hash, it could not have
+    // verified it either.
+    let emitted: string;
+    try {
+      emitted = decodeURIComponent(target).replace(/^\/+/, "");
+    } catch {
+      throw new Error(
+        `asset-manifest.json maps "${name}" to "${target}", which is not ` +
+          `decodable as a URI component.`,
+      );
+    }
+    if (!Object.prototype.hasOwnProperty.call(assets, emitted)) {
+      throw new Error(
+        `asset-manifest.json maps "${name}" to "${target}", but ` +
+          `asset-hashes.json has no entry for "${emitted}". The client would ` +
+          `resolve that name to a file it never downloaded and cannot verify.`,
+      );
+    }
+  }
+
+  if (opts.cdnBase === "") {
+    if (opts.requireCdnBase) {
+      throw new Error(
+        "CDN_BASE is unset. This descriptor would tell every Steam client to " +
+          "fetch release assets from this app server instead of the CDN, " +
+          "which the architecture forbids and which risks the app server for " +
+          "web players as well. Set CDN_BASE for this environment.",
+      );
+    }
+    log.warn(
+      "CDN_BASE is unset — desktop release assets will be served from the app's own origin instead of a CDN. Expected outside production, where there is no CDN.",
+    );
+  }
+
+  return {
+    schemaVersion: 1,
+    clientVersion: opts.clientVersion,
+    coreVersion: coreRaw.trim(),
+    minShellVersion: MIN_SHELL_VERSION,
+    cdnBase: opts.cdnBase,
+    template: {
+      html,
+      sha256: createHash("sha256").update(html).digest("hex"),
+    },
+    assets,
+    assetManifest,
+  };
+}
+
+export function getDescriptor(
+  staticDir: string,
+  opts: BuildOpts,
+): Promise<ReleaseDescriptor> {
+  cached ??= buildDescriptor(staticDir, opts).catch((err: unknown) => {
+    // Do not cache a failure: a transient read error would otherwise poison
+    // the endpoint for the life of the process.
+    cached = null;
+    throw err;
+  });
+  return cached;
+}

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -6,6 +6,7 @@ import http from "http";
 import path from "path";
 import { fileURLToPath } from "url";
 import { GameEnv } from "../core/configuration/Config";
+import { getDescriptor } from "./DesktopRelease";
 import { logger } from "./Logger";
 import { MapPlaylist } from "./MapPlaylist";
 import { MasterLobbyService } from "./MasterLobbyService";
@@ -41,6 +42,45 @@ app.use(async (req, res, next) => {
     }
   } else {
     next();
+  }
+});
+
+// Desktop (Steam) shell release descriptor. See openfront-desktop's
+// docs/superpowers/specs/2026-08-20-runtime-asset-updating-design.md.
+//
+// version.json is polled once a minute by every running desktop client, so it
+// is deliberately tiny and separately cacheable; release.json is fetched only
+// when that pointer changes. Both must be reachable without a bot challenge --
+// see OPE-192.
+const staticDir = path.join(__dirname, "../../static");
+const descriptorOpts = () => ({
+  clientVersion: ServerEnv.gitCommit(),
+  cdnBase: ServerEnv.cdnBase(),
+  // Production must have a CDN: without one this descriptor would point every
+  // Steam client at this app server for ~570MB of assets. Dev and preprod have
+  // no CDN, and same-origin is what the web client already does there.
+  requireCdnBase: ServerEnv.env() === GameEnv.Prod,
+});
+
+app.get("/desktop/version.json", async (_req, res) => {
+  try {
+    const d = await getDescriptor(staticDir, descriptorOpts());
+    res.setHeader("Cache-Control", "public, max-age=0, s-maxage=30");
+    res.json({ clientVersion: d.clientVersion, coreVersion: d.coreVersion });
+  } catch (error) {
+    log.error("Error building desktop version pointer:", error);
+    res.status(500).json({ error: "unavailable" });
+  }
+});
+
+app.get("/desktop/release.json", async (_req, res) => {
+  try {
+    const d = await getDescriptor(staticDir, descriptorOpts());
+    res.setHeader("Cache-Control", "public, max-age=0, s-maxage=30");
+    res.json(d);
+  } catch (error) {
+    log.error("Error building desktop release descriptor:", error);
+    res.status(500).json({ error: "unavailable" });
   }
 });
 

--- a/tests/BuildAssetHashes.test.ts
+++ b/tests/BuildAssetHashes.test.ts
@@ -1,0 +1,112 @@
+import { createHash } from "crypto";
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { beforeEach, describe, expect, it } from "vitest";
+import { hashDirectory, hashSourceTree } from "../scripts/buildAssetHashes";
+
+let dir: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "hashes-"));
+});
+
+describe("hashDirectory", () => {
+  it("hashes every file with a posix-relative key and no leading slash", async () => {
+    await fs.mkdir(path.join(dir, "assets"), { recursive: true });
+    await fs.writeFile(path.join(dir, "assets", "index-abc.js"), "hello");
+
+    const result = await hashDirectory(dir);
+
+    const expected = createHash("sha256").update("hello").digest("hex");
+    expect(result).toEqual({
+      "assets/index-abc.js": { sha256: expected, bytes: 5 },
+    });
+  });
+
+  it("excludes index.html, which is served as a template not an asset", async () => {
+    await fs.writeFile(path.join(dir, "index.html"), "<html></html>");
+    await fs.writeFile(path.join(dir, "asset-manifest.json"), "{}");
+
+    const result = await hashDirectory(dir);
+
+    expect(result["index.html"]).toBeUndefined();
+    expect(result["asset-manifest.json"]).toBeUndefined();
+  });
+
+  // The real static/ carries these alongside the hashed roots. Emitting them
+  // would give the descriptor a url of "/LICENSE", which the desktop shell's
+  // safeOverlayPath rejects -- and it throws on the first offender, so the
+  // whole descriptor fails to parse and every Steam client lands in `failed`.
+  it("excludes unhashed root files copied through the build, such as LICENSE", async () => {
+    await fs.mkdir(path.join(dir, "assets"), { recursive: true });
+    await fs.writeFile(path.join(dir, "assets", "index-abc.js"), "hello");
+    for (const name of [
+      "LICENSE",
+      "ads.txt",
+      "privacy-policy.html",
+      "robots.txt",
+      "terms-of-service.html",
+      "version.txt",
+    ]) {
+      await fs.writeFile(path.join(dir, name), name);
+    }
+
+    const result = await hashDirectory(dir);
+
+    expect(Object.keys(result)).toEqual(["assets/index-abc.js"]);
+  });
+
+  it("emits only paths under assets/ or _assets/", async () => {
+    await fs.mkdir(path.join(dir, "_assets", "maps"), { recursive: true });
+    await fs.mkdir(path.join(dir, "assets"), { recursive: true });
+    await fs.mkdir(path.join(dir, "other"), { recursive: true });
+    await fs.writeFile(path.join(dir, "_assets", "maps", "a.bin"), "a");
+    await fs.writeFile(path.join(dir, "assets", "b.js"), "b");
+    await fs.writeFile(path.join(dir, "other", "c.txt"), "c");
+
+    const result = await hashDirectory(dir);
+
+    expect(Object.keys(result).sort()).toEqual([
+      "_assets/maps/a.bin",
+      "assets/b.js",
+    ]);
+  });
+});
+
+describe("hashSourceTree", () => {
+  it("is stable across runs and changes when a file changes", async () => {
+    await fs.writeFile(path.join(dir, "a.ts"), "export const a = 1;");
+    const first = await hashSourceTree(dir);
+    expect(await hashSourceTree(dir)).toBe(first);
+
+    await fs.writeFile(path.join(dir, "a.ts"), "export const a = 2;");
+    expect(await hashSourceTree(dir)).not.toBe(first);
+  });
+
+  it("distinguishes a path/content split that concatenation would collide", async () => {
+    // "a" holding "bc" and "ab" holding "c" produce the same byte stream when
+    // path and content are fed in unseparated. Length-prefixing keeps them
+    // distinct, so a rename that shifts bytes across the boundary still moves
+    // the hash.
+    await fs.writeFile(path.join(dir, "a"), "bc");
+    const first = await hashSourceTree(dir);
+
+    const other = await fs.mkdtemp(path.join(os.tmpdir(), "hashes-"));
+    await fs.writeFile(path.join(other, "ab"), "c");
+
+    expect(await hashSourceTree(other)).not.toBe(first);
+  });
+
+  it("does not depend on directory read order", async () => {
+    await fs.writeFile(path.join(dir, "z.ts"), "z");
+    await fs.writeFile(path.join(dir, "a.ts"), "a");
+    const first = await hashSourceTree(dir);
+
+    const other = await fs.mkdtemp(path.join(os.tmpdir(), "hashes-"));
+    await fs.writeFile(path.join(other, "a.ts"), "a");
+    await fs.writeFile(path.join(other, "z.ts"), "z");
+
+    expect(await hashSourceTree(other)).toBe(first);
+  });
+});

--- a/tests/DesktopRelease.test.ts
+++ b/tests/DesktopRelease.test.ts
@@ -1,0 +1,397 @@
+import fs from "fs/promises";
+import os from "os";
+import path from "path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildDescriptor,
+  clearDesktopReleaseCache,
+  getDescriptor,
+} from "../src/server/DesktopRelease";
+
+const { warnMock } = vi.hoisted(() => ({ warnMock: vi.fn() }));
+
+vi.mock("../src/server/Logger", () => ({
+  logger: {
+    child: () => ({ warn: warnMock }),
+  },
+}));
+
+let dir: string;
+
+beforeEach(async () => {
+  clearDesktopReleaseCache();
+  warnMock.mockClear();
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "release-"));
+  await fs.writeFile(
+    path.join(dir, "index.html"),
+    "<html><%- cdnBase %></html>",
+  );
+  await fs.writeFile(path.join(dir, "core-version.txt"), "abc123\n");
+  await fs.writeFile(
+    path.join(dir, "asset-manifest.json"),
+    JSON.stringify({ "images/a.png": "/_assets/images/a.deadbeef.png" }),
+  );
+  await fs.writeFile(
+    path.join(dir, "asset-hashes.json"),
+    JSON.stringify({
+      "_assets/images/a.deadbeef.png": { sha256: "f".repeat(64), bytes: 12 },
+      "assets/index-xyz.js": { sha256: "e".repeat(64), bytes: 34 },
+    }),
+  );
+});
+
+describe("buildDescriptor", () => {
+  it("carries the template inline with its own hash", async () => {
+    const d = await buildDescriptor(dir, {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    });
+
+    expect(d.template.html).toBe("<html><%- cdnBase %></html>");
+    expect(d.template.sha256).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("lists every hashed file with a leading-slash url", async () => {
+    const d = await buildDescriptor(dir, {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    });
+
+    expect(d.assets["assets/index-xyz.js"]).toEqual({
+      url: "/assets/index-xyz.js",
+      sha256: "e".repeat(64),
+      bytes: 34,
+    });
+    expect(Object.keys(d.assets)).toHaveLength(2);
+  });
+
+  it("reports the core version with the trailing newline stripped", async () => {
+    const d = await buildDescriptor(dir, {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    });
+
+    expect(d.coreVersion).toBe("abc123");
+  });
+
+  // A build-time failure beats 100% of clients failing at runtime: the shell's
+  // parseDescriptor aborts the WHOLE descriptor on the first url outside
+  // /assets/ and /_assets/, so a stray hash entry is not a degraded asset, it
+  // is every Steam player stuck in `failed`.
+  it("throws when a hash entry is outside the allowed roots, naming the offender", async () => {
+    await fs.writeFile(
+      path.join(dir, "asset-hashes.json"),
+      JSON.stringify({
+        "assets/index-xyz.js": { sha256: "e".repeat(64), bytes: 34 },
+        LICENSE: { sha256: "d".repeat(64), bytes: 11 },
+      }),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/LICENSE/);
+  });
+
+  // The prefix alone is not the shell's rule. parseDescriptor runs the full
+  // safeOverlayPath over both the KEY and the url, so a filename containing any
+  // of these would pass a prefix-only guard here and then abort the parse of
+  // the whole descriptor for 100% of clients -- the same class of bug as the
+  // root-file case above, just latent until someone adds such a filename.
+  it.each([
+    ["a percent sign", "_assets/images/50%25-off.deadbeef.png"],
+    ["a backslash", "_assets/images\\evil.deadbeef.png"],
+    ["a query string", "assets/index.js?v=2"],
+    ["a fragment", "assets/index.js#frag"],
+    ["a traversal segment", "assets/../../etc/passwd"],
+    ["a NUL byte", "assets/index\u0000.js"],
+  ])("throws when an asset key contains %s", async (_label, key) => {
+    await fs.writeFile(
+      path.join(dir, "asset-hashes.json"),
+      JSON.stringify({
+        "assets/index-xyz.js": { sha256: "e".repeat(64), bytes: 34 },
+        [key]: { sha256: "d".repeat(64), bytes: 11 },
+      }),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/safeOverlayPath/);
+  });
+
+  // sha256/bytes come from a generated file and were previously cast without
+  // being checked, so a malformed entry passed the build and only surfaced
+  // once the shell's parseDescriptor rejected the WHOLE descriptor at
+  // runtime -- the same failure class as the path checks above.
+  it.each([
+    ["missing", undefined],
+    ["too short", "e".repeat(63)],
+    ["uppercase", "E".repeat(64)],
+    ["not hex", "g".repeat(64)],
+  ])("throws when an asset hash's sha256 is %s", async (_label, sha256) => {
+    await fs.writeFile(
+      path.join(dir, "asset-hashes.json"),
+      JSON.stringify({
+        "assets/index-xyz.js": { sha256, bytes: 34 },
+      }),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/sha256/);
+  });
+
+  it.each([
+    ["a string", "34"],
+    ["negative", -1],
+    ["non-integer", 1.5],
+    ["missing", undefined],
+  ])("throws when an asset hash's bytes is %s", async (_label, bytes) => {
+    await fs.writeFile(
+      path.join(dir, "asset-hashes.json"),
+      JSON.stringify({
+        "assets/index-xyz.js": { sha256: "e".repeat(64), bytes },
+      }),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/bytes/);
+  });
+
+  // Nothing checked these at build time at all before.
+  it.each([
+    ["escapes the overlay", "/../../etc/passwd"],
+    ["is outside the allowed roots", "/etc/passwd"],
+    ["hides traversal behind encoding", "/assets/..%2f..%2fescape"],
+    ["is malformed encoding", "/assets/a%zz.js"],
+  ])("throws when a manifest value %s", async (_label, target) => {
+    await fs.writeFile(
+      path.join(dir, "asset-manifest.json"),
+      JSON.stringify({ "images/a.png": target }),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/safeManifestTarget/);
+  });
+
+  // The guard must not be so strict it rejects what the real build emits.
+  it("accepts the real build's shapes: a literal space in a key, %20 in a manifest value", async () => {
+    await fs.writeFile(
+      path.join(dir, "asset-hashes.json"),
+      JSON.stringify({
+        "_assets/flags/1_East Anglia.719bac9ef408.svg": {
+          sha256: "f".repeat(64),
+          bytes: 12,
+        },
+      }),
+    );
+    await fs.writeFile(
+      path.join(dir, "asset-manifest.json"),
+      JSON.stringify({
+        "flags/1_East Anglia.svg":
+          "/_assets/flags/1_East%20Anglia.719bac9ef408.svg",
+      }),
+    );
+
+    const d = await buildDescriptor(dir, {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    });
+
+    expect(d.assets["_assets/flags/1_East Anglia.719bac9ef408.svg"].url).toBe(
+      "/_assets/flags/1_East Anglia.719bac9ef408.svg",
+    );
+    expect(d.assetManifest["flags/1_East Anglia.svg"]).toBe(
+      "/_assets/flags/1_East%20Anglia.719bac9ef408.svg",
+    );
+  });
+
+  // The descriptor's `assets` map is keyed by EMITTED PATH; asset-manifest.json
+  // maps SEMANTIC NAME -> hashed url. Deriving one from the other leaves every
+  // _assets/** lookup missing, so the two must both travel.
+  it("carries asset-manifest.json verbatim as the semantic mapping", async () => {
+    const d = await buildDescriptor(dir, {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    });
+
+    expect(d.assetManifest).toEqual({
+      "images/a.png": "/_assets/images/a.deadbeef.png",
+    });
+    // Distinct key-spaces: the semantic name is not an assets key.
+    expect(d.assets["images/a.png"]).toBeUndefined();
+  });
+
+  it("throws rather than serving a descriptor whose asset manifest is empty", async () => {
+    await fs.writeFile(path.join(dir, "asset-manifest.json"), "{}");
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "s",
+        cdnBase: "https://c",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/asset-manifest\.json/);
+  });
+
+  it("names the key when a hash entry is not an object", async () => {
+    // JSON null is typeof "object", so reading .sha256 off it throws a bare
+    // TypeError naming nothing -- losing the key and the reason, which is the
+    // whole point of failing at build time rather than in every client.
+    await fs.writeFile(
+      path.join(dir, "asset-hashes.json"),
+      JSON.stringify({ "assets/index-xyz.js": null }),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "s",
+        cdnBase: "https://c",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/assets\/index-xyz\.js.*is not an object/);
+  });
+
+  it.each([
+    ["asset-hashes.json", "asset-hashes.json"],
+    ["asset-manifest.json", "asset-manifest.json"],
+  ])("rejects %s when it is an array rather than an object", async (file) => {
+    // `as Record<...>` is a cast, not a check. An array survives it, and
+    // Object.entries on one yields index keys that flow into the descriptor as
+    // if they were asset names.
+    await fs.writeFile(
+      path.join(dir, file),
+      JSON.stringify(["/_assets/images/a.deadbeef.png"]),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/must contain a JSON object/);
+  });
+
+  it("throws rather than serving a descriptor with no assets", async () => {
+    await fs.writeFile(path.join(dir, "asset-hashes.json"), "{}");
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "s",
+        cdnBase: "https://c",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/asset-hashes\.json/);
+  });
+
+  it("throws on an empty cdnBase when one is required (production)", async () => {
+    // Without a CDN the descriptor would send every Steam client to the app
+    // server for ~570MB of assets, which risks web players too.
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "",
+        requireCdnBase: true,
+      }),
+    ).rejects.toThrow(/CDN_BASE is unset/);
+  });
+
+  it("names the manifest target when it has no entry in asset-hashes.json", async () => {
+    // A manifest target the download set never lists is fetched by the client
+    // but never downloaded or hash-verified -- it 404s at runtime.
+    const manifest = JSON.parse(
+      await fs.readFile(path.join(dir, "asset-manifest.json"), "utf8"),
+    );
+    manifest["ghost/thing.png"] = "/_assets/ghost/thing.deadbeef.png";
+    await fs.writeFile(
+      path.join(dir, "asset-manifest.json"),
+      JSON.stringify(manifest),
+    );
+
+    await expect(
+      buildDescriptor(dir, {
+        clientVersion: "sha-1",
+        cdnBase: "https://cdn.example",
+        requireCdnBase: false,
+      }),
+    ).rejects.toThrow(/ghost\/thing\.deadbeef\.png/);
+  });
+
+  it("warns but does not throw when cdnBase is empty and not required", async () => {
+    const d = await buildDescriptor(dir, {
+      clientVersion: "sha-1",
+      cdnBase: "",
+      requireCdnBase: false,
+    });
+
+    expect(d.cdnBase).toBe("");
+    expect(Object.keys(d.assets)).toHaveLength(2);
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toMatch(/CDN_BASE/);
+  });
+});
+
+describe("getDescriptor", () => {
+  it("memoises: repeat calls with the same arguments do not rebuild", async () => {
+    const opts = {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    };
+
+    const d1 = await getDescriptor(dir, opts);
+    const d2 = await getDescriptor(dir, opts);
+
+    expect(d2).toBe(d1);
+  });
+
+  it("does not stay poisoned by a rejected build — a later call can retry and succeed", async () => {
+    const hashesPath = path.join(dir, "asset-hashes.json");
+    const goodHashes = await fs.readFile(hashesPath, "utf-8");
+    await fs.rm(hashesPath);
+
+    const opts = {
+      clientVersion: "sha-1",
+      cdnBase: "https://cdn.example",
+      requireCdnBase: false,
+    };
+
+    await expect(getDescriptor(dir, opts)).rejects.toThrow();
+
+    await fs.writeFile(hashesPath, goodHashes);
+
+    const d = await getDescriptor(dir, opts);
+    expect(d.assets["assets/index-xyz.js"]).toEqual({
+      url: "/assets/index-xyz.js",
+      sha256: "e".repeat(64),
+      bytes: 34,
+    });
+  });
+});


### PR DESCRIPTION
Backport of the **server half** of #5061 (`eb9f013b`) onto `v33`, so production serves the desktop release descriptor before v34 ships.

## Why

Without these routes the app server answers `/desktop/version.json` and `/desktop/release.json` with the SPA shell (`200 text/html`). The desktop shell reads that as "this backend serves no descriptor" and reports the client as `current` — so a Steam client is frozen on whatever its depot baseline holds, the runtime asset updater is inert, and nothing anywhere reports a problem.

Confirmed live against production before doing this:

```
GET https://openfront.io/desktop/release.json
HTTP/1.1 200 OK
Content-Type: text/html; charset=utf-8
```

## What's here

Taken by path rather than by cherry-pick, so none of the main-only neighbours in those hunks could ride along.

| File | Note |
|---|---|
| `src/server/DesktopRelease.ts` | verbatim from `eb9f013b` |
| `src/server/Master.ts` | endpoint mounting |
| `scripts/buildAssetHashes.ts` | verbatim |
| `tests/DesktopRelease.test.ts` | verbatim |
| `tests/BuildAssetHashes.test.ts` | verbatim |
| `package.json` | `build-prod` chaining |
| `Dockerfile` | `COPY scripts ./scripts` only |

The four new files are **byte-identical** to `eb9f013b` (blob hashes match); the `Master.ts` and `package.json` added lines diff clean against the source commit.

**The Dockerfile line is mandatory.** `build-prod` now runs the hashing script, and only the container build runs it from a copied tree — omitting it fails the image with `ERR_MODULE_NOT_FOUND`, and no unit test can catch that. `COPY zbin ./zbin` from the original hunk is dropped: zbin doesn't exist on this branch.

Dependencies verified present on `v33`: `ServerEnv.gitCommit()`, `ServerEnv.cdnBase()`, `ServerEnv.env()`, `GameEnv`, `path`, `log`. `DesktopRelease.ts` itself imports only `crypto`/`fs`/`path`/`./Logger`.

## Deliberately excluded — the client half

`DesktopUpdateBar`, `DesktopShell`'s update bridge, `GameModeSelector` gating, `LobbyCard`'s `blocked` option, and their tests.

`main` extracted lobby-card rendering into `components/LobbyCard.ts`, which doesn't exist on `v33`, and `renderSmallActionCard` has nine call sites here against main's eight. That's hand-reworked UI on a release branch for a progress indicator — not a trade worth making in a hotfix. It arrives normally with v34.

**Consequence:** v33 desktop clients download updates with no progress bar and no multiplayer gating. Neither is a regression — today they receive no updates on prod at all, so there is nothing to show and nothing to gate.

## Testing

- `tsc --noEmit` clean
- The 41 backported tests pass
- `npm run build-prod` clean, emitting `asset-hashes.json` (1886 files) and `core-version.txt`
- `getDescriptor` over that build returns a valid descriptor — **1886 assets, 580.2 MB, both key-spaces populated**, schemaVersion 1, template hashed

Opened primarily to exercise the deployment.

Note on `prettier --check`: it fails identically on untouched `v33` files in a Windows checkout, because the repo stores CRLF. These files are at baseline parity — `prettier --write` was deliberately not run, since it would rewrite every line ending and produce a huge false diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F3BJYJyYb6co8naiE3ENXG