### PR TITLE
Show spectator-specific spawn message during spawn phase 👁️

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -813,11 +813,13 @@
   "heads_up_message": {
     "catching_up": "Catching up...",
     "choose_spawn": "Choose a starting location",
+    "choose_spawn_spectator": "Players are choosing starting locations",
     "dont_show_again": "Don't show again",
     "ffa_collusion": "Reminder: teaming up before the game is not allowed in FFA",
     "multiplayer_game_paused": "Game paused by Lobby Creator",
     "pvp_immunity_active": "PVP immunity active for {seconds}s",
     "random_spawn": "Random spawn is enabled. Selecting starting location for you...",
+    "random_spawn_spectator": "Random spawn is enabled",
     "singleplayer_game_paused": "Game paused"
   },
   "help_modal": {

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -613,6 +613,7 @@ async function createClientGame(
     userSettings,
     lobbyConfig.gameRecord !== undefined,
     lobbyConfig.gameStartInfo.listed,
+    lobbyConfig.spectator === true,
   );
   let gameMap: TerrainMapData;
 

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -301,12 +301,13 @@ export class Transport {
     this.eventBus.on(SendToggleGameStartTimer, (e) =>
       this.onSendToggleGameStartTimer(e),
     );
-    this.eventBus.on(SendSpectateEvent, (e) =>
+    this.eventBus.on(SendSpectateEvent, (e) => {
+      this.lobbyConfig.spectator = e.spectator;
       this.sendMsg({
         type: "spectate",
         spectator: e.spectator,
-      } satisfies ClientSpectateMessage),
-    );
+      } satisfies ClientSpectateMessage);
+    });
   }
 
   private startPing() {

--- a/src/client/hud/layers/HeadsUpMessage.ts
+++ b/src/client/hud/layers/HeadsUpMessage.ts
@@ -162,6 +162,14 @@ export class HeadsUpMessage extends LitElement implements Controller {
     if (this.isOvertimeNotice) {
       return translateText("overtime.started");
     }
+    if (
+      this.game.config().isReplay() ||
+      this.game.config().isIntentionalSpectator()
+    ) {
+      return this.game.config().isRandomSpawn()
+        ? translateText("heads_up_message.random_spawn_spectator")
+        : translateText("heads_up_message.choose_spawn_spectator");
+    }
     return this.game.config().isRandomSpawn()
       ? translateText("heads_up_message.random_spawn")
       : translateText("heads_up_message.choose_spawn");
@@ -218,6 +226,7 @@ export class HeadsUpMessage extends LitElement implements Controller {
           : null}
         ${this.game?.inSpawnPhase() &&
         !this.game.config().isReplay() &&
+        !this.game.config().isIntentionalSpectator() &&
         this.game.config().gameConfig().rankedType !== RankedType.OneVOne &&
         this.game.config().gameConfig().gameMode === GameMode.FFA &&
         this.game.config().gameConfig().gameType === GameType.Public &&

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -150,10 +150,16 @@ export class Config {
     private _userSettings: UserSettings | null,
     private _isReplay: boolean,
     public readonly listed: boolean = false,
+    private _spectator: boolean = false,
   ) {}
 
   isReplay(): boolean {
     return this._isReplay;
+  }
+
+  /** True when the player joined the lobby as a spectator (watch-only). */
+  isIntentionalSpectator(): boolean {
+    return this._spectator;
   }
 
   traitorDefenseDebuff(): number {

--- a/tests/ConfigSpectator.test.ts
+++ b/tests/ConfigSpectator.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { Config } from "../src/core/configuration/Config";
+import { GameConfig } from "../src/core/Schemas";
+
+const dummyGameConfig = {} as unknown as GameConfig;
+
+describe("Config.isIntentionalSpectator", () => {
+  it("defaults to false when constructor arg is omitted", () => {
+    const cfg = new Config(dummyGameConfig, null, false);
+    expect(cfg.isIntentionalSpectator()).toBe(false);
+  });
+
+  it("returns false when explicitly set to false", () => {
+    const cfg = new Config(dummyGameConfig, null, false, false, false);
+    expect(cfg.isIntentionalSpectator()).toBe(false);
+  });
+
+  it("returns true when explicitly set to true", () => {
+    const cfg = new Config(dummyGameConfig, null, false, false, true);
+    expect(cfg.isIntentionalSpectator()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Description:

This is confusing if you are a spectator or watching a replay:

<img width="292" height="63" alt="image" src="https://github.com/user-attachments/assets/b62e2bdb-2ce4-4ce6-852b-099fbaeb55b6" />

So lets do this:

<img width="396" height="58" alt="image" src="https://github.com/user-attachments/assets/0f432cd9-c1e3-4ca5-8111-0fdd9607c353" />

I also changed the random spawn message, because it can also be confusing:

<img width="613" height="63" alt="image" src="https://github.com/user-attachments/assets/e30209ed-a3c6-4f11-a1e8-fc285c4e4dfb" />

Changes:
- Added `isIntentionalSpectator()` to `Config` that checks the lobby's spectator flag, distinct from `GameView.isSpectator()` which also returns true for unspawned players.
- `Transport` now updates `lobbyConfig.spectator` when the spectator toggle changes in the lobby UI, so the flag is correct when `Config` is created at game start.
- `HeadsUpMessage` uses `isIntentionalSpectator()` (plus `isReplay()`) to show the spectator-specific messages and to hide the FFA collusion warning from spectators.
- Added two new i18n keys: `choose_spawn_spectator` and `random_spawn_spectator`.


## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin