### PR TITLE
show a player's cosmetics in the player info panel

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1359,6 +1359,8 @@
     "betrayals": "Betrayals",
     "break_alliance": "Break Alliance",
     "chat": "Chat",
+    "cosmetic_get": "Get it in the store",
+    "cosmetics": "Wearing",
     "emotes": "Emojis",
     "flip_rocket_trajectory": "Flip rocket trajectory",
     "gold": "Gold",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1359,7 +1359,7 @@
     "betrayals": "Betrayals",
     "break_alliance": "Break Alliance",
     "chat": "Chat",
-    "cosmetic_get": "Get it in the store",
+    "cosmetic_get_label": "{name} (Get it in the store)",
     "cosmetics": "Wearing",
     "emotes": "Emojis",
     "flip_rocket_trajectory": "Flip rocket trajectory",

--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -22,6 +22,7 @@ import {
   ResolvedCosmetic,
 } from "./Cosmetics";
 import { translateText } from "./Utils";
+import { matchesStoreItem } from "./WornCosmetics";
 
 type StoreTab =
   | "cosmetics"
@@ -33,6 +34,13 @@ type StoreTab =
 
 const COSMETICS_SUB_TABS = ["patterns", "flags", "crowns"] as const;
 type CosmeticsSubTab = (typeof COSMETICS_SUB_TABS)[number];
