### PR TITLE
Fix nation flags colliding when two nations share a display name

### DIFF
--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -160,19 +160,11 @@ export class GameView implements GameMap {
       humans.map((h) => [h.clientID, h.cosmetics ?? {}]),
     );
 
-    for (const nation of this._mapData.nations) {
-      // Nations don't have client ids, so we use their name as the key instead.
-      this._cosmetics.set(nation.name, {
-        flag: nation.flag ? `/flags/${nation.flag}.svg` : undefined,
-      } satisfies PlayerCosmetics);
-    }
-    for (const extra of this._mapData.additionalNations) {
-      // Only set if not already provided by a manifest nation with the same name.
-      if (this._cosmetics.has(extra.name)) continue;
-      this._cosmetics.set(extra.name, {
-        flag: extra.flag ? `/flags/${extra.flag}.svg` : undefined,
-      } satisfies PlayerCosmetics);
-    }
+    // Nation-type players carry their own flag on the wire (PlayerUpdate.nationFlag,
+    // sourced from the manifest via PlayerInfo) rather than being looked up here by
+    // name — some maps define multiple nations with the same display name (e.g.
+    // India's and Pakistan's "Punjab", split by the 1947 partition), and a name-keyed
+    // lookup can't tell those apart. See the Nation-branch in update() below.
 
     const mapW = this._map.width();
     const mapH = this._map.height();
