### PR TITLE
test(server): GameServer test harness, golden wire transcript, refactor plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 build/
-node_modules/
+node_modules
 .worktrees/
 out/
 static/

--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -1,0 +1,173 @@
+# GameServer.ts — testing & refactor plan
+
+`src/server/GameServer.ts` is ~2,400 lines, changes in most feature PRs, and
+has 13 responsibilities in one class. This document is the plan for making it
+testable and then splitting it up. It is a living checklist: tick items off as
+PRs land.
+
+## Diagnosis
+
+**The class.** ~40 public methods; features land as "add a field, add a method,
+add a branch in `joinClient` / `handleIntent` / `phase()`", so those three keep
+growing.
+
+**The tests (the actual problem).** Tests could only exercise the class by
+reaching past its API:
+
+- ~150 `(game as any).x` reach-ins across 29 private members. Top offenders:
+  `gameStartInfo`, `archiveGame` (spied), `intents`, `_hasStarted = true`,
+  `winner`, `handleClientDisconnect`.
+- 6 files `vi.mock("../../src/core/Schemas")` to stub
+  `GameStartInfoSchema.safeParse` — only because fixture IDs like `"p1"` fail
+  the 8-char `ID` regex.
+- 13 files each define their own `makeMockWs` / `makeClient` / `mockLogger`.
+- Hidden dependencies force the rest: `archive()`, `fetchCustomTribes()`,
+  `ServerEnv.env()` (static), `console.error`, two internal `setInterval`s.
+
+**Coverage gaps** (no test at all): duplicate-session kick, 3-per-IP cap,
+`host_left` lobby close, `rejoinClient` identity / verified-badge update and
+`lastTurn` slicing, the "ws already closed" race in `addListeners`,
+`maxGameDuration`, 60s ping prune in `phase()`, `checkDisconnectedStatus`
+toggling, `findOutOfSyncClients` majority logic.
+
+**Structural smells.**
+
+- Seven parallel collections describe one population: `activeClients` (public
+  array), `allClients`, `websockets`, `persistentIdToClientId`,
+  `admittedPersistentIds`, `kickedPersistentIds`, `clientsDisconnectedStatus`.
+  Hand-reconciled in `joinClient`, `rejoinClient`, `kickClient`,
+  `handleClientDisconnect`, `phase()`.
+- `phase()` is a query with side effects (closes sockets, prunes clients,
+  re-tallies the winner) and `GameManager` calls it 2–3× per tick.
+- Lifecycle is four booleans (`_hasPrestarted`, `_hasStarted`, `_hasEnded`,
+  `isPaused`) plus `hasReachedMaxPlayerCount`; `hasStarted()` means
+  "prestarted OR started".
+- `updateGameConfig` is 100 lines of field-by-field copy.
+- `end()` is `async` but awaits nothing; the promise from `archive()` is not
+  awaited, so the surrounding `try/catch` only catches synchronous throws.
+
+## Principles
+
+1. **Client-visible wire behaviour must not change.** The contract is the
+   frames on the socket and the archived record.
+2. **Tests before moves.** No extraction lands without characterization tests
+   for the code being moved.
+3. **One concern per PR**, each deleting the reach-ins for that concern.
+4. **Don't fix behaviour while moving it.** Suspected bugs get a note and their
+   own PR.
+
+## Phase 0 — Test infrastructure (no production changes)
+
+- [x] `tests/util/GameServerHarness.ts`: one `mockLogger()`, `makeMockWs()`
+      (drivable: `emit(ClientMessage)`, `trigger("close")`, captured sends),
+      `makeClient(opts)`, `makeGame(opts)`, `startGame(game)` that runs real
+      `prestart()` + `start()` instead of setting `_hasStarted`.
+- [x] Schema-valid fixture IDs (`cid("p1")` → `"p1000000"`), then delete every
+      `vi.mock("../../src/core/Schemas")`.
+- [x] Golden wire transcript test: a scripted full game under fake timers;
+      snapshot the decoded server frames per client and the archived record.
+      This is the regression net for every later phase.
+- [x] Migrate the duplicated helpers onto the harness (thin local adapters are
+      fine; test bodies stay unchanged).
+
+Verify: `npm test` green; no `vi.mock` of `Schemas` under `tests/server`.
+
+Status (2026-08-25): done. `tests/util/GameServerHarness.ts`,
+`tests/server/GameServerWire.test.ts` (+ snapshot). Reach-ins 150 → 82,
+`Schemas` mocks 6 → 0, private `makeMockWs` copies 13 → 0. What is left
+reaches for `archiveGame` (10), `gameStartInfo` (9), `intents` (8), `winner`
+(6) — Phase 2's dependency injection and a `startInfo()` accessor remove most
+of it.
+
+## Phase 1 — Characterization tests for uncovered paths
+
+Written against current behaviour, using the harness:
+
+- [ ] `joinClient`: dup-session kicks the _old_ client (Prod), 3-IP cap
+      (Public, non-Dev), host-left closes lobby and `phase()` → `Finished`.
+- [ ] `rejoinClient`: identity update drops `verified` only when the username
+      changes; ignored after start; `lastTurn` slicing; old socket closed.
+- [ ] `addListeners`: corrupt frame → `invalid_message` kick; ws
+      `readyState >= 2` race handled as a disconnect.
+- [ ] `phase()`: 60s ping prune, `maxGameDuration`, the
+      `noActive && warmupOver && noRecentPings` exit.
+- [ ] `findOutOfSyncClients`: majority, strict-majority flip, single client,
+      `turns[n].hash` set on agreement.
+- [ ] `checkDisconnectedStatus`: only every 5 turns, flips both ways,
+      spectators emit no `mark_disconnected`.
+
+## Phase 2 — Inject the hidden dependencies
+
+- [ ] Replace the 10-positional-arg constructor with `GameServerOptions` plus a
+      `GameServerDeps` object `{ archive, fetchTribes, env, turnIntervalMs,
+  telemetry, buildHash }` defaulting to the real modules.
+      `GameManager.createGame` is the only production caller.
+- [ ] Replace `console.error` in `prestart()` with `this.log.error`.
+- [ ] Leave `Date.now()` alone — fake timers already cover it.
+
+Verify: golden snapshot unchanged; no `vi.mock` of server modules in
+GameServer tests; no `archiveGame` spies.
+
+## Phase 3 — Extract pure modules (lowest risk first)
+
+Each is a move, not a rewrite. Existing tests are re-pointed at the module.
+
+| Module                                                                    | From                                                | Existing tests to re-home                              |
+| ------------------------------------------------------------------------- | --------------------------------------------------- | ------------------------------------------------------ |
+| `ConfigPatch.ts`: `applyGameConfigPatch()`, `hostCheatsEnabled`           | `updateGameConfig`                                  | AdminBotIntent, HostedLobbyListing                     |
+| `NameVisibility.ts`: `seesReal`, `anonName`, `startInfoFor`, lobby roster | name-visibility helpers, `startInfoFor`, `gameInfo` | AnonymizeNames, AnonymizeNamesTeammates, AdminClanTags |
+| `DesyncDetector.ts`: `findOutOfSyncClients` + sent set                    | `handleSynchronization`                             | new (Phase 1)                                          |
+| `Consensus.ts`: winner vote + retally, live-stats rounds + prune          | `handleWinner`, `handleLiveStats`                   | WinnerVoteRetally, LiveStats                           |
+| `ListingState.ts`: listed/listedAt/label/accent/featured/autoStart        | scattered fields                                    | HostedLobbyListing                                     |
+| `MatchTelemetryRecorder.ts`: sequence, tick counts, finished flag         | `emitTelemetry*`                                    | MatchTelemetryIntegration                              |
+
+Notes:
+
+- `applyGameConfigPatch` must preserve `null → undefined` on nullable keys and
+  the _unconditional_ `hostCheats` assignment.
+- The `allowedPublicIds` → delist side effect stays in `GameServer`.
+
+Verify per PR: golden snapshot unchanged; module has its own unit tests; the
+corresponding `(game as any)` uses are gone.
+
+## Phase 4 — Roster
+
+- [ ] `Roster.ts` collapsing the seven collections: `add`, `reconnect`,
+      `markLeft`, `kick`, `pruneStale(now)`, `active()`, `players()`,
+      `byPersistentId()`, `votingUniqueIPs()`, `wasAdmitted()`, `isKicked()`.
+- [ ] `GameServer` keeps the _policy_ (allowlist, IP cap, dup-session,
+      host-left) and delegates bookkeeping.
+- [ ] Make `activeClients` private; `GameManager.activeClients()` uses
+      `numClients()`.
+
+Only after Phases 1–3: every roster path then has a test.
+
+## Phase 5 — Message ingress and intent dispatch
+
+- [ ] `ClientSocket.attach(client, { onMessage, onClose })`: decode → validate
+      → rate-limit → spectator-block. `GameServer.handleClientMessage(client,
+  msg)` keeps the switch. Tests call `handleClientMessage` directly; keep a
+      few frame-level tests for the decode/kick paths.
+- [ ] `authorizeIntent(intent, actor): IntentOutcome | null` (pure guards,
+      table-testable) separated from the effects in `handleIntent`.
+
+## Phase 6 — Lifecycle state machine
+
+- [ ] One `state: "lobby" | "prestart" | "started" | "ended"` plus `paused`
+      replaces the booleans. `hasStarted()` becomes `state !== "lobby"`.
+- [ ] Split `phase()` into `pruneStaleClients()` (side effects; called once per
+      `GameManager.tick`) and a pure `phase()`. `publicLobbies()` /
+      `listedLobbies()` stop mutating state.
+- [ ] Decide whether `end()` should await `archive()` after checking how
+      `Archive.ts` handles rejections.
+
+## Out of scope
+
+Renaming intents/messages; changing the archive record shape (replays depend
+on it — `tests/replay/ReplayGame.ts`); touching `Worker.ts` / `Master.ts`
+beyond the constructor call.
+
+## Expected result
+
+`GameServer.ts` ≈ 700–900 lines of orchestration, ~6 focused modules with
+direct unit tests, and no `(game as any)` under `tests/server`.

--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -99,9 +99,9 @@ Written against current behaviour, using the harness:
 ## Phase 2 — Inject the hidden dependencies
 
 - [ ] Replace the 10-positional-arg constructor with `GameServerOptions` plus a
-      `GameServerDeps` object `{ archive, fetchTribes, env, turnIntervalMs,
-  telemetry, buildHash }` defaulting to the real modules.
-      `GameManager.createGame` is the only production caller.
+      `GameServerDeps` object (`archive`, `fetchTribes`, `env`,
+      `turnIntervalMs`, `telemetry`, `buildHash`) defaulting to the real
+      modules. `GameManager.createGame` is the only production caller.
 - [ ] Replace `console.error` in `prestart()` with `this.log.error`.
 - [ ] Leave `Date.now()` alone — fake timers already cover it.
 
@@ -145,9 +145,9 @@ Only after Phases 1–3: every roster path then has a test.
 ## Phase 5 — Message ingress and intent dispatch
 
 - [ ] `ClientSocket.attach(client, { onMessage, onClose })`: decode → validate
-      → rate-limit → spectator-block. `GameServer.handleClientMessage(client,
-  msg)` keeps the switch. Tests call `handleClientMessage` directly; keep a
-      few frame-level tests for the decode/kick paths.
+      → rate-limit → spectator-block. The message switch stays in
+      `GameServer.handleClientMessage(client, msg)`. Tests call it directly;
+      keep a few frame-level tests for the decode/kick paths.
 - [ ] `authorizeIntent(intent, actor): IntentOutcome | null` (pure guards,
       table-testable) separated from the effects in `handleIntent`.
 

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/var/home/bazzite/OpenFrontIO/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/var/home/bazzite/OpenFrontIO/node_modules

--- a/tests/server/AdminBotRoster.test.ts
+++ b/tests/server/AdminBotRoster.test.ts
@@ -4,6 +4,11 @@ import { registerAdminBotRoutes } from "../../src/server/AdminBotRoutes";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
 import { ServerEnv } from "../../src/server/ServerEnv";
+import {
+  makeClient as harnessClient,
+  mockLogger,
+  mockWsOf,
+} from "../util/GameServerHarness";
 import { testGameConfig } from "../util/Wire";
 
 // The roster endpoint is the ONE place a per-game clientID can be tied back to an
