### PR TITLE
Add trusted-only lobbies gated on account trust tier

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1542,6 +1542,8 @@
     "teams_hvn": "Humans vs Nations",
     "teams_hvn_detailed": "{num} Humans vs {num} Nations",
     "title": "Waiting for Game Start...",
+    "trusted_locked": "Trusted accounts only. Your account isn't trusted yet.",
+    "trusted_unlocked": "Trusted accounts only. Your account is trusted.",
     "waiting_for_players": "Waiting for players"
   },
   "radial_menu": {

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1542,6 +1542,9 @@
     "teams_hvn": "Humans vs Nations",
     "teams_hvn_detailed": "{num} Humans vs {num} Nations",
     "title": "Waiting for Game Start...",
+    "trust_required_body": "You must have a trusted account to join this game. Please play more games or make any purchase to become trusted.",
+    "trust_required_ok": "OK",
+    "trust_required_title": "Trusted account required",
     "trusted_locked": "Trusted accounts only. Your account isn't trusted yet.",
     "trusted_unlocked": "Trusted accounts only. Your account is trusted.",
     "waiting_for_players": "Waiting for players"

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -13,8 +13,10 @@ import {
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
 import "./components/IOSAddToHomeScreenBanner";
 import {
+  canJoinTrustedLobby,
   lobbyCard,
   mapAspectRatios,
+  trustRequiredDialog,
   viewerIsTrusted,
 } from "./components/LobbyCard";
 import { multiplayerAllowed, type DesktopUpdateState } from "./DesktopShell";
@@ -51,6 +53,7 @@ export class GameModeSelector extends LitElement {
   @state() private inputValid: boolean = true;
   @state() private desktopUpdateState: DesktopUpdateState | null = null;
   @state() private viewerTrusted: boolean = false;
+  @state() private showTrustRequired: boolean = false;
   private serverTimeOffset: number = 0;
   private defaultLobbyTime: number = 0;
 
@@ -283,6 +286,9 @@ export class GameModeSelector extends LitElement {
             true,
           )}
         </div>
+        ${this.showTrustRequired
+          ? trustRequiredDialog(() => (this.showTrustRequired = false))
+          : nothing}
       </div>
     `;
   }
@@ -424,6 +430,10 @@ export class GameModeSelector extends LitElement {
   private validateAndJoin(lobby: PublicGameInfo) {
     if (this.blockedByUpdate()) return;
     if (!this.validateUsername()) return;
+    if (!canJoinTrustedLobby(lobby, this.viewerTrusted)) {
+      this.showTrustRequired = true;
+      return;
+    }
 
     this.dispatchEvent(
       new CustomEvent("join-lobby", {

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -1,6 +1,7 @@
 import { html, LitElement, nothing, type TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { ClientEnv } from "src/client/ClientEnv";
+import { UserMeResponse } from "../core/ApiSchemas";
 import {
   Duos,
   GameMapType,
@@ -11,7 +12,11 @@ import {
 } from "../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
 import "./components/IOSAddToHomeScreenBanner";
-import { lobbyCard, mapAspectRatios } from "./components/LobbyCard";
+import {
+  lobbyCard,
+  mapAspectRatios,
+  viewerIsTrusted,
+} from "./components/LobbyCard";
 import { multiplayerAllowed, type DesktopUpdateState } from "./DesktopShell";
 import { HostLobbyModal } from "./HostLobbyModal";
 import { JoinLobbyModal } from "./JoinLobbyModal";
@@ -45,6 +50,7 @@ export class GameModeSelector extends LitElement {
   @state() private lobbies: PublicGames | null = null;
   @state() private inputValid: boolean = true;
   @state() private desktopUpdateState: DesktopUpdateState | null = null;
+  @state() private viewerTrusted: boolean = false;
   private serverTimeOffset: number = 0;
   private defaultLobbyTime: number = 0;
 
@@ -76,6 +82,7 @@ export class GameModeSelector extends LitElement {
       "desktop-update-state",
       this.onDesktopUpdateState,
     );
+    document.addEventListener("userMeResponse", this.onUserMe);
     // Pick up the current value in case username-input validated before us.
     const usernameInput = document.querySelector(
       "username-input",
@@ -95,6 +102,7 @@ export class GameModeSelector extends LitElement {
       "desktop-update-state",
       this.onDesktopUpdateState,
     );
+    document.removeEventListener("userMeResponse", this.onUserMe);
     super.disconnectedCallback();
   }
 
@@ -104,6 +112,12 @@ export class GameModeSelector extends LitElement {
 
   private onDesktopUpdateState = (e: Event) => {
     this.desktopUpdateState = (e as CustomEvent<DesktopUpdateState>).detail;
+  };
+
+  private onUserMe = (e: Event) => {
+    this.viewerTrusted = viewerIsTrusted(
+      (e as CustomEvent<UserMeResponse | false>).detail,
+    );
   };
 
   public stop() {
@@ -402,6 +416,7 @@ export class GameModeSelector extends LitElement {
       timeDisplayUppercase,
       disabled: !this.inputValid,
       blocked: shouldBlockMultiplayerAction(this.desktopUpdateState),
+      viewerTrusted: this.viewerTrusted,
       onClick: () => this.validateAndJoin(lobby),
     });
   }

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -1,6 +1,7 @@
 import { html, nothing, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { repeat } from "lit/directives/repeat.js";
+import { UserMeResponse } from "../../core/ApiSchemas";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../../core/Schemas";
 import { type DesktopUpdateState } from "../DesktopShell";
@@ -34,7 +35,7 @@ import {
   NUMERIC_TEAM_CONFIGS,
   saveFilterProfile,
 } from "./DetailedGameViewFilters";
-import { lobbyCard, mapAspectRatios } from "./LobbyCard";
+import { lobbyCard, mapAspectRatios, viewerIsTrusted } from "./LobbyCard";
 import { modalHeader } from "./ui/ModalHeader";
 import { styledSelect } from "./ui/StyledSelect";
 
@@ -100,6 +101,7 @@ export class DetailedGameViewModal extends BaseModal {
   @state() private selectedProfile = "";
   @state() private profileName = "";
   @state() private desktopUpdateState: DesktopUpdateState | null = null;
+  @state() private viewerTrusted: boolean = false;
 
   private serverTimeOffset = 0;
   private countdownTimer: number | null = null;
@@ -159,6 +161,7 @@ export class DetailedGameViewModal extends BaseModal {
       "desktop-update-state",
       this.onDesktopUpdateState,
     );
+    document.addEventListener("userMeResponse", this.onUserMe);
   }
 
   disconnectedCallback() {
@@ -166,12 +169,19 @@ export class DetailedGameViewModal extends BaseModal {
       "desktop-update-state",
       this.onDesktopUpdateState,
     );
+    document.removeEventListener("userMeResponse", this.onUserMe);
     this.onClose();
     super.disconnectedCallback();
   }
 
   private onDesktopUpdateState = (e: Event) => {
     this.desktopUpdateState = (e as CustomEvent<DesktopUpdateState>).detail;
+  };
+
+  private onUserMe = (e: Event) => {
+    this.viewerTrusted = viewerIsTrusted(
+      (e as CustomEvent<UserMeResponse | false>).detail,
+    );
   };
 
   // ---- Slot animation ----
@@ -395,6 +405,7 @@ export class DetailedGameViewModal extends BaseModal {
       // swallow the click that's supposed to make the update bar wiggle. join()
       // does the actual refusing.
       blocked: shouldBlockMultiplayerAction(this.desktopUpdateState),
+      viewerTrusted: this.viewerTrusted,
       onClick: () => this.join(lobby),
     });
   }

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -35,7 +35,13 @@ import {
   NUMERIC_TEAM_CONFIGS,
   saveFilterProfile,
 } from "./DetailedGameViewFilters";
-import { lobbyCard, mapAspectRatios, viewerIsTrusted } from "./LobbyCard";
+import {
+  canJoinTrustedLobby,
+  lobbyCard,
+  mapAspectRatios,
+  trustRequiredDialog,
+  viewerIsTrusted,
+} from "./LobbyCard";
 import { modalHeader } from "./ui/ModalHeader";
 import { styledSelect } from "./ui/StyledSelect";
 
@@ -102,6 +108,7 @@ export class DetailedGameViewModal extends BaseModal {
   @state() private profileName = "";
   @state() private desktopUpdateState: DesktopUpdateState | null = null;
   @state() private viewerTrusted: boolean = false;
+  @state() private showTrustRequired: boolean = false;
 
   private serverTimeOffset = 0;
   private countdownTimer: number | null = null;
@@ -257,6 +264,9 @@ export class DetailedGameViewModal extends BaseModal {
 
     return html`
       <div class="custom-scrollbar p-4 lg:p-6 flex flex-col gap-4">
+        ${this.showTrustRequired
+          ? trustRequiredDialog(() => (this.showTrustRequired = false))
+          : nothing}
         ${this.showFilters ? this.renderFilterPanel() : nothing}
         ${shown.length === 0
           ? html`<p class="py-12 text-center text-sm text-white/50">
@@ -742,6 +752,12 @@ export class DetailedGameViewModal extends BaseModal {
     // leave the modal open and tell the player why, not vanish silently. This
     // sits above the hosted/public branch below so both paths are covered.
     if (this.blockedByUpdate()) return;
+    // Also before close(): the popup explains how to become trusted, so it
+    // must stay on screen with the browser rather than vanish with it.
+    if (!canJoinTrustedLobby(lobby, this.viewerTrusted)) {
+      this.showTrustRequired = true;
+      return;
+    }
     this.close();
 
     // Hosted lobbies are private games a subscriber listed publicly: joining

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -172,8 +172,7 @@ export function lobbyCard({
               )}
             </div>`
           : html`<div></div>`}
-        <div class="shrink-0 flex items-center gap-1">
-          ${trustedOnly ? trustLockIcon(viewerTrusted) : null}
+        <div class="shrink-0">
           <span
             class="text-xs font-bold tracking-widest ${timeDisplayUppercase
               ? "uppercase"
@@ -184,9 +183,12 @@ export function lobbyCard({
       </div>
       <!-- Bottom bar: map name + mode, with player count floating above -->
       <div
-        class="absolute bottom-0 left-0 right-0 flex flex-col px-3 py-2 bg-black/55 backdrop-blur-sm rounded-b-2xl"
+        class="absolute bottom-0 left-0 right-0 flex flex-col px-3 py-2 bg-black/55 backdrop-blur-sm rounded-b-2xl ${trustedOnly
+          ? "pr-10"
+          : ""}"
         style="overflow: visible;"
       >
+        ${trustedOnly ? trustLockIcon(viewerTrusted) : null}
         <span
           class="absolute bottom-full right-2 mb-1 flex items-center gap-1 text-xs font-bold tracking-widest bg-black/70 backdrop-blur-sm px-2 py-0.5 rounded"
         >
@@ -217,8 +219,9 @@ export function lobbyCard({
   `;
 }
 
-// Closed lock: the viewer can't join this trusted-only lobby. Open lock: they
-// can. Heroicons mini lock-closed / lock-open.
+// Bottom-right corner of the card. Red closed lock: the viewer can't join this
+// trusted-only lobby. Green open lock: they can. Heroicons mini
+// lock-closed / lock-open.
 function trustLockIcon(viewerTrusted: boolean): TemplateResult {
   const label = translateText(
     viewerTrusted
@@ -226,7 +229,9 @@ function trustLockIcon(viewerTrusted: boolean): TemplateResult {
       : "public_lobby.trusted_locked",
   );
   return html`<span
-    class="flex items-center bg-black/70 backdrop-blur-sm px-1.5 py-1 rounded"
+    class="absolute bottom-2 right-2 flex items-center bg-black/70 backdrop-blur-sm px-1.5 py-1 rounded ${viewerTrusted
+      ? "text-green-400"
+      : "text-red-400"}"
     title=${label}
     aria-label=${label}
     data-trust=${viewerTrusted ? "unlocked" : "locked"}

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -4,6 +4,7 @@ import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo } from "../../core/Schemas";
 import { terrainMapFileLoader } from "../TerrainMapFileLoader";
 import { getMapName, getModifierLabels, translateText } from "../Utils";
+import "./ConfirmDialog";
 
 /**
  * Whether the signed-in player may join trusted-only lobbies, from the
@@ -12,6 +13,32 @@ import { getMapName, getModifierLabels, translateText } from "../Utils";
  */
 export function viewerIsTrusted(userMe: UserMeResponse | false): boolean {
   return userMe !== false && userMe.player.trustTier === "trusted";
+}
+
+/** Whether the viewer may join `lobby`: it is open, or they are trusted. */
+export function canJoinTrustedLobby(
+  lobby: PublicGameInfo,
+  viewerTrusted: boolean,
+): boolean {
+  return lobby.gameConfig?.trusted !== true || viewerTrusted;
+}
+
+/**
+ * Popup shown instead of attempting to join a trusted-only lobby the viewer
+ * can't get into (the server would refuse them anyway). Tells them how to
+ * become trusted rather than letting the join fail.
+ */
+export function trustRequiredDialog(onClose: () => void): TemplateResult {
+  return html`<confirm-dialog
+    .heading=${translateText("public_lobby.trust_required_title")}
+    .message=${translateText("public_lobby.trust_required_body")}
+    variant="warning"
+    .showClose=${true}
+    .buttons=${"confirmOnly"}
+    .confirmText=${translateText("public_lobby.trust_required_ok")}
+    @cancel=${onClose}
+    @confirm=${onClose}
+  ></confirm-dialog>`;
 }
 
 /**

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -1,8 +1,18 @@
-import { html, TemplateResult } from "lit";
+import { html, svg, TemplateResult } from "lit";
+import { UserMeResponse } from "../../core/ApiSchemas";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo } from "../../core/Schemas";
 import { terrainMapFileLoader } from "../TerrainMapFileLoader";
-import { getMapName, getModifierLabels } from "../Utils";
+import { getMapName, getModifierLabels, translateText } from "../Utils";
+
+/**
+ * Whether the signed-in player may join trusted-only lobbies, from the
+ * userMeResponse Main dispatches. Logged out, an API without the field, and a
+ * failed computation (null) all read as untrusted.
+ */
+export function viewerIsTrusted(userMe: UserMeResponse | false): boolean {
+  return userMe !== false && userMe.player.trustTier === "trusted";
+}
 
 /**
  * The map-image lobby card used on the homepage and in the More Games lobby
@@ -63,6 +73,12 @@ export interface LobbyCardOptions {
    * leaving a gated card that looks broken instead of explaining itself.
    */
   blocked?: boolean;
+  /**
+   * Whether the viewer's account is trusted (viewerIsTrusted). Only matters
+   * for a trusted-only lobby, whose card shows a closed lock when the viewer
+   * can't join it and an open one when they can.
+   */
+  viewerTrusted?: boolean;
   /** Card height; defaults to the homepage's fill-the-grid-cell sizing. */
   heightClass?: string;
 }
@@ -75,6 +91,7 @@ export function lobbyCard({
   onClick,
   disabled = false,
   blocked = false,
+  viewerTrusted = false,
   heightClass = "h-44 sm:h-full",
 }: LobbyCardOptions): TemplateResult {
   const mapType = lobby.gameConfig!.gameMap as GameMapType;
@@ -109,6 +126,8 @@ export function lobbyCard({
   if (modifierLabels.length > 1) {
     modifierLabels.sort((a, b) => a.length - b.length);
   }
+
+  const trustedOnly = lobby.gameConfig?.trusted === true;
 
   return html`
     <button
@@ -153,7 +172,8 @@ export function lobbyCard({
               )}
             </div>`
           : html`<div></div>`}
-        <div class="shrink-0">
+        <div class="shrink-0 flex items-center gap-1">
+          ${trustedOnly ? trustLockIcon(viewerTrusted) : null}
           <span
             class="text-xs font-bold tracking-widest ${timeDisplayUppercase
               ? "uppercase"
@@ -195,4 +215,38 @@ export function lobbyCard({
       </div>
     </button>
   `;
+}
+
+// Closed lock: the viewer can't join this trusted-only lobby. Open lock: they
+// can. Heroicons mini lock-closed / lock-open.
+function trustLockIcon(viewerTrusted: boolean): TemplateResult {
+  const label = translateText(
+    viewerTrusted
+      ? "public_lobby.trusted_unlocked"
+      : "public_lobby.trusted_locked",
+  );
+  return html`<span
+    class="flex items-center bg-black/70 backdrop-blur-sm px-1.5 py-1 rounded"
+    title=${label}
+    aria-label=${label}
+    data-trust=${viewerTrusted ? "unlocked" : "locked"}
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      class="h-4 w-4"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      ${viewerTrusted
+        ? svg`<path
+            d="M14.5 1A4.5 4.5 0 0 0 10 5.5V9H3a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-1.5V5.5a3 3 0 1 1 6 0v2.75a.75.75 0 0 0 1.5 0V5.5A4.5 4.5 0 0 0 14.5 1Z"
+          ></path>`
+        : svg`<path
+            fill-rule="evenodd"
+            d="M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z"
+            clip-rule="evenodd"
+          ></path>`}
+    </svg>
+  </span>`;
 }

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -177,6 +177,10 @@ export const UserMeResponseSchema = z.object({
     // True when the player may list a custom lobby publicly. The API decides
     // which subscriptions/grants confer this.
     canCreatePublicLobbies: z.boolean(),
+    // Account trust as computed by the API. "untrusted" means new, unlinked or
+    // banned, never an accusation. null when the API's computation failed;
+    // absent on an API that predates the field. Both read as untrusted.
+    trustTier: z.enum(["untrusted", "trusted"]).nullable().optional(),
     // Account username (custom-usernames). All optional so responses from an
     // API without the feature still parse; absent means the same as never set.
     // `username` is the server-resolved DISPLAY form — the bare base for an

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -454,6 +454,11 @@ export const GameConfigSchema = z.object({
   maxPlayers: zb.uint().optional(),
   // OFM: allowlist of publicIds allowed to join (admin-only, see create_game).
   allowedPublicIds: z.array(z.string()).max(200).optional(),
+  // Only accounts the API reports as trusted (users/@me `trustTier`) may join.
+  // Enforced server-side at join (GameServer.joinClient); advertised in the
+  // lobby browser so a card can show a lock. No host UI yet: set through
+  // create_game / update_game_config.
+  trusted: z.boolean().optional(),
   maxTimerValue: zb.uint({ min: 1, max: 120 }).nullable().optional(), // In minutes
   customAllianceDuration: zb.uint({ max: 15 }).nullable().optional(), // In minutes; 0 disables alliances
   startDelay: zb.uint({ max: 600 }).nullable().optional(), // In seconds

--- a/src/server/Client.ts
+++ b/src/server/Client.ts
@@ -26,5 +26,8 @@ export class Client {
     // Set once at join, and again by GameServer when someone arrives after the
     // game has started — the player list is already frozen, so they can only watch.
     public spectator: boolean = false,
+    // Whether the API reported this account as trusted when it joined (the
+    // gate for GameConfig.trusted). Anonymous joins are never trusted.
+    public readonly trusted: boolean = false,
   ) {}
 }

--- a/src/server/ConfigPatch.ts
+++ b/src/server/ConfigPatch.ts
@@ -23,6 +23,7 @@ const COPIED_KEYS = [
   "disabledUnits",
   "playerTeams",
   "allowedPublicIds",
+  "trusted",
   "doomsdayClock",
   "overtime",
   "anonymizeNames",

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -47,7 +47,13 @@ export class GameManager {
   joinClient(
     client: Client,
     gameID: GameID,
-  ): "joined" | "kicked" | "rejected" | "not_allowlisted" | "not_found" {
+  ):
+    | "joined"
+    | "kicked"
+    | "rejected"
+    | "not_allowlisted"
+    | "not_trusted"
+    | "not_found" {
     const game = this.games.get(gameID);
     if (!game) return "not_found";
     return game.joinClient(client);

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -627,7 +627,7 @@ export class GameServer {
 
   public joinClient(
     client: Client,
-  ): "joined" | "kicked" | "rejected" | "not_allowlisted" {
+  ): "joined" | "kicked" | "rejected" | "not_allowlisted" | "not_trusted" {
     // e.g. the host left an unstarted lobby and GameManager hasn't pruned
     // it yet.
     if (this._hasEnded) {
@@ -645,6 +645,13 @@ export class GameServer {
         clientID: client.clientID,
       });
       return "not_allowlisted";
+    }
+
+    if (!this.passesTrustGate(client)) {
+      this.log.warn("client not trusted, rejecting", {
+        clientID: client.clientID,
+      });
+      return "not_trusted";
     }
 
     // gameStartInfo.players is frozen at start, so a late arrival could never
@@ -1301,6 +1308,15 @@ export class GameServer {
     return client.publicId !== undefined && allowed.includes(client.publicId);
   }
 
+  // Trusted-only lobbies (GameConfig.trusted) admit only accounts the API
+  // reported as trusted at join time. Shared by joinClient and the seat toggle
+  // for the same reason as passesAllowlist; admins bypass it the same way.
+  private passesTrustGate(client: Client): boolean {
+    if (this.gameConfig.trusted !== true) return true;
+    if (isAdminRole(client.role)) return true;
+    return client.trusted;
+  }
+
   // Switch a client between playing and watching from the lobby screen. Seating
   // is refused once the game has started (the player list is frozen), when the
   // lobby is full, or when the allowlist does not name them — the toggle must
@@ -1312,6 +1328,7 @@ export class GameServer {
     if (!spectator) {
       if (this._hasStarted || this._hasEnded) return;
       if (!this.passesAllowlist(client)) return;
+      if (!this.passesTrustGate(client)) return;
       const max = this.gameConfig.maxPlayers;
       if (max !== undefined && this.playerCount() >= max) return;
     }

--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -35,6 +35,10 @@ const MAX_PLAYER_COUNT = 125;
 
 // Share of public FFA games that run with overtime enabled.
 const OVERTIME_FFA_CHANCE = 0.25;
+// Share of scheduled public games (FFA, team and special alike) that are
+// trusted-only (GameConfig.trusted): only accounts the API reports as trusted
+// may join. Rolled independently of the map and modifier rolls.
+const TRUSTED_PUBLIC_CHANCE = 1 / 3;
 
 const TEAM_WEIGHTS: { config: TeamCountConfig; weight: number }[] = [
   { config: 2, weight: 10 },
@@ -142,6 +146,14 @@ export class MapPlaylist {
   };
 
   public async gameConfig(type: ScheduledPublicGameType): Promise<GameConfig> {
+    const config = await this.rollConfig(type);
+    if (Math.random() < TRUSTED_PUBLIC_CHANCE) {
+      config.trusted = true;
+    }
+    return config;
+  }
+
+  private async rollConfig(type: ScheduledPublicGameType): Promise<GameConfig> {
     if (type === "special") {
       return this.getSpecialConfig();
     }

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -578,6 +578,7 @@ export async function startWorker() {
         let publicId: string | undefined;
         let friends: string[] = [];
         let ownedClanTags: string[] = [];
+        let trusted = false;
         let accountUsername:
           | { username?: string | null; usernameStatus?: string }
           | undefined;
@@ -605,6 +606,7 @@ export async function startWorker() {
           friends = result.response.player.friends;
           ownedClanTags = result.response.player.clans?.map((c) => c.tag) ?? [];
           accountUsername = result.response.player;
+          trusted = result.response.player.trustTier === "trusted";
 
           if (allowedFlares !== undefined) {
             const allowed =
@@ -678,6 +680,7 @@ export async function startWorker() {
           publicId,
           friends,
           clientMsg.spectator === true,
+          trusted,
         );
 
         const joinResult = gm.joinClient(client, clientMsg.gameID);
@@ -697,6 +700,12 @@ export async function startWorker() {
             workerId,
           });
           ws.close(1002, "You are not whitelisted");
+        } else if (joinResult === "not_trusted") {
+          log.info(`untrusted client tried to join game ${clientMsg.gameID}`, {
+            gameID: clientMsg.gameID,
+            workerId,
+          });
+          ws.close(1002, "Trusted account required");
         } else if (joinResult === "rejected") {
           log.info(`client rejected from game ${clientMsg.gameID}`, {
             gameID: clientMsg.gameID,

--- a/tests/client/LobbyCardTrust.test.ts
+++ b/tests/client/LobbyCardTrust.test.ts
@@ -66,12 +66,14 @@ describe("lobbyCard trust lock", () => {
   it("shows a closed lock when the viewer can't join a trusted-only lobby", () => {
     const icon = trustIcon(renderCard(lobby(true), false));
     expect(icon?.dataset.trust).toBe("locked");
+    expect(icon?.classList.contains("text-red-400")).toBe(true);
     expect(icon?.getAttribute("title")).toBe("public_lobby.trusted_locked");
   });
 
   it("shows an open lock when the viewer is trusted", () => {
     const icon = trustIcon(renderCard(lobby(true), true));
     expect(icon?.dataset.trust).toBe("unlocked");
+    expect(icon?.classList.contains("text-green-400")).toBe(true);
     expect(icon?.getAttribute("title")).toBe("public_lobby.trusted_unlocked");
   });
 });

--- a/tests/client/LobbyCardTrust.test.ts
+++ b/tests/client/LobbyCardTrust.test.ts
@@ -1,0 +1,91 @@
+import { render } from "lit";
+import { describe, expect, it, vi } from "vitest";
+import type { UserMeResponse } from "../../src/core/ApiSchemas";
+import { GameMapType, GameMode } from "../../src/core/game/Game";
+import type { GameConfig, PublicGameInfo } from "../../src/core/Schemas";
+
+vi.mock("../../src/client/TerrainMapFileLoader", () => ({
+  terrainMapFileLoader: {
+    getMapData: vi.fn((map: GameMapType) => ({
+      webpPath: `/maps/${map}.webp`,
+    })),
+  },
+}));
+
+vi.mock("../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  getMapName: vi.fn((m: string | undefined) => m ?? null),
+  getModifierLabels: vi.fn(() => []),
+}));
+
+import {
+  lobbyCard,
+  viewerIsTrusted,
+} from "../../src/client/components/LobbyCard";
+
+function lobby(trusted?: boolean): PublicGameInfo {
+  return {
+    gameID: "game0001",
+    numClients: 3,
+    publicGameType: "ffa",
+    gameConfig: {
+      gameMap: GameMapType.World,
+      gameMode: GameMode.FFA,
+      maxPlayers: 8,
+      ...(trusted === undefined ? {} : { trusted }),
+    } as unknown as GameConfig,
+  };
+}
+
+function renderCard(l: PublicGameInfo, viewerTrusted: boolean): HTMLElement {
+  const host = document.createElement("div");
+  render(
+    lobbyCard({
+      lobby: l,
+      subtitle: "FFA",
+      timeDisplay: "0:30",
+      viewerTrusted,
+      onClick: () => {},
+    }),
+    host,
+  );
+  return host;
+}
+
+function trustIcon(host: HTMLElement): HTMLElement | null {
+  return host.querySelector("[data-trust]");
+}
+
+describe("lobbyCard trust lock", () => {
+  it("shows no lock on a lobby that is not trusted-only", () => {
+    expect(trustIcon(renderCard(lobby(), false))).toBeNull();
+    expect(trustIcon(renderCard(lobby(), true))).toBeNull();
+    expect(trustIcon(renderCard(lobby(false), false))).toBeNull();
+  });
+
+  it("shows a closed lock when the viewer can't join a trusted-only lobby", () => {
+    const icon = trustIcon(renderCard(lobby(true), false));
+    expect(icon?.dataset.trust).toBe("locked");
+    expect(icon?.getAttribute("title")).toBe("public_lobby.trusted_locked");
+  });
+
+  it("shows an open lock when the viewer is trusted", () => {
+    const icon = trustIcon(renderCard(lobby(true), true));
+    expect(icon?.dataset.trust).toBe("unlocked");
+    expect(icon?.getAttribute("title")).toBe("public_lobby.trusted_unlocked");
+  });
+});
+
+describe("viewerIsTrusted", () => {
+  const me = (trustTier: unknown) =>
+    ({ player: { trustTier } }) as unknown as UserMeResponse;
+
+  it("is true only for an explicit trusted tier", () => {
+    expect(viewerIsTrusted(me("trusted"))).toBe(true);
+    expect(viewerIsTrusted(me("untrusted"))).toBe(false);
+    // null: the API's computation failed. undefined: an older API.
+    expect(viewerIsTrusted(me(null))).toBe(false);
+    expect(viewerIsTrusted(me(undefined))).toBe(false);
+    expect(viewerIsTrusted(false)).toBe(false);
+  });
+});

--- a/tests/client/TrustedJoinGate.test.ts
+++ b/tests/client/TrustedJoinGate.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClientEnv } from "../../src/client/ClientEnv";
+import { GameMapType, GameMode } from "../../src/core/game/Game";
+import type {
+  GameConfig,
+  PublicGameInfo,
+  PublicGames,
+} from "../../src/core/Schemas";
+
+// Same socket stand-in as GameModeSelectorGatingWiring: keep the update
+// callback so a lobby snapshot can be pushed in and a card rendered.
+const { lobbiesCallbackRef } = vi.hoisted(() => ({
+  lobbiesCallbackRef: { current: null as ((g: PublicGames) => void) | null },
+}));
+
+vi.mock("../../src/client/LobbySocket", () => ({
+  PublicLobbySocket: class {
+    constructor(onUpdate: (g: PublicGames) => void) {
+      lobbiesCallbackRef.current = onUpdate;
+    }
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+// Registers <game-mode-selector> as a side effect.
+import "../../src/client/GameModeSelector";
+
+function lobby(trusted: boolean): PublicGameInfo {
+  return {
+    gameID: "trust001",
+    numClients: 3,
+    publicGameType: "ffa",
+    gameConfig: {
+      gameMap: GameMapType.World,
+      gameMode: GameMode.FFA,
+      maxPlayers: 8,
+      trusted,
+    } as unknown as GameConfig,
+  };
+}
+
+let selector: HTMLElement & { updateComplete: Promise<unknown> };
+let joinLobby: ReturnType<typeof vi.fn>;
+
+async function pushLobby(l: PublicGameInfo): Promise<void> {
+  lobbiesCallbackRef.current?.({ serverTime: Date.now(), games: { ffa: [l] } });
+  await selector.updateComplete;
+}
+
+async function setViewerTrust(trustTier: string): Promise<void> {
+  document.dispatchEvent(
+    new CustomEvent("userMeResponse", { detail: { player: { trustTier } } }),
+  );
+  await selector.updateComplete;
+}
+
+async function clickCard(): Promise<void> {
+  const card = selector.querySelector("button.group") as HTMLButtonElement;
+  expect(card).not.toBeNull();
+  card.click();
+  await selector.updateComplete;
+}
+
+const dialog = () => selector.querySelector("confirm-dialog");
+
+beforeEach(async () => {
+  window.BOOTSTRAP_CONFIG = {
+    gameEnv: "dev",
+    numWorkers: 1,
+    turnstileSiteKey: "",
+    jwtAudience: "test",
+    instanceId: "test",
+    gitCommit: "test",
+  };
+  ClientEnv.reset();
+  joinLobby = vi.fn();
+  document.addEventListener("join-lobby", joinLobby as EventListener);
+  lobbiesCallbackRef.current = null;
+  selector = document.createElement("game-mode-selector") as HTMLElement & {
+    updateComplete: Promise<unknown>;
+  };
+  document.body.appendChild(selector);
+  await selector.updateComplete;
+});
+
+afterEach(() => {
+  document.removeEventListener("join-lobby", joinLobby as EventListener);
+  document.body.innerHTML = "";
+  window.BOOTSTRAP_CONFIG = undefined;
+  ClientEnv.reset();
+  vi.restoreAllMocks();
+});
+
+describe("joining a trusted-only lobby from the homepage", () => {
+  it("shows the trust popup instead of joining when the viewer is untrusted", async () => {
+    await pushLobby(lobby(true));
+    await setViewerTrust("untrusted");
+    await clickCard();
+    expect(joinLobby).not.toHaveBeenCalled();
+    expect(dialog()).not.toBeNull();
+  });
+
+  it("closes the popup on dismiss", async () => {
+    await pushLobby(lobby(true));
+    await clickCard();
+    expect(dialog()).not.toBeNull();
+    dialog()!.dispatchEvent(new CustomEvent("cancel"));
+    await selector.updateComplete;
+    expect(dialog()).toBeNull();
+  });
+
+  it("joins when the viewer is trusted", async () => {
+    await pushLobby(lobby(true));
+    await setViewerTrust("trusted");
+    await clickCard();
+    expect(joinLobby).toHaveBeenCalledTimes(1);
+    expect(dialog()).toBeNull();
+  });
+
+  it("joins an open lobby regardless of trust", async () => {
+    await pushLobby(lobby(false));
+    await clickCard();
+    expect(joinLobby).toHaveBeenCalledTimes(1);
+    expect(dialog()).toBeNull();
+  });
+});

--- a/tests/core/ApiSchemas.test.ts
+++ b/tests/core/ApiSchemas.test.ts
@@ -38,3 +38,35 @@ describe("UserMeResponseSchema steam identity", () => {
     expect(parsed.user.steam?.avatarUrl).toBeNull();
   });
 });
+
+// trustTier is optional/nullable so an API without the field, or one whose
+// trust computation failed (null), still parses; only the two tiers are valid.
+describe("UserMeResponseSchema trustTier", () => {
+  const parseWith = (player: Record<string, unknown>) =>
+    UserMeResponseSchema.parse({ user: {}, player });
+
+  it("accepts trusted and untrusted", () => {
+    expect(
+      parseWith({ ...samplePlayer(), trustTier: "trusted" }).player.trustTier,
+    ).toBe("trusted");
+    expect(
+      parseWith({ ...samplePlayer(), trustTier: "untrusted" }).player.trustTier,
+    ).toBe("untrusted");
+  });
+
+  it("accepts null and an absent field", () => {
+    expect(
+      parseWith({ ...samplePlayer(), trustTier: null }).player.trustTier,
+    ).toBeNull();
+    expect(parseWith(samplePlayer()).player.trustTier).toBeUndefined();
+  });
+
+  it("rejects an unknown tier", () => {
+    expect(
+      UserMeResponseSchema.safeParse({
+        user: {},
+        player: { ...samplePlayer(), trustTier: "admin" },
+      }).success,
+    ).toBe(false);
+  });
+});

--- a/tests/server/ConfigPatch.test.ts
+++ b/tests/server/ConfigPatch.test.ts
@@ -32,6 +32,7 @@ const EDITABLE: { [K in keyof GameConfig]?: GameConfig[K] } = {
   disabledUnits: [UnitType.AtomBomb],
   playerTeams: 3,
   allowedPublicIds: ["pub-a"],
+  trusted: true,
   doomsdayClock: { enabled: true, speed: "fast" },
   overtime: { enabled: true, startMinutes: 20 },
   anonymizeNames: true,

--- a/tests/server/MapPlaylistTrusted.test.ts
+++ b/tests/server/MapPlaylistTrusted.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GameConfigSchema } from "../../src/core/Schemas";
+import { MapPlaylist } from "../../src/server/MapPlaylist";
+
+vi.mock("../../src/server/MapLandTiles", () => ({
+  getMapLandTiles: async () => 1_000_000,
+}));
+
+// A third of scheduled public games are trusted-only, whatever their type.
+// The roll is the LAST Math.random() call gameConfig makes, so a spy that
+// answers every earlier roll (map, modifiers) with the same value still
+// decides trust by that value.
+describe("MapPlaylist trusted-only public games", () => {
+  let randomSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    randomSpy = vi.spyOn(Math, "random");
+  });
+
+  afterEach(() => {
+    randomSpy.mockRestore();
+  });
+
+  for (const type of ["ffa", "team", "special"] as const) {
+    it(`marks a ${type} lobby trusted-only on a low roll`, async () => {
+      randomSpy.mockReturnValue(0.1);
+      const config = await new MapPlaylist().gameConfig(type);
+      expect(config.trusted).toBe(true);
+      expect(GameConfigSchema.safeParse(config).success).toBe(true);
+    });
+
+    it(`leaves a ${type} lobby open on a high roll`, async () => {
+      randomSpy.mockReturnValue(0.9);
+      const config = await new MapPlaylist().gameConfig(type);
+      expect(config.trusted).toBeUndefined();
+    });
+  }
+
+  it("rolls trust at the one-third threshold", async () => {
+    randomSpy.mockReturnValue(1 / 3 - 0.001);
+    expect((await new MapPlaylist().gameConfig("ffa")).trusted).toBe(true);
+    randomSpy.mockReturnValue(1 / 3 + 0.001);
+    expect((await new MapPlaylist().gameConfig("ffa")).trusted).toBeUndefined();
+  });
+});

--- a/tests/server/TrustedJoin.test.ts
+++ b/tests/server/TrustedJoin.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { GameType } from "../../src/core/game/Game";
+import {
+  cid,
+  makeClient as harnessClient,
+  makeGame as harnessGame,
+} from "../util/GameServerHarness";
+
+const C1 = cid("t1");
+const C2 = cid("t2");
+const C3 = cid("t3");
+
+function makeClient(
+  clientID: string,
+  persistentID: string,
+  trusted: boolean,
+  role: string | null = null,
+) {
+  return harnessClient({
+    clientID,
+    persistentID,
+    trusted,
+    role,
+    username: "TestUser",
+  });
+}
+
+function makeGame(trusted?: boolean) {
+  return harnessGame({
+    config: {
+      gameType: GameType.Private,
+      ...(trusted === undefined ? {} : { trusted }),
+    },
+  });
+}
+
+describe("GameServer - trusted-only lobbies (GameConfig.trusted)", () => {
+  it("admits trusted accounts and rejects untrusted ones", () => {
+    const game = makeGame(true);
+    expect(game.joinClient(makeClient(C1, "p1", true))).toBe("joined");
+    expect(game.joinClient(makeClient(C2, "p2", false))).toBe("not_trusted");
+  });
+
+  it("lets admins and root bypass the gate", () => {
+    const game = makeGame(true);
+    expect(game.joinClient(makeClient(C1, "p1", false, "admin"))).toBe(
+      "joined",
+    );
+    expect(game.joinClient(makeClient(C2, "p2", false, "root"))).toBe("joined");
+  });
+
+  it("does not let mod or unknown roles bypass the gate", () => {
+    const game = makeGame(true);
+    expect(game.joinClient(makeClient(C1, "p1", false, "mod"))).toBe(
+      "not_trusted",
+    );
+    expect(game.joinClient(makeClient(C2, "p2", false, "flagged"))).toBe(
+      "not_trusted",
+    );
+  });
+
+  it("does not restrict joins when trusted is unset or false", () => {
+    expect(makeGame().joinClient(makeClient(C1, "p1", false))).toBe("joined");
+    expect(makeGame(false).joinClient(makeClient(C2, "p2", false))).toBe(
+      "joined",
+    );
+  });
+
+  it("applies the gate once update_game_config turns it on", () => {
+    const game = makeGame();
+    game.updateGameConfig({ trusted: true });
+    expect(game.gameConfig.trusted).toBe(true);
+    expect(game.joinClient(makeClient(C1, "p1", false))).toBe("not_trusted");
+    expect(game.joinClient(makeClient(C2, "p2", true))).toBe("joined");
+  });
+
+  it("checks the allowlist before trust", () => {
+    const game = harnessGame({
+      config: {
+        gameType: GameType.Private,
+        trusted: true,
+        allowedPublicIds: ["pub-ok"],
+      },
+    });
+    expect(
+      game.joinClient(
+        harnessClient({
+          clientID: C3,
+          persistentID: "p3",
+          publicId: "pub-no",
+          trusted: true,
+          username: "TestUser",
+        }),
+      ),
+    ).toBe("not_allowlisted");
+  });
+});

--- a/tests/util/GameServerHarness.ts
+++ b/tests/util/GameServerHarness.ts
@@ -113,6 +113,7 @@ export interface ClientOpts {
   publicId?: string;
   friends?: string[];
   spectator?: boolean;
+  trusted?: boolean;
 }
 
 let nextClient = 1;
@@ -138,6 +139,7 @@ export function makeClient(opts: ClientOpts = {}): Client {
     opts.publicId,
     opts.friends ?? [],
     opts.spectator ?? false,
+    opts.trusted ?? false,
   );
 }
 


### PR DESCRIPTION
## Summary
- Adds `GameConfig.trusted`: when set, only accounts the API reports as trusted (`/users/@me` → `player.trustTier === "trusted"`) may join. Admins/root bypass it, mirroring `allowedPublicIds`.
- The worker reads the tier from the `getUserMe` call it already makes on first join and passes it into `Client`; `GameServer.joinClient` returns `"not_trusted"` (socket closed with `Trusted account required`) and the Play/Spectate seat toggle re-checks it. Anonymous joins are never trusted.
- A random third of the master's scheduled public games (FFA, team and special) are trusted-only: `MapPlaylist.gameConfig` rolls `TRUSTED_PUBLIC_CHANCE = 1/3` after building each config.
- No host UI: for private lobbies the flag is only settable through `create_game` / `update_game_config` (added to `ConfigPatch` copied keys), so hosts can't make a lobby trusted-only from the host modal yet.
- Public lobby cards (homepage `GameModeSelector` and Detailed View) show a red closed lock in the bottom-right corner of a trusted-only lobby the viewer can't join and a green open lock when their account is trusted, tracked from Main's `userMeResponse` event. Clicking a locked card doesn't attempt the join: a popup explains that a trusted account is needed and how to become trusted (play more games or make a purchase). New i18n keys under `public_lobby.trust*`.
- `UserMeResponseSchema` gains `trustTier` as optional/nullable so an older API (or a failed trust computation) still parses and reads as untrusted.

## Test plan
- New `tests/server/TrustedJoin.test.ts` (gate, admin bypass, mod/unknown roles, unset/false config, `update_game_config` enabling it, allowlist checked first), `tests/server/MapPlaylistTrusted.test.ts` (roll applies to ffa/team/special, threshold at 1/3) `tests/client/LobbyCardTrust.test.ts` (icon state/colour + `viewerIsTrusted`) and `tests/client/TrustedJoinGate.test.ts` (mounted homepage: popup instead of join when untrusted, join when trusted/open); `ConfigPatch.test.ts` covers the new key.
- `npx vitest tests/server tests/zbin --run` green (48 server files / 495 tests + zbin); client lobby tests (`GameModeSelectorGatingWiring`, `JoinLobbyModal`, `LobbySocket`, `NewLobbyMessages`, `ApiUserMeLogout`) pass.
- `tsc --noEmit`, oxlint/eslint, Prettier clean.
- Screenshotted the real homepage in headless Chromium: red closed lock logged out, green open lock after a trusted `userMeResponse`, no icon on a normal lobby, and the trust-required popup on clicking a locked card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
