### PR TITLE
Fix: Station disconnect from long clusters or during cluster merges

### DIFF
--- a/src/core/game/TrainStation.ts
+++ b/src/core/game/TrainStation.ts
@@ -136,7 +136,7 @@ export class TrainStation {
 
   setCluster(cluster: Cluster | null) {
     // Properly disconnect cluster if it's already set
-    if (this.cluster !== null) {
+    if (this.cluster !== null && this.cluster !== cluster) {
       this.cluster.removeStation(this);
     }
     this.cluster = cluster;

--- a/tests/core/game/Cluster.test.ts
+++ b/tests/core/game/Cluster.test.ts
@@ -1,67 +1,71 @@
-import { vi, type Mocked } from "vitest";
 import { UnitType } from "../../../src/core/game/Game";
 import { Cluster, TrainStation } from "../../../src/core/game/TrainStation";
 
-const createMockStation = (id: string): Mocked<TrainStation> => {
-  return {
-    id,
-    unit: {
-      type: vi.fn(() => UnitType.City),
+const createStation = (id: number = 1): TrainStation => {
+  const station = new TrainStation(
+    { ticks: () => 0 } as any,
+    {
+      type: () => UnitType.City,
+      owner: () => ({ canTrade: () => true }),
     } as any,
-    setCluster: vi.fn(),
-    getCluster: vi.fn(() => null),
-  } as any;
+  );
+  station.id = id;
+  return station;
 };
 
 describe("Cluster tests", () => {
   let cluster: Cluster;
-  let stationA: Mocked<TrainStation>;
-  let stationB: Mocked<TrainStation>;
-  let stationC: Mocked<TrainStation>;
+  let stationA: TrainStation;
+  let stationB: TrainStation;
+  let stationC: TrainStation;
 
   beforeEach(() => {
     cluster = new Cluster();
-    stationA = createMockStation("A");
-    stationB = createMockStation("B");
-    stationC = createMockStation("C");
+    stationA = createStation(1);
+    stationB = createStation(2);
+    stationC = createStation(3);
   });
 
-  test("addStation adds a station and sets cluster", () => {
+  test("addStation adds station and sets cluster bidirectionally", () => {
     cluster.addStation(stationA);
-
     expect(cluster.has(stationA)).toBe(true);
-    expect(stationA.setCluster).toHaveBeenCalledWith(cluster);
+    expect(stationA.getCluster()).toBe(cluster);
+  });
+
+  test("duplicate addStation is idempotent and preserves trade destination", () => {
+    cluster.addStation(stationA);
+    cluster.addStation(stationA);
+    expect(cluster.has(stationA)).toBe(true);
+    expect(stationA.getCluster()).toBe(cluster);
+    expect(
+      cluster.hasAnyTradeDestination({ canTrade: () => true } as any),
+    ).toBe(true);
   });
 
   test("removeStation removes station from cluster", () => {
     cluster.addStation(stationA);
     cluster.removeStation(stationA);
-
     expect(cluster.has(stationA)).toBe(false);
   });
 
   test("addStations adds multiple stations and sets cluster", () => {
-    const set = new Set([stationA, stationB]);
-
-    cluster.addStations(set);
-
+    cluster.addStations(new Set([stationA, stationB]));
     expect(cluster.has(stationA)).toBe(true);
     expect(cluster.has(stationB)).toBe(true);
-    expect(stationA.setCluster).toHaveBeenCalledWith(cluster);
-    expect(stationB.setCluster).toHaveBeenCalledWith(cluster);
+    expect(stationA.getCluster()).toBe(cluster);
+    expect(stationB.getCluster()).toBe(cluster);
   });
 
-  test("merge combines stations from another cluster", () => {
+  test("merge combines stations from another cluster and migrates clusters", () => {
     const otherCluster = new Cluster();
     otherCluster.addStation(stationB);
     otherCluster.addStation(stationC);
-
     cluster.addStation(stationA);
     cluster.merge(otherCluster);
-
     expect(cluster.has(stationA)).toBe(true);
     expect(cluster.has(stationB)).toBe(true);
     expect(cluster.has(stationC)).toBe(true);
+    expect(stationB.getCluster()).toBe(cluster);
   });
 
   test("has returns false for non-member stations", () => {


### PR DESCRIPTION

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

None - small fix, big issue.

## Description:

On the main Discord many bug reports started coming in about factories not producing trains. This took me a good while to investigate because the tests did seem to test connecting. [Thread with 9 reports](https://discord.com/channels/1284581928254701718/1530715070063972433) [Report 2 months ago](https://discord.com/channels/1284581928254701718/1520149582988710110)

### Bug origin
- Introduced in PR #3185, Feb 13th
- Added cluster disconnection logic to [TrainStation.setCluster](src/core/game/TrainStation.ts#L137-L143)
- Unconditionally called removeStation without checking if the station was already in the target cluster.

### Mechanisms and triggers
- [Cluster.addStation](src/core/game/TrainStation.ts#L174-L180) registers the station and invokes [TrainStation.setCluster](src/core/game/TrainStation.ts#L137-L143).
- Calling addStation on a registered station caused setCluster to delete it from stations.
- Empty tradeStations prevented factories from finding valid destinations, permanently stopping train production.
- Small clusters avoided the bug -- a 4-hop distance check suppressed duplicate neighbor connections.
- Snapping at rail junctions triggered the bug by processing multiple rail segments.
- Branching tracks or factories that closed loops longer than 4 hops triggered duplicate connection calls.
- Connecting networks across player borders forced cluster merges triggering the bug
- June 2026 updates expanded range to 110 tiles and track length to 155 tiles, causing long-loop connections to form more frequently.

### Over-mocking in tests
- [tests/core/game/RailNetwork.test.ts](tests/core/game/RailNetwork.test.ts) and [tests/core/game/Cluster.test.ts](tests/core/game/Cluster.test.ts) replaced setCluster with dummy vi.fn().
- Tests only checked that setCluster was called, did not check cluster state.
- TrainStation and Cluster instances were never executed together during connection tests.

### Fixes/prevention
- [TrainStation.setCluster](src/core/game/TrainStation.ts#L137-L143) now checks that this.cluster != new cluster
- Duplicate addStation calls now retain all trade stations.
- [tests/core/game/Cluster.test.ts](tests/core/game/Cluster.test.ts) updated to use TrainStation instances and directly test duplicate addStation.


## Please complete the following:

- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
