### PR TITLE
refactor(server): extract the config patch out of GameServer

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -159,6 +159,21 @@ Notes:
 Verify per PR: golden snapshot unchanged; module has its own unit tests; the
 corresponding `(game as any)` uses are gone.
 
+Status:
+
+- [x] `ConfigPatch.ts` (2026-08-25): `applyGameConfigPatch` + `hostCheatsEnabled`;
+      `updateGameConfig` is 12 lines, keeping only the whitelist → delist
+      side effect. Two explicit key lists, checked against `GameConfig` with
+      `satisfies`; the nullable list is exactly the schema's
+      `.nullable().optional()` keys. `tests/server/ConfigPatch.test.ts` is
+      table-driven over every key. The existing tests through `GameServer`
+      (AdminBotIntent, HostedLobbyListing) stay where they are.
+- [ ] `NameVisibility.ts`
+- [ ] `DesyncDetector.ts`
+- [ ] `Consensus.ts`
+- [ ] `ListingState.ts`
+- [ ] `MatchTelemetryRecorder.ts`
+
 ## Phase 4 — Roster
 
 - [ ] `Roster.ts` collapsing the seven collections: `add`, `reconnect`,

--- a/src/server/ConfigPatch.ts
+++ b/src/server/ConfigPatch.ts
@@ -1,0 +1,99 @@
+import { GameConfig } from "../core/Schemas";
+
+// The host edits its lobby through update_game_config, which carries a
+// partial GameConfig. Only the keys listed here are taken from it. gameType,
+// maxPlayers and the listing flag are deliberately absent: each has its own
+// guarded path (handleIntent rejects a switch to Public; listing goes through
+// the authenticated listing endpoint).
+
+// Copied whenever the patch carries them.
+const COPIED_KEYS = [
+  "gameMap",
+  "gameMapSize",
+  "difficulty",
+  "nations",
+  "bots",
+  "infiniteGold",
+  "donateGold",
+  "infiniteTroops",
+  "donateTroops",
+  "instantBuild",
+  "randomSpawn",
+  "gameMode",
+  "disabledUnits",
+  "playerTeams",
+  "allowedPublicIds",
+  "doomsdayClock",
+  "overtime",
+  "anonymizeNames",
+  "nameReveals",
+  "nameRevealPublicIds",
+] as const satisfies readonly (keyof GameConfig)[];
+
+// `.nullable().optional()` in the schema: the wire says null to clear a
+// value, the stored config says undefined.
+const NULLABLE_KEYS = [
+  "maxTimerValue",
+  "startDelay",
+  "spawnImmunityDuration",
+  "goldMultiplier",
+  "startingGold",
+  "disableAlliances",
+  "customAllianceDuration",
+  "waterNukes",
+] as const satisfies readonly (keyof GameConfig)[];
+
+type NullableKey = (typeof NULLABLE_KEYS)[number];
+
+function copy<K extends keyof GameConfig>(
+  target: GameConfig,
+  patch: Partial<GameConfig>,
+  key: K,
+): void {
+  const value = patch[key];
+  if (value !== undefined) {
+    target[key] = value;
+  }
+}
+
+function copyNullable<K extends NullableKey>(
+  target: GameConfig,
+  patch: Partial<GameConfig>,
+  key: K,
+): void {
+  const value = patch[key];
+  if (value !== undefined) {
+    // Every NULLABLE_KEY is optional in GameConfig, so undefined is legal
+    // for it; TypeScript cannot see that through the generic key.
+    target[key] = (value ?? undefined) as GameConfig[K];
+  }
+}
+
+// Applies a host's config patch to a game's stored config, in place.
+export function applyGameConfigPatch(
+  target: GameConfig,
+  patch: Partial<GameConfig>,
+): void {
+  for (const key of COPIED_KEYS) {
+    copy(target, patch, key);
+  }
+  for (const key of NULLABLE_KEYS) {
+    copyNullable(target, patch, key);
+  }
+  // Unconditional on purpose: the host clears cheats by omitting hostCheats
+  // (the full config it sends has hostCheats: undefined when the toggle is
+  // off), so `undefined` here means "clear", not "leave unchanged".
+  target.hostCheats = patch.hostCheats;
+}
+
+// Whether the host-only cheat block actually grants anything: mere presence
+// isn't enough, the client can send hostCheats with every field off.
+export function hostCheatsEnabled(hc: GameConfig["hostCheats"]): boolean {
+  return (
+    hc !== undefined &&
+    (hc.infiniteGold === true ||
+      hc.infiniteTroops === true ||
+      typeof hc.goldMultiplier === "number" ||
+      typeof hc.startingGold === "number")
+  );
+}

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -52,6 +52,7 @@ import {
 import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
 import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";
+import { applyGameConfigPatch, hostCheatsEnabled } from "./ConfigPatch";
 import { fetchCustomTribes } from "./CustomTribes";
 import { ServerEnv } from "./ServerEnv";
 import {
@@ -107,18 +108,6 @@ const SPECTATOR_BLOCKED_MESSAGES = new Set([
   "hash",
 ]);
 const KICK_REASON_INVALID_MESSAGE = "kick_reason.invalid_message";
-
-// Whether the host-only cheat block actually grants anything: mere presence
-// isn't enough, the client can send hostCheats with every field off.
-function hostCheatsEnabled(hc: GameConfig["hostCheats"]): boolean {
-  return (
-    hc !== undefined &&
-    (hc.infiniteGold === true ||
-      hc.infiniteTroops === true ||
-      typeof hc.goldMultiplier === "number" ||
-      typeof hc.startingGold === "number")
-  );
-}
 
 export interface GameServerOptions {
   id: string;
@@ -480,103 +469,17 @@ export class GameServer {
   }
 
   public updateGameConfig(gameConfig: Partial<GameConfig>): void {
-    if (gameConfig.gameMap !== undefined) {
-      this.gameConfig.gameMap = gameConfig.gameMap;
+    applyGameConfigPatch(this.gameConfig, gameConfig);
+    // A join whitelist and public listing are mutually exclusive: a listed
+    // lobby must be joinable by anyone who finds it in the lobby browser.
+    if (
+      gameConfig.allowedPublicIds !== undefined &&
+      this.listed &&
+      this.hasJoinWhitelist()
+    ) {
+      this.setListed(false);
+      this.log.info("delisted lobby: join whitelist enabled");
     }
-    if (gameConfig.gameMapSize !== undefined) {
-      this.gameConfig.gameMapSize = gameConfig.gameMapSize;
-    }
-    if (gameConfig.difficulty !== undefined) {
-      this.gameConfig.difficulty = gameConfig.difficulty;
-    }
-    if (gameConfig.nations !== undefined) {
-      this.gameConfig.nations = gameConfig.nations;
-    }
-    if (gameConfig.bots !== undefined) {
-      this.gameConfig.bots = gameConfig.bots;
-    }
-    if (gameConfig.infiniteGold !== undefined) {
-      this.gameConfig.infiniteGold = gameConfig.infiniteGold;
-    }
-    if (gameConfig.donateGold !== undefined) {
-      this.gameConfig.donateGold = gameConfig.donateGold;
-    }
-    if (gameConfig.infiniteTroops !== undefined) {
-      this.gameConfig.infiniteTroops = gameConfig.infiniteTroops;
-    }
-    if (gameConfig.donateTroops !== undefined) {
-      this.gameConfig.donateTroops = gameConfig.donateTroops;
-    }
-    if (gameConfig.maxTimerValue !== undefined) {
-      this.gameConfig.maxTimerValue = gameConfig.maxTimerValue ?? undefined;
-    }
-    if (gameConfig.startDelay !== undefined) {
-      this.gameConfig.startDelay = gameConfig.startDelay ?? undefined;
-    }
-    if (gameConfig.instantBuild !== undefined) {
-      this.gameConfig.instantBuild = gameConfig.instantBuild;
-    }
-    if (gameConfig.randomSpawn !== undefined) {
-      this.gameConfig.randomSpawn = gameConfig.randomSpawn;
-    }
-    if (gameConfig.spawnImmunityDuration !== undefined) {
-      this.gameConfig.spawnImmunityDuration =
-        gameConfig.spawnImmunityDuration ?? undefined;
-    }
-    if (gameConfig.gameMode !== undefined) {
-      this.gameConfig.gameMode = gameConfig.gameMode;
-    }
-    if (gameConfig.disabledUnits !== undefined) {
-      this.gameConfig.disabledUnits = gameConfig.disabledUnits;
-    }
-    if (gameConfig.playerTeams !== undefined) {
-      this.gameConfig.playerTeams = gameConfig.playerTeams;
-    }
-    if (gameConfig.goldMultiplier !== undefined) {
-      this.gameConfig.goldMultiplier = gameConfig.goldMultiplier ?? undefined;
-    }
-    if (gameConfig.startingGold !== undefined) {
-      this.gameConfig.startingGold = gameConfig.startingGold ?? undefined;
-    }
-    if (gameConfig.disableAlliances !== undefined) {
-      this.gameConfig.disableAlliances =
-        gameConfig.disableAlliances ?? undefined;
-    }
-    if (gameConfig.customAllianceDuration !== undefined) {
-      this.gameConfig.customAllianceDuration =
-        gameConfig.customAllianceDuration ?? undefined;
-    }
-    if (gameConfig.allowedPublicIds !== undefined) {
-      this.gameConfig.allowedPublicIds = gameConfig.allowedPublicIds;
-      // A join whitelist and public listing are mutually exclusive: a listed
-      // lobby must be joinable by anyone who finds it in the lobby browser.
-      if (this.listed && this.hasJoinWhitelist()) {
-        this.setListed(false);
-        this.log.info("delisted lobby: join whitelist enabled");
-      }
-    }
-    if (gameConfig.waterNukes !== undefined) {
-      this.gameConfig.waterNukes = gameConfig.waterNukes ?? undefined;
-    }
-    if (gameConfig.doomsdayClock !== undefined) {
-      this.gameConfig.doomsdayClock = gameConfig.doomsdayClock;
-    }
-    if (gameConfig.overtime !== undefined) {
-      this.gameConfig.overtime = gameConfig.overtime;
-    }
-    if (gameConfig.anonymizeNames !== undefined) {
-      this.gameConfig.anonymizeNames = gameConfig.anonymizeNames;
-    }
-    if (gameConfig.nameReveals !== undefined) {
-      this.gameConfig.nameReveals = gameConfig.nameReveals;
-    }
-    if (gameConfig.nameRevealPublicIds !== undefined) {
-      this.gameConfig.nameRevealPublicIds = gameConfig.nameRevealPublicIds;
-    }
-    // Unconditional on purpose: the host clears cheats by omitting hostCheats
-    // (the full config it sends has hostCheats: undefined when the toggle is
-    // off), so `undefined` here means "clear", not "leave unchanged".
-    this.gameConfig.hostCheats = gameConfig.hostCheats;
   }
 
   // Dispatch a control/gameplay intent from either a websocket client or the

--- a/tests/server/ConfigPatch.test.ts
+++ b/tests/server/ConfigPatch.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+import {
+  Difficulty,
+  GameMapSize,
+  GameMapType,
+  GameMode,
+  GameType,
+  UnitType,
+} from "../../src/core/game/Game";
+import { GameConfig } from "../../src/core/Schemas";
+import {
+  applyGameConfigPatch,
+  hostCheatsEnabled,
+} from "../../src/server/ConfigPatch";
+import { testGameConfig } from "../util/Wire";
+
+// One value per key the host may edit, each different from testGameConfig's
+// default so a copy is observable.
+const EDITABLE: { [K in keyof GameConfig]?: GameConfig[K] } = {
+  gameMap: GameMapType.Europe,
+  gameMapSize: GameMapSize.Compact,
+  difficulty: Difficulty.Hard,
+  nations: "disabled",
+  bots: 42,
+  infiniteGold: true,
+  donateGold: false,
+  infiniteTroops: true,
+  donateTroops: false,
+  instantBuild: true,
+  randomSpawn: true,
+  gameMode: GameMode.Team,
+  disabledUnits: [UnitType.AtomBomb],
+  playerTeams: 3,
+  allowedPublicIds: ["pub-a"],
+  doomsdayClock: { enabled: true, speed: "fast" },
+  overtime: { enabled: true, startMinutes: 20 },
+  anonymizeNames: true,
+  nameReveals: ["c1000000"],
+  nameRevealPublicIds: ["pub-b"],
+};
+
+// `.nullable().optional()` in the schema: null clears, undefined leaves alone.
+const NULLABLE: { [K in keyof GameConfig]?: NonNullable<GameConfig[K]> } = {
+  maxTimerValue: 30,
+  startDelay: 10,
+  spawnImmunityDuration: 50,
+  goldMultiplier: 2,
+  startingGold: 1000,
+  disableAlliances: true,
+  customAllianceDuration: 5,
+  waterNukes: true,
+};
+
+describe("applyGameConfigPatch", () => {
+  it.each(Object.entries(EDITABLE))(
+    "copies %s when the patch carries it",
+    (key, value) => {
+      const target = testGameConfig();
+      applyGameConfigPatch(target, { [key]: value });
+      expect(target[key as keyof GameConfig]).toEqual(value);
+    },
+  );
+
+  it("leaves every key alone when the patch omits it", () => {
+    const target = testGameConfig({ ...EDITABLE, ...NULLABLE });
+    const before = structuredClone(target);
+    applyGameConfigPatch(target, {});
+    expect(target).toEqual({ ...before, hostCheats: undefined });
+  });
+
+  it.each(Object.entries(NULLABLE))(
+    "sets %s from a value and clears it to undefined from null",
+    (key, value) => {
+      const target = testGameConfig();
+      applyGameConfigPatch(target, { [key]: value });
+      expect(target[key as keyof GameConfig]).toEqual(value);
+
+      applyGameConfigPatch(target, { [key]: null });
+      expect(key in target).toBe(true);
+      expect(target[key as keyof GameConfig]).toBeUndefined();
+    },
+  );
+
+  it("replaces hostCheats unconditionally, so omitting it clears it", () => {
+    // The host's full config carries hostCheats: undefined when the toggle
+    // is off; that has to clear, not preserve.
+    const target = testGameConfig({ hostCheats: { infiniteGold: true } });
+    applyGameConfigPatch(target, { bots: 1 });
+    expect(target.hostCheats).toBeUndefined();
+
+    applyGameConfigPatch(target, { hostCheats: { startingGold: 5 } });
+    expect(target.hostCheats).toEqual({ startingGold: 5 });
+  });
+
+  it("ignores gameType and maxPlayers, which have their own guarded paths", () => {
+    const target = testGameConfig({
+      gameType: GameType.Private,
+      maxPlayers: 4,
+    });
+    applyGameConfigPatch(target, { gameType: GameType.Public, maxPlayers: 99 });
+    expect(target.gameType).toBe(GameType.Private);
+    expect(target.maxPlayers).toBe(4);
+  });
+
+  it("ignores keys that are not part of GameConfig at all", () => {
+    // e.g. the listing flag, which lives on the GameServer, not the config.
+    const target = testGameConfig();
+    applyGameConfigPatch(target, { listed: true } as Partial<GameConfig>);
+    expect("listed" in target).toBe(false);
+  });
+});
+
+describe("hostCheatsEnabled", () => {
+  it("is off without a block, or with a block that grants nothing", () => {
+    expect(hostCheatsEnabled(undefined)).toBe(false);
+    expect(hostCheatsEnabled({})).toBe(false);
+    expect(
+      hostCheatsEnabled({
+        infiniteGold: false,
+        infiniteTroops: false,
+        goldMultiplier: null,
+        startingGold: null,
+      }),
+    ).toBe(false);
+  });
+
+  it.each([
+    { infiniteGold: true },
+    { infiniteTroops: true },
+    { goldMultiplier: 1 },
+    { startingGold: 0 },
+  ])("is on when %o grants something", (block) => {
+    expect(hostCheatsEnabled(block)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of `docs/GameServerRefactor.md`, first of six module extractions (Phases 0–2: #5114, #5116, #5117). A pure move with no behaviour change — the golden wire snapshot is untouched and the existing `update_game_config` tests pass unmodified.

- **`src/server/ConfigPatch.ts`** (new): `applyGameConfigPatch(target, patch)` replaces the ~100-line field-by-field `updateGameConfig`. It is driven by two explicit key lists, each checked against `GameConfig` with `satisfies`: 20 keys copied when the patch carries them, and the 8 keys the schema marks `.nullable().optional()` where `null` clears to `undefined` (the list matches the schema exactly). `hostCheats` stays unconditional — omitting it clears it, as the host's full config relies on. `gameType`, `maxPlayers` and the listing flag stay uncopyable. `hostCheatsEnabled` moves with it.
- **`GameServer.updateGameConfig`** is now 12 lines: the call plus the whitelist → delist side effect, still guarded on `patch.allowedPublicIds !== undefined` exactly as before (deliberately not widened). Net −97 lines.
- **`tests/server/ConfigPatch.test.ts`**: 37 table-driven tests — every copied key, every nullable key (value sets, `null` clears, `{}` leaves alone), `hostCheats` cleared by omission, `gameType`/`maxPlayers`/`listed` ignored, and the `hostCheatsEnabled` truth table.

## Test plan

- `npx vitest tests/server --run`: 46 files / 475 tests green (was 45 / 438).
- Golden snapshot (`GameServerWire.test.ts.snap`): unchanged.
- Mutation check: dropping `bots` from the copied-key list fails 2 tests (the module test and `AdminBotIntent`'s "mutates the config"); restored.
- `tsc --noEmit`, prettier, oxlint, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)