### PR TITLE
test(server): characterize the untested GameServer paths

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -83,18 +83,31 @@ of it.
 
 Written against current behaviour, using the harness:
 
-- [ ] `joinClient`: dup-session kicks the _old_ client (Prod), 3-IP cap
+- [x] `joinClient`: dup-session kicks the _old_ client (Prod), 3-IP cap
       (Public, non-Dev), host-left closes lobby and `phase()` → `Finished`.
-- [ ] `rejoinClient`: identity update drops `verified` only when the username
+- [x] `rejoinClient`: identity update drops `verified` only when the username
       changes; ignored after start; `lastTurn` slicing; old socket closed.
-- [ ] `addListeners`: corrupt frame → `invalid_message` kick; ws
+- [x] `addListeners`: corrupt frame → `invalid_message` kick; ws
       `readyState >= 2` race handled as a disconnect.
-- [ ] `phase()`: 60s ping prune, `maxGameDuration`, the
+- [x] `phase()`: 60s ping prune, `maxGameDuration`, the
       `noActive && warmupOver && noRecentPings` exit.
-- [ ] `findOutOfSyncClients`: majority, strict-majority flip, single client,
+- [x] `findOutOfSyncClients`: majority, strict-majority flip, single client,
       `turns[n].hash` set on agreement.
-- [ ] `checkDisconnectedStatus`: only every 5 turns, flips both ways,
+- [x] `checkDisconnectedStatus`: only every 5 turns, flips both ways,
       spectators emit no `mark_disconnected`.
+
+Status (2026-08-25): done — `tests/server/GameServerJoin.test.ts`,
+`GameServerRejoin.test.ts`, `GameServerPhase.test.ts`,
+`GameServerDesync.test.ts` (35 tests, all through the public API and the
+wire; no `(game as any)`). Host-left teardown was already covered by
+`HostedLobbyListing.test.ts`. Each file was checked against a hand mutation of
+the branch it covers (5-turn boundary, strict-majority flip, post-start
+identity update, dup-session kick) and failed as expected.
+
+Suspected bug pinned as current behaviour (own PR, not a refactor side
+effect): a prod duplicate-session kick calls `kickClient()` on the old
+connection, which bans the shared persistentID — so the surviving session can
+no longer be looked up (`getClientIdForPersistentId`) or reconnect.
 
 ## Phase 2 — Inject the hidden dependencies
 

