### PR TITLE
Block ctrl+wheel page zoom over HUD panels

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -78,6 +78,7 @@ import "./components/BannedModal";
 import "./components/DesktopUpdateBar";
 import "./components/MarketingConsentToast";
 import {
+  installCtrlWheelZoomBlocker,
   installDoubleTapZoomBlocker,
   installSafariPinchZoomBlocker,
 } from "./utilities/DisableSafariPinchZoom";
@@ -1256,6 +1257,11 @@ const bootstrap = () => {
   // Same for double-tap "smart zoom", which `touch-action: manipulation`
   // alone does not reliably stop on iOS. See issue #4609.
   installDoubleTapZoomBlocker();
+
+  // Chrome and Firefox report a trackpad pinch as ctrl+wheel, which only the
+  // map canvas cancels — so pinching over a HUD panel zoomed the page instead
+  // of the map. See issue #5098.
+  installCtrlWheelZoomBlocker();
 
   initLayout();
   new Client().initialize();

--- a/src/client/utilities/DisableSafariPinchZoom.ts
+++ b/src/client/utilities/DisableSafariPinchZoom.ts
@@ -98,3 +98,48 @@ export function installDoubleTapZoomBlocker(
     { passive: false },
   );
 }
+
+/**
+ * Blocks the page-level pinch-to-zoom gesture in browsers that deliver it as
+ * a ctrl+wheel event — i.e. everything that is not Safari.
+ *
+ * {@link installSafariPinchZoomBlocker} covers WebKit, which reports a pinch
+ * through `GestureEvent`. Chrome and Firefox instead synthesize a `wheel`
+ * event with `ctrlKey` set, and the only listener for that lives on the map
+ * canvas (see {@link ../InputHandler}). HUD overlays are stacked above the
+ * canvas rather than nested inside it, so a pinch over the leaderboard, the
+ * build menu or any other panel never reaches that listener, nothing calls
+ * `preventDefault()`, and the browser zooms the whole page instead of the
+ * map.
+ *
+ * The listener is registered in the capture phase on purpose: HUD components
+ * such as `PlayerPanel` and `EmojiTable` call `stopPropagation()` on `wheel`
+ * to keep their own scrolling, which would stop a bubble-phase listener on
+ * `document` from ever running.
+ *
+ * Only ctrl+wheel is cancelled. A plain wheel keeps scrolling the panels that
+ * are `overflow-y-auto`, and the canvas listener still receives the event and
+ * zooms the map, because cancelling the browser's default action does not
+ * stop the event from propagating.
+ *
+ * The listener lives for the document's lifetime; the browser releases it
+ * when the page is torn down, so no disposer is needed.
+ *
+ * @param target - The EventTarget to attach the listener to. Defaults to
+ *   `document`.
+ *
+ * @see https://github.com/openfrontio/OpenFrontIO/issues/5098
+ */
+export function installCtrlWheelZoomBlocker(
+  target: EventTarget = document,
+): void {
+  target.addEventListener(
+    "wheel",
+    (e) => {
+      if ((e as WheelEvent).ctrlKey) {
+        e.preventDefault();
+      }
+    },
+    { capture: true, passive: false },
+  );
+}

--- a/tests/client/DisableSafariPinchZoom.test.ts
+++ b/tests/client/DisableSafariPinchZoom.test.ts
@@ -1,4 +1,5 @@
 import {
+  installCtrlWheelZoomBlocker,
   installDoubleTapZoomBlocker,
   installSafariPinchZoomBlocker,
 } from "../../src/client/utilities/DisableSafariPinchZoom";
