### PR TITLE
feat(client): show queue position on detailed view lobby cards

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -504,6 +504,7 @@
     "per_team": "Players per team",
     "profile_name": "Profile name",
     "profiles": "Profiles",
+    "queue_position": "Queue: {position}",
     "queued": "Up next",
     "reset": "Reset",
     "save_profile": "Save",

--- a/src/client/components/DetailedGameViewFilters.ts
+++ b/src/client/components/DetailedGameViewFilters.ts
@@ -215,6 +215,33 @@ export function filterAndSortLobbies(
     .sort(compare);
 }
 
+/**
+ * How far back each waiting lobby sits in its bucket's queue, 1-based, where 1
+ * is the lobby directly behind the one counting down. The counting-down lobby
+ * itself isn't in the map — it shows its countdown instead — and neither are
+ * hosted lobbies, which aren't queued at all. Positions come from the
+ * *unfiltered* list so hiding a lobby with a filter doesn't renumber the ones
+ * still shown, and are counted per bucket, since each bucket has its own queue.
+ */
+export function queuePositions(lobbies: PublicGameInfo[]): Map<string, number> {
+  const positions = new Map<string, number>();
+  const buckets = new Map<string, PublicGameInfo[]>();
+  for (const lobby of lobbies) {
+    const type = lobby.publicGameType;
+    if (type === undefined || type === "hosted") continue;
+    if (lobby.startsAt !== undefined) continue;
+    const bucket = buckets.get(type);
+    if (bucket === undefined) buckets.set(type, [lobby]);
+    else bucket.push(lobby);
+  }
+  for (const bucket of buckets.values()) {
+    // Already in the server's queue order; compare() would treat them all as
+    // ties anyway, so no sort is needed here.
+    bucket.forEach((lobby, index) => positions.set(lobby.gameID, index + 1));
+  }
+  return positions;
+}
+
 // ---- Saved filter profiles ----
 
 export const FILTER_PROFILES_KEY = "detailed-view-filter-profiles";

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -32,6 +32,7 @@ import {
   LobbySourceFilter,
   NAMED_TEAM_CONFIGS,
   NUMERIC_TEAM_CONFIGS,
+  queuePositions,
   saveFilterProfile,
 } from "./DetailedGameViewFilters";
 import { lobbyCard, mapAspectRatios } from "./LobbyCard";
