### PR TITLE
fix(server): add stop mechanism to PollingLoop and use it on worker shutdown (#2921)

### DIFF
--- a/src/server/PollingLoop.ts
+++ b/src/server/PollingLoop.ts
@@ -9,16 +9,31 @@ const log = logger.child({ comp: "polling" });
  *
  * @param task The async function to execute.
  * @param intervalMs The delay in milliseconds before the next execution.
+ * @returns A function that stops the loop. Safe to call more than once. If a
+ *   task is already in flight when called, that task is allowed to finish,
+ *   but no further execution is scheduled.
  */
-export function startPolling(task: () => Promise<void>, intervalMs: number) {
+export function startPolling(
+  task: () => Promise<void>,
+  intervalMs: number,
+): () => void {
+  let stopped = false;
+  let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
   const runLoop = () => {
     task()
       .catch((error) => {
         log.error("Error in polling loop:", error);
       })
       .finally(() => {
-        setTimeout(runLoop, intervalMs);
+        if (stopped) return;
+        timeoutHandle = setTimeout(runLoop, intervalMs);
       });
   };
   runLoop();
+
+  return () => {
+    stopped = true;
+    clearTimeout(timeoutHandle);
+  };
 }

--- a/src/server/PrivilegeRefresher.ts
+++ b/src/server/PrivilegeRefresher.ts
@@ -17,6 +17,7 @@ export class PrivilegeRefresher {
     new FailOpenPrivilegeChecker();
 
   private log: Logger;
+  private stopPolling: (() => void) | null = null;
 
   constructor(
     private cosmeticsEndpoint: string,
@@ -32,7 +33,16 @@ export class PrivilegeRefresher {
     this.log.info(
       `Starting privilege refresher with interval ${this.refreshInterval}`,
     );
-    startPolling(() => this.loadPrivilegeChecker(), this.refreshInterval);
+    this.stopPolling = startPolling(
+      () => this.loadPrivilegeChecker(),
+      this.refreshInterval,
+    );
+  }
+
+  // Stops the refresh loop. Safe to call even if start() was never called.
+  public stop(): void {
+    this.stopPolling?.();
+    this.stopPolling = null;
   }
 
   public get(): PrivilegeChecker {

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -74,9 +74,14 @@ export async function startWorker() {
   // Initialize lobby service (handles WebSocket upgrade routing)
   const lobbyService = new WorkerLobbyService(server, wss, gm, log);
 
+  let stopMatchmakingPolling: (() => void) | undefined;
+  let serverClosed = false;
   setTimeout(
     () => {
-      startMatchmakingPolling(gm);
+      // The server may have already closed during this delay; don't start
+      // a loop that would then never get stopped.
+      if (serverClosed) return;
+      stopMatchmakingPolling = startMatchmakingPolling(gm);
     },
     1000 + Math.random() * 2000,
   );
@@ -92,6 +97,14 @@ export async function startWorker() {
     log,
   );
   privilegeRefresher.start();
+
+  // Both loops otherwise poll forever: stop them when the HTTP server shuts
+  // down instead of leaking timers past the point the worker is destroyed.
+  server.on("close", () => {
+    serverClosed = true;
+    stopMatchmakingPolling?.();
+    privilegeRefresher.stop();
+  });
 
   // Middleware to handle /wX path prefix
   app.use((req, res, next) => {
@@ -746,11 +759,16 @@ export async function startWorker() {
   });
 }
 
-async function startMatchmakingPolling(gm: GameManager) {
+// Returns a handle that stops both matchmaking polling loops.
+function startMatchmakingPolling(gm: GameManager): () => void {
   // One checkin serves exactly one queue, so a host serving both modes
   // runs one long-poll loop per mode.
-  startMatchmakingLoop(gm, "1v1");
-  startMatchmakingLoop(gm, "2v2");
+  const stop1v1 = startMatchmakingLoop(gm, "1v1");
+  const stop2v2 = startMatchmakingLoop(gm, "2v2");
+  return () => {
+    stop1v1();
+    stop2v2();
+  };
 }
 
 const MatchmakingAssignmentSchema = z.object({
@@ -761,8 +779,11 @@ const MatchmakingAssignmentSchema = z.object({
   teams: z.array(z.array(z.string())).optional(),
 });
 
-function startMatchmakingLoop(gm: GameManager, mode: "1v1" | "2v2") {
-  startPolling(
+function startMatchmakingLoop(
+  gm: GameManager,
+  mode: "1v1" | "2v2",
+): () => void {
+  return startPolling(
     async () => {
       try {
         const url = `${ServerEnv.jwtIssuer() + "/matchmaking/checkin"}`;

--- a/tests/server/PollingLoop.test.ts
+++ b/tests/server/PollingLoop.test.ts
@@ -74,4 +74,64 @@ describe("PollingLoop", () => {
     // Second call
     expect(taskCallCount).toBe(2);
   });
+
+  it("should stop scheduling future executions once stopped", async () => {
+    let taskCallCount = 0;
+    const task = vi.fn().mockImplementation(async () => {
+      taskCallCount++;
+    });
+
+    const stop = startPolling(task, 100);
+
+    // Initial call
+    expect(taskCallCount).toBe(1);
+    await new Promise(process.nextTick);
+
+    stop();
+
+    // Even after many intervals, no further calls should be scheduled.
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(taskCallCount).toBe(1);
+  });
+
+  it("should let an in-flight task finish but not schedule another run", async () => {
+    let taskCallCount = 0;
+    let resolveTask: ((value?: void) => void) | undefined;
+
+    const task = vi.fn().mockImplementation(() => {
+      taskCallCount++;
+      return new Promise<void>((resolve) => {
+        resolveTask = resolve;
+      });
+    });
+
+    const stop = startPolling(task, 100);
+    expect(taskCallCount).toBe(1);
+
+    // Stop while the first task is still in flight.
+    stop();
+
+    // Let the in-flight task complete - this must not throw and must not
+    // schedule a follow-up run.
+    resolveTask?.();
+    await new Promise(process.nextTick);
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(taskCallCount).toBe(1);
+  });
+
+  it("should be safe to call stop multiple times", async () => {
+    const task = vi.fn().mockResolvedValue(undefined);
+
+    const stop = startPolling(task, 100);
+    await new Promise(process.nextTick);
+
+    expect(() => {
+      stop();
+      stop();
+    }).not.toThrow();
+
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(task).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #2921

## Description:

`startPolling` kicked off a recursive `setTimeout` loop with no way to cancel it, so long-lived loops like the privilege refresher and the matchmaking checkins (1v1/2v2) kept polling forever even after the thing that started them was logically done — exactly the symptom described in #2921.

`startPolling` now returns a `stop()` handle:
- Calling it prevents any future run from being scheduled.
- A task that's already in flight is allowed to finish; it just won't schedule a follow-up run afterward.
- Safe to call more than once.

That handle is wired up in the two places the issue calls out:
- `PrivilegeRefresher` now exposes a `stop()` method backed by the handle.
- In `Worker.ts`, both matchmaking polling loops (1v1 and 2v2) and the privilege refresher are now stopped from the HTTP server's existing `close` event handler — the same pattern already used there for `telemetry.stop()` — instead of leaking timers past worker shutdown. The matchmaking loop's own startup is staggered by a random 1-3s delay, so a `serverClosed` flag guards the case where `close` fires during that window, before the loop has even started.

`MasterLobbyService`'s two `startPolling` call sites are intentionally left untouched: they simply ignore the new return value, so nothing there changes behaviorally. I kept this PR scoped to the two call sites the issue explicitly names rather than inventing a shutdown path for the master process where none currently exists.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Server-side background worker cleanup)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — No user-facing text)
- [x] I have added relevant tests to the test directory (`tests/server/PollingLoop.test.ts`: covers `stop()` while idle, `stop()` while a task is in flight, and idempotent double `stop()`)
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
