### PR TITLE
Reduce Sol/Sierpinski public frequency to 1, remove Labyrinth

### DIFF
--- a/map-generator/assets/maps/labyrinth/info.json
+++ b/map-generator/assets/maps/labyrinth/info.json
@@ -3,7 +3,7 @@
   "name": "Labyrinth",
   "translation_key": "map.labyrinth",
   "categories": ["arcade"],
-  "multiplayer_frequency": 6,
+  "multiplayer_frequency": 0,
   "nations": [
     {
       "coordinates": [50, 50],

--- a/map-generator/assets/maps/sierpinski/info.json
+++ b/map-generator/assets/maps/sierpinski/info.json
@@ -3,7 +3,7 @@
   "name": "Sierpinski",
   "translation_key": "map.sierpinski",
   "categories": ["arcade"],
-  "multiplayer_frequency": 10,
+  "multiplayer_frequency": 1,
   "nations": [
     {
       "coordinates": [216, 701],

--- a/map-generator/assets/maps/sol/info.json
+++ b/map-generator/assets/maps/sol/info.json
@@ -3,7 +3,7 @@
   "name": "Sol",
   "translation_key": "map.sol",
   "categories": ["cosmic"],
-  "multiplayer_frequency": 20,
+  "multiplayer_frequency": 1,
   "nations": [
     {
       "coordinates": [2419, 1241],

--- a/resources/maps/labyrinth/manifest.json
+++ b/resources/maps/labyrinth/manifest.json
@@ -243,7 +243,7 @@
     "num_land_tiles": 372162,
     "width": 680
   },
-  "multiplayer_frequency": 6,
+  "multiplayer_frequency": 0,
   "name": "Labyrinth",
   "nations": [
     {

--- a/resources/maps/sierpinski/manifest.json
+++ b/resources/maps/sierpinski/manifest.json
@@ -16,7 +16,7 @@
     "num_land_tiles": 143268,
     "width": 700
   },
-  "multiplayer_frequency": 10,
+  "multiplayer_frequency": 1,
   "name": "Sierpinski",
   "nations": [
     {

--- a/resources/maps/sol/manifest.json
+++ b/resources/maps/sol/manifest.json
@@ -206,7 +206,7 @@
     "num_land_tiles": 209669,
     "width": 2216
   },
-  "multiplayer_frequency": 20,
+  "multiplayer_frequency": 1,
   "name": "Sol",
   "nations": [
     {

--- a/src/core/game/Maps.gen.ts
+++ b/src/core/game/Maps.gen.ts
@@ -1122,7 +1122,7 @@ export const maps: readonly MapInfo[] = [
     type: GameMapType.Labyrinth,
     translationKey: "map.labyrinth",
     categories: ["arcade"],
-    multiplayerFrequency: 6,
+    multiplayerFrequency: 0,
   },
   {
     id: "LasVegasStrip",
@@ -1481,14 +1481,14 @@ export const maps: readonly MapInfo[] = [
     type: GameMapType.Sierpinski,
     translationKey: "map.sierpinski",
     categories: ["arcade"],
-    multiplayerFrequency: 10,
+    multiplayerFrequency: 1,
   },
   {
     id: "Sol",
     type: GameMapType.Sol,
     translationKey: "map.sol",
     categories: ["cosmic"],
-    multiplayerFrequency: 20,
+    multiplayerFrequency: 1,
     themes: ["space"],
     customTribes: [
       { name: "Actaea", coordinates: [237, 727] },

--- a/tests/MapConsistency.test.ts
+++ b/tests/MapConsistency.test.ts
@@ -36,6 +36,7 @@ const FREQUENCY_EXEMPTIONS: Set<GameMapName> = new Set([
   "BritanniaClassic",
   "ChoppingBlock",
   "Luna",
+  "Labyrinth",
 ]);
 
 // Keys in the en.json "map" section that are UI strings, not map names.


### PR DESCRIPTION
## Summary
- Set `multiplayer_frequency` for Sol from 20 → 1 and Sierpinski from 10 → 1 so they appear far less often in public FFA/team/special playlists.
- Set Labyrinth's `multiplayer_frequency` to 0, removing it from public rotations entirely (still selectable in singleplayer and private lobbies), following the Luna precedent in #5123.
- Each value is mirrored across `map-generator/assets/maps/<map>/info.json`, `resources/maps/<map>/manifest.json`, and the generated `src/core/game/Maps.gen.ts` (Go isn't available locally to run `npm run gen-maps`; the output is identical).
- Added Labyrinth to `FREQUENCY_EXEMPTIONS` in `tests/MapConsistency.test.ts` since it now has a zero frequency.

## Test plan
- `npx vitest tests/MapConsistency.test.ts tests/server/MapPlaylistOvertime.test.ts --run` — 18/18 pass
- `npx tsc --noEmit` — clean
- `npx prettier --check` on all changed files — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)