--- a/tests/server/GameServerDesync.test.ts
+++ b/tests/server/GameServerDesync.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGameWireContext } from "../../src/core/ZbinWire";
+import { Client } from "../../src/server/Client";
+import { GameServer } from "../../src/server/GameServer";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  makeMockWs,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
+
+// Characterization tests for desync detection: the hash tally itself
+// (findOutOfSyncClients) and what the turn loop does with its verdict every
+// ten turns. See docs/GameServerRefactor.md, Phase 1.
+
+const TURN_MS = 100;
+const IDS = ["a", "b", "c", "d"].map(cid);
+
+async function reportHash(client: Client, turnNumber: number, hash: number) {
+  await mockWsOf(client).emit({ type: "hash", hash, turnNumber });
+}
+
+function lobbyWith(count: number) {
+  const game = makeGame();
+  const clients = IDS.slice(0, count).map((clientID) =>
+    makeClient({ clientID }),
+  );
+  for (const c of clients) game.joinClient(c);
+  return { game, clients };
+}
+
+describe("GameServer.findOutOfSyncClients", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("flags the minority that disagrees with the majority hash", async () => {
+    const { game, clients } = lobbyWith(3);
+    const [a, b, c] = clients;
+    await reportHash(a, 0, 1);
+    await reportHash(b, 0, 1);
+    await reportHash(c, 0, 2);
+
+    const result = game.findOutOfSyncClients(0);
+    expect(result.mostCommonHash).toBe(1);
+    expect(result.outOfSyncClients).toEqual([c]);
+  });
+
+  it("treats everyone as out of sync when no hash has a majority", async () => {
+    // Three different answers: whichever hash was seen first "wins" the
+    // count, but with a strict majority disagreeing nobody can be trusted.
+    const { game, clients } = lobbyWith(3);
+    const [a, b, c] = clients;
+    await reportHash(a, 0, 1);
+    await reportHash(b, 0, 2);
+    await reportHash(c, 0, 3);
+
+    const result = game.findOutOfSyncClients(0);
+    expect(result.mostCommonHash).toBe(1);
+    expect(result.outOfSyncClients).toEqual([a, b, c]);
+  });
+
+  it("keeps an even split as-is, siding with the first-seen hash", async () => {
+    // Two of four is not a STRICT majority, so only the second pair is
+    // flagged rather than the whole room.
+    const { game, clients } = lobbyWith(4);
+    const [a, b, c, d] = clients;
+    await reportHash(a, 0, 1);
+    await reportHash(b, 0, 1);
+    await reportHash(c, 0, 2);
+    await reportHash(d, 0, 2);
+
+    const result = game.findOutOfSyncClients(0);
+    expect(result.mostCommonHash).toBe(1);
+    expect(result.outOfSyncClients).toEqual([c, d]);
+  });
+
+  it("ignores clients that have not reported that turn", async () => {
+    const { game, clients } = lobbyWith(3);
+    const [a, b] = clients;
+    await reportHash(a, 0, 1);
+    await reportHash(b, 0, 1);
+    await reportHash(b, 1, 7); // a different turn does not count either
+
+    const result = game.findOutOfSyncClients(0);
+    expect(result.mostCommonHash).toBe(1);
+    expect(result.outOfSyncClients).toEqual([]);
+  });
+
+  it("has nothing to compare with one report, or none", async () => {
+    const { game, clients } = lobbyWith(1);
+    expect(game.findOutOfSyncClients(0)).toEqual({
+      mostCommonHash: null,
+      outOfSyncClients: [],
+    });
+
+    await reportHash(clients[0], 0, 1);
+    expect(game.findOutOfSyncClients(0)).toEqual({
+      mostCommonHash: 1,
+      outOfSyncClients: [],
+    });
+  });
+});
+
+describe("desync handling in the turn loop", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  // The turn log as a reconnecting client would receive it.
+  function replayedTurns(game: GameServer, persistentID: string, ctx: any) {
+    const ws = makeMockWs();
+    if (!game.rejoinClient(ws as any, persistentID, 0)) {
+      throw new Error("rejoin failed");
+    }
+    const start = ws.sent(ctx).find((m) => m.type === "start");
+    if (start?.type !== "start") throw new Error("no start frame");
+    return start.turns;
+  }
+
+  function startedWith(count: number) {
+    const { game, clients } = lobbyWith(count);
+    startGame(game);
+    const ctx = createGameWireContext(
+      clients.map((c) => ({ clientID: c.clientID })),
+    );
+    return { game, clients, ctx };
+  }
+
+  const desyncFramesOn = (client: Client, ctx: any) =>
+    mockWsOf(client)
+      .sent(ctx)
+      .filter((m) => m.type === "desync");
+
+  it("records the agreed hash on the turn and tells nobody", async () => {
+    const { game, clients, ctx } = startedWith(3);
+    for (const c of clients) await reportHash(c, 0, 1234);
+    // The check for turn 0 runs once ten turns are in the log.
+    vi.advanceTimersByTime(10 * TURN_MS);
+
+    for (const c of clients) expect(desyncFramesOn(c, ctx)).toEqual([]);
+    expect(game.numDesyncedClients()).toBe(0);
+    const turns = replayedTurns(game, clients[0].persistentID, ctx);
+    expect(turns[0].hash).toBe(1234);
+  });
+
+  it("tells a disagreeing client once, counts it, and records no hash", async () => {
+    const { game, clients, ctx } = startedWith(3);
+    const [a, b, c] = clients;
+    // c disagrees on turn 0 and again on turn 10.
+    for (const x of [a, b]) await reportHash(x, 0, 1234);
+    await reportHash(c, 0, 4321);
+    for (const x of [a, b]) await reportHash(x, 10, 5678);
+    await reportHash(c, 10, 8765);
+    // Checks run at 10 turns (for turn 0) and 20 turns (for turn 10).
+    vi.advanceTimersByTime(20 * TURN_MS);
+
+    expect(desyncFramesOn(a, ctx)).toEqual([]);
+    expect(desyncFramesOn(b, ctx)).toEqual([]);
+    // One notice, for the first disagreement; the second is not repeated.
+    expect(desyncFramesOn(c, ctx)).toEqual([
+      {
+        type: "desync",
+        turn: 0,
+        correctHash: 1234,
+        clientsWithCorrectHash: 2,
+        totalActiveClients: 3,
+      },
+    ]);
+    expect(game.numDesyncedClients()).toBe(1);
+
+    // A contested turn gets no hash in the log.
+    const turns = replayedTurns(game, a.persistentID, ctx);
+    expect(turns[0].hash).toBeUndefined();
+    expect(turns[10].hash).toBeUndefined();
+  });
+
+  it("does not check at all with a single active client", async () => {
+    // Nothing to compare against — so even a reported hash is not recorded.
+    const { game, clients, ctx } = startedWith(1);
+    await reportHash(clients[0], 0, 1234);
+    vi.advanceTimersByTime(10 * TURN_MS);
+
+    expect(game.numDesyncedClients()).toBe(0);
+    const turns = replayedTurns(game, clients[0].persistentID, ctx);
+    expect(turns[0].hash).toBeUndefined();
+  });
+});

