### PR TITLE
feat(lobby): run overtime as a modifier on 1/4 of public FFA games

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1500,6 +1500,7 @@
     "hard_nations": "Hard Nations",
     "nukes_disabled": "Nukes Disabled",
     "nukes_disabled_label": "Nukes",
+    "overtime": "Overtime",
     "peace_time": "4min Peace",
     "peace_time_label": "PVP Immunity",
     "ports_disabled": "Ports Disabled",

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -241,6 +241,12 @@ export function getActiveModifiers(
     }
     result.push(info);
   }
+  if (modifiers.isOvertime) {
+    result.push({
+      labelKey: "overtime.title",
+      badgeKey: "public_game_modifier.overtime",
+    });
+  }
   return result;
 }
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -422,6 +422,7 @@ export const GameConfigSchema = z.object({
       isPeaceTime: z.boolean().optional(),
       isWaterNukes: z.boolean().optional(),
       isDoomsdayClock: z.boolean().optional(),
+      isOvertime: z.boolean().optional(),
     })
     .optional(),
   nations: zb.union(

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -165,6 +165,7 @@ export interface PublicGameModifiers {
   isPeaceTime?: boolean;
   isWaterNukes?: boolean;
   isDoomsdayClock?: boolean;
+  isOvertime?: boolean;
 }
 
 // Largest bulk-purchase amount an intent may carry (mirrored by the intent

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -33,6 +33,9 @@ const SPECIAL_ONLY_MAPS = new Set<GameMapType>([
 // Hard cap on player count for performance. Applied after compact-map reduction.
 const MAX_PLAYER_COUNT = 125;
 
+// Share of public FFA games that run with overtime enabled.
+const OVERTIME_FFA_CHANCE = 0.25;
+
 const TEAM_WEIGHTS: { config: TeamCountConfig; weight: number }[] = [
   { config: 2, weight: 10 },
   { config: 3, weight: 10 },
@@ -151,6 +154,11 @@ export class MapPlaylist {
 
     let isCompact: boolean | undefined =
       this.playlists[type].length % 3 === 0 || undefined;
+    // Overtime (the win threshold sinking after 30 minutes) runs as a
+    // modifier on a quarter of public FFA games.
+    const isOvertime: boolean | undefined =
+      (mode === GameMode.FFA && Math.random() < OVERTIME_FFA_CHANCE) ||
+      undefined;
     if (
       isCompact &&
       mode === GameMode.Team &&
@@ -178,6 +186,7 @@ export class MapPlaylist {
       gameMapSize: isCompact ? GameMapSize.Compact : GameMapSize.Normal,
       publicGameModifiers: {
         isCompact,
+        isOvertime,
       },
       difficulty:
         playerTeams === HumansVsNations ? Difficulty.Hard : Difficulty.Medium,
@@ -196,9 +205,7 @@ export class MapPlaylist {
       spawnImmunityDuration: this.getSpawnImmunityDuration(playerTeams),
       disabledUnits: [],
       disableClanTags: mode === GameMode.FFA ? true : undefined,
-      // Public lobbies are untimed, so overtime (the win threshold sinking
-      // after 30 minutes) is on by default as the anti-stalemate backstop.
-      overtime: { enabled: true },
+      overtime: isOvertime ? { enabled: true } : undefined,
     } satisfies GameConfig;
   }
 
@@ -417,9 +424,6 @@ export class MapPlaylist {
       disabledUnits,
       waterNukes: isWaterNukes ? true : undefined,
       disableClanTags: mode === GameMode.FFA ? true : undefined,
-      // Untimed like the standard rotation: overtime on by default (the
-      // doomsday-clock presets keep it too — it's a harmless backstop there).
-      overtime: { enabled: true },
     } satisfies GameConfig;
   }
 

--- a/tests/client/OvertimeModifierBadge.test.ts
+++ b/tests/client/OvertimeModifierBadge.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { getActiveModifiers } from "../../src/client/Utils";
+
+// Overtime runs as a public FFA modifier, so an active isOvertime modifier
+// must surface a lobby badge like every other rotation modifier.
+describe("overtime public modifier", () => {
+  it("surfaces an overtime badge when the modifier is active", () => {
+    const mods = getActiveModifiers({ isOvertime: true });
+    expect(mods).toHaveLength(1);
+    expect(mods[0].badgeKey).toBe("public_game_modifier.overtime");
+    expect(mods[0].labelKey).toBe("overtime.title");
+  });
+
+  it("omits the badge when the modifier is absent", () => {
+    expect(getActiveModifiers({})).toHaveLength(0);
+    expect(getActiveModifiers({ isOvertime: false })).toHaveLength(0);
+  });
+});

--- a/tests/server/MapPlaylistOvertime.test.ts
+++ b/tests/server/MapPlaylistOvertime.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GameMode } from "../../src/core/game/Game";
+import { GameConfigSchema } from "../../src/core/Schemas";
+import { MapPlaylist } from "../../src/server/MapPlaylist";
+
+vi.mock("../../src/server/MapLandTiles", () => ({
+  getMapLandTiles: async () => 1_000_000,
+}));
+
+// Overtime is a modifier on a quarter of public FFA games: it should follow
+// the roll in FFA, and never appear in team or special lobbies.
+describe("MapPlaylist overtime", () => {
+  let randomSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    randomSpy = vi.spyOn(Math, "random");
+  });
+
+  afterEach(() => {
+    randomSpy.mockRestore();
+  });
+
+  it("enables overtime and its lobby modifier on a low FFA roll", async () => {
+    randomSpy.mockReturnValue(0.1);
+    const config = await new MapPlaylist().gameConfig("ffa");
+    expect(config.gameMode).toBe(GameMode.FFA);
+    expect(config.overtime).toEqual({ enabled: true });
+    expect(config.publicGameModifiers?.isOvertime).toBe(true);
+    expect(GameConfigSchema.safeParse(config).success).toBe(true);
+  });
+
+  it("leaves overtime off on a high FFA roll", async () => {
+    randomSpy.mockReturnValue(0.9);
+    const config = await new MapPlaylist().gameConfig("ffa");
+    expect(config.overtime).toBeUndefined();
+    expect(config.publicGameModifiers?.isOvertime).toBeUndefined();
+  });
+
+  it("never enables overtime in team lobbies", async () => {
+    randomSpy.mockReturnValue(0.1);
+    const config = await new MapPlaylist().gameConfig("team");
+    expect(config.gameMode).toBe(GameMode.Team);
+    expect(config.overtime).toBeUndefined();
+    expect(config.publicGameModifiers?.isOvertime).toBeUndefined();
+  });
+
+  it("never enables overtime in special lobbies", async () => {
+    randomSpy.mockReturnValue(0.1);
+    const config = await new MapPlaylist().gameConfig("special");
+    expect(config.overtime).toBeUndefined();
+    expect(config.publicGameModifiers?.isOvertime).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

#5062 enabled overtime on **every** public lobby (FFA, team, and special). This narrows it to a 25% roll on public FFA games only, and surfaces it as a public game modifier so the lobby card shows an **Overtime** badge like the other rotation modifiers.

## Changes

- **`src/server/MapPlaylist.ts`** — new `OVERTIME_FFA_CHANCE = 0.25`. `gameConfig()` rolls it for FFA only; a hit sets `overtime: { enabled: true }` and `publicGameModifiers.isOvertime: true`. Team lobbies never roll it; the unconditional overtime was removed from `getSpecialConfig()`.
- **`src/core/game/Game.ts`** / **`src/core/Schemas.ts`** — optional `isOvertime` on `PublicGameModifiers` (interface + Zod schema). Same path `isDoomsdayClock` took; client and server ship as one build so the zbin wire layout change is safe.
- **`src/client/Utils.ts`** — `getActiveModifiers()` emits an overtime badge, so `LobbyCard` picks it up automatically. The join-modal detail view already lists overtime via `c.overtime?.enabled`.
- **`resources/lang/en.json`** — `public_game_modifier.overtime: "Overtime"`.

## Tests

- `tests/server/MapPlaylistOvertime.test.ts` — mocks `getMapLandTiles` and `Math.random`; verifies FFA gets overtime + modifier on a low roll, nothing on a high roll, and team/special lobbies never get it. Validates the resulting config against `GameConfigSchema`.
- `tests/client/OvertimeModifierBadge.test.ts` — badge key/label for `isOvertime`.

`tsc`, ESLint, and Prettier are clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