@@ -383,12 +375,13 @@ export class GameView implements GameMap {
           this,
           pu,
           gu.playerNameViewData?.[pu.id],
-          // First check human by clientID, then check nation by name.
-          // Only match by name for actual Nations — not Bots (tribes) whose
-          // random names may coincidentally match a nation name.
+          // Humans get cosmetics by clientID. Nations carry their flag
+          // directly on the update (see PlayerUpdate.nationFlag) rather than
+          // being looked up by name — some maps define multiple nations with
+          // the same display name (e.g. India's and Pakistan's "Punjab").
           this._cosmetics.get(pu.clientID ?? "") ??
-            (pu.playerType === PlayerType.Nation
-              ? this._cosmetics.get(pu.name!)
+            (pu.playerType === PlayerType.Nation && pu.nationFlag
+              ? ({ flag: `/flags/${pu.nationFlag}.svg` } satisfies PlayerCosmetics)
               : undefined) ??
             {},
         );

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -381,7 +381,9 @@ export class GameView implements GameMap {
           // the same display name (e.g. India's and Pakistan's "Punjab").
           this._cosmetics.get(pu.clientID ?? "") ??
             (pu.playerType === PlayerType.Nation && pu.nationFlag
-              ? ({ flag: `/flags/${pu.nationFlag}.svg` } satisfies PlayerCosmetics)
+              ? ({
+                  flag: `/flags/${pu.nationFlag}.svg`,
+                } satisfies PlayerCosmetics)
               : undefined) ??
             {},
         );

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -449,6 +449,11 @@ export class PlayerInfo {
     // Server-pinned team slot (index into the game's team list) for
     // matchmade team games; null = assign normally.
     public readonly teamIndex: number | null = null,
+    // Manifest flag code (e.g. "in", "pk") for PlayerType.Nation players.
+    // Carried from the map manifest through to the client so it can render
+    // the correct flag even when multiple nations on a map share a display
+    // name (e.g. India's and Pakistan's "Punjab").
+    public readonly nationFlag: string | null = null,
   ) {
     this.displayName = formatPlayerDisplayName(this.name, this.clanTag);
   }

--- a/src/core/game/GameUpdateUtils.ts
+++ b/src/core/game/GameUpdateUtils.ts
@@ -40,6 +40,7 @@ export function diffPlayerUpdate(
     prev.name === next.name &&
     prev.displayName === next.displayName &&
     prev.clanTag === next.clanTag &&
+    prev.nationFlag === next.nationFlag &&
     prev.team === next.team &&
     prev.smallID === next.smallID &&
     prev.playerType === next.playerType &&
@@ -92,6 +93,7 @@ export function diffPlayerUpdate(
   setIfDifferent("name", prev.name === next.name);
   setIfDifferent("displayName", prev.displayName === next.displayName);
   setIfDifferent("clanTag", prev.clanTag === next.clanTag);
+  setIfDifferent("nationFlag", prev.nationFlag === next.nationFlag);
   setIfDifferent("team", prev.team === next.team);
   setIfDifferent("smallID", prev.smallID === next.smallID);
   setIfDifferent("playerType", prev.playerType === next.playerType);

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -233,6 +233,7 @@ export interface PlayerUpdate {
   name?: string;
   displayName?: string;
   clanTag?: string | null;
+  nationFlag?: string | null;
   team?: Team;
   smallID?: number;
   playerType?: PlayerType;

--- a/src/core/game/NationCreation.ts
+++ b/src/core/game/NationCreation.ts
@@ -37,7 +37,17 @@ export function createNationsForGame(
       n.coordinates !== undefined
         ? new Cell(n.coordinates[0], n.coordinates[1])
         : undefined,
-      new PlayerInfo(n.name, PlayerType.Nation, null, random.nextID()),
+      new PlayerInfo(
+        n.name,
+        PlayerType.Nation,
+        null,
+        random.nextID(),
+        false,
+        null,
+        [],
+        null,
+        n.flag ?? null,
+      ),
     );
 
   const isCompactMap = gameStart.config.gameMapSize === GameMapSize.Compact;
@@ -121,7 +131,17 @@ function createRandomNations(
       nations.push(
         new Nation(
           spawnCell,
-          new PlayerInfo(extra.name, PlayerType.Nation, null, random.nextID()),
+          new PlayerInfo(
+            extra.name,
+            PlayerType.Nation,
+            null,
+            random.nextID(),
+            false,
+            null,
+            [],
+            null,
+            extra.flag ?? null,
+          ),
         ),
       );
       usedNames.add(extra.name);

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -338,6 +338,7 @@ export class PlayerImpl implements Player {
       name: this.name(),
       displayName: this.displayName(),
       clanTag: this.clanTag(),
+      nationFlag: this.nationFlag(),
       id: this.id(),
       team: this.team() ?? undefined,
       smallID: this.smallID(),
@@ -386,6 +387,9 @@ export class PlayerImpl implements Player {
   }
   clanTag(): string | null {
     return this.playerInfo.clanTag;
+  }
+  nationFlag(): string | null {
+    return this.playerInfo.nationFlag;
   }
   clientID(): ClientID | null {
     return this.playerInfo.clientID;

--- a/tests/GameUpdateUtils.test.ts
+++ b/tests/GameUpdateUtils.test.ts
@@ -89,6 +89,20 @@ describe("diffPlayerUpdate", () => {
     expect(diff.clanTag).toBe("ABCDE");
   });
 
+  it("carries a changed nationFlag and stays quiet when it is unchanged", () => {
+    expect(
+      diffPlayerUpdate(
+        makePlayerUpdate({ nationFlag: "in" }),
+        makePlayerUpdate({ nationFlag: "in" }),
+      ),
+    ).toBeNull();
+    const diff = diffPlayerUpdate(
+      makePlayerUpdate({ nationFlag: null }),
+      makePlayerUpdate({ nationFlag: "pk" }),
+    )!;
+    expect(diff.nationFlag).toBe("pk");
+  });
+
   it("emits killedBy + deathPosition when a player is eliminated", () => {
     const prev = makePlayerUpdate({ killedBy: null, deathPosition: null });
     const next = makePlayerUpdate({ killedBy: "client-b", deathPosition: 3 });

--- a/tests/NationCreation.test.ts
+++ b/tests/NationCreation.test.ts
@@ -271,6 +271,55 @@ describe("createNationsForGame: additionalNations pool", () => {
     expect(withoutCoords!.spawnCell).toBeUndefined();
   });
 
+  test("carries each manifest nation's own flag through, even when names collide", () => {
+    // Regression test: maps can define multiple nations with the same display
+    // name (e.g. India's and Pakistan's "Punjab", split by the 1947
+    // partition). Each Nation instance must keep its own flag rather than
+    // depending on a name-keyed lookup that only the last-defined one wins.
+    const manifest: ManifestNation[] = [
+      { coordinates: [840, 305], name: "Punjab", flag: "in" },
+      { coordinates: [637, 464], name: "Punjab", flag: "pk" },
+    ];
+    const random = new PseudoRandom(5);
+
+    const nations = createNationsForGame(
+      makeGameStart(2),
+      manifest,
+      [],
+      0,
+      random,
+    );
+
+    expect(nations).toHaveLength(2);
+    const flags = nations.map((n) => n.playerInfo.nationFlag).sort();
+    expect(flags).toEqual(["in", "pk"]);
+  });
+
+  test("carries flags from additionalNations through too", () => {
+    const manifest = makeManifestNations(1);
+    const extras: AdditionalNation[] = [
+      { name: "WithFlag", flag: "fr" },
+      { name: "WithoutFlag" },
+    ];
+    const random = new PseudoRandom(5);
+
+    const nations = createNationsForGame(
+      makeGameStart(3),
+      manifest,
+      extras,
+      0,
+      random,
+    );
+
+    const withFlag = nations.find((n) => n.playerInfo.name === "WithFlag");
+    const withoutFlag = nations.find(
+      (n) => n.playerInfo.name === "WithoutFlag",
+    );
+
+    expect(withFlag!.playerInfo.nationFlag).toBe("fr");
+    expect(withoutFlag!.playerInfo.nationFlag).toBeNull();
+  });
+
   test("produces unique nation names overall", () => {
     const manifest = makeManifestNations(3);
     const extras = makeAdditionalNations(["Ex1", "Ex2", "Ex3"]);

--- a/tests/util/viewStubs.ts
+++ b/tests/util/viewStubs.ts
@@ -119,6 +119,7 @@ export function makePlayerUpdate(
     name: "Alice",
     displayName: "Alice",
     clanTag: null,
+    nationFlag: null,
     id: "player-a",
     smallID: 1,
     playerType: PlayerType.Human,


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #5109

## Description:

On maps that define two nations with the same display name (e.g. Indian
Subcontinent's two "Punjab" entries India's and Pakistan's, split by the
1947 partition), both nations rendered with the same flag in-game,
regardless of which was actually India's or Pakistan's.

Root cause: the client resolved a Nation-type player's flag by looking up
its display name in a `Map<string, PlayerCosmetics>` (`GameView.ts`).
Since both "Punjab" entries share a name, the second-defined one silently
overwrote the first's map entry, so every nation named "Punjab" resolved
to whichever flag was defined last in the manifest.

Fix: each nation's flag now travels with its own `PlayerInfo`, through
`PlayerImpl`'s per-tick `PlayerUpdate`, so the client reads the flag
directly off the specific player instance instead of re-deriving it
client-side by name. No more lookup, no more collision.

**Testing performed:**
- Added unit tests covering the regression directly (two same-named
  manifest nations keep distinct flags) and the wire-diffing change
  (`nationFlag` is included in `diffPlayerUpdate`/`applyStateUpdate`).
- `npm test` - full suite passes (3574 tests).
- `npm run lint` and `tsc --noEmit` — clean.
- Manually verified in a local `npm run dev` singleplayer game on the
  Indian Subcontinent map: both Punjab territories now show their correct
  flag (🇮🇳 / 🇵🇰).

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

phaniiiii

<img width="1917" height="963" alt="image" src="https://github.com/user-attachments/assets/6bc57458-555f-4899-9319-a281a0e67d21" />