--- a/tests/server/GameServerJoin.test.ts
+++ b/tests/server/GameServerJoin.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GameEnv } from "../../src/core/configuration/Config";
+import { GameType } from "../../src/core/game/Game";
+import { ServerEnv } from "../../src/server/ServerEnv";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  makeMockWs,
+  mockWsOf,
+} from "../util/GameServerHarness";
+
+// Characterization tests for joinClient paths that had no coverage: the
+// production-only guards (one session per account, three connections per
+// IP), a socket that is already dead when it joins, and a frame the server
+// cannot decode. They pin current behaviour so the refactor in
+// docs/GameServerRefactor.md cannot change it unnoticed.
+
+describe("GameServer.joinClient — environment guards", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe("one session per account (prod only)", () => {
+    const account = (tag: string) =>
+      makeClient({ clientID: cid(tag), persistentID: "acct-pid" });
+
+    it("kicks the existing session and seats the new one", () => {
+      vi.spyOn(ServerEnv, "env").mockReturnValue(GameEnv.Prod);
+      const game = makeGame();
+      const first = account("first");
+      const second = account("second");
+      expect(game.joinClient(first)).toBe("joined");
+      expect(game.joinClient(second)).toBe("joined");
+
+      // The OLD connection is the one told to go, so the newest client is the
+      // one left holding the game (it may want to replay it afterwards).
+      expect(mockWsOf(first).sent()).toContainEqual({
+        type: "error",
+        error: "kick_reason.duplicate_session",
+      });
+      expect(mockWsOf(first).close).toHaveBeenCalledWith(
+        1000,
+        "kick_reason.duplicate_session",
+      );
+      expect(mockWsOf(second).close).not.toHaveBeenCalled();
+      expect(game.numClients()).toBe(1);
+      expect(game.gameInfo().clients?.map((c) => c.clientID)).toEqual([
+        cid("second"),
+      ]);
+    });
+
+    it("bans the account's persistentID as a side effect (current behaviour)", () => {
+      // kickClient() records the persistentID, and the survivor shares it: the
+      // seated session can no longer be looked up or reconnected. Pinned so a
+      // fix is a deliberate change, not a refactor side effect.
+      vi.spyOn(ServerEnv, "env").mockReturnValue(GameEnv.Prod);
+      const game = makeGame();
+      game.joinClient(account("first"));
+      game.joinClient(account("second"));
+
+      expect(game.getClientIdForPersistentId("acct-pid")).toBeNull();
+      expect(game.wasAdmitted("acct-pid")).toBe(false);
+      expect(game.rejoinClient(makeMockWs() as any, "acct-pid")).toBe(false);
+    });
+
+    it("is not enforced outside prod", () => {
+      vi.spyOn(ServerEnv, "env").mockReturnValue(GameEnv.Preprod);
+      const game = makeGame();
+      const first = account("first");
+      expect(game.joinClient(first)).toBe("joined");
+      expect(game.joinClient(account("second"))).toBe("joined");
+      expect(mockWsOf(first).close).not.toHaveBeenCalled();
+      expect(game.numClients()).toBe(2);
+    });
+  });
+
+  describe("three connections per IP (public games, outside dev)", () => {
+    const sameIp = (tag: string) =>
+      makeClient({ clientID: cid(tag), ip: "9.9.9.9" });
+
+    it("rejects the fourth connection from one IP", () => {
+      vi.spyOn(ServerEnv, "env").mockReturnValue(GameEnv.Prod);
+      const game = makeGame({ config: { gameType: GameType.Public } });
+      expect(game.joinClient(sameIp("a"))).toBe("joined");
+      expect(game.joinClient(sameIp("b"))).toBe("joined");
+      expect(game.joinClient(sameIp("c"))).toBe("joined");
+      expect(game.joinClient(sameIp("d"))).toBe("rejected");
+      // Another IP is still welcome.
+      expect(
+        game.joinClient(makeClient({ clientID: cid("e"), ip: "8.8.8.8" })),
+      ).toBe("joined");
+      expect(game.numClients()).toBe(4);
+    });
+
+    it("does not apply to private games", () => {
+      vi.spyOn(ServerEnv, "env").mockReturnValue(GameEnv.Prod);
+      const game = makeGame({ config: { gameType: GameType.Private } });
+      for (const tag of ["a", "b", "c", "d"]) {
+        expect(game.joinClient(sameIp(tag))).toBe("joined");
+      }
+    });
+
+    it("is skipped in dev, where multi-tab testing is same-IP", () => {
+      vi.spyOn(ServerEnv, "env").mockReturnValue(GameEnv.Dev);
+      const game = makeGame({ config: { gameType: GameType.Public } });
+      for (const tag of ["a", "b", "c", "d"]) {
+        expect(game.joinClient(sameIp(tag))).toBe("joined");
+      }
+    });
+  });
+});
+
+describe("GameServer.joinClient — socket already dead on arrival", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("treats a socket that closed before listeners attached as a disconnect", () => {
+    // The 'close' event already fired, so the handler registered by
+    // addListeners would never run; the join has to notice on its own.
+    const game = makeGame();
+    const ws = makeMockWs();
+    ws.readyState = 3; // CLOSED
+    const client = makeClient({
+      clientID: cid("dead"),
+      persistentID: "dead-pid",
+      ws,
+    });
+    expect(game.joinClient(client)).toBe("joined");
+
+    // ...but they are gone at once: no seat, and no reconnect mapping since
+    // the lobby has not started.
+    expect(game.numClients()).toBe(0);
+    expect(game.getClientIdForPersistentId("dead-pid")).toBeNull();
+    // Admission survives, as after any lobby-phase drop.
+    expect(game.wasAdmitted("dead-pid")).toBe(true);
+  });
+});
+
+describe("GameServer — undecodable frame", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("kicks the sender with invalid_message and bans the account", async () => {
+    const game = makeGame();
+    const client = makeClient({
+      clientID: cid("bad"),
+      persistentID: "bad-pid",
+    });
+    game.joinClient(client);
+
+    await mockWsOf(client).trigger(
+      "message",
+      Buffer.from([0xff, 0xff, 0xff, 0xff]),
+    );
+
+    expect(mockWsOf(client).sent()).toContainEqual({
+      type: "error",
+      error: "kick_reason.invalid_message",
+    });
+    expect(mockWsOf(client).close).toHaveBeenCalledWith(
+      1000,
+      "kick_reason.invalid_message",
+    );
+    expect(game.numClients()).toBe(0);
+    // A kick is a ban: the same account cannot come back on a new connection.
+    expect(
+      game.joinClient(
+        makeClient({ clientID: cid("bad2"), persistentID: "bad-pid" }),
+      ),
+    ).toBe("kicked");
+  });
+});

