### PR TITLE
fix(homepage): stop the lobby cards drawing a rim, and let the pills breathe

### DIFF
--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -168,9 +168,9 @@ export function lobbyCard({
     lobby.gameConfig?.publicGameModifiers,
     lobby.gameConfig?.doomsdayClock?.speed,
   );
-  // Sort by length for visual consistency (shorter labels first)
+  // Longest first: on a short card the pills that say the most stay legible.
   if (modifierLabels.length > 1) {
-    modifierLabels.sort((a, b) => a.length - b.length);
+    modifierLabels.sort((a, b) => b.length - a.length);
   }
 
   const trustedOnly = lobby.gameConfig?.trusted === true;
@@ -180,16 +180,15 @@ export function lobbyCard({
       @click=${onClick}
       ?disabled=${disabled}
       aria-disabled=${blocked}
-      class="group relative w-full ${heightClass} text-white uppercase rounded-2xl transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] bg-surface hover:shadow-[var(--shadow-lobby-card-hover)] ${disabled
+      class="group relative w-full ${heightClass} text-white uppercase rounded-2xl overflow-hidden transition-all duration-200 hover:scale-[1.02] active:scale-[0.98] bg-surface hover:shadow-[var(--shadow-lobby-card-hover)] ${disabled
         ? "opacity-50 cursor-not-allowed pointer-events-none"
         : blocked
           ? "opacity-50 cursor-not-allowed"
           : ""}"
     >
-      <!-- Image clipped separately so overflow-hidden doesn't block absolute children -->
-      <div
-        class="absolute inset-0 rounded-2xl overflow-hidden pointer-events-none"
-      >
+      <!-- The card is the only rounded, clipping box: a radius on this layer
+           and on the name bar too drew a rim along the corners. -->
+      <div class="absolute inset-0 pointer-events-none">
         ${mapImageSrc
           ? html`<img
               src="${mapImageSrc}"
@@ -206,9 +205,7 @@ export function lobbyCard({
         class="absolute inset-x-2 top-2 flex items-start justify-between gap-2"
       >
         ${modifierLabels.length > 0
-          ? html`<div
-              class="flex flex-col items-start gap-1 mt-[2px] min-w-0 max-w-[65%]"
-            >
+          ? html`<div class="flex flex-col items-start gap-1 mt-[2px] min-w-0">
               ${modifierLabels.map(
                 (label) =>
                   html`<span
@@ -229,7 +226,7 @@ export function lobbyCard({
       </div>
       <!-- Bottom bar: map name + mode, with player count floating above -->
       <div
-        class="absolute bottom-0 left-0 right-0 flex flex-col px-3 py-2 bg-black/55 backdrop-blur-sm rounded-b-2xl ${trustedOnly
+        class="absolute bottom-0 left-0 right-0 flex flex-col px-3 py-2 bg-black/55 backdrop-blur-sm ${trustedOnly
           ? "pr-10"
           : ""}"
         style="overflow: visible;"

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -67,6 +67,16 @@ export function trustRequiredDialog(
  */
 
 /**
+ * The blue pills on a card's top row: the modifier labels on the left and the
+ * countdown on the right. One class string so the two can't drift apart.
+ * `inline-block` is load-bearing -- an inline span paints its background over
+ * the font's content area rather than the line box, which makes the pill 4px
+ * shorter than a blockified one and changes height when the font swaps in.
+ */
+const CARD_PILL_CLASS =
+  "inline-block px-2 py-1 rounded text-xs font-bold tracking-widest bg-malibu-blue text-white";
+
+/**
  * Aspect ratios keyed by map, loaded lazily from each map's manifest. Shared
  * so the second component to render a map doesn't refetch it.
  */
@@ -205,11 +215,10 @@ export function lobbyCard({
         class="absolute inset-x-2 top-2 flex items-start justify-between gap-2"
       >
         ${modifierLabels.length > 0
-          ? html`<div class="flex flex-col items-start gap-1 mt-[2px] min-w-0">
+          ? html`<div class="flex flex-col items-start gap-1 min-w-0">
               ${modifierLabels.map(
                 (label) =>
-                  html`<span
-                    class="px-2 py-1 rounded text-xs font-bold uppercase tracking-widest bg-malibu-blue text-white shadow-[var(--shadow-malibu-blue-pill)]"
+                  html`<span class="${CARD_PILL_CLASS} uppercase"
                     >${label}</span
                   >`,
               )}
@@ -217,9 +226,9 @@ export function lobbyCard({
           : html`<div></div>`}
         <div class="shrink-0">
           <span
-            class="text-xs font-bold tracking-widest ${timeDisplayUppercase
+            class="${CARD_PILL_CLASS} ${timeDisplayUppercase
               ? "uppercase"
-              : "normal-case"} bg-malibu-blue text-white px-2 py-1 rounded"
+              : "normal-case"}"
             >${timeDisplay}</span
           >
         </div>

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -72,6 +72,9 @@ export function trustRequiredDialog(
  * `inline-block` is load-bearing -- an inline span paints its background over
  * the font's content area rather than the line box, which makes the pill 4px
  * shorter than a blockified one and changes height when the font swaps in.
+ * Both pills must also be direct children of the top row's flex container:
+ * wrapped in a block, a pill sits on a line box instead and the strut of the
+ * card's larger inherited font pushes it a couple of pixels down.
  */
 const CARD_PILL_CLASS =
   "inline-block px-2 py-1 rounded text-xs font-bold tracking-widest bg-malibu-blue text-white";
@@ -224,14 +227,12 @@ export function lobbyCard({
               )}
             </div>`
           : html`<div></div>`}
-        <div class="shrink-0">
-          <span
-            class="${CARD_PILL_CLASS} ${timeDisplayUppercase
-              ? "uppercase"
-              : "normal-case"}"
-            >${timeDisplay}</span
-          >
-        </div>
+        <span
+          class="${CARD_PILL_CLASS} shrink-0 ${timeDisplayUppercase
+            ? "uppercase"
+            : "normal-case"}"
+          >${timeDisplay}</span
+        >
       </div>
       <!-- Bottom bar: map name + mode, with player count floating above -->
       <div

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -67,14 +67,9 @@ export function trustRequiredDialog(
  */
 
 /**
- * The blue pills on a card's top row: the modifier labels on the left and the
- * countdown on the right. One class string so the two can't drift apart.
- * `inline-block` is load-bearing -- an inline span paints its background over
- * the font's content area rather than the line box, which makes the pill 4px
- * shorter than a blockified one and changes height when the font swaps in.
- * Both pills must also be direct children of the top row's flex container:
- * wrapped in a block, a pill sits on a line box instead and the strut of the
- * card's larger inherited font pushes it a couple of pixels down.
+ * One class for both of the top row's pills so they can't drift apart. Keep
+ * them direct flex children of the row: wrapped in a block, a pill picks up a
+ * line box and renders 4px short and 2px low.
  */
 const CARD_PILL_CLASS =
   "inline-block px-2 py-1 rounded text-xs font-bold tracking-widest bg-malibu-blue text-white";


### PR DESCRIPTION
Two cosmetic fixes to the homepage lobby cards. One file, one commit — `main`'s layout, card selection and ordering are untouched.

**The cards drew a rim along their corners.** Three nested radii — the card button, the image wrapper inside it, and the name bar at its foot — plus the bar's `backdrop-filter` left a bright 1–2px line tracing each corner. The card is now the only rounded, clipping box: the image layer and the name bar are flat and get clipped by it. Found by pixel measurement at DPR 1–8 rather than by eye.

**Modifier pills lose their `max-w-[65%]` cap and sort longest first,** so on a small card the labels that say the most are the ones that stay legible, and a long label uses the width the card actually has.

## History

This PR previously carried a much larger homepage redesign plus a server-side promotion rotation. Both are out: the ordering work only existed to give the redesign a single ordered queue to render, and with `main`'s per-bucket cards (FFA as the main card, team and special beside it) there is nothing for it to do. Nothing was deleted — if any of it is wanted later it is on these branches:

- [`homepage-ui`](https://github.com/openfrontio/OpenFrontIO/tree/homepage-ui) — the full play-surface redesign: hero card, `UPCOMING` column, full-width `SOLO` row, `PlayPage` grid changes.
- [`homepage-rotation`](https://github.com/openfrontio/OpenFrontIO/tree/homepage-rotation) — the master's promotion rotation and `PublicGameInfo.queuePosition`, stacked on the above.
- [`t3code/a0aa255a`](https://github.com/openfrontio/OpenFrontIO/tree/t3code/a0aa255a) — a smaller take on the buttons: full-width `SOLO` with `CREATE` / `RANKED` / `JOIN` underneath, and a per-card expand control replacing the `DETAILED VIEW` button.

## Testing

`npm test` — 339 files / 4026 tests, plus 57 / 588 on the server pass, exit 0. `tsc`, `oxlint`, `eslint` and Prettier clean.

The rim itself was measured in a real browser when it was first found. This diff has not had a fresh browser pass: the machine it was written on is arm64 and the pinned headless Chromium is x86-64, so the harness won't run there. Worth a glance at a card's corners and at a card carrying two or three modifier pills before merging.