@@ -146,6 +147,87 @@ describe("installDoubleTapZoomBlocker", () => {
         "touchend",
         expect.any(Function),
         { passive: false },
+      );
+    } finally {
+      addEventListenerSpy.mockRestore();
+    }
+  });
+});
+
+function dispatchWheel(
+  target: EventTarget,
+  { ctrlKey = false }: { ctrlKey?: boolean } = {},
+): Event {
+  // jsdom's WheelEvent carries no ctrlKey we can set through the constructor,
+  // so dispatch a plain cancelable Event with the one property the blocker
+  // reads stubbed onto it.
+  const event = new Event("wheel", { bubbles: true, cancelable: true });
+  Object.defineProperty(event, "ctrlKey", { value: ctrlKey });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe("installCtrlWheelZoomBlocker", () => {
+  it("cancels a ctrl+wheel event, which is how Chrome and Firefox report a pinch", () => {
+    const target = document.createElement("div");
+    installCtrlWheelZoomBlocker(target);
+
+    expect(dispatchWheel(target, { ctrlKey: true }).defaultPrevented).toBe(
+      true,
+    );
+  });
+
+  it("leaves a plain wheel event alone so scrollable panels keep scrolling", () => {
+    const target = document.createElement("div");
+    installCtrlWheelZoomBlocker(target);
+
+    expect(dispatchWheel(target).defaultPrevented).toBe(false);
+  });
+
+  it("cancels a pinch over a panel that stops propagation (#5098)", () => {
+    // PlayerPanel and EmojiTable call stopPropagation() on wheel, which would
+    // hide the event from a bubble-phase listener on document.
+    const scope = document.createElement("div");
+    const panel = scope.appendChild(document.createElement("div"));
+    panel.addEventListener("wheel", (e) => e.stopPropagation());
+    installCtrlWheelZoomBlocker(scope);
+
+    expect(dispatchWheel(panel, { ctrlKey: true }).defaultPrevented).toBe(true);
+  });
+
+  it("still lets the canvas listener see the event, so map zoom keeps working", () => {
+    const scope = document.createElement("div");
+    const canvas = scope.appendChild(document.createElement("canvas"));
+    const onWheel = vi.fn();
+    canvas.addEventListener("wheel", onWheel);
+    installCtrlWheelZoomBlocker(scope);
+
+    dispatchWheel(canvas, { ctrlKey: true });
+    expect(onWheel).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not affect events dispatched at unrelated targets", () => {
+    const scope = document.createElement("div");
+    const other = document.createElement("div");
+    installCtrlWheelZoomBlocker(scope);
+
+    expect(dispatchWheel(other, { ctrlKey: true }).defaultPrevented).toBe(
+      false,
+    );
+  });
+
+  it("defaults to attaching the listener to document in the capture phase", () => {
+    const addEventListenerSpy = vi
+      .spyOn(document, "addEventListener")
+      .mockImplementation(() => {});
+
+    try {
+      installCtrlWheelZoomBlocker();
+
+      expect(addEventListenerSpy).toHaveBeenCalledWith(
+        "wheel",
+        expect.any(Function),
+        { capture: true, passive: false },
       );
     } finally {
       addEventListenerSpy.mockRestore();


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #5098

## Description:

Chrome and Firefox report a trackpad pinch as a `wheel` event with `ctrlKey` set. The only listener for that lives on the map canvas:

```ts
this.canvas.addEventListener("wheel", (e) => { ...; e.preventDefault(); }, { passive: false });
```

HUD overlays are stacked above the canvas rather than nested inside it, so a pinch over the leaderboard, the build menu or any other panel never reached that listener. `preventDefault()` was never called and the browser zoomed the whole page instead of the map.

This adds `installCtrlWheelZoomBlocker` next to the existing page-zoom guards in `DisableSafariPinchZoom.ts` and installs it from `bootstrap()`, matching how `installSafariPinchZoomBlocker` (#2330) and `installDoubleTapZoomBlocker` (#4609) are already wired up.

Two decisions worth calling out:

- **Capture phase.** `PlayerPanel` and `EmojiTable` call `stopPropagation()` on `wheel` to keep their own scrolling, which would stop a bubble-phase listener on `document` from ever running. Registering in the capture phase means the blocker sees the event before those panels do.
- **Gated on `ctrlKey`.** A plain wheel is left untouched, so the `overflow-y-auto` panels (`GameLeftSidebar`, `EventsDisplay`, `ChatDisplay`, ...) keep scrolling. Cancelling the default action does not stop propagation, so the canvas listener still receives ctrl+wheel and zooms the map as before.

Safari was never affected — it delivers a pinch through WebKit's `GestureEvent`, which the existing blocker already covers document-wide. This brings the other browsers in line with what Safari already does: the page does not zoom, and the gesture is not forwarded to the map either.

This is the HUD remainder of #137, which reported the same symptom on a Chromium laptop trackpad and was fixed by #158 — that PR touched only `InputHandler.ts`, i.e. the canvas.

### Testing

Six tests added to `tests/client/DisableSafariPinchZoom.test.ts`, following the existing patterns in that file: ctrl+wheel is cancelled, plain wheel is not, a panel calling `stopPropagation()` is still covered, the event still reaches a canvas listener, unrelated targets are unaffected, and the default target/options are `document` with `{ capture: true, passive: false }`.

I checked the two non-obvious invariants hold by breaking them on purpose: flipping `capture` to `false` fails the `stopPropagation` test, and dropping the `ctrlKey` gate fails the plain-wheel test.

Verified by hand in the dev server on macOS, in both Chrome and Zen Browser:

- pinching over the leaderboard, the player panel and the emoji table no longer zooms the page
- panel scrolling still works with a plain wheel
- pinch over the map canvas still zooms the map

## Please complete the following:

- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

joon_hyeok0204