--- a/tests/server/GameServerPhase.test.ts
+++ b/tests/server/GameServerPhase.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGameWireContext } from "../../src/core/ZbinWire";
+import { GamePhase } from "../../src/server/GameServer";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
+
+// Characterization tests for the time-driven parts of GameServer: the phase
+// GameManager polls, the 60s ping prune that runs inside it, and the
+// connection-status marks the turn loop injects every five turns. See
+// docs/GameServerRefactor.md, Phase 1.
+
+const T0 = 1_700_000_000_000;
+const TURN_MS = 100;
+const HOUR = 60 * 60 * 1000;
+
+describe("GameServer.phase()", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("is Lobby until startsAt, then Active", () => {
+    const game = makeGame({ startsAt: T0 + 10_000 });
+    game.joinClient(makeClient());
+    expect(game.phase()).toBe(GamePhase.Lobby);
+
+    vi.advanceTimersByTime(10_001);
+    expect(game.phase()).toBe(GamePhase.Active);
+  });
+
+  it("stays Lobby indefinitely without a start time", () => {
+    const game = makeGame();
+    game.joinClient(makeClient());
+    vi.advanceTimersByTime(HOUR);
+    expect(game.phase()).toBe(GamePhase.Lobby);
+  });
+
+  it("leaves Lobby as soon as the last seat fills, before startsAt", () => {
+    const game = makeGame({
+      startsAt: T0 + 10_000,
+      config: { maxPlayers: 1 },
+    });
+    game.joinClient(makeClient());
+    expect(game.phase()).toBe(GamePhase.Active);
+  });
+
+  it("finishes an unattended game 30s after its start time", () => {
+    // Nobody ever connected: Active through the warm-up window (clients may
+    // still be loading), Finished once it passes with no pings received.
+    const game = makeGame({ startsAt: T0 + 1000 });
+    vi.advanceTimersByTime(1001);
+    expect(game.phase()).toBe(GamePhase.Active);
+
+    vi.advanceTimersByTime(30_000);
+    expect(game.phase()).toBe(GamePhase.Finished);
+  });
+
+  it("finishes once the game is older than the 3h maximum", () => {
+    // Checked ahead of everything else, so even a lobby that never got a
+    // start time is reaped.
+    const game = makeGame({ createdAt: T0 - 3 * HOUR - 1 });
+    expect(game.phase()).toBe(GamePhase.Finished);
+  });
+
+  it("drops a client that has not pinged for 60s and keeps one that has", async () => {
+    const game = makeGame({ startsAt: T0 + 1000 });
+    const quiet = makeClient({ clientID: cid("quiet") });
+    const chatty = makeClient({ clientID: cid("chatty") });
+    game.joinClient(quiet);
+    game.joinClient(chatty);
+
+    vi.advanceTimersByTime(60_500);
+    await mockWsOf(chatty).emit({ type: "ping" });
+
+    expect(game.phase()).toBe(GamePhase.Active);
+    expect(mockWsOf(quiet).close).toHaveBeenCalledWith(
+      1000,
+      "no heartbeats received, closing connection",
+    );
+    expect(mockWsOf(chatty).close).not.toHaveBeenCalled();
+    expect(game.numClients()).toBe(1);
+  });
+
+  it("finishes a started game once every client has gone quiet", () => {
+    const game = makeGame({ startsAt: T0 + 1000 });
+    game.joinClient(makeClient());
+    game.joinClient(makeClient());
+    vi.advanceTimersByTime(1001);
+    startGame(game);
+
+    // 60s without pings prunes both; the game is then unattended.
+    vi.advanceTimersByTime(60_500);
+    expect(game.phase()).toBe(GamePhase.Finished);
+    expect(game.numClients()).toBe(0);
+  });
+});
+
+describe("connection status marks in the turn log", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  // Every mark_disconnected intent the observer's socket received, keyed by
+  // the turn it was committed in.
+  function marksSeenBy(observerWs: ReturnType<typeof mockWsOf>, ctx: any) {
+    const marks: Record<number, [string, boolean][]> = {};
+    for (const frame of observerWs.sent(ctx)) {
+      if (frame.type !== "turn") continue;
+      const found = frame.turn.intents.flatMap((i) =>
+        i.type === "mark_disconnected"
+          ? [[i.clientID, i.isDisconnected] as [string, boolean]]
+          : [],
+      );
+      if (found.length > 0) marks[frame.turn.turnNumber] = found;
+    }
+    return marks;
+  }
+
+  it("marks a silent player on the next 5-turn boundary, and back once it pings", async () => {
+    const P1 = cid("p1");
+    const P2 = cid("p2");
+    const game = makeGame();
+    const p1 = makeClient({ clientID: P1 });
+    const p2 = makeClient({ clientID: P2 });
+    game.joinClient(p1);
+    game.joinClient(p2);
+    startGame(game);
+    const ctx = createGameWireContext([{ clientID: P1 }, { clientID: P2 }]);
+
+    // p1 went quiet more than 30s ago (the disconnect timeout).
+    p1.lastPing = Date.now() - 31_000;
+    // Turns 0..5: the check fires as turn 4 commits (5 turns in the log),
+    // and its mark rides in turn 5.
+    vi.advanceTimersByTime(6 * TURN_MS);
+    expect(game.isClientDisconnected(P1)).toBe(true);
+    expect(game.isClientDisconnected(P2)).toBe(false);
+
+    // p1 is heard from again: the next boundary marks them reconnected.
+    await mockWsOf(p1).emit({ type: "ping" });
+    vi.advanceTimersByTime(5 * TURN_MS);
+    expect(game.isClientDisconnected(P1)).toBe(false);
+
+    expect(marksSeenBy(mockWsOf(p2), ctx)).toEqual({
+      // Joining records both as connected.
+      0: [
+        [P1, false],
+        [P2, false],
+      ],
+      5: [[P1, true]],
+      10: [[P1, false]],
+    });
+  });
+
+  it("never marks a spectator, whose status the simulation cannot use", () => {
+    const P1 = cid("p1");
+    const CAST = cid("cast");
+    const game = makeGame();
+    const p1 = makeClient({ clientID: P1 });
+    const cast = makeClient({ clientID: CAST, spectator: true });
+    game.joinClient(p1);
+    game.joinClient(cast);
+    startGame(game);
+    const ctx = createGameWireContext([{ clientID: P1 }]);
+
+    cast.lastPing = Date.now() - 31_000;
+    vi.advanceTimersByTime(6 * TURN_MS);
+
+    // Tracked server-side...
+    expect(game.isClientDisconnected(CAST)).toBe(true);
+    // ...but never written into the turn log.
+    const marks = marksSeenBy(mockWsOf(p1), ctx);
+    expect(marks).toEqual({ 0: [[P1, false]] });
+  });
+});

