### PR TITLE
Normalize attack troops to the amount actually deducted

### DIFF
--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -114,7 +114,11 @@ export class AttackExecution implements Execution {
       .attackAmount(this._owner, this.target);
     if (this.removeTroops) {
       this.startTroops = Math.min(this._owner.troops(), this.startTroops);
-      this._owner.removeTroops(this.startTroops);
+      // Take the amount that was actually deducted, not the amount asked for.
+      // removeTroops() floors, so a fractional request leaves the attack
+      // holding troops the owner never paid for — and retreat refunds the
+      // combined total, turning the leftover fractions into free troops.
+      this.startTroops = this._owner.removeTroops(this.startTroops);
     }
     this.attack = this._owner.createAttack(
       this.target,

--- a/tests/Attack.test.ts
+++ b/tests/Attack.test.ts
@@ -636,3 +636,90 @@ describe("Attack immunity", () => {
     expect(nation.outgoingAttacks()).toHaveLength(0);
   });
 });
+
+describe("Fractional attack troop duplication (#4948)", () => {
+  let dupeGame: Game;
+  let dupeAttacker: Player;
+  let dupeDefender: Player;
+
+  beforeEach(async () => {
+    dupeGame = await setup("ocean_and_land", {
+      infiniteGold: true,
+      instantBuild: true,
+    });
+    const attackerInfo = new PlayerInfo(
+      "attacker dude",
+      PlayerType.Human,
+      null,
+      "attacker_id",
+    );
+    const defenderInfo = new PlayerInfo(
+      "defender dude",
+      PlayerType.Human,
+      null,
+      "defender_id",
+    );
+    dupeGame.addPlayer(attackerInfo);
+    dupeGame.addPlayer(defenderInfo);
+
+    dupeGame.addExecution(
+      new SpawnExecution(
+        gameID,
+        dupeGame.player(attackerInfo.id).info(),
+        dupeGame.ref(0, 10),
+      ),
+      new SpawnExecution(
+        gameID,
+        dupeGame.player(defenderInfo.id).info(),
+        dupeGame.ref(0, 15),
+      ),
+    );
+    dupeGame.executeNextTick();
+    dupeGame.executeNextTick();
+
+    dupeAttacker = dupeGame.player(attackerInfo.id);
+    dupeDefender = dupeGame.player(defenderInfo.id);
+  });
+
+  function outgoingTroops(): number {
+    return dupeAttacker
+      .outgoingAttacks()
+      .reduce((sum, attack) => sum + attack.troops(), 0);
+  }
+
+  it("carries only the troops that were actually deducted", () => {
+    dupeGame.addExecution(
+      new AttackExecution(50.7, dupeAttacker, dupeDefender.id()),
+    );
+    dupeGame.executeNextTick();
+
+    // removeTroops() floors, so 50.7 costs the owner 50. The attack must not
+    // be worth more than that, or retreat refunds troops nobody paid for.
+    expect(outgoingTroops()).toBe(50);
+  });
+
+  it("does not accumulate value from a burst of sub-troop attacks", () => {
+    for (let i = 0; i < 10; i++) {
+      dupeGame.addExecution(
+        new AttackExecution(0.999, dupeAttacker, dupeDefender.id()),
+      );
+    }
+    dupeGame.executeNextTick();
+
+    // Each request deducts 0. Combining ten of them must not produce an
+    // attack worth 9.99 that retreat would refund as 9 free troops.
+    expect(outgoingTroops()).toBe(0);
+  });
+
+  it("keeps attack troops integral so combining cannot drift", () => {
+    for (let i = 0; i < 5; i++) {
+      dupeGame.addExecution(
+        new AttackExecution(20.4, dupeAttacker, dupeDefender.id()),
+      );
+    }
+    dupeGame.executeNextTick();
+
+    expect(Number.isInteger(outgoingTroops())).toBe(true);
+    expect(outgoingTroops()).toBe(100);
+  });
+});


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #4948

## Description:

`removeTroops()` floors through `toInt()`, and so does `addTroops()`, but `AttackImpl.setTroops()` stores whatever it is given. `AttackExecution.init()` called `removeTroops(this.startTroops)` and threw the return value away, then created the attack with the *requested* amount — so a fractional request left the attack holding troops the owner never paid for.

Combining outgoing attacks on the same target sums those fractions, and retreat refunds the combined total through a single `floor`, which is where the free troops in the report come from: ten requests of `0.999` each deduct `0`, combine into `9.99`, and refund `9`.

`removeTroops()` already returns the amount it actually removed, so the fix is to keep it:

```ts
this.startTroops = this._owner.removeTroops(this.startTroops);
```

That holds the invariant "attack troops == troops actually deducted". It covers every source of fractional troops at once, not just the intent path: `Config.attackAmount()` returns `troops() / 5` (`/ 20` for bots) for the nullable `troops` path, `AiAttackBehavior.forceSendAttack()` uses `troops() / 2`, and the client sends `attackRatio * player.troops()` with `attackRatio` defaulting to `0.2`.

### On tightening the schema

@evanpelle suggested requiring `troops` to be an integer in `AttackIntentSchema`. I left that out of this PR, because it can't land on its own:

- Archived games are validated with `GameRecordSchema.parse()` (`Archive.ts`, `JoinLobbyModal.ts`), and that reaches `AttackIntentSchema` through `TurnSchema.intents`. I checked that `zb.uint()` rejects a value like `5000.2`, and existing replays are full of fractional troop counts — so every archived game recorded so far would fail to load.
- The client would also need to round at the same time, or every normal attack would be rejected.

I'd appreciate any thoughts on how you'd want to handle that.

I also left the `removeTroops === false` branch alone. Flooring `startTroops` there would make a boat attack carry less than was deducted at departure, and the `removeTroops === false && sourceTile === null` combination that the retreat path guards against isn't reachable from any current call site.

### Testing

Three regression tests in `tests/Attack.test.ts`, driving the real simulation through `setup()`:

- a `50.7` request produces an attack worth `50`
- ten `0.999` requests combine to `0` rather than `9.99`
- five `20.4` requests combine to `100`, not `102`

I checked they actually catch the bug by reverting the fix — all three fail, with the middle one reporting `9.99`, the same number as the report.

`npm test` shows no new failures against this branch's baseline (+3 passed, 0 new failures). Note that the suite already has pre-existing failures on `main` in my environment, from `localStorage.getItem is not a function` in the jsdom setup — unrelated to this change.

## Please complete the following:

- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

joon_hyeok0204