### PR TITLE
fix(client): clear inventory search when switching category tabs

### DIFF
--- a/src/client/InventoryModal.ts
+++ b/src/client/InventoryModal.ts
@@ -732,6 +732,12 @@ export class InventoryModal extends BaseModal {
     this.search = "";
   }
 
+  // A query typed for skins rarely matches anything in flags, so a stale
+  // search reads as an empty tab. Reset it whenever the category changes.
+  protected onTabEnter(_key: string): void {
+    this.search = "";
+  }
+
   private selectCosmetic(resolved: ResolvedCosmetic) {
     if (resolved.type === "pattern") {
       this.selectPattern(resolvedToPlayerPattern(resolved), resolved);


### PR DESCRIPTION
The inventory search box lives in the modal header and is shared by every category tab. A query typed while browsing skins stayed in the box after switching to flags, crowns or effects, so the new tab was filtered by an unrelated query and usually rendered empty — looking like a loading bug rather than a filter.

`InventoryModal` now overrides `BaseModal.onTabEnter()` to reset `this.search`. Since this modal sets `hideTabs: true`, the tab strip is never rendered and `inventory-loadout-bar`'s category buttons are the only interactive trigger — they call `setActiveTab()`, which fires `onTabEnter()`. The input is bound with `.value=${this.search}`, so the box visibly empties.

`onTabEnter()` also fires once from `BaseModal.open()`, which is a no-op since `onClose()` already clears the query.

Sub-tabs inside the effects tab (`effects-grid` in `tabbed` mode) manage their own tab bar and don't route through `setActiveTab`, so switching effect type still keeps the query. Left alone to keep this change to the reported case.

## Testing

No tests added — this is a client-only presentation change (Lit component state), outside the `src/core` test requirement, and `InventoryModal` has no existing test harness. `tsc --noEmit`, oxlint and prettier are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
