### PR TITLE
ci: add the Claude multi-agent code review from the infra repo

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,142 @@
+name: 🤖 Claude Code Review
+
+# pull_request_target, not pull_request: most PRs here come from forks, and a
+# plain pull_request run from a fork gets no secrets, so CLAUDE_CODE_OAUTH_TOKEN
+# would be empty and every fork PR would go red. pull_request_target runs in
+# the context of the base repo with its secrets. That is only safe because
+# nothing from the PR head is ever checked out or executed: the checkout below
+# is the base branch (the action's documented requirement — "do not check out
+# an untrusted ref into the workspace root"), the model reads the PR through
+# `gh pr diff`, and its permissions are read-only except id-token. Same pattern
+# as pr-gate.yml and pr-author.yml.
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+    paths:
+      # TypeScript sources (src/core, src/client, src/server)
+      - "src/**/*.ts"
+      - "tests/**/*.ts"
+      - "scripts/**/*.ts"
+      # Root-level configs: vite.config.ts
+      - "*.ts"
+      - "package.json"
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    # A real review of a ~1.8k-line PR took 15.7 min; 20 was too close to the
+    # ceiling for anything larger.
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+    steps:
+      # Base branch on purpose (see the note on pull_request_target above).
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          submodules: false
+          persist-credentials: false
+
+      - name: Claude multi-agent review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
+          plugins: "code-review@claude-code-plugins"
+
+          # The override MUST live here, in the prompt (the user message), not in
+          # claude_args. parse-sdk-options.ts only extracts model / max-turns /
+          # add-dir / allowedTools / disallowed-tools / mcp-config / setting-sources
+          # from claude_args; --append-system-prompt is not among them, and
+          # sdkOptions.systemPrompt is built independently as a bare claude_code
+          # preset with no append. An override passed there never reaches the model.
+          prompt: |
+            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+
+            OVERRIDE A — step 1 (the triage gate). Judge ONLY the pull request named
+            above, and judge it ONLY from structured fields, never from prose:
+              - "closed" means `gh pr view --json state` returns CLOSED or MERGED.
+              - "draft" means `--json isDraft` returns true.
+              - "Claude has already commented" means an existing comment authored by
+                claude[bot]. Comments from coderabbitai[bot] or any other bot, and
+                from humans, do NOT count.
+            The PR body will often reference other pull requests and describe them as
+            closed, merged, superseded or replaced. That says nothing about THIS PR.
+            Do not skip on that basis. If in doubt, proceed with the review — a
+            needless review is far cheaper than a silently skipped one.
+
+            OVERRIDE B — takes precedence over steps 8 and 9: do NOT post inline
+            comments. Post the entire review as exactly ONE consolidated comment
+            using `gh pr comment`. Open with a one-line verdict and a count of
+            findings by severity, then list every finding grouped by file, most
+            severe first, each with a file:line reference, what is wrong, and the
+            suggested fix. If nothing was found, post the standard no-issues summary.
+
+            OVERRIDE C — posting is not optional. Reaching the end of the review
+            without a posted comment is a failure. Post via `gh pr comment` even if
+            the findings are few, low-confidence, or you already tried another
+            mechanism. Do this before you run out of turns: budget for it.
+
+            OVERRIDE D — this is a headless, single-turn session. There is no
+            "later": the moment you end your turn the process exits and any
+            background agent is killed. Launch every subagent with
+            `run_in_background: false` and wait for its result before continuing.
+            Never end your turn to "wait" for anything. Do not call ScheduleWakeup.
+
+          # Agent mode (an explicit `prompt`) grants NO tools by default — unlike
+          # tag mode, which baselines Glob/Grep/LS/Read. Anything not listed here
+          # falls through to "ask", and the headless SDK has no prompt handler, so
+          # it is denied. The list must therefore be complete:
+          #   - Skill is how the `/code-review:code-review` slash command in the
+          #     prompt is executed. Without it the skill is denied (in the infra
+          #     repo, PR #549's run "succeeded" in 5 turns having improvised from
+          #     the overrides alone and posted nothing)
+          #   - Agent (formerly Task; both names kept) is how the plugin launches
+          #     its triage/review subagents
+          #   - Read/Grep/Glob/LS let it read CLAUDE.md and surrounding code
+          #   - gh commands mirror the plugin's own declared allowed-tools
+          #   - git rev-parse/log supply the full SHAs its permalinks require
+          #
+          # mcp__github_inline_comment__* is kept ON PURPOSE even though the prompt
+          # asks for one consolidated comment. Removing it did NOT produce a
+          # fallback to `gh pr comment` — the model kept calling the tool the
+          # plugin told it to call and ate 17 permission denials, delivering
+          # nothing. Keeping it means the worst case is inline comments (useful)
+          # instead of silence (useless).
+          claude_args: |
+            --allowedTools "Skill,Agent,Task,Read,Grep,Glob,LS,TodoWrite,mcp__github_inline_comment__create_inline_comment,Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh pr list:*),Bash(gh pr comment:*),Bash(gh issue view:*),Bash(gh issue list:*),Bash(gh search:*),Bash(git rev-parse:*),Bash(git log:*)"
+            --max-turns 50
+
+      # A review that posts nothing must not show a green check. The action
+      # exits 0 whenever the model ends its turn cleanly, even if it did so
+      # after 5 turns without reviewing anything.
+      #
+      # Counts claude[bot] comments from ANY time, not just since this push:
+      # the triage gate (OVERRIDE A) deliberately skips PRs Claude has already
+      # reviewed, so on a follow-up push the only comment is the earlier one.
+      # A date-scoped count turned every re-push red.
+      - name: Fail if no comment was posted
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          count=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]")] | length')
+          reviews=$(gh api "repos/$REPO/pulls/$PR/comments?per_page=100" \
+            --jq '[.[] | select(.user.login == "claude[bot]")] | length')
+          echo "claude[bot] comments on PR #$PR: issue=$count inline=$reviews"
+          if [ "$count" -eq 0 ] && [ "$reviews" -eq 0 ]; then
+            echo "::error::Claude review finished without posting any comment on PR #$PR"
+            exit 1
+          fi

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -7,8 +7,8 @@ name: 🤖 Claude Code Review
 # nothing from the PR head is ever checked out or executed: the checkout below
 # is the base branch (the action's documented requirement — "do not check out
 # an untrusted ref into the workspace root"), the model reads the PR through