+
+/** Sub-tab holding the catalog item a store deep link points at. */
+export function subTabForItem(itemKey: string): CosmeticsSubTab {
+  if (itemKey.startsWith("crown:")) return "crowns";
+  if (itemKey.startsWith("flag:")) return "flags";
+  return "patterns";
+}
 
 interface StoreBrowserOptions {
   emptyTranslationKey: string;
@@ -50,6 +58,9 @@ export class StoreModal extends BaseModal {
   private affiliateCode: string | null = null;
   private userMeResponse: UserMeResponse | false = false;
   private cosmeticsSubTab: CosmeticsSubTab = "patterns";
+  // Item the URL asked for (`#modal=store&item=<key>`). Held until its group
+  // is visible, then inspected so the store opens on that item.
+  private requestedItem: string | null = null;
   private inspected: ResolvedCosmetic | null = null;
   private visibleGroups: readonly (readonly ResolvedCosmetic[])[] = [];
 
@@ -211,6 +222,16 @@ export class StoreModal extends BaseModal {
     groups: readonly (readonly ResolvedCosmetic[])[],
   ): void {
     const visible = groups.flat();
+    const wanted = this.requestedItem;
+    if (wanted !== null) {
+      const match = visible.find((item) => matchesStoreItem(item.key, wanted));
+      // The catalog loads after open, so keep the request until its item shows.
+      if (match !== undefined) {
+        this.requestedItem = null;
+        this.inspected = match;
+        return;
+      }
+    }
     const current = visible.find((item) => item.key === this.inspected?.key);
     this.inspected = current ?? groups[0]?.[0] ?? null;
   }
@@ -511,6 +532,10 @@ export class StoreModal extends BaseModal {
     const affiliate =
       typeof args?.affiliateCode === "string" ? args.affiliateCode : null;
     this.affiliateCode = affiliate;
+    this.requestedItem = typeof args?.item === "string" ? args.item : null;
+    if (this.requestedItem !== null) {
+      this.cosmeticsSubTab = subTabForItem(this.requestedItem);
+    }
     this.cosmetics ??= await fetchCosmetics();
     this.selectVisible(this.groupsForTab(this.activeTab));
     await this.refresh();
@@ -518,6 +543,7 @@ export class StoreModal extends BaseModal {
 
   protected onClose(): void {
     this.affiliateCode = null;
+    this.requestedItem = null;
     this.selectVisible(this.groupsForTab(this.activeTab));
   }
 

--- a/src/client/WornCosmetics.ts
+++ b/src/client/WornCosmetics.ts
@@ -34,6 +34,13 @@ export function wornCosmetics(
   catalog: ResolvedCosmetic[],
 ): WornCosmetic[] {
   const byKey = new Map(catalog.map((r) => [r.key, r]));
+  // the catalog keys effects by their map key, which need not equal the
+  // effect's name, so match on effectType plus the name both sides carry
+  const effectByName = new Map(
+    catalog
+      .filter((r) => r.type === "effect")
+      .map((r) => [`${r.effectType}:${r.cosmetic?.name}`, r]),
+  );
   const worn: WornCosmetic[] = [];
 
   const add = (
@@ -83,9 +90,11 @@ export function wornCosmetics(
     );
   }
   for (const effect of Object.values(cosmetics.effects ?? {})) {
+    const resolved =
+      effectByName.get(`${effect.effectType}:${effect.name}`) ?? null;
     add(
       "effect",
-      `effect:${effect.effectType}:${effect.name}`,
+      resolved?.key ?? `effect:${effect.effectType}:${effect.name}`,
       effect.name,
       null,
       null,

--- a/src/client/WornCosmetics.ts
+++ b/src/client/WornCosmetics.ts
@@ -1,0 +1,121 @@
+import { PlayerCosmetics, PlayerPattern } from "../core/Schemas";
+import { ResolvedCosmetic } from "./Cosmetics";
+
+export type WornCosmeticType = "pattern" | "skin" | "crown" | "effect";
+
+export type WornCosmetic = {
+  type: WornCosmeticType;
+  /** Catalog key, same format `resolveCosmetics` produces. */
+  key: string;
+  name: string;
+  /** Catalog entry, or null when the catalog isn't loaded or dropped the item. */
+  resolved: ResolvedCosmetic | null;
+  /** Patterns only — taken from the player, so it renders without the catalog. */
+  pattern: PlayerPattern | null;
+  /** Skins and crowns only. */
+  imageUrl: string | null;
+  /** "unknown" when the item isn't in the catalog, so no store link is offered. */
+  relationship: ResolvedCosmetic["relationship"] | "unknown";
+};
+
+function keyForWornPattern(pattern: PlayerPattern): string {
+  return pattern.colorPalette
+    ? `pattern:${pattern.name}:${pattern.colorPalette.name}`
+    : `pattern:${pattern.name}`;
+}
+
+/**
+ * The cosmetics a player is wearing, paired with the viewer's catalog so the
+ * UI knows whether the viewer already owns each one. Flags are left out: the
+ * panel already shows the flag, and nation flags aren't store items.
+ */
+export function wornCosmetics(
+  cosmetics: PlayerCosmetics,
+  catalog: ResolvedCosmetic[],
+): WornCosmetic[] {
+  const byKey = new Map(catalog.map((r) => [r.key, r]));
+  const worn: WornCosmetic[] = [];
+
+  const add = (
+    type: WornCosmeticType,
+    key: string,
+    name: string,
+    pattern: PlayerPattern | null,
+    imageUrl: string | null,
+  ) => {
+    const resolved = byKey.get(key) ?? null;
+    worn.push({
+      type,
+      key,
+      name,
+      resolved,
+      pattern,
+      imageUrl,
+      relationship: resolved?.relationship ?? "unknown",
+    });
+  };
+
+  if (cosmetics.pattern) {
+    add(
+      "pattern",
+      keyForWornPattern(cosmetics.pattern),
+      cosmetics.pattern.name,
+      cosmetics.pattern,
+      null,
+    );
+  }
+  if (cosmetics.skin) {
+    add(
+      "skin",
+      `skin:${cosmetics.skin.name}`,
+      cosmetics.skin.name,
+      null,
+      cosmetics.skin.url,
+    );
+  }
+  if (cosmetics.crown) {
+    add(
+      "crown",
+      `crown:${cosmetics.crown.name}`,
+      cosmetics.crown.name,
+      null,
+      cosmetics.crown.url,
+    );
+  }
+  for (const effect of Object.values(cosmetics.effects ?? {})) {
+    add(
+      "effect",
+      `effect:${effect.effectType}:${effect.name}`,
+      effect.name,
+      null,
+      null,
+    );
+  }
+
+  return worn;
+}
+
+/**
+ * Hash route that opens the store on the item, for `ModalRouter`. Effects only
+ * get their tab — the effects grid has no per-item target.
+ */
+export function storeRouteFor(worn: WornCosmetic): string | null {
+  if (worn.relationship !== "purchasable") return null;
+  if (worn.type === "effect") {
+    return "#modal=store&tab=effects";
+  }
+  return `#modal=store&tab=cosmetics&item=${encodeURIComponent(worn.key)}`;
+}
+
+/**
+ * Whether a catalog key is the item a store deep link asked for. Pattern
+ * palette variants collapse into one store tile, so any variant of the
+ * requested pattern matches.
+ */
+export function matchesStoreItem(key: string, wanted: string): boolean {
+  if (key === wanted) return true;
+  if (!key.startsWith("pattern:") || !wanted.startsWith("pattern:")) {
+    return false;
+  }
+  return key.split(":")[1] === wanted.split(":")[1];
+}

--- a/src/client/components/WornCosmeticsRow.ts
+++ b/src/client/components/WornCosmeticsRow.ts
@@ -1,0 +1,164 @@
+import { html, LitElement, nothing, TemplateResult } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { UserMeResponse } from "../../core/ApiSchemas";
+import {
+  Cosmetics,
+  Effect,
+  isNukeExplosionEffect,
+} from "../../core/CosmeticSchemas";
+import { PlayerCosmetics } from "../../core/Schemas";
+import { getUserMe } from "../Api";
+import {
+  fetchCosmetics,
+  resolveCosmetics,
+  translateCosmetic,
+} from "../Cosmetics";
+import { translateText } from "../Utils";
+import { storeRouteFor, WornCosmetic, wornCosmetics } from "../WornCosmetics";
+import "./EffectPreview";
+import { renderPatternPreview } from "./PatternPreview";
+
+const rarityRing: Record<string, string> = {
+  common: "ring-white/15",
+  uncommon: "ring-green-400/50",
+  rare: "ring-blue-400/50",
+  epic: "ring-purple-300/50",
+  legendary: "ring-orange-400/60",
+};
+
+/**
+ * The cosmetics a player is wearing, as a row of small tiles under their name.
+ * Tiles the viewer doesn't own link to that item in the store, opened in a new
+ * tab so the running game is left alone.
+ */
+@customElement("worn-cosmetics-row")
+export class WornCosmeticsRow extends LitElement {
+  @property({ attribute: false })
+  cosmetics: PlayerCosmetics = {};
+
+  @state() private catalog: Cosmetics | null = null;
+  @state() private userMe: UserMeResponse | false = false;
+
+  createRenderRoot() {
+    return this;
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+    void this.load();
+  }
+
+  private async load() {
+    const [catalog, userMe] = await Promise.all([
+      fetchCosmetics(),
+      getUserMe(),
+    ]);
+    this.catalog = catalog;
+    this.userMe = userMe;
+  }
+
+  private openStore(worn: WornCosmetic) {
+    const route = storeRouteFor(worn);
+    if (route === null) return;
+    window.open(
+      new URL(route, `${window.location.origin}/`).toString(),
+      "_blank",
+      "noopener",
+    );
+  }
+
+  private displayName(worn: WornCosmetic): string {
+    if (worn.type === "crown") return translateCosmetic("crowns", worn.name);
+    if (worn.type === "effect") return translateCosmetic("effects", worn.name);
+    return translateCosmetic("territory_patterns.pattern", worn.name);
+  }
+
+  private renderPreview(worn: WornCosmetic): TemplateResult {
+    if (worn.pattern !== null) {
+      return renderPatternPreview(worn.pattern, 48, 48);
+    }
+    if (worn.imageUrl !== null) {
+      return html`<img
+        src=${worn.imageUrl}
+        alt=""
+        class="h-full w-full object-contain pointer-events-none"
+        draggable="false"
+        loading="lazy"
+      />`;
+    }
+    const effect = worn.resolved?.cosmetic as Effect | undefined;
+    if (effect === undefined) {
+      return html`<span class="text-xs font-bold text-white/40">?</span>`;
+    }
+    if (isNukeExplosionEffect(effect)) {
+      return effect.attributes.type === "sparkles"
+        ? html`<sparkles-swatch
+            class="block h-full w-full"
+            .explosion=${effect.attributes}
+          ></sparkles-swatch>`
+        : html`<shockwave-swatch
+            class="block h-full w-full"
+            .explosion=${effect.attributes}
+          ></shockwave-swatch>`;
+    }
+    return html`<trail-swatch
+      class="block h-full w-full"
+      .trail=${effect.attributes}
+    ></trail-swatch>`;
+  }
+
+  private renderTile(worn: WornCosmetic): TemplateResult {
+    const name = this.displayName(worn);
+    const buyable = storeRouteFor(worn) !== null;
+    const rarity = worn.resolved?.cosmetic?.rarity ?? "";
+    const ring = rarityRing[rarity] ?? "ring-white/15";
+    const label = buyable
+      ? `${name} (${translateText("player_panel.cosmetic_get")})`
+      : name;
+
+    return html`
+      <button
+        type="button"
+        class=${`relative h-11 w-11 shrink-0 overflow-hidden rounded-lg bg-white/5 p-1 ring-1 ${ring}
+          ${buyable ? "cursor-pointer transition hover:bg-white/10 active:scale-95" : "cursor-default"}`}
+        title=${label}
+        aria-label=${label}
+        ?disabled=${!buyable}
+        @click=${(e: Event) => {
+          e.stopPropagation();
+          this.openStore(worn);
+        }}
+      >
+        ${this.renderPreview(worn)}
+        ${buyable
+          ? html`<span
+              class="absolute bottom-0 right-0 rounded-tl bg-malibu-blue px-1 text-[10px] font-black leading-tight text-white"
+              aria-hidden="true"
+              >+</span
+            >`
+          : nothing}
+      </button>
+    `;
+  }
+
+  render() {
+    const worn = wornCosmetics(
+      this.cosmetics,
+      resolveCosmetics(this.catalog, this.userMe, null),
+    );
+    if (worn.length === 0) return nothing;
+
+    return html`
+      <div class="flex items-center gap-2">
+        <span
+          class="text-xs font-semibold uppercase tracking-wider text-zinc-400"
+        >
+          ${translateText("player_panel.cosmetics")}
+        </span>
+        <div class="flex flex-wrap items-center gap-1.5">
+          ${worn.map((w) => this.renderTile(w))}
+        </div>
+      </div>
+    `;
+  }
+}

--- a/src/client/components/WornCosmeticsRow.ts
+++ b/src/client/components/WornCosmeticsRow.ts
@@ -43,6 +43,12 @@ export class WornCosmeticsRow extends LitElement {
     return this;
   }
 
+  protected updated(): void {
+    // Light DOM, so the host stays a flex item even when nothing renders and
+    // would add a gap under the identity row for a player with no cosmetics.
+    this.toggleAttribute("hidden", this.childElementCount === 0);
+  }
+
   connectedCallback() {
     super.connectedCallback();
     void this.load();

--- a/src/client/components/WornCosmeticsRow.ts
+++ b/src/client/components/WornCosmeticsRow.ts
@@ -119,7 +119,7 @@ export class WornCosmeticsRow extends LitElement {
     const rarity = worn.resolved?.cosmetic?.rarity ?? "";
     const ring = rarityRing[rarity] ?? "ring-white/15";
     const label = buyable
-      ? `${name} (${translateText("player_panel.cosmetic_get")})`
+      ? translateText("player_panel.cosmetic_get_label", { name })
       : name;
 
     return html`

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -16,6 +16,7 @@ import { Emoji, flattenedEmojiTable } from "../../../core/Util";
 import { fetchLobbyListed } from "../../Api";
 import { actionButton } from "../../components/ui/ActionButton";
 import "../../components/ui/Divider";
+import "../../components/WornCosmeticsRow";
 import { Controller } from "../../Controller";
 import {
   CloseViewEvent,
@@ -989,6 +990,11 @@ export class PlayerPanel extends LitElement implements Controller {
                     <div class="mb-1">
                       ${this.renderIdentityRow(other, viewer)}
                     </div>
+
+                    <!-- Cosmetics the player is wearing -->
+                    <worn-cosmetics-row
+                      .cosmetics=${other.cosmetics}
+                    ></worn-cosmetics-row>
 
                     ${this.sendTarget && !isSpectator
                       ? html`

--- a/tests/client/WornCosmetics.test.ts
+++ b/tests/client/WornCosmetics.test.ts
@@ -22,6 +22,22 @@ function catalogEntry(
   };
 }
 
+function effectEntry(
+  key: string,
+  effectType: string,
+  name: string,
+  relationship: ResolvedCosmetic["relationship"],
+): ResolvedCosmetic {
+  return {
+    type: "effect",
+    cosmetic: { name, rarity: "rare" } as never,
+    colorPalette: null,
+    relationship,
+    key,
+    effectType,
+  } as ResolvedCosmetic;
+}
+
 const wornPattern: PlayerCosmetics = {
   pattern: {
     name: "hearts",
@@ -102,6 +118,24 @@ describe("storeRouteFor", () => {
       ]);
       expect(storeRouteFor(worn)).toBeNull();
     }
+  });
+
+  it("matches an effect whose catalog key differs from its name", () => {
+    // the catalog keys effects by their map key, which need not be the name
+    const [worn] = wornCosmetics(
+      { effects: { nukeTrail: { name: "embers", effectType: "nukeTrail" } } },
+      [
+        effectEntry(
+          "effect:nukeTrail:ember_v2",
+          "nukeTrail",
+          "embers",
+          "purchasable",
+        ),
+      ],
+    );
+
+    expect(worn.key).toBe("effect:nukeTrail:ember_v2");
+    expect(worn.relationship).toBe("purchasable");
   });
 
   it("sends effects to their tab, which has no per-item target", () => {

--- a/tests/client/WornCosmetics.test.ts
+++ b/tests/client/WornCosmetics.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import { ResolvedCosmetic } from "../../src/client/Cosmetics";
+import { subTabForItem } from "../../src/client/Store";
+import {
+  matchesStoreItem,
+  storeRouteFor,
+  wornCosmetics,
+} from "../../src/client/WornCosmetics";
+import { PlayerCosmetics } from "../../src/core/Schemas";
+
+function catalogEntry(
+  key: string,
+  type: ResolvedCosmetic["type"],
+  relationship: ResolvedCosmetic["relationship"],
+): ResolvedCosmetic {
+  return {
+    type,
+    cosmetic: { name: key.split(":")[1], rarity: "rare" } as never,
+    colorPalette: null,
+    relationship,
+    key,
+  };
+}
+
+const wornPattern: PlayerCosmetics = {
+  pattern: {
+    name: "hearts",
+    patternData: "AAAAAA",
+    colorPalette: {
+      name: "red",
+      primaryColor: "#ff0000",
+      secondaryColor: "#000000",
+    },
+  },
+};
+
+describe("wornCosmetics", () => {
+  it("matches a worn pattern to its colour variant in the catalog", () => {
+    const [worn] = wornCosmetics(wornPattern, [
+      catalogEntry("pattern:hearts", "pattern", "purchasable"),
+      catalogEntry("pattern:hearts:red", "pattern", "owned"),
+    ]);
+
+    expect(worn.key).toBe("pattern:hearts:red");
+    expect(worn.relationship).toBe("owned");
+    expect(worn.pattern?.name).toBe("hearts");
+  });
+
+  it("still renders a pattern the catalog doesn't list", () => {
+    const [worn] = wornCosmetics(wornPattern, []);
+
+    expect(worn.relationship).toBe("unknown");
+    expect(worn.pattern?.patternData).toBe("AAAAAA");
+    expect(storeRouteFor(worn)).toBeNull();
+  });
+
+  it("lists skins, crowns and every effect slot", () => {
+    const worn = wornCosmetics(
+      {
+        skin: { name: "mountain", url: "/skin.png" },
+        crown: { name: "gold", url: "/crown.png" },
+        effects: {
+          nukeTrail: { name: "embers", effectType: "nukeTrail" },
+          transportShipTrail: {
+            name: "foam",
+            effectType: "transportShipTrail",
+          },
+        },
+      },
+      [],
+    );
+
+    expect(worn.map((w) => w.key)).toEqual([
+      "skin:mountain",
+      "crown:gold",
+      "effect:nukeTrail:embers",
+      "effect:transportShipTrail:foam",
+    ]);
+    expect(worn[0].imageUrl).toBe("/skin.png");
+  });
+
+  it("skips the flag, which the panel already shows", () => {
+    expect(wornCosmetics({ flag: "us" }, [])).toEqual([]);
+  });
+});
+
+describe("storeRouteFor", () => {
+  it("links a purchasable item to its store tile", () => {
+    const [worn] = wornCosmetics(wornPattern, [
+      catalogEntry("pattern:hearts:red", "pattern", "purchasable"),
+    ]);
+
+    expect(storeRouteFor(worn)).toBe(
+      "#modal=store&tab=cosmetics&item=pattern%3Ahearts%3Ared",
+    );
+  });
+
+  it("offers no link for owned or blocked items", () => {
+    for (const relationship of ["owned", "blocked"] as const) {
+      const [worn] = wornCosmetics(wornPattern, [
+        catalogEntry("pattern:hearts:red", "pattern", relationship),
+      ]);
+      expect(storeRouteFor(worn)).toBeNull();
+    }
+  });
+
+  it("sends effects to their tab, which has no per-item target", () => {
+    const [worn] = wornCosmetics(
+      { effects: { nukeTrail: { name: "embers", effectType: "nukeTrail" } } },
+      [catalogEntry("effect:nukeTrail:embers", "effect", "purchasable")],
+    );
+
+    expect(storeRouteFor(worn)).toBe("#modal=store&tab=effects");
+  });
+});
+
+describe("store deep links", () => {
+  it("matches any colour variant of the requested pattern", () => {
+    expect(matchesStoreItem("pattern:hearts:blue", "pattern:hearts:red")).toBe(
+      true,
+    );
+    expect(matchesStoreItem("pattern:stars:red", "pattern:hearts:red")).toBe(
+      false,
+    );
+    expect(matchesStoreItem("crown:gold", "crown:gold")).toBe(true);
+    expect(matchesStoreItem("crown:gold", "crown:silver")).toBe(false);
+  });
+
+  it("opens the sub-tab holding the item", () => {
+    expect(subTabForItem("crown:gold")).toBe("crowns");
+    expect(subTabForItem("flag:pirate")).toBe("flags");
+    expect(subTabForItem("pattern:hearts:red")).toBe("patterns");
+    expect(subTabForItem("skin:mountain")).toBe("patterns");
+  });
+});

--- a/tests/client/WornCosmeticsRow.test.ts
+++ b/tests/client/WornCosmeticsRow.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ResolvedCosmetic } from "../../src/client/Cosmetics";
+
+const { getUserMe, fetchCosmetics, resolveCosmetics } = vi.hoisted(() => ({
+  getUserMe: vi.fn(async () => false),
+  fetchCosmetics: vi.fn(async () => null),
+  resolveCosmetics: vi.fn((): ResolvedCosmetic[] => []),
+}));
+
+vi.mock("../../src/client/Api", () => ({ getUserMe }));
+vi.mock("../../src/client/Cosmetics", () => ({
+  fetchCosmetics,
+  resolveCosmetics,
+  translateCosmetic: (_prefix: string, name: string) => name,
+}));
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string) => key,
+}));
+
+import { WornCosmeticsRow } from "../../src/client/components/WornCosmeticsRow";
+
+function crownEntry(
+  relationship: ResolvedCosmetic["relationship"],
+): ResolvedCosmetic {
+  return {
+    type: "crown",
+    cosmetic: { name: "gold", rarity: "legendary" } as never,
+    colorPalette: null,
+    relationship,
+    key: "crown:gold",
+  };
+}
+
+async function renderRow(): Promise<WornCosmeticsRow> {
+  if (!customElements.get("worn-cosmetics-row")) {
+    customElements.define("worn-cosmetics-row", WornCosmeticsRow);
+  }
+  const el = document.createElement("worn-cosmetics-row") as WornCosmeticsRow;
+  el.cosmetics = { crown: { name: "gold", url: "/crown.png" } };
+  document.body.appendChild(el);
+  await el.updateComplete;
+  // Second settle: the catalog and account load after the first render.
+  await Promise.resolve();
+  await el.updateComplete;
+  return el;
+}
+
+describe("worn-cosmetics-row", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    resolveCosmetics.mockReturnValue([]);
+  });
+
+  it("renders nothing for a player with no cosmetics", async () => {
+    const el = await renderRow();
+    el.cosmetics = {};
+    await el.updateComplete;
+
+    expect(el.querySelector("button")).toBeNull();
+  });
+
+  it("opens the store in a new tab for an item the viewer can buy", async () => {
+    resolveCosmetics.mockReturnValue([crownEntry("purchasable")]);
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    const el = await renderRow();
+    const tile = el.querySelector("button")!;
+    expect(tile.hasAttribute("disabled")).toBe(false);
+    tile.click();
+
+    expect(open).toHaveBeenCalledWith(
+      expect.stringContaining("#modal=store&tab=cosmetics&item=crown%3Agold"),
+      "_blank",
+      "noopener",
+    );
+    open.mockRestore();
+  });
+
+  it("shows an owned item without a store link", async () => {
+    resolveCosmetics.mockReturnValue([crownEntry("owned")]);
+    const open = vi.spyOn(window, "open").mockReturnValue(null);
+
+    const el = await renderRow();
+    const tile = el.querySelector("button")!;
+    tile.click();
+
+    expect(tile.hasAttribute("disabled")).toBe(true);
+    expect(open).not.toHaveBeenCalled();
+    open.mockRestore();
+  });
+});

--- a/tests/client/WornCosmeticsRow.test.ts
+++ b/tests/client/WornCosmeticsRow.test.ts
@@ -57,6 +57,15 @@ describe("worn-cosmetics-row", () => {
     await el.updateComplete;
 
     expect(el.querySelector("button")).toBeNull();
+    // The host must not keep taking up a flex gap once it has no tiles.
+    expect(el.hasAttribute("hidden")).toBe(true);
+  });
+
+  it("unhides the host once the player has cosmetics", async () => {
+    resolveCosmetics.mockReturnValue([crownEntry("owned")]);
+    const el = await renderRow();
+
+    expect(el.hasAttribute("hidden")).toBe(false);
   });
 
   it("opens the store in a new tab for an item the viewer can buy", async () => {


### PR DESCRIPTION
Resolves #3147

## Description:

shows what a player is wearing in their info panel, pattern skin crown and effects as small tiles under the name, and anything you dont own links straight to that item in the store instead of making you go find it by name.

the store link opens in a new tab so the game keeps running behind it, and it lands on the right item rather than the top of the catalog, `storeRouteFor` builds `#modal=store&tab=cosmetics&item=<key>` and the store picks that item up in `onOpen` and inspects it once its group is visible. pattern palette variants collapse into one store tile so any variant of a pattern matches the one thats worn. effects just go to the effects tab since theyre not individually addressable.

rebased onto current main today, the store half got rewritten on the way since #4962 redesigned it, the deep link now just sets `inspected` through `reconcileInspection` instead of the scroll and highlight thing i had before, which turned out smaller and fits how the new store already works.

| desktop | mobile |
| --- | --- |
| ![desktop](https://raw.githubusercontent.com/CodingSelim/OpenFrontIO/pr-screenshots/shots/desktop.png) | ![mobile](https://raw.githubusercontent.com/CodingSelim/OpenFrontIO/pr-screenshots/shots/mobile.png) |

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

tsc clean, full suite green locally (3660 + 438), lint and prettier clean.

## Please put your Discord username so you can be contacted if a bug or regression is found:

forgedpost