@@ -103,6 +104,8 @@ export class DetailedGameViewModal extends BaseModal {
 
   private serverTimeOffset = 0;
   private countdownTimer: number | null = null;
+  /** Queue position per lobby, recomputed from the unfiltered list each render. */
+  private queuePositions = new Map<string, number>();
 
   private lobbySocket = new PublicLobbySocket((lobbies) => {
     this.lobbies = lobbies;
@@ -242,6 +245,7 @@ export class DetailedGameViewModal extends BaseModal {
 
     const all = flattenLobbies(this.lobbies.games);
     const shown = filterAndSortLobbies(all, this.filters);
+    this.queuePositions = queuePositions(all);
     const ofType = (lobbies: PublicGameInfo[], type: string) =>
       lobbies.filter((lobby) => lobby.publicGameType === type);
 
@@ -402,11 +406,17 @@ export class DetailedGameViewModal extends BaseModal {
   private timeDisplay(lobby: PublicGameInfo): string {
     if (lobby.startsAt === undefined) {
       // Scheduled lobbies only get a countdown once they're the active one for
-      // their bucket; the one queued behind it is simply next up. Hosted
-      // lobbies never get one — they start when the host says so.
-      return lobby.publicGameType === "hosted"
-        ? translateText("public_lobby.waiting_for_players")
-        : translateText("detailed_view.queued");
+      // their bucket; the ones behind it show where they sit in the queue.
+      // Hosted lobbies never get one — they start when the host says so.
+      if (lobby.publicGameType === "hosted") {
+        return translateText("public_lobby.waiting_for_players");
+      }
+      // The lobby directly behind the countdown is simply next up; the ones
+      // behind it say how far back they are.
+      const position = this.queuePositions.get(lobby.gameID);
+      return position === undefined || position === 1
+        ? translateText("detailed_view.queued")
+        : translateText("detailed_view.queue_position", { position });
     }
     const seconds = getSecondsUntilServerTimestamp(
       lobby.startsAt,

--- a/tests/client/DetailedGameViewFilters.test.ts
+++ b/tests/client/DetailedGameViewFilters.test.ts
@@ -11,6 +11,7 @@ import {
   LobbyFilters,
   MAX_FILTER_PROFILES,
   normalizeFilters,
+  queuePositions,
   saveFilterProfile,
 } from "../../src/client/components/DetailedGameViewFilters";
 import {
@@ -233,6 +234,44 @@ describe("filterAndSortLobbies", () => {
         (l) => l.gameID,
       ),
     ).toEqual(["team1"]);
+  });
+});
+
+describe("queuePositions", () => {
+  it("numbers each bucket's waiting lobbies from the front of its queue", () => {
+    const positions = queuePositions([
+      lobby({ gameID: "ffa-live", startsAt: 100 }),
+      lobby({ gameID: "ffa-1" }),
+      lobby({ gameID: "ffa-2" }),
+      lobby({ gameID: "team-live", publicGameType: "team", startsAt: 50 }),
+      lobby({ gameID: "team-1", publicGameType: "team" }),
+    ]);
+    expect(positions.get("ffa-1")).toBe(1);
+    expect(positions.get("ffa-2")).toBe(2);
+    // Each bucket queues separately, so team starts from 1 again.
+    expect(positions.get("team-1")).toBe(1);
+  });
+
+  it("leaves out the lobby counting down and hosted lobbies", () => {
+    const positions = queuePositions([
+      lobby({ gameID: "ffa-live", startsAt: 100 }),
+      lobby({ gameID: "hosted1", publicGameType: "hosted" }),
+      lobby({ gameID: "ffa-1" }),
+    ]);
+    expect(positions.has("ffa-live")).toBe(false);
+    expect(positions.has("hosted1")).toBe(false);
+    expect(positions.get("ffa-1")).toBe(1);
+  });
+
+  it("keeps the server's queue order rather than re-deriving one", () => {
+    const positions = queuePositions(
+      ["zulu", "alpha", "mike"].map((gameID) => lobby({ gameID })),
+    );
+    expect([...positions]).toEqual([
+      ["zulu", 1],
+      ["alpha", 2],
+      ["mike", 3],
+    ]);
   });
 });
 


### PR DESCRIPTION
## What

Scheduled lobbies waiting behind the one counting down all showed the same "Up next" in the Detailed View, so a pane of six gave no sense of how far back a lobby actually was.

The lobby directly behind the countdown keeps **Up next**; the ones behind it now show **Queue: 2**, **Queue: 3**, and so on — same rough width as the old label, so card layout is unchanged.

## How

- New `queuePositions()` in `DetailedGameViewFilters.ts`: 1-based index per bucket over the lobbies with no countdown.
  - Derived from the **unfiltered** lobby list, so hiding a lobby with a filter doesn't renumber the ones still shown.
  - Counted **per bucket**, since FFA / Team / Special each have their own queue.
  - The counting-down lobby (it shows its countdown) and hosted lobbies (not queued — they start when the host says so) are left out.
  - Uses the server's queue order as sent; no client-side re-derivation.
- `DetailedGameViewModal.timeDisplay()` renders position 1 as the existing `detailed_view.queued` string and the rest via the new `detailed_view.queue_position` key.

## i18n

Adds `detailed_view.queue_position` = `"Queue: {position}"` to `resources/lang/en.json` only; other locales are Crowdin-managed.

## Testing

- 3 new unit tests in `tests/client/DetailedGameViewFilters.test.ts` (per-bucket numbering, exclusion of counting-down/hosted lobbies, queue-order preservation).
- `npx vitest tests/client/DetailedGameViewFilters.test.ts --run` — 29 passed.
- `npx tsc --noEmit`, `npm run lint`, Prettier — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)