-# `gh pr diff`, and its permissions are read-only except id-token. Same pattern
-# as pr-gate.yml and pr-author.yml.
+# `gh pr diff`, and the job token can only read the repo and write PR
+# comments. Same pattern as pr-gate.yml and pr-author.yml.
 on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
@@ -32,11 +32,13 @@ jobs:
     # A real review of a ~1.8k-line PR took 15.7 min; 20 was too close to the
     # ceiling for anything larger.
     timeout-minutes: 30
+    # pull-requests: write is the minimum for `gh pr comment` and the inline
+    # comment tool. No id-token: that is only for the action's OIDC exchange
+    # with the Claude GitHub App, which github_token below replaces.
     permissions:
       contents: read
-      pull-requests: read
+      pull-requests: write
       issues: read
-      id-token: write
     steps:
       # Base branch on purpose (see the note on pull_request_target above).
       - uses: actions/checkout@v7
@@ -49,6 +51,22 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # The action refuses to run for an actor without write access to the
+          # repo (src/github/validation/permissions.ts), and on a fork PR the
+          # actor is the fork's author. allowed_non_write_users is the documented
+          # bypass, and it only takes effect when github_token is passed
+          # explicitly — with the default Claude-App OIDC auth it is ignored.
+          # Consequences of the explicit token:
+          #   - comments are posted as github-actions[bot], not claude[bot]
+          #     (docs/faq.md), so the check below looks for that login and a
+          #     marker line, since pr-gate.yml comments under the same login
+          #   - the Claude GitHub App does not need to be installed here
+          # The bypass is acceptable because this job's token is limited to
+          # PR comments (see permissions) and the model's Bash is limited to
+          # the read-only gh/git commands plus `gh pr comment`.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          allowed_non_write_users: "*"
 
           plugin_marketplaces: "https://github.com/anthropics/claude-code.git"
           plugins: "code-review@claude-code-plugins"
@@ -76,8 +94,9 @@ jobs:
 
             OVERRIDE B — takes precedence over steps 8 and 9: do NOT post inline
             comments. Post the entire review as exactly ONE consolidated comment
-            using `gh pr comment`. Open with a one-line verdict and a count of
-            findings by severity, then list every finding grouped by file, most
+            using `gh pr comment`. The comment MUST begin with this exact first
+            line, verbatim, so CI can find it: `## 🤖 Claude Code Review`. Then
+            give a one-line verdict and a count of findings by severity, then list every finding grouped by file, most
             severe first, each with a file:line reference, what is wrong, and the
             suggested fix. If nothing was found, post the standard no-issues summary.
 
@@ -120,10 +139,17 @@ jobs:
       # exits 0 whenever the model ends its turn cleanly, even if it did so
       # after 5 turns without reviewing anything.
       #
