### PR TITLE
Focus the other player when a chat message is clicked

### DIFF
--- a/src/client/hud/layers/EventsDisplay.ts
+++ b/src/client/hud/layers/EventsDisplay.ts
@@ -329,10 +329,12 @@ export class EventsDisplay extends LitElement implements Controller {
     }
 
     let otherPlayerDiplayName: string = "";
+    let otherPlayerSmallID: number | undefined;
     if (event.recipient !== null) {
       //'recipient' parameter contains sender ID or recipient ID
       const player = this.game.player(event.recipient);
       otherPlayerDiplayName = player ? player.displayName() : "";
+      otherPlayerSmallID = player?.smallID();
     }
 
     this.addEvent({
@@ -344,6 +346,7 @@ export class EventsDisplay extends LitElement implements Controller {
       highlight: true,
       type: MessageType.CHAT,
       unsafeDescription: false,
+      focusID: otherPlayerSmallID,
     });
     this.eventBus.emit(new PlaySoundEffectEvent("message"));
   }

--- a/tests/client/graphics/layers/EventsDisplayChatFocus.test.ts
+++ b/tests/client/graphics/layers/EventsDisplayChatFocus.test.ts
@@ -1,0 +1,78 @@
+/**
+ * A quick-chat entry in the events feed must carry the other party's smallID
+ * as focusID, so clicking it moves the camera to them (#5101). The feed
+ * already renders any event with a focusID as a button that emits
+ * GoToPlayerEvent; chat was the one entry type not filling it in.
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("lit/directive.js", () => ({}));
+vi.mock("lit/directives/unsafe-html.js", () => ({
+  unsafeHTML: (s: string) => s,
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  renderNumber: vi.fn(),
+  renderTroops: vi.fn(),
+  getMessageTypeClasses: vi.fn(() => ""),
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventsDisplay } from "../../../../src/client/hud/layers/EventsDisplay";
+import { GameUpdateType } from "../../../../src/core/game/GameUpdates";
+
+describe("EventsDisplay chat focus (#5101)", () => {
+  let ed: EventsDisplay;
+  const myPlayer = { smallID: () => 1, displayName: () => "Me" };
+  const other = { smallID: () => 2, displayName: () => "Bob" };
+
+  beforeEach(() => {
+    ed = new EventsDisplay();
+    (ed as unknown as { game: unknown }).game = {
+      myPlayer: () => myPlayer,
+      player: (id: string) => (id === "bob" ? other : myPlayer),
+      ticks: () => 0,
+    };
+    (ed as unknown as { eventBus: unknown }).eventBus = { emit: vi.fn() };
+  });
+
+  const chatUpdate = (isFrom: boolean) => ({
+    type: GameUpdateType.DisplayChatEvent,
+    key: "help",
+    category: "help",
+    target: undefined,
+    playerID: 1,
+    isFrom,
+    recipient: "bob",
+  });
+
+  it("focuses the sender of a received message", () => {
+    ed.onDisplayChatEvent(chatUpdate(true) as never);
+    const events = (ed as unknown as { events: { focusID?: number }[] }).events;
+    expect(events).toHaveLength(1);
+    expect(events[0].focusID).toBe(2);
+  });
+
+  it("focuses the recipient of a sent message", () => {
+    ed.onDisplayChatEvent(chatUpdate(false) as never);
+    const events = (ed as unknown as { events: { focusID?: number }[] }).events;
+    expect(events[0].focusID).toBe(2);
+  });
+});


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #5101

## Description:

Clicking a quick-chat line in the events feed now moves the camera to the other player — the sender for a received message, the recipient for one you sent.

The plumbing was already there: `renderEventRow` turns any feed entry carrying a `focusID` into a button that emits `GoToPlayerEvent`, and alliance requests, betrayals and emojis all use it. Quick chat was the only entry type that never filled `focusID` in, so a "Please send me troops!" in a team game gave you no way to find who sent it.

`QuickChatExecution` already calls `displayChat` twice with the *other* party's id in `recipient`, and `onDisplayChatEvent` already resolves that player to render their name — so this just carries their `smallID` through to the event:

```ts
otherPlayerSmallID = player?.smallID();
...
focusID: otherPlayerSmallID,
```

Behaviour matches the alliance/emoji entries sitting next to it in the feed, and the button styling is the shared `renderButton` those already use — no new visual treatment.

## Please complete the following:

- [x] I have added screenshots for all UI updates — n/a: no new UI or styling, the chat row now uses the same `renderButton` treatment as the focusable entries already in the feed
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — n/a: no new user-facing text
- [x] I have added relevant tests to the test directory

`tests/client/graphics/layers/EventsDisplayChatFocus.test.ts` covers both directions and fails without the fix (`expected undefined to be 2`). `npm run lint`, `npx prettier --check .` and `tsc --noEmit` are clean.

## Please put your Discord username so you can be contacted if a bug or regression is found:

slewinus