--- a/tests/server/GameServerRejoin.test.ts
+++ b/tests/server/GameServerRejoin.test.ts
@@ -1,0 +1,204 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGameWireContext } from "../../src/core/ZbinWire";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  makeMockWs,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
+
+// Characterization tests for rejoinClient: socket hand-over, the pre-start
+// identity update (and the verified badge it may cost), and the turn replay
+// a mid-game reconnect receives. See docs/GameServerRefactor.md, Phase 1.
+
+const P1 = cid("p1");
+const TURN_MS = 100;
+
+describe("GameServer.rejoinClient", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("returns false for a persistentID that never joined", () => {
+    expect(makeGame().rejoinClient(makeMockWs() as any, "nobody")).toBe(false);
+  });
+
+  it("moves the client onto the new socket and closes the old one", () => {
+    const game = makeGame();
+    const client = makeClient({ clientID: P1, persistentID: "p1-pid" });
+    const oldWs = mockWsOf(client);
+    game.joinClient(client);
+
+    const newWs = makeMockWs();
+    expect(game.rejoinClient(newWs as any, "p1-pid")).toBe(true);
+
+    expect(oldWs.close).toHaveBeenCalledOnce();
+    expect(client.ws).toBe(newWs);
+    // One seat, not two.
+    expect(game.numClients()).toBe(1);
+    // Lobby traffic now reaches the new socket.
+    vi.advanceTimersByTime(1000);
+    expect(newWs.sent().map((m) => m.type)).toContain("lobby_info");
+  });
+
+  it("refuses a kicked player", () => {
+    const game = makeGame();
+    game.joinClient(makeClient({ clientID: P1, persistentID: "p1-pid" }));
+    game.kickClient(P1);
+    expect(game.rejoinClient(makeMockWs() as any, "p1-pid")).toBe(false);
+  });
+
+  describe("identity update", () => {
+    it("applies a screened username / clan change before the start", () => {
+      const game = makeGame();
+      const client = makeClient({
+        clientID: P1,
+        persistentID: "p1-pid",
+        username: "OldName",
+        clanTag: "OLD",
+      });
+      game.joinClient(client);
+
+      game.rejoinClient(makeMockWs() as any, "p1-pid", 0, {
+        username: "NewName",
+        clanTag: "NEW",
+      });
+
+      expect(game.storedIdentity("p1-pid")).toEqual({
+        username: "NewName",
+        clanTag: "NEW",
+      });
+      const seen = game.gameInfo().clients?.find((c) => c.clientID === P1);
+      expect(seen?.username).toBe("NewName");
+      expect(seen?.clanTag).toBe("NEW");
+    });
+
+    it("drops the verified badge when the username changes", () => {
+      // The badge vouches for the exact join name; the rejoin path skips the
+      // Worker's badge validation, so a rename under it must lose it.
+      const game = makeGame();
+      const client = makeClient({
+        clientID: P1,
+        persistentID: "p1-pid",
+        username: "OldName",
+        cosmetics: { verified: true },
+      });
+      game.joinClient(client);
+
+      game.rejoinClient(makeMockWs() as any, "p1-pid", 0, {
+        username: "NewName",
+        clanTag: null,
+      });
+
+      expect(client.cosmetics?.verified).toBeUndefined();
+      const seen = game.gameInfo().clients?.find((c) => c.clientID === P1);
+      expect(seen?.verified).toBeUndefined();
+    });
+
+    it("keeps the verified badge when only the clan tag changes", () => {
+      const game = makeGame();
+      const client = makeClient({
+        clientID: P1,
+        persistentID: "p1-pid",
+        username: "SameName",
+        clanTag: "OLD",
+        cosmetics: { verified: true },
+      });
+      game.joinClient(client);
+
+      game.rejoinClient(makeMockWs() as any, "p1-pid", 0, {
+        username: "SameName",
+        clanTag: "NEW",
+      });
+
+      expect(client.cosmetics?.verified).toBe(true);
+      expect(game.storedIdentity("p1-pid")?.clanTag).toBe("NEW");
+    });
+
+    it("is ignored once the game has started", () => {
+      // The roster is frozen in gameStartInfo; a later rename would make the
+      // lobby record disagree with what every client was told.
+      const game = makeGame();
+      const client = makeClient({
+        clientID: P1,
+        persistentID: "p1-pid",
+        username: "OldName",
+        clanTag: "OLD",
+      });
+      game.joinClient(client);
+      startGame(game);
+
+      expect(
+        game.rejoinClient(makeMockWs() as any, "p1-pid", 0, {
+          username: "NewName",
+          clanTag: "NEW",
+        }),
+      ).toBe(true);
+
+      expect(game.storedIdentity("p1-pid")).toEqual({
+        username: "OldName",
+        clanTag: "OLD",
+      });
+    });
+  });
+
+  describe("after the start", () => {
+    function playedGame(turns: number) {
+      const game = makeGame();
+      const client = makeClient({ clientID: P1, persistentID: "p1-pid" });
+      game.joinClient(client);
+      startGame(game);
+      vi.advanceTimersByTime(turns * TURN_MS);
+      const ctx = createGameWireContext([{ clientID: P1 }]);
+      return { game, client, ctx };
+    }
+
+    const startFrameOn = (ws: ReturnType<typeof makeMockWs>, ctx: any) => {
+      const start = ws.sent(ctx).find((m) => m.type === "start");
+      if (start?.type !== "start") throw new Error("no start frame");
+      return start;
+    };
+
+    it("replays only the turns the client missed, from lastTurn", () => {
+      const { game, ctx } = playedGame(5);
+      const newWs = makeMockWs();
+      expect(game.rejoinClient(newWs as any, "p1-pid", 3)).toBe(true);
+
+      const start = startFrameOn(newWs, ctx);
+      expect(start.turns.map((t) => t.turnNumber)).toEqual([3, 4]);
+      expect(start.myClientID).toBe(P1);
+    });
+
+    it("replays the whole game when lastTurn is omitted", () => {
+      const { game, ctx } = playedGame(5);
+      const newWs = makeMockWs();
+      game.rejoinClient(newWs as any, "p1-pid");
+
+      expect(startFrameOn(newWs, ctx).turns.map((t) => t.turnNumber)).toEqual([
+        0, 1, 2, 3, 4,
+      ]);
+    });
+
+    it("keeps the reconnect mapping across a mid-game socket drop", async () => {
+      // Only a LOBBY-phase drop clears the mapping (to free the seat); once
+      // the game runs, the seat is theirs to come back to.
+      const { game, client, ctx } = playedGame(2);
+      await mockWsOf(client).trigger("close");
+      expect(game.numClients()).toBe(0);
+      expect(game.getClientIdForPersistentId("p1-pid")).toBe(P1);
+
+      const newWs = makeMockWs();
+      expect(game.rejoinClient(newWs as any, "p1-pid", 0)).toBe(true);
+      expect(game.numClients()).toBe(1);
+      expect(startFrameOn(newWs, ctx).turns).toHaveLength(2);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Phase 1 of `docs/GameServerRefactor.md` (Phase 0 landed in #5114). **Test-only** — no production code changes. Before the refactor moves these paths into their own modules, they need tests that pin what they do today; none of them had any.

- **`tests/server/GameServerJoin.test.ts`** — the prod-only duplicate-session kick (the *old* connection is the one told to go), the three-connections-per-IP cap for public games outside dev (and that it does not apply to private games or in dev), a socket that is already closed when it joins, and an undecodable frame → `invalid_message` kick + ban.
- **`tests/server/GameServerRejoin.test.ts`** — socket hand-over (old one closed, seat count unchanged), the pre-start identity update, the verified badge dropped only when the *username* changes, update ignored once started, turn replay from `lastTurn`, and a mid-game drop keeping its reconnect mapping.
- **`tests/server/GameServerPhase.test.ts`** — Lobby → Active → Finished transitions, the full-lobby early exit, the 3h maximum, the 60s ping prune, and the `mark_disconnected` intents the turn loop injects every five turns (both directions; never for a spectator).
- **`tests/server/GameServerDesync.test.ts`** — `findOutOfSyncClients` tallies (majority, no majority → everyone, even split, unreported turn, single client) and the turn loop's one-time desync notice, `numDesyncedClients()`, and agreed-hash recording.

Everything goes through the public API and the wire (decoded frames) — no `(game as any)`.

**Suspected bug, pinned as current behaviour rather than fixed** (documented in the plan doc for its own PR): a prod duplicate-session kick calls `kickClient()` on the old connection, which bans the *shared* persistentID — so the surviving session can no longer be looked up (`getClientIdForPersistentId`) or reconnect.

## Test plan

- `npx vitest tests/server --run`: 45 files / 438 tests green (was 41 / 403).
- Because characterization tests passing first try proves little, each file was checked against a hand mutation of the branch it covers in `GameServer.ts` (5-turn boundary → 6, strict-majority `>` → `>=`, identity update allowed after start, dup-session kick removed). Each mutation failed 1–4 of the new tests; all reverted.
- prettier, oxlint, eslint, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)