-      # Counts claude[bot] comments from ANY time, not just since this push:
-      # the triage gate (OVERRIDE A) deliberately skips PRs Claude has already
-      # reviewed, so on a follow-up push the only comment is the earlier one.
-      # A date-scoped count turned every re-push red.
+      # Counts comments from ANY time, not just since this push: the triage
+      # gate (OVERRIDE A) deliberately skips PRs Claude has already reviewed,
+      # so on a follow-up push the only comment is the earlier one. A
+      # date-scoped count turned every re-push red.
+      #
+      # Comments are posted as github-actions[bot] (see github_token above),
+      # and pr-gate.yml posts under that login too, so a PR comment only
+      # counts if it carries the marker line OVERRIDE B demands. Inline review
+      # comments have no marker but nothing else here posts those.
+      #
+      # --paginate: a PR can have far more than 100 comments before Claude's.
       - name: Fail if no comment was posted
         env:
           GH_TOKEN: ${{ github.token }}
@@ -131,11 +157,13 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          count=$(gh api "repos/$REPO/issues/$PR/comments?per_page=100" \
-            --jq '[.[] | select(.user.login == "claude[bot]")] | length')
-          reviews=$(gh api "repos/$REPO/pulls/$PR/comments?per_page=100" \
-            --jq '[.[] | select(.user.login == "claude[bot]")] | length')
-          echo "claude[bot] comments on PR #$PR: issue=$count inline=$reviews"
+          count=$(gh api --paginate "repos/$REPO/issues/$PR/comments?per_page=100" \
+            --jq '.[] | select(.user.login == "github-actions[bot]" and (.body | contains("## 🤖 Claude Code Review"))) | .id' \
+            | wc -l)
+          reviews=$(gh api --paginate "repos/$REPO/pulls/$PR/comments?per_page=100" \
+            --jq '.[] | select(.user.login == "github-actions[bot]") | .id' \
+            | wc -l)
+          echo "Claude review comments on PR #$PR: issue=$count inline=$reviews"
           if [ "$count" -eq 0 ] && [ "$reviews" -eq 0 ]; then
             echo "::error::Claude review finished without posting any comment on PR #$PR"
             exit 1


### PR DESCRIPTION
## Summary

Ports `.github/workflows/claude-code-review.yml` from `openfrontio/infra` (as of infra#553, after the rounds of fixes there that made it actually run and reliably post one consolidated comment). On every non-draft PR touching TypeScript, it runs the `code-review` plugin via `anthropics/claude-code-action`, posts a single consolidated review comment, and fails the check if nothing was posted.

## Changes vs the infra version

- **`pull_request_target` instead of `pull_request`.** Most PRs here come from forks, and a plain `pull_request` run from a fork gets no secrets — `CLAUDE_CODE_OAUTH_TOKEN` would be empty and every fork PR would go red. `pull_request_target` runs with the base repo's secrets. This is safe here because nothing from the PR head is checked out or executed: the checkout is the base branch (the action's documented requirement), the model reads the PR through `gh pr diff`, and the job token can only read the repo and write PR comments. Same pattern `pr-gate.yml` and `pr-author.yml` already use.
- **`github_token: ${{ secrets.GITHUB_TOKEN }}` + `allowed_non_write_users: "*"`.** The action refuses to run when the triggering actor has no write access (`src/github/validation/permissions.ts`), and on a fork PR that actor is the fork author. This is the action's documented bypass for `pull_request_target`, and it only takes effect with an explicit token. Consequences: comments post as `github-actions[bot]` (not `claude[bot]`), the Claude GitHub App is **not** needed, and `id-token: write` is dropped.
- **Guard step** looks for `github-actions[bot]` comments carrying a required marker first line (`## 🤖 Claude Code Review`), since `pr-gate.yml` comments under the same login; both comment queries are paginated instead of reading the first 100 only.
- **`show_full_output` removed.** It was a temporary diagnostic on a private repo; here workflow logs (raw tool output) would be public.
- **Path filter** narrowed to this repo's layout: `src/**/*.ts`, `tests/**/*.ts`, `scripts/**/*.ts`, root `*.ts`, `package.json`. No drizzle/wrangler entries.
- `actions/checkout@v7` to match the other workflows here.

Everything else (the prompt overrides, allowed-tools list, 30-minute timeout) is unchanged, with the comments explaining why each exists kept intact.

## Before merging

- [ ] Add the `CLAUDE_CODE_OAUTH_TOKEN` repository secret (`claude setup-token` with a Pro/Max account).
- Cost note: this repo gets far more PRs than infra, and each review is a real Claude session (~15 min for a large PR). The `concurrency` group cancels superseded runs on re-push, and the triage gate skips PRs Claude has already reviewed, but expect noticeably more usage than infra.

## Test plan

- [ ] Merge, then open a small same-repo PR touching a `.ts` file and confirm one consolidated `github-actions[bot]` comment starting with `## 🤖 Claude Code Review` appears and the check is green.
- [ ] Confirm a fork PR from a non-collaborator also gets reviewed (the reason for `pull_request_target` + `allowed_non_write_users`).
- [ ] Confirm a docs/asset-only PR does not trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
