### PR TITLE
fix(client): respect Anonymous Names in event messages that name another player (#2412)

### DIFF
--- a/src/client/hud/layers/EventsDisplay.ts
+++ b/src/client/hud/layers/EventsDisplay.ts
@@ -248,6 +248,27 @@ export class EventsDisplay extends LitElement implements Controller {
     this.requestUpdate();
   }
 
+  // The core simulation runs identically for every client and has no notion
+  // of Anonymous Names, so a params.name value it bakes into a DisplayEvent
+  // is always the subject's real name. When the message identifies that
+  // subject via focusPlayerID, re-resolve the name through this viewer's own
+  // PlayerView instead, which already respects the local Anonymous Names
+  // setting - otherwise a message like "X conquered you" leaks X's real name
+  // even when this viewer has Anonymous Names turned on.
+  private resolveParams(
+    event: DisplayMessageUpdate,
+  ): Record<string, string | number> {
+    const params = event.params;
+    if (params?.name === undefined || event.focusPlayerID === undefined) {
+      return params ?? {};
+    }
+    const subject = this.game.playerBySmallID(event.focusPlayerID);
+    if (!subject.isPlayer()) {
+      return params;
+    }
+    return { ...params, name: subject.displayName() };
+  }
+
   onDisplayMessageEvent(event: DisplayMessageUpdate) {
     const myPlayer = this.game.myPlayer();
     if (
@@ -265,7 +286,7 @@ export class EventsDisplay extends LitElement implements Controller {
 
     let description: string = event.message;
     if (event.message.startsWith("events_display.")) {
-      description = translateText(event.message, event.params ?? {});
+      description = translateText(event.message, this.resolveParams(event));
     }
 
     const unitView =

--- a/src/core/execution/TradeShipExecution.ts
+++ b/src/core/execution/TradeShipExecution.ts
@@ -76,6 +76,7 @@ export class TradeShipExecution implements Execution {
         undefined,
         { name: tradeShipOwner.displayName() },
         this.tradeShip.id(),
+        tradeShipOwner.id(),
       );
     }
 
@@ -188,6 +189,8 @@ export class TradeShipExecution implements Execution {
           gold: renderNumber(gold),
           name: this.origOwner.displayName(),
         },
+        undefined,
+        this.origOwner.id(),
       );
       // Record stats
       this.mg

--- a/src/core/execution/alliance/AllianceExtensionExecution.ts
+++ b/src/core/execution/alliance/AllianceExtensionExecution.ts
@@ -51,6 +51,8 @@ export class AllianceExtensionExecution implements Execution {
         this.from.id(),
         undefined,
         { name: to.displayName() },
+        undefined,
+        to.id(),
       );
       mg.displayMessage(
         "events_display.alliance_renewed",
@@ -58,6 +60,8 @@ export class AllianceExtensionExecution implements Execution {
         this.toID,
         undefined,
         { name: this.from.displayName() },
+        undefined,
+        this.from.id(),
       );
     } else if (alliance.onlyOneAgreedToExtend() && !wasOnlyOneAgreed) {
       // Send message to the other player that someone wants to renew
@@ -68,6 +72,8 @@ export class AllianceExtensionExecution implements Execution {
         this.toID,
         undefined,
         { name: this.from.displayName() },
+        undefined,
+        this.from.id(),
       );
     }
   }

--- a/src/core/execution/alliance/AllianceRequestExecution.ts
+++ b/src/core/execution/alliance/AllianceRequestExecution.ts
@@ -154,6 +154,8 @@ export class AllianceRequestExecution implements Execution {
         launcher.id(),
         undefined,
         { name: other.displayName(), count },
+        undefined,
+        other.id(),
       );
 
       this.mg.displayMessage(
@@ -162,6 +164,8 @@ export class AllianceRequestExecution implements Execution {
         other.id(),
         undefined,
         { name: launcher.displayName(), count },
+        undefined,
+        launcher.id(),
       );
     }
   }

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -1304,6 +1304,8 @@ export class GameImpl implements Game {
         {
           name: conquered.displayName(),
         },
+        undefined,
+        conquered.id(),
       );
     } else {
       this.displayMessage(
@@ -1315,6 +1317,8 @@ export class GameImpl implements Game {
           gold: renderNumber(goldCaptured),
           name: conquered.displayName(),
         },
+        undefined,
+        conquered.id(),
       );
       conqueror.addGold(goldCaptured);
       conquered.removeGold(gold);

--- a/tests/AllianceExtensionExecution.test.ts
+++ b/tests/AllianceExtensionExecution.test.ts
@@ -134,6 +134,8 @@ describe("AllianceExtensionExecution", () => {
       player2.id(),
       undefined,
       { name: player1.displayName() },
+      undefined,
+      player1.id(),
     );
     expect(displayMessageSpy).toHaveBeenCalledTimes(1);
 

--- a/tests/client/graphics/layers/EventsDisplayAnonymousNames.test.ts
+++ b/tests/client/graphics/layers/EventsDisplayAnonymousNames.test.ts
@@ -1,0 +1,115 @@
+/**
+ * A DisplayEvent's params.name is always the subject's real name, because
+ * the core simulation is identical for every client and has no notion of
+ * the Anonymous Names setting. When a message identifies its subject via
+ * focusPlayerID, EventsDisplay must re-resolve the name through this
+ * viewer's own PlayerView (which does respect Anonymous Names) instead of
+ * trusting the raw baked string - otherwise messages like "X conquered you"
+ * leak X's real name even with Anonymous Names turned on.
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("lit/directive.js", () => ({}));
+vi.mock("lit/directives/unsafe-html.js", () => ({
+  unsafeHTML: (s: string) => s,
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  // Echo back whatever name ended up in params so the test can assert on it
+  // directly, without needing real translation strings.
+  translateText: vi.fn(
+    (key: string, params?: Record<string, string | number>) =>
+      params?.name !== undefined ? String(params.name) : key,
+  ),
+  renderNumber: vi.fn(),
+  renderTroops: vi.fn(),
+  getMessageTypeClasses: vi.fn(() => ""),
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventsDisplay } from "../../../../src/client/hud/layers/EventsDisplay";
+import { GameUpdateType } from "../../../../src/core/game/GameUpdates";
+
+describe("EventsDisplay resolves player names via focusPlayerID", () => {
+  let ed: EventsDisplay;
+  const myPlayer = { smallID: () => 1, displayName: () => "Me" };
+  // What THIS viewer should see for player 2 - e.g. an Anonymous Names
+  // codename when that setting is on, distinct from whatever real name the
+  // simulation baked into the raw update.
+  const subject = { smallID: () => 2, displayName: () => "Silent Falcon" };
+
+  beforeEach(() => {
+    ed = new EventsDisplay();
+    (ed as unknown as { game: unknown }).game = {
+      myPlayer: () => myPlayer,
+      playerBySmallID: (id: number) =>
+        id === 2
+          ? { ...subject, isPlayer: () => true }
+          : { isPlayer: () => false },
+      unit: () => undefined,
+      ticks: () => 0,
+    };
+  });
+
+  it("substitutes the viewer's own resolved name when focusPlayerID is set", () => {
+    ed.onDisplayMessageEvent({
+      type: GameUpdateType.DisplayEvent,
+      message: "events_display.conquered_no_gold",
+      messageType: 0,
+      playerID: 1,
+      params: { name: "RealName" }, // raw name baked in by the simulation
+      focusPlayerID: 2,
+    } as never);
+
+    const events = (ed as unknown as { events: { description: string }[] })
+      .events;
+    expect(events).toHaveLength(1);
+    expect(events[0].description).toBe("Silent Falcon");
+    expect(events[0].description).not.toBe("RealName");
+  });
+
+  it("falls back to the raw params when focusPlayerID is absent", () => {
+    ed.onDisplayMessageEvent({
+      type: GameUpdateType.DisplayEvent,
+      message: "events_display.some_other_message",
+      messageType: 0,
+      playerID: 1,
+      params: { name: "RealName" },
+    } as never);
+
+    const events = (ed as unknown as { events: { description: string }[] })
+      .events;
+    expect(events[0].description).toBe("RealName");
+  });
+
+  it("falls back to the raw params when focusPlayerID doesn't resolve to a player", () => {
+    ed.onDisplayMessageEvent({
+      type: GameUpdateType.DisplayEvent,
+      message: "events_display.conquered_no_gold",
+      messageType: 0,
+      playerID: 1,
+      params: { name: "RealName" },
+      focusPlayerID: 999, // resolves to TerraNullius via the mock above
+    } as never);
+
+    const events = (ed as unknown as { events: { description: string }[] })
+      .events;
+    expect(events[0].description).toBe("RealName");
+  });
+});

--- a/tests/core/executions/TradeShipExecution.test.ts
+++ b/tests/core/executions/TradeShipExecution.test.ts
@@ -149,6 +149,7 @@ describe("TradeShipExecution", () => {
       undefined,
       { name: pirate.displayName() },
       tradeShip.id(),
+      pirate.id(),
     );
   });
 


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #2412

## Description:

The core simulation runs identically on every client and has no notion of the personal Anonymous Names setting, so a `DisplayEvent`'s `params.name` was always the subject's real name — baked in as a raw string by whichever execution generated the message (conquest, alliance renewal, an alliance nuke getting cancelled, a trade ship getting captured). `PlayerView.name()`/`displayName()` already correctly respect the viewer's own Anonymous Names toggle, but nothing routed these messages through it: a player with Anonymous Names on would still see "RealName conquered you" instead of their anonymous codename.

`DisplayEvent` already had an unused `focusPlayerID` field (defined and plumbed through the update pipeline, but never actually set by any caller). This PR reuses it:

- `EventsDisplay` now resolves `params.name` from `focusPlayerID` through the viewer's own `PlayerView.displayName()` when both are present, instead of trusting the raw string — falling back to the raw params otherwise, so messages that don't name another player are unaffected.
- Added `focusPlayerID` to every `displayMessage()` call across `GameImpl` (conquest), `AllianceRequestExecution` (nuke cancelled on alliance accept), `AllianceExtensionExecution` (renewal messages), and `TradeShipExecution` (ship captured / gold received) that names another player. `NukeExecution`'s bomb-detonated message already did this correctly — it's the pattern the rest of these now follow.
- Checked every other `displayMessage()` call in `src/core` (`UnitImpl`, `SAMMissileExecution`, and the remaining ones in `AttackExecution`/`TransportShipExecution`/`DeleteUnitExecution`): none of them name another player, so they're unaffected.

## Please complete the following:

- [ ] I have added screenshots for all UI updates (N/A — Text rendering logic fix)
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file (N/A — Reuses existing message keys)
- [x] I have added relevant tests to the test directory (`tests/client/graphics/layers/EventsDisplayAnonymousNames.test.ts` (3 cases covering resolution via focusPlayerID, fallback with no focusPlayerID, and fallback if focusPlayerID doesn't resolve)). Updated existing tests whose `toHaveBeenCalledWith` expected the new parameter.
- [x] I confirm I have thoroughly tested these changes and take full responsibility for any bugs introduced

## Please put your Discord username so you can be contacted if a bug or regression is found:

barfires