@@ -80,40 +85,17 @@ describe("GameServer.roster() — the real projection", () => {
   // real GameServer, because the projection's value is its SEMANTICS: it reads
   // allClients, so a player who joined and then disconnected still appears in
   // the mapping the host has to reconcile against the game record.
-  function makeMockWs() {
-    return {
-      on: () => {},
-      removeAllListeners: () => {},
-      send: vi.fn(),
-      close: vi.fn(),
-      readyState: 1,
-    };
-  }
   function makeClient(id: string, publicId?: string): Client {
-    return new Client(
-      id,
-      `${id}-pid`,
-      null,
-      null,
-      undefined,
-      `10.1.0.${ipOctet++}`,
-      id,
-      null,
-      makeMockWs() as any,
-      undefined,
+    return harnessClient({
+      clientID: id,
+      persistentID: `${id}-pid`,
+      username: id,
       publicId,
-      [],
-    );
+    });
   }
-  let ipOctet = 1;
-  const logger: any = {
-    child: vi.fn().mockReturnThis(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  };
+  const logger = mockLogger();
 
-  it("maps every joiner — including one who already disconnected", () => {
+  it("maps every joiner — including one who already disconnected", async () => {
     vi.useFakeTimers();
     try {
       const game = new GameServer(
@@ -129,7 +111,7 @@ describe("GameServer.roster() — the real projection", () => {
       expect(game.joinClient(leaves)).toBe("joined");
       expect(game.joinClient(anon)).toBe("joined");
 
-      (game as any).handleClientDisconnect(leaves);
+      await mockWsOf(leaves).trigger("close");
 
       const players = game.roster();
       expect(players).toEqual([

--- a/tests/server/AllowlistJoin.test.ts
+++ b/tests/server/AllowlistJoin.test.ts
@@ -1,69 +1,35 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("../../src/core/Schemas", async () => {
-  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
-  return {
-    ...actual,
-    GameStartInfoSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-    ServerPrestartMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-    ClientMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-  };
-});
-
 import { GameType } from "../../src/core/game/Game";
-import { Client } from "../../src/server/Client";
-import { GameServer } from "../../src/server/GameServer";
-import { testGameConfig } from "../util/Wire";
+import {
+  cid,
+  makeClient as harnessClient,
+  makeGame as harnessGame,
+  mockWsOf,
+} from "../util/GameServerHarness";
 
-function makeMockWs() {
-  return {
-    on: () => {},
-    removeAllListeners: () => {},
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-  };
-}
+const C1 = cid("c1");
+const C1B = cid("c1b");
+const C2 = cid("c2");
+const C3 = cid("c3");
 
 function makeClient(
   clientID: string,
   persistentID: string,
   publicId: string | undefined,
   role: string | null = null,
-): Client {
-  return new Client(
+) {
+  return harnessClient({
     clientID,
     persistentID,
-    null,
-    role,
-    undefined,
-    "127.0.0.1",
-    "TestUser",
-    null,
-    makeMockWs() as any,
-    undefined,
     publicId,
-    [],
-  );
+    role,
+    username: "TestUser",
+  });
 }
 
 describe("GameServer - allowlist (allowedPublicIds)", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
   });
 
   afterEach(() => {
@@ -73,105 +39,105 @@ describe("GameServer - allowlist (allowedPublicIds)", () => {
   });
 
   function makeGame(allowedPublicIds?: string[]) {
-    return new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({
+    return harnessGame({
+      config: {
         gameType: GameType.Private,
         ...(allowedPublicIds ? { allowedPublicIds } : {}),
-      }),
-    );
+      },
+    });
   }
 
   it("admits only listed publicIds and rejects others", () => {
     const game = makeGame(["pub-ok"]);
-    expect(game.joinClient(makeClient("c1", "p1", "pub-ok"))).toBe("joined");
-    expect(game.joinClient(makeClient("c2", "p2", "pub-no"))).toBe(
+    expect(game.joinClient(makeClient(C1, "p1", "pub-ok"))).toBe("joined");
+    expect(game.joinClient(makeClient(C2, "p2", "pub-no"))).toBe(
       "not_allowlisted",
     );
-    expect(game.joinClient(makeClient("c3", "p3", undefined))).toBe(
+    expect(game.joinClient(makeClient(C3, "p3", undefined))).toBe(
       "not_allowlisted",
     );
   });
 
   it("lets admins and root bypass the allowlist", () => {
     const game = makeGame(["pub-ok"]);
-    expect(game.joinClient(makeClient("c1", "p1", "pub-no", "admin"))).toBe(
+    expect(game.joinClient(makeClient(C1, "p1", "pub-no", "admin"))).toBe(
       "joined",
     );
-    expect(game.joinClient(makeClient("c2", "p2", "pub-no", "root"))).toBe(
+    expect(game.joinClient(makeClient(C2, "p2", "pub-no", "root"))).toBe(
       "joined",
     );
     // No publicId at all (anonymous persistent-ID join) still bypasses.
-    expect(game.joinClient(makeClient("c3", "p3", undefined, "admin"))).toBe(
+    expect(game.joinClient(makeClient(C3, "p3", undefined, "admin"))).toBe(
       "joined",
     );
   });
 
   it("does not let mod or unknown roles bypass the allowlist", () => {
     const game = makeGame(["pub-ok"]);
-    expect(game.joinClient(makeClient("c1", "p1", "pub-no", "mod"))).toBe(
+    expect(game.joinClient(makeClient(C1, "p1", "pub-no", "mod"))).toBe(
       "not_allowlisted",
     );
-    expect(game.joinClient(makeClient("c2", "p2", "pub-no", "flagged"))).toBe(
+    expect(game.joinClient(makeClient(C2, "p2", "pub-no", "flagged"))).toBe(
       "not_allowlisted",
     );
   });
 
   it("still keeps a kicked admin out of an allowlisted lobby", () => {
     const game = makeGame(["pub-ok"]);
-    expect(game.joinClient(makeClient("c1", "p1", "pub-no", "admin"))).toBe(
+    expect(game.joinClient(makeClient(C1, "p1", "pub-no", "admin"))).toBe(
       "joined",
     );
-    game.kickClient("c1");
-    expect(game.joinClient(makeClient("c1b", "p1", "pub-no", "admin"))).toBe(
+    game.kickClient(C1);
+    expect(game.joinClient(makeClient(C1B, "p1", "pub-no", "admin"))).toBe(
       "kicked",
     );
   });
 
   it("does not restrict joins when no allowlist is set", () => {
     const game = makeGame();
-    expect(game.joinClient(makeClient("c1", "p1", "anything"))).toBe("joined");
+    expect(game.joinClient(makeClient(C1, "p1", "anything"))).toBe("joined");
   });
 
   it("treats an empty allowlist as no restriction", () => {
     const game = makeGame([]);
-    expect(game.joinClient(makeClient("c1", "p1", "anything"))).toBe("joined");
+    expect(game.joinClient(makeClient(C1, "p1", "anything"))).toBe("joined");
   });
 
   it("lets a previously-rejected player in once the allowlist is cleared", () => {
     const game = makeGame(["pub-ok"]);
-    expect(game.joinClient(makeClient("c2", "p2", "pub-no"))).toBe(
+    expect(game.joinClient(makeClient(C2, "p2", "pub-no"))).toBe(
       "not_allowlisted",
     );
     game.updateGameConfig({ allowedPublicIds: [] });
-    expect(game.joinClient(makeClient("c2", "p2", "pub-no"))).toBe("joined");
+    expect(game.joinClient(makeClient(C2, "p2", "pub-no"))).toBe("joined");
   });
 
   it("keeps allowedPublicIds on the stored config (read like other settings)", () => {
     const game = makeGame(["pub-ok"]);
-    expect((game.gameConfig as any).allowedPublicIds).toEqual(["pub-ok"]);
+    expect(game.gameConfig.allowedPublicIds).toEqual(["pub-ok"]);
   });
 
   it("keeps publicId lists out of the start info (wire + archived record)", () => {
-    const game = new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({
+    const game = harnessGame({
+      config: {
         gameType: GameType.Private,
         allowedPublicIds: ["pub-ok"],
         nameRevealPublicIds: ["pub-reveal"],
-      }),
-    );
-    expect(game.joinClient(makeClient("c1", "p1", "pub-ok"))).toBe("joined");
+      },
+    });
+    const c1 = makeClient(C1, "p1", "pub-ok");
+    expect(game.joinClient(c1)).toBe("joined");
     game.start();
 
-    const config = (game as any).gameStartInfo.config;
-    expect(config.allowedPublicIds).toBeUndefined();
-    expect(config.nameRevealPublicIds).toBeUndefined();
+    // The start message carries the same config object the archive reads.
+    const start = mockWsOf(c1)
+      .sent()
+      .find((m) => m.type === "start");
+    expect(start).toBeDefined();
+    const config = start!.type === "start" ? start!.gameStartInfo.config : null;
+    expect(config?.allowedPublicIds).toBeUndefined();
+    expect(config?.nameRevealPublicIds).toBeUndefined();
     // The server still enforces the allowlist from its own config.
-    expect((game.gameConfig as any).allowedPublicIds).toEqual(["pub-ok"]);
+    expect(game.gameConfig.allowedPublicIds).toEqual(["pub-ok"]);
   });
 });

--- a/tests/server/AnonymizeNames.test.ts
+++ b/tests/server/AnonymizeNames.test.ts
@@ -2,17 +2,11 @@ import { GameType } from "../../src/core/game/Game";
 import { UsernameSchema } from "../../src/core/Schemas";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import {
+  makeClient as harnessClient,
+  mockLogger,
+} from "../util/GameServerHarness";
 import { testGameConfig } from "../util/Wire";
-
-function makeMockWs() {
-  return {
-    on: () => {},
-    removeAllListeners: () => {},
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-  };
-}
 
 function makeClient(
   clientID: string,
@@ -24,20 +18,16 @@ function makeClient(
   friends: string[] = [],
   cosmetics: { verified?: boolean } | undefined = undefined,
 ): Client {
-  return new Client(
+  return harnessClient({
     clientID,
     persistentID,
-    null,
-    role,
-    undefined,
-    "127.0.0.1",
     username,
     clanTag,
-    makeMockWs() as any,
-    cosmetics,
+    role,
     publicId,
     friends,
-  );
+    cosmetics,
+  });
 }
 
 // creator = lobby host, admin = admin role, alice + bob = regular players.
@@ -47,12 +37,7 @@ function makeGame(
   nameReveals: string[] = [],
   nameRevealPublicIds: string[] = [],
 ) {
-  const logger: any = {
-    child: vi.fn().mockReturnThis(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  };
+  const logger = mockLogger();
   const game = new GameServer(
     "g1",
     logger,

--- a/tests/server/AnonymizeNamesTeammates.test.ts
+++ b/tests/server/AnonymizeNamesTeammates.test.ts
@@ -1,17 +1,10 @@
 import { GameType } from "../../src/core/game/Game";
-import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
+import {
+  makeClient as harnessClient,
+  mockLogger,
+} from "../util/GameServerHarness";
 import { testGameConfig } from "../util/Wire";
-
-function makeMockWs() {
-  return {
-    on: () => {},
-    removeAllListeners: () => {},
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-  };
-}
 
 // clanTag and friends are populated on purpose. An earlier version of this file
 // left them null/empty, which made the "team-assignment inputs stay blank"
@@ -24,31 +17,21 @@ function makeClient(
   clanTag: string | null = "CLAN",
   friends: string[] = [],
 ) {
-  return new Client(
+  return harnessClient({
     clientID,
-    `${clientID}-pid`,
-    null,
-    null,
-    undefined,
-    "127.0.0.1",
+    persistentID: `${clientID}-pid`,
     username,
     clanTag,
-    makeMockWs() as any,
-    { verified: true },
     publicId,
     friends,
-  );
+    cosmetics: { verified: true },
+  });
 }
 
 // alice+bob are one pinned team, carol+dave the other. Bob is friends with carol,
 // an OPPONENT — so a friends leak to alice would expose a third party.
 function makeGame(matchmakingTeams?: string[][]) {
-  const logger: any = {
-    child: vi.fn().mockReturnThis(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  };
+  const logger = mockLogger();
   const game = new GameServer(
     "g1",
     logger,

--- a/tests/server/CreateNextLobby.test.ts
+++ b/tests/server/CreateNextLobby.test.ts
@@ -1,52 +1,28 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GameType } from "../../src/core/game/Game";
 import { ServerNewLobbyMessage } from "../../src/core/Schemas";
-import { Client } from "../../src/server/Client";
-import { GameServer } from "../../src/server/GameServer";
-import { sentServerMessages, testGameConfig } from "../util/Wire";
+import {
+  makeClient as harnessClient,
+  makeGame as harnessGame,
+  makeMockWs,
+  MockWs,
+} from "../util/GameServerHarness";
+import { sentServerMessages } from "../util/Wire";
 
-function makeMockWs() {
-  const handlers: Record<string, (...args: any[]) => any> = {};
-  return {
-    on: (event: string, handler: (...args: any[]) => any) => {
-      handlers[event] = handler;
-    },
-    removeAllListeners: (_event: string) => {},
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-    trigger: (event: string, ...args: any[]) => handlers[event]?.(...args),
-  };
-}
-
-function makeClient(
-  clientID: string,
-  persistentID: string,
-): { client: Client; ws: ReturnType<typeof makeMockWs> } {
+function makeClient(clientID: string, persistentID: string) {
   const ws = makeMockWs();
-  const client = new Client(
+  const client = harnessClient({
     clientID,
     persistentID,
-    null,
-    null,
-    undefined,
-    "127.0.0.1",
-    "TestUser",
-    null,
-    ws as any,
-    undefined,
-    undefined,
-    [],
-  );
+    username: "TestUser",
+    ws,
+  });
   return { client, ws };
 }
 
 // The successor id the broadcast should carry (8-char id shape).
 const SUCCESSOR_ID = "SUCCES01";
 
-function newLobbyBroadcasts(
-  ws: ReturnType<typeof makeMockWs>,
-): ServerNewLobbyMessage[] {
+function newLobbyBroadcasts(ws: MockWs): ServerNewLobbyMessage[] {
   return sentServerMessages(ws).filter(
     (m): m is ServerNewLobbyMessage => m.type === "new_lobby",
   );
@@ -56,16 +32,8 @@ function newLobbyBroadcasts(
 // finished game after minting the successor: the game must remember the id
 // (so repeat requests reuse it) and broadcast it to everyone still connected.
 describe("GameServer - successor lobby", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
   });
 
   afterEach(() => {
@@ -74,13 +42,7 @@ describe("GameServer - successor lobby", () => {
   });
 
   function makeGame(creatorPersistentID?: string) {
-    return new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private }),
-      creatorPersistentID,
-    );
+    return harnessGame({ creatorPersistentID });
   }
 
   it("broadcasts the successor id to everyone still connected", () => {

--- a/tests/server/GameLifecycle.test.ts
+++ b/tests/server/GameLifecycle.test.ts
@@ -1,33 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-
-vi.mock("../../src/core/Schemas", async () => {
-  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
-  return {
-    ...actual,
-    GameStartInfoSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
-    ServerPrestartMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
-  };
-});
-
-import { GameType } from "../../src/core/game/Game";
-import { GameServer } from "../../src/server/GameServer";
-import { testGameConfig } from "../util/Wire";
+import { GamePhase } from "../../src/server/GameServer";
+import { makeGame, startGame } from "../util/GameServerHarness";
 
 describe("GameLifecycle", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
   });
 
   afterEach(() => {
@@ -36,12 +13,7 @@ describe("GameLifecycle", () => {
   });
 
   it("should not start turn interval if game has ended", async () => {
-    const game = new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private }),
-    );
+    const game = makeGame();
 
     // Call end() first - this should set _hasEnded
     await game.end();
@@ -49,48 +21,35 @@ describe("GameLifecycle", () => {
     // Now call start() - this should be a no-op due to our fix
     game.start();
 
-    // Check if the interval ID is set (it shouldn't be)
-    expect((game as any).endTurnIntervalID).toBeUndefined();
+    // No turn interval was armed.
+    expect(vi.getTimerCount()).toBe(0);
 
     // Check if _hasStarted remained false (or at least no interval was created)
     expect(game.hasStarted()).toBe(false);
   });
 
-  it("should clear turn interval and set _hasEnded on end()", async () => {
-    // We need to initialize the game such that start() can succeed
-    const game = new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private }),
-    );
+  it("should clear turn interval and mark the game ended on end()", async () => {
+    const game = makeGame();
 
-    // Manually trigger prestart to fulfill some internal checks if necessary
-    game.prestart();
-
-    // start() should create the interval
-    game.start();
-    expect((game as any).endTurnIntervalID).toBeDefined();
+    // Take the game through the real lobby -> game transition.
+    startGame(game);
+    // start() arms the turn interval (nobody joined, so no lobby broadcast).
+    expect(vi.getTimerCount()).toBe(1);
 
     // end() should clear it
     await game.end();
-    expect((game as any).endTurnIntervalID).toBeUndefined();
-    expect((game as any)._hasEnded).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(game.phase()).toBe(GamePhase.Finished);
   });
 
   it("should be resilient to multiple end() calls", async () => {
-    const game = new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private }),
-    );
+    const game = makeGame();
 
     await game.end();
-    expect((game as any)._hasEnded).toBe(true);
+    expect(game.phase()).toBe(GamePhase.Finished);
 
     // Should not throw or crash
     await expect(game.end()).resolves.toBeUndefined();
-    expect((game as any)._hasEnded).toBe(true);
+    expect(game.phase()).toBe(GamePhase.Finished);
   });
 });

--- a/tests/server/GameServerTribes.test.ts
+++ b/tests/server/GameServerTribes.test.ts
@@ -1,18 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../src/core/Schemas", async () => {
-  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
-  return {
-    ...actual,
-    GameStartInfoSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
-    ServerPrestartMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
-  };
-});
-
 vi.mock("../../src/server/CustomTribes", () => ({
   fetchCustomTribes: vi.fn(),
 }));
@@ -20,21 +7,12 @@ vi.mock("../../src/server/CustomTribes", () => ({
 import { GameType } from "../../src/core/game/Game";
 import { fetchCustomTribes } from "../../src/server/CustomTribes";
 import { GameServer } from "../../src/server/GameServer";
-import { testGameConfig } from "../util/Wire";
-
-function fakeClient(clientID: string, publicId?: string) {
-  return {
-    clientID,
-    persistentID: `persist-${clientID}`,
-    publicId,
-    friends: [],
-    username: clientID,
-    clanTag: null,
-    role: null,
-    cosmetics: undefined,
-    ws: { readyState: 3, send: vi.fn() },
-  } as any;
-}
+import {
+  makeGame as harnessGame,
+  makeClient,
+  mockLogger,
+  startGame,
+} from "../util/GameServerHarness";
 
 // Lets the fetchCustomTribes .then/.catch chain in fetchTribes() settle.
 async function flushMicrotasks() {
@@ -42,20 +20,19 @@ async function flushMicrotasks() {
   await Promise.resolve();
 }
 
+// The start info start() built. Reaches into the game until it grows an
+// accessor (see docs/GameServerRefactor.md, Phase 2).
+const startInfo = (game: GameServer) => (game as any).gameStartInfo;
+
 describe("GameServer custom tribes", () => {
-  let mockLogger: any;
+  let log: any;
 
   beforeEach(() => {
     // restoreAllMocks doesn't touch vi.mock module mocks — reset the fetch
     // mock's implementation and call history between tests explicitly.
     vi.mocked(fetchCustomTribes).mockReset();
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    log = mockLogger();
   });
 
   afterEach(() => {
@@ -64,16 +41,10 @@ describe("GameServer custom tribes", () => {
   });
 
   function makeGame(config: Record<string, unknown> = {}) {
-    return new GameServer(
-      "testgame",
-      mockLogger,
-      Date.now(),
-      testGameConfig({
-        gameType: GameType.Public,
-        bots: 400,
-        ...config,
-      }),
-    );
+    return harnessGame({
+      log,
+      config: { gameType: GameType.Public, bots: 400, ...config },
+    });
   }
 
   it("fetches the pool at prestart and embeds the tribes in the start info", async () => {
@@ -82,10 +53,9 @@ describe("GameServer custom tribes", () => {
       { name: "Night Wolves" },
     ]);
     const game = makeGame();
-    game.activeClients.push(
-      fakeClient("abcd1234", "pub-1"),
-      fakeClient("efgh5678"), // guest — no account, must be omitted
-    );
+    game.joinClient(makeClient({ clientID: "abcd1234", publicId: "pub-1" }));
+    // guest — no account, must be omitted
+    game.joinClient(makeClient({ clientID: "efgh5678" }));
 
     game.prestart();
     await flushMicrotasks();
@@ -94,7 +64,7 @@ describe("GameServer custom tribes", () => {
     expect(fetchCustomTribes).toHaveBeenCalledWith([
       { clientId: "abcd1234", publicId: "pub-1" },
     ]);
-    expect((game as any).gameStartInfo.tribes).toEqual([
+    expect(startInfo(game).tribes).toEqual([
       { name: "Dragon Riders" },
       { name: "Night Wolves" },
     ]);
@@ -111,9 +81,7 @@ describe("GameServer custom tribes", () => {
     await flushMicrotasks();
     game.start();
 
-    expect((game as any).gameStartInfo.tribes).toEqual([
-      { name: "Dragon Riders" },
-    ]);
+    expect(startInfo(game).tribes).toEqual([{ name: "Dragon Riders" }]);
   });
 
   it("skips the fetch for non-public games", async () => {
@@ -124,7 +92,7 @@ describe("GameServer custom tribes", () => {
     game.start();
 
     expect(fetchCustomTribes).not.toHaveBeenCalled();
-    expect((game as any).gameStartInfo.tribes).toBeUndefined();
+    expect(startInfo(game).tribes).toBeUndefined();
   });
 
   it("skips the fetch when bots are disabled", async () => {
@@ -144,8 +112,8 @@ describe("GameServer custom tribes", () => {
     await flushMicrotasks();
     game.start();
 
-    expect((game as any).gameStartInfo.tribes).toBeUndefined();
-    expect(mockLogger.warn).toHaveBeenCalledWith(
+    expect(startInfo(game).tribes).toBeUndefined();
+    expect(log.warn).toHaveBeenCalledWith(
       expect.stringContaining("failed to fetch custom tribes"),
     );
   });
@@ -154,10 +122,9 @@ describe("GameServer custom tribes", () => {
     vi.mocked(fetchCustomTribes).mockResolvedValue([]);
     const game = makeGame();
 
-    game.prestart();
+    startGame(game);
     await flushMicrotasks();
-    game.start();
 
-    expect((game as any).gameStartInfo.tribes).toBeUndefined();
+    expect(startInfo(game).tribes).toBeUndefined();
   });
 });

--- a/tests/server/GameServerTribes.test.ts
+++ b/tests/server/GameServerTribes.test.ts
@@ -11,7 +11,6 @@ import {
   makeGame as harnessGame,
   makeClient,
   mockLogger,
-  startGame,
 } from "../util/GameServerHarness";
 
 // Lets the fetchCustomTribes .then/.catch chain in fetchTribes() settle.
@@ -122,8 +121,9 @@ describe("GameServer custom tribes", () => {
     vi.mocked(fetchCustomTribes).mockResolvedValue([]);
     const game = makeGame();
 
-    startGame(game);
+    game.prestart();
     await flushMicrotasks();
+    game.start();
 
     expect(startInfo(game).tribes).toBeUndefined();
   });

--- a/tests/server/GameServerWire.test.ts
+++ b/tests/server/GameServerWire.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Keep the real finalizeGameRecord so the archived record is snapshotted as
+// it would be sent; only the network call is stubbed.
+vi.mock("../../src/server/Archive", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/server/Archive")>()),
+  archive: vi.fn(),
+}));
+
+import { GameMode, GameType } from "../../src/core/game/Game";
+import { ClientMessage } from "../../src/core/Schemas";
+import { createGameWireContext } from "../../src/core/ZbinWire";
+import { archive } from "../../src/server/Archive";
+import { ServerEnv } from "../../src/server/ServerEnv";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  makeMockWs,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
+
+// Golden transcript: a scripted game, and every frame the server sends each
+// client along the way, plus the HTTP lobby view, the live stats, and the
+// archived record. Client-visible behaviour is GameServer's contract, so a
+// refactor that leaves this snapshot untouched cannot have changed it.
+//
+// The snapshot is meant to be read when it changes: a diff here is either a
+// deliberate wire change (update it) or a regression (don't).
+
+const T0 = 1_700_000_000_000;
+const TURN_MS = 100; // ServerEnv.turnIntervalMs()
+
+describe("GameServer wire transcript", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+    vi.mocked(archive).mockReset();
+    // finalizeGameRecord stamps these from the environment.
+    vi.spyOn(ServerEnv, "gitCommit").mockReturnValue("golden-commit");
+    vi.spyOn(ServerEnv, "subdomain").mockReturnValue("golden-sub");
+    vi.spyOn(ServerEnv, "domain").mockReturnValue("golden.test");
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("matches the golden transcript for a scripted game", async () => {
+    const HOST = cid("host");
+    const P2 = cid("p2");
+    const P3 = cid("p3");
+    const CAST = cid("cast");
+
+    const game = makeGame({
+      id: cid("golden"),
+      creatorPersistentID: "host-pid",
+      config: { gameType: GameType.Private, maxPlayers: 3 },
+    });
+    const host = makeClient({
+      clientID: HOST,
+      persistentID: "host-pid",
+      username: "HostName",
+      clanTag: "HST",
+      ip: "1.1.1.1",
+      publicId: "host-pub",
+      friends: ["p2-pub"],
+    });
+    const p2 = makeClient({
+      clientID: P2,
+      persistentID: "p2-pid",
+      username: "SecondOne",
+      ip: "2.2.2.2",
+      publicId: "p2-pub",
+      cosmetics: { verified: true },
+    });
+    const p3 = makeClient({
+      clientID: P3,
+      persistentID: "p3-pid",
+      username: "ThirdOne",
+      clanTag: "TRD",
+      ip: "3.3.3.3",
+    });
+    const cast = makeClient({
+      clientID: CAST,
+      persistentID: "cast-pid",
+      username: "Caster",
+      ip: "4.4.4.4",
+      spectator: true,
+    });
+
+    // p3 reconnects on a new socket later; client.ws then points at that one,
+    // so hold on to the original to read what it was sent.
+    const p3Ws = mockWsOf(p3);
+    const late = makeClient({ clientID: cid("late"), ip: "5.5.5.5" });
+
+    // --- Lobby ---
+    expect(game.joinClient(host)).toBe("joined");
+    expect(game.joinClient(p2)).toBe("joined");
+    expect(game.joinClient(cast)).toBe("joined");
+    expect(game.joinClient(p3)).toBe("joined");
+    // A fourth player is turned away; the spectator took no seat.
+    expect(game.joinClient(late)).toBe("rejected");
+
+    vi.advanceTimersByTime(1000); // one lobby_info broadcast tick
+
+    // The host edits the lobby, then arms the start timer.
+    await mockWsOf(host).emit({
+      type: "intent",
+      intent: {
+        type: "update_game_config",
+        config: { bots: 5, gameMode: GameMode.FFA },
+      },
+    });
+    await mockWsOf(host).emit({
+      type: "intent",
+      intent: { type: "toggle_game_start_timer" },
+    });
+    vi.advanceTimersByTime(1000);
+
+    const lobbyHttpView = game.gameInfo();
+
+    // --- Start ---
+    startGame(game);
+    // Same roster, same order, as the start message seeds on the client.
+    const ctx = createGameWireContext([
+      { clientID: HOST },
+      { clientID: P2 },
+      { clientID: P3 },
+    ]);
+
+    // --- Play ---
+    await mockWsOf(p2).emit({
+      type: "intent",
+      intent: { type: "spawn", tile: 1 },
+    });
+    vi.advanceTimersByTime(TURN_MS); // turn 0
+    // A spectator's intent is dropped; p3's lands in turn 1.
+    await mockWsOf(cast).emit({
+      type: "intent",
+      intent: { type: "spawn", tile: 2 },
+    });
+    await mockWsOf(p3).emit({
+      type: "intent",
+      intent: { type: "spawn", tile: 3 },
+    });
+    vi.advanceTimersByTime(TURN_MS); // turn 1
+
+    // Pause flushes its intent into turn 2 at once; the clock then runs
+    // without producing turns. Unpausing lands in turn 3.
+    await mockWsOf(host).emit({
+      type: "intent",
+      intent: { type: "toggle_pause", paused: true },
+    });
+    vi.advanceTimersByTime(3 * TURN_MS);
+    await mockWsOf(host).emit({
+      type: "intent",
+      intent: { type: "toggle_pause", paused: false },
+    });
+
+    // Hashes: everyone agrees on turn 0; p3 disagrees on turn 10.
+    for (const c of [host, p2, p3]) {
+      await mockWsOf(c).emit({ type: "hash", hash: 1234.5, turnNumber: 0 });
+    }
+    for (const c of [host, p2]) {
+      await mockWsOf(c).emit({ type: "hash", hash: 99, turnNumber: 10 });
+    }
+    await mockWsOf(p3).emit({ type: "hash", hash: 98, turnNumber: 10 });
+    // Turns 4..20: the sync check runs at 10 turns (for turn 0) and at 20
+    // (for turn 10).
+    vi.advanceTimersByTime(17 * TURN_MS);
+
+    // p3's socket drops; they reconnect on a new one asking for turns from 5.
+    await p3Ws.trigger("close");
+    const p3Again = makeMockWs();
+    expect(game.rejoinClient(p3Again as any, "p3-pid", 5)).toBe(true);
+
+    // Live stats consensus from two of three IPs.
+    const stats = {
+      turn: 10,
+      players: [
+        {
+          clientID: HOST,
+          tilesOwned: 10,
+          troops: 100,
+          gold: "50",
+          isAlive: true,
+          team: null,
+          killedBy: null,
+          deathPosition: null,
+        },
+      ],
+    };
+    await mockWsOf(host).emit({ type: "live_stats", stats });
+    await mockWsOf(p2).emit({ type: "live_stats", stats });
+
+    // Winner: host and p2 vote (2 of 3 IPs); p3 never does.
+    const winnerMsg: ClientMessage = {
+      type: "winner",
+      winner: ["player", HOST],
+      allPlayersStats: {},
+    };
+    await mockWsOf(host).emit(winnerMsg);
+    await mockWsOf(p2).emit(winnerMsg);
+    expect(archive).toHaveBeenCalledOnce();
+
+    // --- End ---
+    await game.end();
+
+    expect({
+      lobbyHttpView,
+      liveStats: game.liveStats(),
+      frames: {
+        host: mockWsOf(host).sent(ctx),
+        p2: mockWsOf(p2).sent(ctx),
+        p3: p3Ws.sent(ctx),
+        p3Again: p3Again.sent(ctx),
+        cast: mockWsOf(cast).sent(ctx),
+        late: mockWsOf(late).sent(),
+      },
+      closes: {
+        host: mockWsOf(host).close.mock.calls,
+        p2: mockWsOf(p2).close.mock.calls,
+        p3: p3Ws.close.mock.calls,
+        p3Again: p3Again.close.mock.calls,
+        cast: mockWsOf(cast).close.mock.calls,
+      },
+      archived: vi.mocked(archive).mock.calls[0][0],
+    }).toMatchSnapshot();
+  });
+});

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -15,7 +15,6 @@ import {
   MAX_HOSTED_LOBBIES,
 } from "../../src/core/Schemas";
 import { LOBBY_LABEL_MAX, sanitizeLobbyLabel } from "../../src/core/Util";
-import { Client } from "../../src/server/Client";
 import { GameManager } from "../../src/server/GameManager";
 import {
   GamePhase,
@@ -29,6 +28,12 @@ import {
 import { MasterLobbyService } from "../../src/server/MasterLobbyService";
 import { ServerEnv } from "../../src/server/ServerEnv";
 import { WorkerLobbyService } from "../../src/server/WorkerLobbyService";
+import {
+  makeClient as harnessClient,
+  mockLogger as harnessLogger,
+  makeMockWs,
+  MockWs,
+} from "../util/GameServerHarness";
 import { decodeSentLobbyMessage, testGameConfig } from "../util/Wire";
 
 vi.mock("../../src/server/Logger", () => ({
@@ -45,12 +50,7 @@ vi.mock("../../src/server/PollingLoop", () => ({
   startPolling: vi.fn(),
 }));
 
-const mockLogger: any = {
-  child: vi.fn().mockReturnThis(),
-  info: vi.fn(),
-  warn: vi.fn(),
-  error: vi.fn(),
-};
+const mockLogger = harnessLogger();
 
 const CREATOR = "11111111-1111-4111-8111-111111111111";
 const OTHER_CREATOR = "22222222-2222-4222-8222-222222222222";
@@ -257,29 +257,16 @@ describe("listed lobby auto-start", () => {
   });
 });
 
-function fakeWs() {
-  const ws = new EventEmitter() as any;
-  ws.readyState = WebSocket.OPEN;
-  ws.send = vi.fn();
-  ws.close = vi.fn();
-  return ws;
-}
+const fakeWs = makeMockWs;
 
-function makeClient(clientID: string, persistentID: string, ws: any) {
-  return new Client(
+function makeClient(clientID: string, persistentID: string, ws: MockWs) {
+  return harnessClient({
     clientID,
     persistentID,
-    null,
-    null,
-    undefined,
-    "1.2.3.4",
-    `user_${clientID}`,
-    null,
+    ip: "1.2.3.4",
+    username: `user_${clientID}`,
     ws,
-    undefined,
-    undefined,
-    [],
-  );
+  });
 }
 
 describe("host-left lobby teardown", () => {
@@ -292,7 +279,7 @@ describe("host-left lobby teardown", () => {
     vi.useRealTimers();
   });
 
-  it("ends, delists and prunes an unstarted lobby when the host leaves", () => {
+  it("ends, delists and prunes an unstarted lobby when the host leaves", async () => {
     const gm = new GameManager(mockLogger);
     const game = gm.createGame("g-host-leaves", undefined, CREATOR)!;
     game.setListed(true);
@@ -305,7 +292,7 @@ describe("host-left lobby teardown", () => {
     );
     expect(gm.listedLobbies()).toHaveLength(1);
 
-    hostWs.emit("close");
+    await hostWs.trigger("close");
 
     // Remaining players are kicked and the ghost leaves the listing...
     expect(guestWs.close).toHaveBeenCalled();
@@ -337,7 +324,7 @@ describe("host-left lobby teardown", () => {
     expect(game.joinClient({} as any)).toBe("rejected");
   });
 
-  it("does not tear down when the host disconnects during prestart", () => {
+  it("does not tear down when the host disconnects during prestart", async () => {
     // During the lobby -> game transition the host modal closes and sockets
     // churn; a starting game (e.g. listed-lobby auto-start) must survive it.
     const gm = new GameManager(mockLogger);
@@ -348,7 +335,7 @@ describe("host-left lobby teardown", () => {
     game.joinClient(makeClient("host", CREATOR, hostWs));
     (game as any)._hasPrestarted = true;
 
-    hostWs.emit("close");
+    await hostWs.trigger("close");
 
     expect((game as any)._hasEnded).toBe(false);
     expect(game.phase()).not.toBe(GamePhase.Finished);

--- a/tests/server/KickPlayerAuthorization.test.ts
+++ b/tests/server/KickPlayerAuthorization.test.ts
@@ -1,71 +1,27 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  makeClient as harnessClient,
+  makeGame as harnessGame,
+  makeMockWs,
+  MockWs,
+} from "../util/GameServerHarness";
+import { clientFrame } from "../util/Wire";
 
-vi.mock("../../src/core/Schemas", async () => {
-  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
-  return {
-    ...actual,
-    GameStartInfoSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
-    ServerPrestartMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data: data }),
-    },
-  };
-});
-
-import { GameType } from "../../src/core/game/Game";
-import { Client } from "../../src/server/Client";
-import { GameServer } from "../../src/server/GameServer";
-import { clientFrame, testGameConfig } from "../util/Wire";
-
-function makeMockWs() {
-  const handlers: Record<string, (...args: any[]) => any> = {};
-  return {
-    on: (event: string, handler: (...args: any[]) => any) => {
-      handlers[event] = handler;
-    },
-    removeAllListeners: (_event: string) => {},
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-    trigger: (event: string, ...args: any[]) => handlers[event]?.(...args),
-  };
-}
-
-function makeClient(
-  clientID: string,
-  persistentID: string,
-  role?: string,
-): { client: Client; ws: ReturnType<typeof makeMockWs> } {
+function makeClient(clientID: string, persistentID: string, role?: string) {
   const ws = makeMockWs();
-  const client = new Client(
+  const client = harnessClient({
     clientID,
     persistentID,
-    null,
-    role ?? null,
-    undefined,
-    "127.0.0.1",
-    "TestUser",
-    null,
-    ws as any,
-    undefined,
-    undefined,
-    [],
-  );
+    role: role ?? null,
+    username: "TestUser",
+    ws,
+  });
   return { client, ws };
 }
 
 describe("GameServer - kick_player authorization", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
   });
 
   afterEach(() => {
@@ -74,19 +30,10 @@ describe("GameServer - kick_player authorization", () => {
   });
 
   function makeGame(creatorPersistentID?: string) {
-    return new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private }),
-      creatorPersistentID,
-    );
+    return harnessGame({ creatorPersistentID });
   }
 
-  async function sendKickMessage(
-    ws: ReturnType<typeof makeMockWs>,
-    target: string,
-  ) {
+  async function sendKickMessage(ws: MockWs, target: string) {
     await ws.trigger(
       "message",
       clientFrame({

--- a/tests/server/MatchTelemetryIntegration.test.ts
+++ b/tests/server/MatchTelemetryIntegration.test.ts
@@ -12,7 +12,6 @@ import {
   GameMode,
   GameType,
 } from "../../src/core/game/Game";
-import { Client } from "../../src/server/Client";
 import { GameManager } from "../../src/server/GameManager";
 import { GameServer } from "../../src/server/GameServer";
 import type {
@@ -20,6 +19,11 @@ import type {
   MatchTelemetryEmitter,
   MatchTelemetryEvent,
 } from "../../src/server/telemetry/MatchTelemetry";
+import {
+  makeClient as harnessClient,
+  makeMockWs,
+  mockLogger,
+} from "../util/GameServerHarness";
 import { clientFrame, testGameConfig } from "../util/Wire";
 
 class RecordingEmitter implements MatchTelemetryEmitter {
@@ -37,35 +41,15 @@ class RecordingEmitter implements MatchTelemetryEmitter {
   stop() {}
 }
 
-function makeMockWs() {
-  const handlers: Record<string, (...args: any[]) => any> = {};
-  return {
-    on: (event: string, handler: (...args: any[]) => any) =>
-      (handlers[event] = handler),
-    removeAllListeners: vi.fn(),
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-    trigger: (event: string, ...args: any[]) => handlers[event]?.(...args),
-  };
-}
-
 function makeClient() {
   const ws = makeMockWs();
-  const client = new Client(
-    "clientAB",
-    "persistentABC",
-    null,
-    null,
-    undefined,
-    "127.0.0.1",
-    "TestUser",
-    null,
-    ws as any,
-    undefined,
-    "publicABC",
-    [],
-  );
+  const client = harnessClient({
+    clientID: "clientAB",
+    persistentID: "persistentABC",
+    username: "TestUser",
+    publicId: "publicABC",
+    ws,
+  });
   return { client, ws };
 }
 
@@ -77,12 +61,7 @@ describe("GameServer match telemetry", () => {
     vi.useFakeTimers();
     vi.setSystemTime(1_700_000_000_000);
     telemetry = new RecordingEmitter();
-    log = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    log = mockLogger();
   });
 
   afterEach(() => {

--- a/tests/server/MatchmakingCancel.test.ts
+++ b/tests/server/MatchmakingCancel.test.ts
@@ -2,47 +2,25 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { GameType, RankedType } from "../../src/core/game/Game";
 import { Client } from "../../src/server/Client";
-import { GamePhase, GameServer } from "../../src/server/GameServer";
-import { sentServerMessages, testGameConfig } from "../util/Wire";
-
-function makeMockWs() {
-  return {
-    on: () => {},
-    removeAllListeners: () => {},
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-  };
-}
+import { GamePhase } from "../../src/server/GameServer";
+import {
+  makeClient as harnessClient,
+  makeGame,
+  mockWsOf,
+} from "../util/GameServerHarness";
 
 function makeClient(clientID: string, persistentID: string): Client {
-  return new Client(
+  return harnessClient({
     clientID,
     persistentID,
-    null,
-    null,
-    undefined,
-    "127.0.0.1",
-    "TestUser",
-    null,
-    makeMockWs() as any,
-    undefined,
-    `pub-${persistentID}`,
-    [],
-  );
+    username: "TestUser",
+    publicId: `pub-${persistentID}`,
+  });
 }
 
 describe("GameServer - short-handed matchmade game cancellation", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
   });
 
   afterEach(() => {
@@ -52,14 +30,10 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
   });
 
   function makeRankedGame(rankedType: RankedType, maxPlayers: number) {
-    return new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Public, rankedType, maxPlayers }),
-      undefined,
-      Date.now() + 15000,
-    );
+    return makeGame({
+      config: { gameType: GameType.Public, rankedType, maxPlayers },
+      startsAt: Date.now() + 15000,
+    });
   }
 
   it("cancels a 2v2 game missing a player: kicks the connected, ends the game", () => {
@@ -74,11 +48,11 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
     expect(game.cancelShortHandedMatch()).toBe(true);
 
     for (const c of clients) {
-      expect(sentServerMessages(c.ws as any)).toContainEqual({
+      expect(mockWsOf(c).sent()).toContainEqual({
         type: "error",
         error: "kick_reason.match_cancelled",
       });
-      expect(c.ws.close).toHaveBeenCalled();
+      expect(mockWsOf(c).close).toHaveBeenCalled();
     }
     expect(game.phase()).toBe(GamePhase.Finished);
   });
@@ -101,36 +75,28 @@ describe("GameServer - short-handed matchmade game cancellation", () => {
   });
 
   it("does not cancel unknown ranked types — new modes must opt in", () => {
-    const game = new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({
+    const game = makeGame({
+      config: {
         gameType: GameType.Public,
         rankedType: RankedType.TwoVTwo,
         maxPlayers: 6,
-      }),
-      undefined,
-      Date.now() + 15000,
-    );
+      },
+      startsAt: Date.now() + 15000,
+    });
     expect(game.joinClient(makeClient("c1", "p1"))).toBe("joined");
     // Swapped in after the join: an unknown ranked type can never reach a real
     // server (CreateGameInput validates it, and the binary wire only encodes
     // declared enum members), so this pokes the guard directly.
-    (game as any).gameConfig.rankedType = "3v3";
+    (game.gameConfig as any).rankedType = "3v3";
 
     expect(game.cancelShortHandedMatch()).toBe(false);
   });
 
   it("does not cancel non-ranked games, even short-handed", () => {
-    const game = new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Public, maxPlayers: 4 }),
-      undefined,
-      Date.now() + 15000,
-    );
+    const game = makeGame({
+      config: { gameType: GameType.Public, maxPlayers: 4 },
+      startsAt: Date.now() + 15000,
+    });
     expect(game.joinClient(makeClient("c1", "p1"))).toBe("joined");
 
     expect(game.cancelShortHandedMatch()).toBe(false);

--- a/tests/server/SpectatorJoin.test.ts
+++ b/tests/server/SpectatorJoin.test.ts
@@ -1,75 +1,49 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-vi.mock("../../src/core/Schemas", async () => {
-  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
-  return {
-    ...actual,
-    GameStartInfoSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-    ServerPrestartMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-  };
-});
+vi.mock("../../src/server/Archive", () => ({
+  archive: vi.fn(),
+  finalizeGameRecord: (record: unknown) => record,
+}));
 
 import { GameType, RankedType } from "../../src/core/game/Game";
 import { ClientMessage } from "../../src/core/Schemas";
+import { createGameWireContext } from "../../src/core/ZbinWire";
+import { archive } from "../../src/server/Archive";
 import { Client } from "../../src/server/Client";
 import { GameServer } from "../../src/server/GameServer";
-import { clientFrame, testGameConfig } from "../util/Wire";
-
-function makeMockWs() {
-  const handlers = new Map<string, (msg: Buffer) => void>();
-  return {
-    on: (event: string, fn: (msg: Buffer) => void) => handlers.set(event, fn),
-    removeAllListeners: () => handlers.clear(),
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-    /** Drive the socket the way a connected client would. */
-    emit: (msg: ClientMessage) => handlers.get("message")?.(clientFrame(msg)),
-  };
-}
+import {
+  cid,
+  makeClient as harnessClient,
+  makeGame as harnessGame,
+  mockLogger,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
 
 function makeClient(
   id: string,
   spectator = false,
   friends: string[] = [],
 ): Client {
-  return new Client(
-    id,
-    `${id}-pid`,
-    null,
-    null,
-    undefined,
-    // Distinct per client: the winner vote is weighted by unique IP, so a shared
-    // one would collapse every electorate to a single voter.
-    `10.0.0.${ipOctet++}`,
-    id,
-    null,
-    makeMockWs() as any,
-    undefined,
-    `${id}-pub`,
+  // The harness hands every client a distinct IP: the winner vote is weighted
+  // by unique IP, so a shared one would collapse every electorate to a single
+  // voter.
+  return harnessClient({
+    clientID: cid(id),
+    persistentID: `${id}-pid`,
+    publicId: `${id}-pub`,
     friends,
     spectator,
-  );
+  });
 }
-
-let ipOctet = 1;
 
 describe("GameServer - spectators", () => {
   let logger: any;
 
   beforeEach(() => {
     vi.useFakeTimers();
-    ipOctet = 1;
-    logger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    vi.mocked(archive).mockReset();
+    logger = mockLogger();
   });
   afterEach(() => {
     vi.clearAllTimers();
@@ -77,12 +51,10 @@ describe("GameServer - spectators", () => {
   });
 
   const makeGame = (maxPlayers?: number) =>
-    new GameServer(
-      "g1",
-      logger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private, maxPlayers }),
-    );
+    harnessGame({
+      log: logger,
+      config: { gameType: GameType.Private, maxPlayers },
+    });
 
   it("takes no lobby slot, so a full game is still watchable", () => {
     const game = makeGame(2);
@@ -103,25 +75,29 @@ describe("GameServer - spectators", () => {
     // Anyone in gameStartInfo.players gets spawned, so a spectator in that list
     // would be playing.
     const game = makeGame();
-    game.joinClient(makeClient("p1"));
+    const p1 = makeClient("p1");
+    game.joinClient(p1);
     game.joinClient(makeClient("cast", true));
-    game.start();
-    const info = (game as any).gameStartInfo;
-    expect(info).toBeDefined();
-    expect(info.players.map((p: any) => p.clientID)).toEqual(["p1"]);
+    startGame(game);
+    const start = mockWsOf(p1)
+      .sent()
+      .find((m) => m.type === "start");
+    expect(start?.type).toBe("start");
+    if (start?.type !== "start") return;
+    expect(start.gameStartInfo.players.map((p) => p.clientID)).toEqual([
+      cid("p1"),
+    ]);
   });
 
   it("still has to be on the allowlist when the lobby sets one", () => {
     // Taking no slot must not become a way around the allowlist.
-    const game = new GameServer(
-      "g1",
-      logger,
-      Date.now(),
-      testGameConfig({
+    const game = harnessGame({
+      log: logger,
+      config: {
         gameType: GameType.Private,
         allowedPublicIds: ["p1-pub"],
-      }),
-    );
+      },
+    });
     expect(game.joinClient(makeClient("cast", true))).toBe("not_allowlisted");
     expect(game.joinClient(makeClient("p1", true))).toBe("joined");
   });
@@ -129,19 +105,17 @@ describe("GameServer - spectators", () => {
   it("does not keep a ranked match alive on its own", () => {
     // 1v1 with one player and one spectator is a one-player game, so the
     // short-handed cancel has to see through the spectator.
-    const game = new GameServer(
-      "g1",
-      logger,
-      Date.now(),
-      testGameConfig({
+    const game = harnessGame({
+      log: logger,
+      config: {
         gameType: GameType.Private,
         maxPlayers: 2,
         rankedType: RankedType.OneVOne,
-      }),
-    );
+      },
+    });
     game.joinClient(makeClient("p1"));
     game.joinClient(makeClient("cast", true));
-    expect((game as any).cancelShortHandedMatch()).toBe(true);
+    expect(game.cancelShortHandedMatch()).toBe(true);
   });
 
   it.each(["intent", "winner", "live_stats", "hash"])(
@@ -150,7 +124,7 @@ describe("GameServer - spectators", () => {
       // Taking no slot must not buy a way into the intent stream.
       const game = makeGame();
       const spies = {
-        intent: vi.spyOn(game as any, "handleIntent"),
+        intent: vi.spyOn(game, "handleIntent"),
         winner: vi.spyOn(game as any, "handleWinner"),
         live_stats: vi.spyOn(game as any, "handleLiveStats"),
       };
@@ -162,7 +136,7 @@ describe("GameServer - spectators", () => {
         live_stats: { type: "live_stats", stats: { turn: 1, players: [] } },
         hash: { type: "hash", hash: 42, turnNumber: 1 },
       };
-      await (spectator.ws as any).emit(byType[type]);
+      await mockWsOf(spectator).emit(byType[type]);
       if (type === "hash") {
         // hash has no handler spy — it writes client.hashes, which feeds the
         // desync agreement a spectator must not vote in.
@@ -175,10 +149,10 @@ describe("GameServer - spectators", () => {
 
   it("still handles those messages from a player", async () => {
     const game = makeGame();
-    const handleIntent = vi.spyOn(game as any, "handleIntent");
+    const handleIntent = vi.spyOn(game, "handleIntent");
     const player = makeClient("p1");
     game.joinClient(player);
-    await (player.ws as any).emit({
+    await mockWsOf(player).emit({
       type: "intent",
       intent: { type: "spawn", tile: 1 },
     });
@@ -189,7 +163,7 @@ describe("GameServer - spectators", () => {
     // The player list is frozen at start; a late joiner used to be admitted as a
     // player who could never spawn.
     const game = makeGame();
-    (game as any)._hasStarted = true;
+    startGame(game);
     const late = makeClient("late");
     expect(game.joinClient(late)).toBe("joined");
     expect(late.spectator).toBe(true);
@@ -198,18 +172,26 @@ describe("GameServer - spectators", () => {
   it("does not put a spectator's disconnect into the turn log", () => {
     // mark_disconnected names a player in gameStartInfo; for a spectator it
     // refers to nobody, and it is kept in the archived record where readers take
-    // it as a player having dropped.
+    // it as a player having dropped. Joining records the (connected) status the
+    // same way, so the first turn shows who the server marks.
     const game = makeGame();
     const spectator = makeClient("cast", true);
     game.joinClient(spectator);
-    game.joinClient(makeClient("p1"));
-    (game as any).markClientDisconnected("cast", true);
-    (game as any).markClientDisconnected("p1", true);
-    const marked = (game as any).intents
-      .filter((i: any) => i.type === "mark_disconnected")
-      .map((i: any) => i.clientID);
-    expect(marked).not.toContain("cast");
-    expect(marked).toContain("p1");
+    const p1 = makeClient("p1");
+    game.joinClient(p1);
+    startGame(game);
+    vi.advanceTimersByTime(100);
+    const ctx = createGameWireContext([{ clientID: cid("p1") }]);
+    const turn = mockWsOf(p1)
+      .sent(ctx)
+      .find((m) => m.type === "turn");
+    expect(turn?.type).toBe("turn");
+    if (turn?.type !== "turn") return;
+    const marked = turn.turn.intents
+      .filter((i) => i.type === "mark_disconnected")
+      .map((i) => i.clientID);
+    expect(marked).not.toContain(cid("cast"));
+    expect(marked).toContain(cid("p1"));
   });
 
   it("keeps a spectator out of a player's friends list", () => {
@@ -221,11 +203,11 @@ describe("GameServer - spectators", () => {
     const player = makeClient("p1", false, ["cast-pub", "p2-pub"]);
     game.joinClient(player);
     game.joinClient(makeClient("p2"));
-    const friendsFor = (game as any).buildFriendsLookup();
-    expect(friendsFor(player)).toEqual(["p2"]);
+    const seen = game.gameInfo().clients?.find((c) => c.clientID === cid("p1"));
+    expect(seen?.friends).toEqual([cid("p2")]);
   });
 
-  it("does not make the winner vote unreachable", () => {
+  it("does not make the winner vote unreachable", async () => {
     // The vote needs a strict majority of the electorate's IPs. Counting
     // spectators in that total but barring them from voting means four players
     // watched by five spectators can never reach consensus — so the game never
@@ -236,93 +218,89 @@ describe("GameServer - spectators", () => {
     for (const id of ["c1", "c2", "c3", "c4", "c5"]) {
       game.joinClient(makeClient(id, true));
     }
-    // Archiving is a separate concern and needs a started game; the quorum is
-    // what's under test.
-    vi.spyOn(game as any, "archiveGame").mockImplementation(() => {});
+    startGame(game);
     for (const p of players) {
-      (game as any).handleWinner(p, {
+      await mockWsOf(p).emit({
         type: "winner",
-        winner: ["player", "p1"],
+        winner: ["player", cid("p1")],
         allPlayersStats: {},
       });
     }
-    expect((game as any).winner).not.toBeNull();
+    // Consensus archives the game.
+    expect(archive).toHaveBeenCalledOnce();
   });
 
   describe("switching between playing and watching", () => {
-    const setSpectator = (game: GameServer, c: Client, spectator: boolean) =>
-      (game as any).setSpectator(c, spectator);
+    const setSpectator = (_game: GameServer, c: Client, spectator: boolean) =>
+      mockWsOf(c).emit({ type: "spectate", spectator });
 
-    it("a spectator can take a free seat before the start", () => {
+    it("a spectator can take a free seat before the start", async () => {
       const game = makeGame(2);
       const c = makeClient("cast", true);
       game.joinClient(c);
-      setSpectator(game, c, false);
+      await setSpectator(game, c, false);
       expect(c.spectator).toBe(false);
       expect(
-        game.gameInfo().clients?.find((x) => x.clientID === "cast")?.spectator,
+        game.gameInfo().clients?.find((x) => x.clientID === cid("cast"))
+          ?.spectator,
       ).toBeUndefined();
     });
 
-    it("a player can drop back to watching, freeing the seat", () => {
+    it("a player can drop back to watching, freeing the seat", async () => {
       const game = makeGame(1);
       const p = makeClient("p1");
       game.joinClient(p);
       expect(game.joinClient(makeClient("p2"))).toBe("rejected");
-      setSpectator(game, p, true);
+      await setSpectator(game, p, true);
       expect(game.joinClient(makeClient("p2"))).toBe("joined");
     });
 
-    it("cannot take a seat that would exceed the cap", () => {
+    it("cannot take a seat that would exceed the cap", async () => {
       const game = makeGame(1);
       game.joinClient(makeClient("p1"));
       const c = makeClient("cast", true);
       game.joinClient(c);
-      setSpectator(game, c, false);
+      await setSpectator(game, c, false);
       expect(c.spectator).toBe(true);
     });
 
-    it("cannot take a seat the allowlist does not name them for", () => {
+    it("cannot take a seat the allowlist does not name them for", async () => {
       // The allowlist can gain entries AFTER someone is already in the lobby
       // (update_game_config replaces it), so being inside is not proof of a
       // seat. Without this, the toggle is a way past the allowlist the moment
       // anything admits a non-listed spectator.
-      const game = new GameServer(
-        "g1",
-        logger,
-        Date.now(),
-        testGameConfig({
+      const game = harnessGame({
+        log: logger,
+        config: {
           gameType: GameType.Private,
           allowedPublicIds: ["p1-pub"],
-        }),
-      );
+        },
+      });
       const listed = makeClient("p1", true);
       const unlisted = makeClient("cast", true);
       // Admit both while... the unlisted one cannot join an allowlisted lobby
       // today, so simulate the post-join list change: join first, then set it.
-      const open = new GameServer(
-        "g2",
-        logger,
-        Date.now(),
-        testGameConfig({ gameType: GameType.Private }),
-      );
+      const open = harnessGame({
+        log: logger,
+        config: { gameType: GameType.Private },
+      });
       open.joinClient(unlisted);
-      (open as any).gameConfig.allowedPublicIds = ["someone-else-pub"];
-      setSpectator(open, unlisted, false);
+      open.updateGameConfig({ allowedPublicIds: ["someone-else-pub"] });
+      await setSpectator(open, unlisted, false);
       expect(unlisted.spectator).toBe(true);
 
       game.joinClient(listed);
-      setSpectator(game, listed, false);
+      await setSpectator(game, listed, false);
       expect(listed.spectator).toBe(false);
     });
 
-    it("cannot become a player once the game has started", () => {
+    it("cannot become a player once the game has started", async () => {
       // gameStartInfo.players is frozen, so a new player could never spawn.
       const game = makeGame();
       const c = makeClient("cast", true);
       game.joinClient(c);
-      (game as any)._hasStarted = true;
-      setSpectator(game, c, false);
+      startGame(game);
+      await setSpectator(game, c, false);
       expect(c.spectator).toBe(true);
     });
 
@@ -333,10 +311,14 @@ describe("GameServer - spectators", () => {
       const game = makeGame();
       game.joinClient(makeClient("p1"));
       game.joinClient(makeClient("cast", true));
-      const seen = game.gameInfo("cast").clients ?? [];
-      expect(seen.map((c) => c.clientID)).toEqual(["p1", "cast"]);
-      expect(seen.find((c) => c.clientID === "p1")?.spectator).toBeUndefined();
-      expect(seen.find((c) => c.clientID === "cast")?.spectator).toBe(true);
+      const seen = game.gameInfo(cid("cast")).clients ?? [];
+      expect(seen.map((c) => c.clientID)).toEqual([cid("p1"), cid("cast")]);
+      expect(
+        seen.find((c) => c.clientID === cid("p1"))?.spectator,
+      ).toBeUndefined();
+      expect(seen.find((c) => c.clientID === cid("cast"))?.spectator).toBe(
+        true,
+      );
     });
   });
 
@@ -344,7 +326,7 @@ describe("GameServer - spectators", () => {
     // A caster arriving mid-game is the normal case; a late player already
     // gets the same treatment, so this only has to keep working.
     const game = makeGame();
-    (game as any)._hasStarted = true;
+    startGame(game);
     expect(game.joinClient(makeClient("cast", true))).toBe("joined");
   });
 });

--- a/tests/server/TurnstileReadmit.test.ts
+++ b/tests/server/TurnstileReadmit.test.ts
@@ -1,78 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  cid,
+  makeClient as harnessClient,
+  makeGame,
+  makeMockWs,
+  MockWs,
+} from "../util/GameServerHarness";
 
-vi.mock("../../src/core/Schemas", async () => {
-  const actual = (await vi.importActual("../../src/core/Schemas")) as any;
-  return {
-    ...actual,
-    GameStartInfoSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-    ServerPrestartMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-    ClientMessageSchema: {
-      safeParse: (data: any) => ({ success: true, data }),
-    },
-  };
-});
+const C1 = cid("c1");
 
-import { GameType } from "../../src/core/game/Game";
-import { Client } from "../../src/server/Client";
-import { GameServer } from "../../src/server/GameServer";
-import { testGameConfig } from "../util/Wire";
-
-// Stateful mock that records listeners so a test can fire the "close" event,
-// exercising GameServer's real ws.on("close") handler.
-function makeMockWs() {
-  const listeners: Record<string, ((...args: any[]) => void)[]> = {};
-  return {
-    on(event: string, cb: (...args: any[]) => void) {
-      (listeners[event] ??= []).push(cb);
-    },
-    removeAllListeners() {
-      for (const k of Object.keys(listeners)) delete listeners[k];
-    },
-    emit(event: string, ...args: any[]) {
-      (listeners[event] ?? []).forEach((cb) => cb(...args));
-    },
-    send: vi.fn(),
-    close: vi.fn(),
-    readyState: 1,
-  };
-}
-
-function makeClient(
-  clientID: string,
-  persistentID: string,
-  ws: ReturnType<typeof makeMockWs>,
-): Client {
-  return new Client(
-    clientID,
-    persistentID,
-    null,
-    null,
-    undefined,
-    "127.0.0.1",
-    "TestUser",
-    null,
-    ws as any,
-    undefined,
-    undefined,
-    [],
-  );
+function makeClient(clientID: string, persistentID: string, ws: MockWs) {
+  return harnessClient({ clientID, persistentID, username: "TestUser", ws });
 }
 
 describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
   });
 
   afterEach(() => {
@@ -81,15 +24,6 @@ describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
     vi.useRealTimers();
   });
 
-  function makeGame() {
-    return new GameServer(
-      "test-game",
-      mockLogger,
-      Date.now(),
-      testGameConfig({ gameType: GameType.Private }),
-    );
-  }
-
   it("reports unknown players as not admitted", () => {
     const game = makeGame();
     expect(game.wasAdmitted("nobody")).toBe(false);
@@ -97,25 +31,23 @@ describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
 
   it("marks a player admitted after a successful join", () => {
     const game = makeGame();
-    expect(game.joinClient(makeClient("c1", "p1", makeMockWs()))).toBe(
-      "joined",
-    );
+    expect(game.joinClient(makeClient(C1, "p1", makeMockWs()))).toBe("joined");
     expect(game.wasAdmitted("p1")).toBe(true);
   });
 
   // Core regression: a lobby-phase disconnect clears the reconnect mapping (to
   // free the slot), but admission must survive so the reconnect skips the
   // single-use Turnstile re-check instead of failing on the spent token.
-  it("keeps a player admitted after a lobby-phase disconnect clears their reconnect mapping", () => {
+  it("keeps a player admitted after a lobby-phase disconnect clears their reconnect mapping", async () => {
     const game = makeGame();
     const ws = makeMockWs();
-    expect(game.joinClient(makeClient("c1", "p1", ws))).toBe("joined");
-    expect(game.getClientIdForPersistentId("p1")).toBe("c1");
+    expect(game.joinClient(makeClient(C1, "p1", ws))).toBe("joined");
+    expect(game.getClientIdForPersistentId("p1")).toBe(C1);
     expect(game.wasAdmitted("p1")).toBe(true);
 
     // Socket drops before the game starts -> the close handler clears the
     // persistentID->clientID mapping.
-    ws.emit("close");
+    await ws.trigger("close");
 
     expect(game.getClientIdForPersistentId("p1")).toBeNull();
     expect(game.wasAdmitted("p1")).toBe(true);
@@ -123,12 +55,10 @@ describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
 
   it("does not treat a kicked player as admitted (kick still forces the gate)", () => {
     const game = makeGame();
-    expect(game.joinClient(makeClient("c1", "p1", makeMockWs()))).toBe(
-      "joined",
-    );
+    expect(game.joinClient(makeClient(C1, "p1", makeMockWs()))).toBe("joined");
     expect(game.wasAdmitted("p1")).toBe(true);
 
-    game.kickClient("c1");
+    game.kickClient(C1);
     expect(game.wasAdmitted("p1")).toBe(false);
   });
 
@@ -137,9 +67,7 @@ describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
   // gone) must force a re-screen.
   it("storedIdentity returns the screened pair for a joined player", () => {
     const game = makeGame();
-    expect(game.joinClient(makeClient("c1", "p1", makeMockWs()))).toBe(
-      "joined",
-    );
+    expect(game.joinClient(makeClient(C1, "p1", makeMockWs()))).toBe("joined");
     expect(game.storedIdentity("p1")).toEqual({
       username: "TestUser",
       clanTag: null,
@@ -147,12 +75,12 @@ describe("GameServer - wasAdmitted (Turnstile re-admission)", () => {
     expect(game.storedIdentity("nobody")).toBeNull();
   });
 
-  it("storedIdentity returns null once a lobby-phase disconnect clears the mapping", () => {
+  it("storedIdentity returns null once a lobby-phase disconnect clears the mapping", async () => {
     const game = makeGame();
     const ws = makeMockWs();
-    expect(game.joinClient(makeClient("c1", "p1", ws))).toBe("joined");
+    expect(game.joinClient(makeClient(C1, "p1", ws))).toBe("joined");
 
-    ws.emit("close");
+    await ws.trigger("close");
 
     // Still admitted (no Turnstile re-check), but with no stored identity
     // the reconnect must be re-screened rather than skipped.

--- a/tests/server/__snapshots__/GameServerWire.test.ts.snap
+++ b/tests/server/__snapshots__/GameServerWire.test.ts.snap
@@ -1,0 +1,1847 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`GameServer wire transcript > matches the golden transcript for a scripted game 1`] = `
+{
+  "archived": {
+    "domain": "golden.test",
+    "gitCommit": "golden-commit",
+    "info": {
+      "config": {
+        "bots": 5,
+        "difficulty": "Medium",
+        "donateGold": true,
+        "donateTroops": true,
+        "gameMap": "World",
+        "gameMapSize": "Normal",
+        "gameMode": "Free For All",
+        "gameType": "Private",
+        "hostCheats": undefined,
+        "infiniteGold": false,
+        "infiniteTroops": false,
+        "instantBuild": false,
+        "maxPlayers": 3,
+        "nations": "default",
+        "randomSpawn": false,
+      },
+      "duration": 2,
+      "end": 1700000004200,
+      "gameID": "golden00",
+      "lobbyCreatedAt": 1700000000000,
+      "lobbyFillTime": 1000,
+      "num_turns": 21,
+      "players": [
+        {
+          "clanTag": "HST",
+          "clientID": "host0000",
+          "cosmetics": undefined,
+          "friends": [
+            "p2000000",
+          ],
+          "isLobbyCreator": true,
+          "persistentID": "host-pid",
+          "stats": undefined,
+          "teamIndex": undefined,
+          "username": "HostName",
+        },
+        {
+          "clanTag": null,
+          "clientID": "p2000000",
+          "cosmetics": {
+            "verified": true,
+          },
+          "friends": undefined,
+          "isLobbyCreator": false,
+          "persistentID": "p2-pid",
+          "stats": undefined,
+          "teamIndex": undefined,
+          "username": "SecondOne",
+        },
+        {
+          "clanTag": "TRD",
+          "clientID": "p3000000",
+          "cosmetics": undefined,
+          "friends": undefined,
+          "isLobbyCreator": false,
+          "persistentID": "p3-pid",
+          "stats": undefined,
+          "teamIndex": undefined,
+          "username": "ThirdOne",
+        },
+      ],
+      "start": 1700000002000,
+      "tribes": undefined,
+      "visibleAt": 1700000001000,
+      "winner": [
+        "player",
+        "host0000",
+      ],
+    },
+    "subdomain": "golden-sub",
+    "turns": [
+      {
+        "hash": 1234.5,
+        "intents": [
+          {
+            "clientID": "host0000",
+            "isDisconnected": false,
+            "type": "mark_disconnected",
+          },
+          {
+            "clientID": "p2000000",
+            "isDisconnected": false,
+            "type": "mark_disconnected",
+          },
+          {
+            "clientID": "p3000000",
+            "isDisconnected": false,
+            "type": "mark_disconnected",
+          },
+          {
+            "clientID": "p2000000",
+            "tile": 1,
+            "type": "spawn",
+          },
+        ],
+        "turnNumber": 0,
+      },
+      {
+        "intents": [
+          {
+            "clientID": "p3000000",
+            "tile": 3,
+            "type": "spawn",
+          },
+        ],
+        "turnNumber": 1,
+      },
+      {
+        "intents": [
+          {
+            "clientID": "host0000",
+            "paused": true,
+            "type": "toggle_pause",
+          },
+        ],
+        "turnNumber": 2,
+      },
+      {
+        "intents": [
+          {
+            "clientID": "host0000",
+            "paused": false,
+            "type": "toggle_pause",
+          },
+        ],
+        "turnNumber": 3,
+      },
+    ],
+    "version": "v0.0.2",
+  },
+  "closes": {
+    "cast": [
+      [
+        1000,
+        "game has ended",
+      ],
+    ],
+    "host": [
+      [
+        1000,
+        "game has ended",
+      ],
+    ],
+    "p2": [
+      [
+        1000,
+        "game has ended",
+      ],
+    ],
+    "p3": [
+      [],
+      [
+        1000,
+        "game has ended",
+      ],
+    ],
+    "p3Again": [
+      [
+        1000,
+        "game has ended",
+      ],
+    ],
+  },
+  "frames": {
+    "cast": [
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 0,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000001000,
+        },
+        "myClientID": "cast0000",
+        "type": "lobby_info",
+      },
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000002000,
+          "startsAt": 1700000001000,
+        },
+        "myClientID": "cast0000",
+        "type": "lobby_info",
+      },
+      {
+        "gameMap": "World",
+        "gameMapSize": "Normal",
+        "type": "prestart",
+      },
+      {
+        "gameStartInfo": {
+          "config": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatedAt": 1700000000000,
+          "players": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "isLobbyCreator": true,
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "cosmetics": {
+                "verified": true,
+              },
+              "isLobbyCreator": false,
+              "username": "SecondOne",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "isLobbyCreator": false,
+              "username": "ThirdOne",
+            },
+          ],
+          "visibleAt": 1700000001000,
+        },
+        "lobbyCreatedAt": 1700000000000,
+        "myClientID": "cast0000",
+        "turns": [],
+        "type": "start",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p3000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "tile": 1,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 0,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "p3000000",
+              "tile": 3,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 1,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": true,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 2,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": false,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 3,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 4,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 5,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 6,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 7,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 8,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 9,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 10,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 11,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 12,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 13,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 14,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 15,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 16,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 17,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 18,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 19,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 20,
+        },
+        "type": "turn",
+      },
+    ],
+    "host": [
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "username": "HostName",
+            },
+          ],
+          "gameConfig": {
+            "bots": 0,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000000000,
+        },
+        "myClientID": "host0000",
+        "type": "lobby_info",
+      },
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 0,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000001000,
+        },
+        "myClientID": "host0000",
+        "type": "lobby_info",
+      },
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000002000,
+          "startsAt": 1700000001000,
+        },
+        "myClientID": "host0000",
+        "type": "lobby_info",
+      },
+      {
+        "gameMap": "World",
+        "gameMapSize": "Normal",
+        "type": "prestart",
+      },
+      {
+        "gameStartInfo": {
+          "config": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatedAt": 1700000000000,
+          "players": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "isLobbyCreator": true,
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "cosmetics": {
+                "verified": true,
+              },
+              "isLobbyCreator": false,
+              "username": "SecondOne",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "isLobbyCreator": false,
+              "username": "ThirdOne",
+            },
+          ],
+          "visibleAt": 1700000001000,
+        },
+        "lobbyCreatedAt": 1700000000000,
+        "myClientID": "host0000",
+        "turns": [],
+        "type": "start",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p3000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "tile": 1,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 0,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "p3000000",
+              "tile": 3,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 1,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": true,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 2,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": false,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 3,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 4,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 5,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 6,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 7,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 8,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 9,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 10,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 11,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 12,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 13,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 14,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 15,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 16,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 17,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 18,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 19,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 20,
+        },
+        "type": "turn",
+      },
+    ],
+    "late": [
+      {
+        "error": "full-lobby",
+        "type": "error",
+      },
+    ],
+    "p2": [
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 0,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000001000,
+        },
+        "myClientID": "p2000000",
+        "type": "lobby_info",
+      },
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000002000,
+          "startsAt": 1700000001000,
+        },
+        "myClientID": "p2000000",
+        "type": "lobby_info",
+      },
+      {
+        "gameMap": "World",
+        "gameMapSize": "Normal",
+        "type": "prestart",
+      },
+      {
+        "gameStartInfo": {
+          "config": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatedAt": 1700000000000,
+          "players": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "isLobbyCreator": true,
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "cosmetics": {
+                "verified": true,
+              },
+              "isLobbyCreator": false,
+              "username": "SecondOne",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "isLobbyCreator": false,
+              "username": "ThirdOne",
+            },
+          ],
+          "visibleAt": 1700000001000,
+        },
+        "lobbyCreatedAt": 1700000000000,
+        "myClientID": "p2000000",
+        "turns": [],
+        "type": "start",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p3000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "tile": 1,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 0,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "p3000000",
+              "tile": 3,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 1,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": true,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 2,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": false,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 3,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 4,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 5,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 6,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 7,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 8,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 9,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 10,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 11,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 12,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 13,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 14,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 15,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 16,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 17,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 18,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 19,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 20,
+        },
+        "type": "turn",
+      },
+    ],
+    "p3": [
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 0,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000001000,
+        },
+        "myClientID": "p3000000",
+        "type": "lobby_info",
+      },
+      {
+        "lobby": {
+          "clients": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "username": "SecondOne",
+              "verified": true,
+            },
+            {
+              "clanTag": null,
+              "clientID": "cast0000",
+              "spectator": true,
+              "username": "Caster",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "username": "ThirdOne",
+            },
+          ],
+          "gameConfig": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatorClientID": "host0000",
+          "serverTime": 1700000002000,
+          "startsAt": 1700000001000,
+        },
+        "myClientID": "p3000000",
+        "type": "lobby_info",
+      },
+      {
+        "gameMap": "World",
+        "gameMapSize": "Normal",
+        "type": "prestart",
+      },
+      {
+        "gameStartInfo": {
+          "config": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatedAt": 1700000000000,
+          "players": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "isLobbyCreator": true,
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "cosmetics": {
+                "verified": true,
+              },
+              "isLobbyCreator": false,
+              "username": "SecondOne",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "isLobbyCreator": false,
+              "username": "ThirdOne",
+            },
+          ],
+          "visibleAt": 1700000001000,
+        },
+        "lobbyCreatedAt": 1700000000000,
+        "myClientID": "p3000000",
+        "turns": [],
+        "type": "start",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p3000000",
+              "isDisconnected": false,
+              "type": "mark_disconnected",
+            },
+            {
+              "clientID": "p2000000",
+              "tile": 1,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 0,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "p3000000",
+              "tile": 3,
+              "type": "spawn",
+            },
+          ],
+          "turnNumber": 1,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": true,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 2,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [
+            {
+              "clientID": "host0000",
+              "paused": false,
+              "type": "toggle_pause",
+            },
+          ],
+          "turnNumber": 3,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 4,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 5,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 6,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 7,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 8,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 9,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 10,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 11,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 12,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 13,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 14,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 15,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 16,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 17,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 18,
+        },
+        "type": "turn",
+      },
+      {
+        "clientsWithCorrectHash": 3,
+        "correctHash": 99,
+        "totalActiveClients": 4,
+        "turn": 10,
+        "type": "desync",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 19,
+        },
+        "type": "turn",
+      },
+      {
+        "turn": {
+          "intents": [],
+          "turnNumber": 20,
+        },
+        "type": "turn",
+      },
+    ],
+    "p3Again": [
+      {
+        "gameStartInfo": {
+          "config": {
+            "bots": 5,
+            "difficulty": "Medium",
+            "donateGold": true,
+            "donateTroops": true,
+            "gameMap": "World",
+            "gameMapSize": "Normal",
+            "gameMode": "Free For All",
+            "gameType": "Private",
+            "infiniteGold": false,
+            "infiniteTroops": false,
+            "instantBuild": false,
+            "maxPlayers": 3,
+            "nations": "default",
+            "randomSpawn": false,
+          },
+          "gameID": "golden00",
+          "listed": false,
+          "lobbyCreatedAt": 1700000000000,
+          "players": [
+            {
+              "clanTag": "HST",
+              "clientID": "host0000",
+              "friends": [
+                "p2000000",
+              ],
+              "isLobbyCreator": true,
+              "username": "HostName",
+            },
+            {
+              "clanTag": null,
+              "clientID": "p2000000",
+              "cosmetics": {
+                "verified": true,
+              },
+              "isLobbyCreator": false,
+              "username": "SecondOne",
+            },
+            {
+              "clanTag": "TRD",
+              "clientID": "p3000000",
+              "isLobbyCreator": false,
+              "username": "ThirdOne",
+            },
+          ],
+          "visibleAt": 1700000001000,
+        },
+        "lobbyCreatedAt": 1700000000000,
+        "myClientID": "p3000000",
+        "turns": [
+          {
+            "intents": [],
+            "turnNumber": 5,
+          },
+          {
+            "intents": [],
+            "turnNumber": 6,
+          },
+          {
+            "intents": [],
+            "turnNumber": 7,
+          },
+          {
+            "intents": [],
+            "turnNumber": 8,
+          },
+          {
+            "intents": [],
+            "turnNumber": 9,
+          },
+          {
+            "intents": [],
+            "turnNumber": 10,
+          },
+          {
+            "intents": [],
+            "turnNumber": 11,
+          },
+          {
+            "intents": [],
+            "turnNumber": 12,
+          },
+          {
+            "intents": [],
+            "turnNumber": 13,
+          },
+          {
+            "intents": [],
+            "turnNumber": 14,
+          },
+          {
+            "intents": [],
+            "turnNumber": 15,
+          },
+          {
+            "intents": [],
+            "turnNumber": 16,
+          },
+          {
+            "intents": [],
+            "turnNumber": 17,
+          },
+          {
+            "intents": [],
+            "turnNumber": 18,
+          },
+          {
+            "intents": [],
+            "turnNumber": 19,
+          },
+          {
+            "intents": [],
+            "turnNumber": 20,
+          },
+        ],
+        "type": "start",
+      },
+    ],
+  },
+  "liveStats": {
+    "players": [
+      {
+        "clientID": "host0000",
+        "connected": true,
+        "deathPosition": null,
+        "gold": "50",
+        "isAlive": true,
+        "killedBy": null,
+        "publicID": "host-pub",
+        "team": null,
+        "tilesOwned": 10,
+        "troops": 100,
+        "username": "HostName",
+      },
+    ],
+    "turn": 10,
+    "winner": "host0000",
+  },
+  "lobbyHttpView": {
+    "accent": undefined,
+    "autoStartAt": undefined,
+    "clients": [
+      {
+        "clanTag": "HST",
+        "clientID": "host0000",
+        "friends": [
+          "p2000000",
+        ],
+        "spectator": undefined,
+        "teamIndex": undefined,
+        "username": "HostName",
+        "verified": undefined,
+      },
+      {
+        "clanTag": null,
+        "clientID": "p2000000",
+        "friends": undefined,
+        "spectator": undefined,
+        "teamIndex": undefined,
+        "username": "SecondOne",
+        "verified": true,
+      },
+      {
+        "clanTag": null,
+        "clientID": "cast0000",
+        "friends": undefined,
+        "spectator": true,
+        "teamIndex": undefined,
+        "username": "Caster",
+        "verified": undefined,
+      },
+      {
+        "clanTag": "TRD",
+        "clientID": "p3000000",
+        "friends": undefined,
+        "spectator": undefined,
+        "teamIndex": undefined,
+        "username": "ThirdOne",
+        "verified": undefined,
+      },
+    ],
+    "featured": undefined,
+    "gameConfig": {
+      "bots": 5,
+      "difficulty": "Medium",
+      "donateGold": true,
+      "donateTroops": true,
+      "gameMap": "World",
+      "gameMapSize": "Normal",
+      "gameMode": "Free For All",
+      "gameType": "Private",
+      "hostCheats": undefined,
+      "infiniteGold": false,
+      "infiniteTroops": false,
+      "instantBuild": false,
+      "maxPlayers": 3,
+      "nations": "default",
+      "randomSpawn": false,
+    },
+    "gameID": "golden00",
+    "label": undefined,
+    "listed": false,
+    "lobbyCreatorClientID": "host0000",
+    "publicGameType": undefined,
+    "serverTime": 1700000002000,
+    "startsAt": 1700000001000,
+  },
+}
+`;

--- a/tests/server/__snapshots__/GameServerWire.test.ts.snap
+++ b/tests/server/__snapshots__/GameServerWire.test.ts.snap
@@ -158,10 +158,6 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
     ],
     "p3": [
       [],
-      [
-        1000,
-        "game has ended",
-      ],
     ],
     "p3Again": [
       [

--- a/tests/util/GameServerHarness.ts
+++ b/tests/util/GameServerHarness.ts
@@ -1,0 +1,168 @@
+// Shared fixtures for tests that drive a GameServer directly.
+//
+// Every fixture here is schema-valid: ids are 8 alphanumerics, usernames are
+// 3+ chars, clan tags 2–5. That matters because the server validates the start
+// info and encodes every frame with the binary wire, both of which reject the
+// "p1" / "creator-cid" placeholders older tests used — those tests could only
+// pass by mocking the Schemas module. Use cid() to spell a readable id.
+
+import { vi } from "vitest";
+import {
+  ClientMessage,
+  GameConfig,
+  PublicGameType,
+  ServerMessage,
+} from "../../src/core/Schemas";
+import { Client } from "../../src/server/Client";
+import { GameServer } from "../../src/server/GameServer";
+import {
+  noopMatchTelemetryEmitter,
+  type MatchTelemetryEmitter,
+} from "../../src/server/telemetry/MatchTelemetry";
+import { ZbContext } from "../../zbin";
+import { clientFrame, decodeSentServerMessage, testGameConfig } from "./Wire";
+
+// A schema-valid 8-char id from a readable tag: cid("p1") === "p1000000".
+// Throws rather than silently mangling a tag that cannot be made valid, so a
+// collision between two tags cannot hide in a fixture.
+export function cid(tag: string): string {
+  if (!/^[A-Za-z0-9]{1,8}$/.test(tag)) {
+    throw new Error(`cid: "${tag}" must be 1-8 alphanumerics`);
+  }
+  return tag.padEnd(8, "0");
+}
+
+export function mockLogger(): any {
+  const log: any = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  };
+  log.child = vi.fn(() => log);
+  return log;
+}
+
+export interface MockWs {
+  on: (event: string, handler: (...args: any[]) => void) => void;
+  removeAllListeners: (event?: string) => void;
+  send: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn>;
+  readyState: number;
+  readonly OPEN: 1;
+  /** Fire a raw ws event ("close", "error", or "message" with a frame). */
+  trigger: (event: string, ...args: any[]) => Promise<void>;
+  /** Drive the socket the way a connected client would. */
+  emit: (msg: ClientMessage) => Promise<void>;
+  /** Every frame the server sent, decoded. Pass the game's dictionary context
+   *  for frames sent after the start message (see Wire.ts). */
+  sent: (ctx?: ZbContext) => ServerMessage[];
+}
+
+// A stateful stand-in for `ws.WebSocket`: records listeners so a test can fire
+// "message" / "close", and captures sends so it can read what the server said.
+export function makeMockWs(): MockWs {
+  const listeners = new Map<string, ((...args: any[]) => void)[]>();
+  const ws: MockWs = {
+    on: (event, handler) => {
+      const list = listeners.get(event) ?? [];
+      list.push(handler);
+      listeners.set(event, list);
+    },
+    removeAllListeners: (event) => {
+      if (event === undefined) listeners.clear();
+      else listeners.delete(event);
+    },
+    send: vi.fn(),
+    close: vi.fn(),
+    readyState: 1,
+    OPEN: 1,
+    trigger: async (event, ...args) => {
+      for (const handler of listeners.get(event) ?? []) {
+        await handler(...args);
+      }
+    },
+    emit: (msg) => ws.trigger("message", clientFrame(msg)),
+    sent: (ctx) =>
+      ws.send.mock.calls.map(([frame]) => decodeSentServerMessage(frame, ctx)),
+  };
+  return ws;
+}
+
+export interface ClientOpts {
+  clientID?: string;
+  persistentID?: string;
+  role?: string | null;
+  ip?: string;
+  username?: string;
+  clanTag?: string | null;
+  ws?: MockWs;
+  cosmetics?: Client["cosmetics"];
+  publicId?: string;
+  friends?: string[];
+  spectator?: boolean;
+}
+
+let nextClient = 1;
+
+// A joined-ready Client. Defaults are distinct per call (id, persistentID,
+// IP): the winner and live-stats votes are weighted by unique IP, so a shared
+// default would collapse every electorate to one voter.
+export function makeClient(opts: ClientOpts = {}): Client {
+  const n = nextClient++;
+  const clientID = opts.clientID ?? cid(`c${n}`);
+  return new Client(
+    clientID,
+    opts.persistentID ?? `${clientID}-pid`,
+    null,
+    opts.role ?? null,
+    undefined,
+    opts.ip ?? `10.0.${Math.floor(n / 256)}.${n % 256}`,
+    opts.username ?? `user_${clientID}`,
+    opts.clanTag ?? null,
+    (opts.ws ?? makeMockWs()) as any,
+    opts.cosmetics,
+    opts.publicId,
+    opts.friends ?? [],
+    opts.spectator ?? false,
+  );
+}
+
+export const mockWsOf = (client: Client): MockWs => client.ws as any;
+
+export interface GameOpts {
+  id?: string;
+  log?: any;
+  createdAt?: number;
+  config?: Partial<GameConfig>;
+  creatorPersistentID?: string;
+  startsAt?: number;
+  publicGameType?: PublicGameType;
+  matchmakingTeams?: string[][];
+  telemetry?: MatchTelemetryEmitter;
+  buildHash?: string;
+}
+
+// A private FFA lobby by default. `config` is layered over testGameConfig so a
+// test names only what it cares about.
+export function makeGame(opts: GameOpts = {}): GameServer {
+  return new GameServer(
+    opts.id ?? cid("game"),
+    opts.log ?? mockLogger(),
+    opts.createdAt ?? Date.now(),
+    testGameConfig(opts.config),
+    opts.creatorPersistentID,
+    opts.startsAt,
+    opts.publicGameType,
+    opts.matchmakingTeams,
+    opts.telemetry ?? noopMatchTelemetryEmitter,
+    opts.buildHash ?? "DEV",
+  );
+}
+
+// Take the game through the real lobby -> game transition (what
+// GameManager.tick does), instead of flipping private flags.
+export function startGame(game: GameServer): void {
+  game.prestart();
+  game.start();
+}

--- a/tests/util/GameServerHarness.ts
+++ b/tests/util/GameServerHarness.ts
@@ -23,13 +23,22 @@ import { ZbContext } from "../../zbin";
 import { clientFrame, decodeSentServerMessage, testGameConfig } from "./Wire";
 
 // A schema-valid 8-char id from a readable tag: cid("p1") === "p1000000".
-// Throws rather than silently mangling a tag that cannot be made valid, so a
-// collision between two tags cannot hide in a fixture.
+// Throws rather than silently mangling a tag that cannot be made valid. Zero
+// padding means tags that differ only by trailing zeros ("c1", "c10") would
+// alias, so every id produced is remembered per test module and a second tag
+// mapping to an existing id throws instead of hiding a collision in a fixture.
+const cidTags = new Map<string, string>();
 export function cid(tag: string): string {
   if (!/^[A-Za-z0-9]{1,8}$/.test(tag)) {
     throw new Error(`cid: "${tag}" must be 1-8 alphanumerics`);
   }
-  return tag.padEnd(8, "0");
+  const id = tag.padEnd(8, "0");
+  const prior = cidTags.get(id);
+  if (prior !== undefined && prior !== tag) {
+    throw new Error(`cid: "${tag}" collides with "${prior}" (both -> ${id})`);
+  }
+  cidTags.set(id, tag);
+  return id;
 }
 
 export function mockLogger(): any {
@@ -61,8 +70,11 @@ export interface MockWs {
 
 // A stateful stand-in for `ws.WebSocket`: records listeners so a test can fire
 // "message" / "close", and captures sends so it can read what the server said.
+// readyState leaves OPEN once the socket is closed from either side, as the
+// real one does, so server guards like `readyState === OPEN` behave the same.
 export function makeMockWs(): MockWs {
   const listeners = new Map<string, ((...args: any[]) => void)[]>();
+  const CLOSED = 3;
   const ws: MockWs = {
     on: (event, handler) => {
       const list = listeners.get(event) ?? [];
@@ -74,10 +86,13 @@ export function makeMockWs(): MockWs {
       else listeners.delete(event);
     },
     send: vi.fn(),
-    close: vi.fn(),
+    close: vi.fn(() => {
+      ws.readyState = CLOSED;
+    }),
     readyState: 1,
     OPEN: 1,
     trigger: async (event, ...args) => {
+      if (event === "close") ws.readyState = CLOSED;
       for (const handler of listeners.get(event) ?? []) {
         await handler(...args);
       }
@@ -107,10 +122,11 @@ let nextClient = 1;
 
 // A joined-ready Client. Defaults are distinct per call (id, persistentID,
 // IP): the winner and live-stats votes are weighted by unique IP, so a shared
-// default would collapse every electorate to one voter.
+// default would collapse every electorate to one voter. The default id is
+// zero-padded on the left ("c0000001") so no two counter values alias.
 export function makeClient(opts: ClientOpts = {}): Client {
   const n = nextClient++;
-  const clientID = opts.clientID ?? cid(`c${n}`);
+  const clientID = opts.clientID ?? `c${String(n).padStart(7, "0")}`;
   return new Client(
     clientID,
     opts.persistentID ?? `${clientID}-pid`,

--- a/tests/util/Wire.ts
+++ b/tests/util/Wire.ts
@@ -20,6 +20,7 @@ import {
   encodeClientMessage,
   encodeLobbyMessage,
 } from "../../src/core/ZbinWire";
+import { ZbContext } from "../../zbin";
 
 // A frame as a client would put it on the wire. Tests hand these to the
 // server's "message" listener.
@@ -29,20 +30,29 @@ export function clientFrame(msg: ClientMessage): Buffer {
 
 // Every server message a mocked `ws.send` captured, decoded back to objects.
 //
-// Frames are decoded without a dictionary context, which is what a peer that
-// has not yet seen the start message does; ids then ride inline. Validation is
-// skipped: the question these helpers answer is "what did the server put on
-// the wire", and server-test fixtures routinely use placeholder clientIDs
-// ("creator-cid") that were never ID-schema-valid. Structural corruption still
-// throws — that is the decoder, not the validator.
-export function sentServerMessages(ws: {
-  send: { mock: { calls: unknown[][] } };
-}): ServerMessage[] {
-  return ws.send.mock.calls.map(([frame]) => decodeSentServerMessage(frame));
+// Without `ctx`, frames are decoded with no dictionary context, which is what
+// a peer that has not yet seen the start message does; ids then ride inline.
+// Once the game has started the server dictionary-encodes player ids, so a
+// test reading post-start frames passes the same context the server built
+// (createGameWireContext over the start-info players). Validation is skipped:
+// the question these helpers answer is "what did the server put on the wire",
+// and server-test fixtures routinely use placeholder clientIDs ("creator-cid")
+// that were never ID-schema-valid. Structural corruption still throws — that
+// is the decoder, not the validator.
+export function sentServerMessages(
+  ws: { send: { mock: { calls: unknown[][] } } },
+  ctx?: ZbContext,
+): ServerMessage[] {
+  return ws.send.mock.calls.map(([frame]) =>
+    decodeSentServerMessage(frame, ctx),
+  );
 }
 
-export function decodeSentServerMessage(frame: unknown): ServerMessage {
-  return ServerMessageSchema.decodeBytesUnvalidated(frame as Uint8Array);
+export function decodeSentServerMessage(
+  frame: unknown,
+  ctx?: ZbContext,
+): ServerMessage {
+  return ServerMessageSchema.decodeBytesUnvalidated(frame as Uint8Array, ctx);
 }
 
 export function lobbyFrame(msg: PublicLobbyMessage): Uint8Array {


### PR DESCRIPTION
## Summary

Phase 0 of a phased plan to make `src/server/GameServer.ts` (2,365 lines, 13 responsibilities) testable and then split it up. **No production code changes** — this PR is test infrastructure plus the plan itself, so later extraction PRs have a regression net.

- **`docs/GameServerRefactor.md`** — the plan as a living checklist: diagnosis (≈150 `(game as any)` reach-ins, 6 files mocking the `Schemas` module, 13 copies of `makeMockWs`, hidden deps on `archive`/`fetchCustomTribes`/`ServerEnv`), principles, and six phases (harness → characterization tests → dependency injection → pure-module extraction → roster → ingress/lifecycle).
- **`tests/util/GameServerHarness.ts`** — one `mockLogger()`, a drivable `makeMockWs()` (`emit(ClientMessage)`, `trigger("close")`, `sent(ctx)`), `makeClient(opts)` with distinct-IP defaults, `makeGame(opts)`, and `startGame()` that runs the real `prestart()`+`start()` instead of flipping `_hasStarted`. `cid("p1")` → `"p1000000"` gives schema-valid ids.
- **Deleted every `vi.mock("../../src/core/Schemas")`** (6 → 0). They existed only because fixture ids like `"p1"` failed the 8-char `ID` regex; with valid ids the real `GameStartInfoSchema` now runs in those tests.
- **Golden wire transcript** (`tests/server/GameServerWire.test.ts` + snapshot): joins incl. a rejected 5th and a spectator, lobby edits, start, spawns, pause/unpause, hash agreement and a desync, socket drop + rejoin from turn 5, live-stats and winner consensus, archive, end. Every server frame per client, the HTTP lobby view, `liveStats()` and the archived record are snapshotted. A refactor that leaves this untouched cannot have changed client-visible behaviour.
- `tests/util/Wire.ts` decode helpers take an optional zbin dictionary context so post-start (dictionary-encoded) frames decode. Several migrated tests now assert on the wire (`spectate`/`winner` messages, the start frame) instead of private state — reach-ins ≈150 → 82.

Two pre-existing quirks noticed and deliberately left alone: the desync message counts spectators in `totalActiveClients`, and `end()` doesn't await `archive()` so its `try/catch` can't see a rejected upload.

## Test plan

- `npx vitest tests/server --run`: 41 files / 403 tests green (was 40 / 402).
- Full `npm test`: 30 failing files, identical to a pristine `git archive HEAD` run (all client tests hitting `localStorage` undefined in this environment — unrelated).
- `prettier`, `oxlint`, `eslint` on changed files clean; `tsc --noEmit` clean.
- Snapshot contents verified by hand: 1 desync frame (to the disagreeing client), 1 `full-lobby` error, 84 turn frames (21 turns × 4 sockets), old socket closed on rejoin, reconnect start frame carries turns from 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
