### PR TITLE
fix(server): release stale websocket references

### DIFF
--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -772,6 +772,7 @@ export class GameServer {
 
     // Close old WebSocket to prevent resource leaks
     if (client.ws !== ws) {
+      this.websockets.delete(client.ws);
       client.ws.removeAllListeners();
       client.ws.close();
     }
@@ -991,6 +992,7 @@ export class GameServer {
   }
 
   private handleClientDisconnect(client: Client) {
+    this.websockets.delete(client.ws);
     this.activeClients = this.activeClients.filter(
       (c) => c.clientID !== client.clientID,
     );

--- a/tests/server/GameServerRejoin.test.ts
+++ b/tests/server/GameServerRejoin.test.ts
@@ -44,6 +44,8 @@ describe("GameServer.rejoinClient", () => {
     expect(client.ws).toBe(newWs);
     // One seat, not two.
     expect(game.numClients()).toBe(1);
+    // Only the current socket should remain strongly referenced by the game.
+    expect((game as any).websockets.size).toBe(1);
     // Lobby traffic now reaches the new socket.
     vi.advanceTimersByTime(1000);
     expect(newWs.sent().map((m) => m.type)).toContain("lobby_info");
@@ -193,11 +195,13 @@ describe("GameServer.rejoinClient", () => {
       const { game, client, ctx } = playedGame(2);
       await mockWsOf(client).trigger("close");
       expect(game.numClients()).toBe(0);
+      expect((game as any).websockets.size).toBe(0);
       expect(game.getClientIdForPersistentId("p1-pid")).toBe(P1);
 
       const newWs = makeMockWs();
       expect(game.rejoinClient(newWs as any, "p1-pid", 0)).toBe(true);
       expect(game.numClients()).toBe(1);
+      expect((game as any).websockets.size).toBe(1);
       expect(startFrameOn(newWs, ctx).turns).toHaveLength(2);
     });
   });


### PR DESCRIPTION
## Summary

Prevent `GameServer` from retaining closed WebSocket instances after client disconnects or reconnects.

## Security impact

Previously, reconnecting clients caused the old socket to remain in the game's `websockets` set. The rejoin path removed its listeners before closing it, so the socket could never remove itself from the set. Repeated reconnects could accumulate socket objects and related resources for the duration of a match, creating a memory-exhaustion denial of service.

## Changes

- Delete the previous socket before closing it during reconnect.
- Delete the active socket when handling disconnects.
- Add regression coverage for reconnect and mid-game disconnect cleanup.

## Verification

- `npx vitest run tests/server`: 481 passed
- `npx vitest run tests/server/GameServerRejoin.test.ts`: 10 passed
- `npx tsc --noEmit`: passed
- `npm run lint`: passed
- `npm audit --omit=dev`: no production vulnerabilities
- Full `npm test`: 3,758 passed; one unrelated locale-sensitive client test fails because the environment formats `1,000` as `1.000`.