### PR TITLE
feat: train and railroad cosmetic effects (gradient/transition recolor)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -570,7 +570,9 @@
     "type": {
       "nukeExplosion": "Nuke Explosion",
       "nukeTrail": "Nuke Trail",
+      "railroad": "Railroad",
       "structures": "Structures",
+      "train": "Train",
       "transportShipTrail": "Boat Trail",
       "warship": "Warship"
     }

--- a/src/client/WebGLFrameBuilder.ts
+++ b/src/client/WebGLFrameBuilder.ts
@@ -197,8 +197,8 @@ export class WebGLFrameBuilder {
   /**
    * Effect-editor overrides (debug GUI): catalog-shaped attributes that
    * replace the LOCAL player's equipped effect per type — this client's
-   * rendering only. Trail /
-   * structures / warship overrides are applied by syncPlayerEffects (the
+   * rendering only. Trail / structures / warship / train / railroad
+   * overrides are applied by syncPlayerEffects (the
    * local player is re-resolved on change); the nukeExplosion override is
    * applied per detonation in resolveDeadUnitExplosions.
    */

--- a/src/client/WebGLFrameBuilder.ts
+++ b/src/client/WebGLFrameBuilder.ts
@@ -33,7 +33,9 @@ import {
 import {
   EFFECT_PALETTE_BLOCKS,
   MAX_TRAIL_COLORS,
+  RAILROAD_EFFECT_BLOCK,
   STRUCTURES_EFFECT_BLOCK,
+  TRAIN_EFFECT_BLOCK,
   WARSHIP_EFFECT_BLOCK,
 } from "./render/gl/utils/ColorUtils";
 import {
@@ -61,10 +63,12 @@ const SMALL_PLAYER_GLOW_RESCAN_TICKS = 10;
 // trail.frag.glsl picks its block from the trail tile's nuke bit — block 0 =
 // transportShipTrail (nuke bit 0), block 1 = nukeTrail (nuke bit 1, set by
 // NUKE_TRAIL_BIT in TrailManager) — structure.frag.glsl reads block
-// STRUCTURES_EFFECT_BLOCK (2), and unit.frag.glsl reads block
-// WARSHIP_EFFECT_BLOCK (3). Reordering TRAIL_EFFECT_TYPES in CosmeticSchemas
-// (or moving the structures/warship blocks) would silently swap effect colors,
-// so these guards fail the build if the shader-coupled order ever drifts.
+// STRUCTURES_EFFECT_BLOCK (2), unit.frag.glsl reads blocks
+// WARSHIP_EFFECT_BLOCK (3) and TRAIN_EFFECT_BLOCK (4), and railroad.frag.glsl
+// reads block RAILROAD_EFFECT_BLOCK (5). Reordering TRAIL_EFFECT_TYPES in
+// CosmeticSchemas (or moving the structures/warship/train/railroad blocks)
+// would silently swap effect colors, so these guards fail the build if the
+// shader-coupled order ever drifts.
 const _EFFECT_BLOCK_ORDER: readonly ["transportShipTrail", "nukeTrail"] =
   TRAIL_EFFECT_TYPES;
 void _EFFECT_BLOCK_ORDER;
@@ -72,6 +76,10 @@ const _STRUCTURES_BLOCK_IS_2: 2 = STRUCTURES_EFFECT_BLOCK;
 void _STRUCTURES_BLOCK_IS_2;
 const _WARSHIP_BLOCK_IS_3: 3 = WARSHIP_EFFECT_BLOCK;
 void _WARSHIP_BLOCK_IS_3;
+const _TRAIN_BLOCK_IS_4: 4 = TRAIN_EFFECT_BLOCK;
+void _TRAIN_BLOCK_IS_4;
+const _RAILROAD_BLOCK_IS_5: 5 = RAILROAD_EFFECT_BLOCK;
+void _RAILROAD_BLOCK_IS_5;
 
 // Attribute → render-param mappings:
 //   size      = the ring's final WIDTH (diameter) in world tiles when it fades
@@ -122,23 +130,32 @@ export function attributesToExplosionParams(
 
 /**
  * A player's equipped catalog effect for a palette-rendered effect type
- * (trails / structures / warship), or undefined when none is equipped or the
+ * (trails / structures / warship / train / railroad), or undefined when none is equipped or the
  * catalog entry isn't of that shape.
  */
 function catalogEffectAttributes(
   catalog: Cosmetics,
   p: PlayerView,
-  effectType: "transportShipTrail" | "nukeTrail" | "structures" | "warship",
+  effectType:
+    | "transportShipTrail"
+    | "nukeTrail"
+    | "structures"
+    | "warship"
+    | "train"
+    | "railroad",
 ): PaletteEffectAttributes | undefined {
   const selected = p.cosmetics.effects?.[effectType];
   if (!selected) return undefined;
   const effect = findEffect(catalog, effectType, selected.name);
   if (!effect || effect.effectType !== effectType) return undefined;
-  // Narrows attributes to trail attrs (structures/warship share the shape).
+  // Narrows attributes to trail attrs (structures/warship/train/railroad
+  // share the shape).
   if (
     !isTrailEffect(effect) &&
     effect.effectType !== "structures" &&
-    effect.effectType !== "warship"
+    effect.effectType !== "warship" &&
+    effect.effectType !== "train" &&
+    effect.effectType !== "railroad"
   ) {
     return undefined;
   }
@@ -161,9 +178,10 @@ export class WebGLFrameBuilder {
   // Per-player effect palette, keyed by smallID. Layout is
   // 4096×(MAX_TRAIL_COLORS·EFFECT_PALETTE_BLOCKS): block 0 (rows 0–7) =
   // transportShipTrail, block 1 (rows 8–15) = nukeTrail, block 2 (rows 16–23)
-  // = structures, block 3 (rows 24–31) = warship. Consumed by TrailPass (block
-  // from the trail tile's nuke bit), StructurePass (block 2), and UnitPass
-  // (block 3).
+  // = structures, block 3 (rows 24–31) = warship, block 4 (rows 32–39) =
+  // train, block 5 (rows 40–47) = railroad. Consumed by TrailPass (block from
+  // the trail tile's nuke bit), StructurePass (block 2), UnitPass (blocks 3
+  // and 4), and RailroadPass (block 5).
   private readonly effectPalette: Float32Array;
   private readonly patternMeta: Float32Array;
   private readonly patternData: Uint8Array;
@@ -602,13 +620,16 @@ export class WebGLFrameBuilder {
       // Resolve each trail-styled effectType into its own block of the effect
       // palette. rowBase block*MAX_TRAIL_COLORS must match the consumer
       // shaders' block layout (ship=0, nuke=1 in trail.frag.glsl; structures=2
-      // in structure.frag.glsl; warship=3 in unit.frag.glsl) — see
-      // _EFFECT_BLOCK_ORDER above. nukeExplosion is not trail-styled and
-      // renders through the FX pass instead.
+      // in structure.frag.glsl; warship=3, train=4 in unit.frag.glsl;
+      // railroad=5 in railroad.frag.glsl) — see _EFFECT_BLOCK_ORDER above.
+      // nukeExplosion is not trail-styled and renders through the FX pass
+      // instead.
       const blockOrder = [
         ...TRAIL_EFFECT_TYPES,
         "structures",
         "warship",
+        "train",
+        "railroad",
       ] as const;
       blockOrder.forEach((effectType, block) => {
         const rowBase = block * MAX_TRAIL_COLORS;

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1093,6 +1093,7 @@ export class GPURenderer {
     this.territoryPass.setHighlightOwner(ownerID);
     this.namePass.setHighlightOwner(ownerID);
     this.structurePass.setHighlightOwner(ownerID);
+    this.railroadPass.setHighlightOwner(ownerID);
   }
   setMouseWorldPos(x: number, y: number): void {
     this.namePass.setMouseWorldPos(x, y);

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -311,8 +311,9 @@ export class GPURenderer {
 
     // Per-player effect texture: EFFECT_PALETTE_BLOCKS stacked blocks of
     // MAX_TRAIL_COLORS rows (block 0 = transportShipTrail, block 1 = nukeTrail,
-    // block 2 = structures, block 3 = warship). Starts zeroed (color count 0
-    // everywhere = no effect → territory/player color).
+    // block 2 = structures, block 3 = warship, block 4 = train, block 5 =
+    // railroad). Starts zeroed (color count 0 everywhere = no effect →
+    // territory/player color).
     const effectRows = MAX_TRAIL_COLORS * EFFECT_PALETTE_BLOCKS;
     this.effectTex = createTexture2D(gl, {
       width: palW,
@@ -539,13 +540,14 @@ export class GPURenderer {
     // --- Night composite ---
     this.nightCompositePass = new NightCompositePass(gl, this.settings);
 
-    // --- Railroad (needs tileTex) ---
+    // --- Railroad (needs tileTex, paletteTex, effectTex) ---
     this.railroadPass = new RailroadPass(
       gl,
       mapW,
       mapH,
       this.res.tileTex,
       this.paletteTex,
+      this.effectTex,
       terrainBytes,
       this.settings,
     );

--- a/src/client/render/gl/debug/EffectEditor.ts
+++ b/src/client/render/gl/debug/EffectEditor.ts
@@ -1,11 +1,11 @@
 /**
  * Effect Editor — the debug GUI folder for tuning cosmetic effects live in
  * a running game. Each sub-folder edits one effect slot (trails, structures,
- * warship, nuke explosion) in the catalog's own attribute shape; enabling a
- * slot overrides the local player's equipped effect of that type via
- * WebGLFrameBuilder.setEffectOverride, so the result shows on your own
- * units / bombs (client-side rendering only — nobody else sees it). "Copy
- * catalog JSON" puts a paste-ready entry on the clipboard.
+ * warship, train, railroad, nuke explosion) in the catalog's own attribute
+ * shape; enabling a slot overrides the local player's equipped effect of that
+ * type via WebGLFrameBuilder.setEffectOverride, so the result shows on your
+ * own units / bombs / rails (client-side rendering only — nobody else sees
+ * it). "Copy catalog JSON" puts a paste-ready entry on the clipboard.
  */
 
 import type GUI from "lil-gui";
@@ -38,6 +38,8 @@ const SLOT_LABELS: Record<EffectType, string> = {
   nukeTrail: "Nuke Trail",
   structures: "Structures",
   warship: "Warship",
+  train: "Train",
+  railroad: "Railroad",
   nukeExplosion: "Nuke Explosion",
 };
 

--- a/src/client/render/gl/debug/EffectEditorState.ts
+++ b/src/client/render/gl/debug/EffectEditorState.ts
@@ -11,6 +11,7 @@ import {
   NukeExplosionAttributesSchema,
   type NukeExplosionType,
   StructuresEffectAttributesSchema,
+  TRAIL_EFFECT_TYPES,
   TrailEffectAttributesSchema,
 } from "../../../../core/CosmeticSchemas";
 import { MAX_NUKE_EXPLOSION_COLORS } from "../../types";
@@ -41,6 +42,8 @@ export const EFFECT_EDITOR_TYPES: Record<EffectType, readonly string[]> = {
   nukeTrail: ["gradient", "transition", "spiral"],
   structures: ["gradient", "transition"],
   warship: ["gradient", "transition"],
+  train: ["gradient", "transition"],
+  railroad: ["gradient", "transition"],
   nukeExplosion: ["shockwave", "sparkles", "embers"],
 };
 
@@ -119,6 +122,11 @@ export function fieldsForType(
   return new Set(base);
 }
 
+/** Whether the slot is a trail (its attributes allow `spiral`). */
+function isTrailEffectType(effectType: EffectType): boolean {
+  return (TRAIL_EFFECT_TYPES as readonly string[]).includes(effectType);
+}
+
 /**
  * The catalog attributes described by a slot's state, validated through the
  * cosmetic schema so what the editor applies is exactly what the catalog
@@ -166,9 +174,9 @@ export function slotAttributes(
   const schema =
     effectType === "nukeExplosion"
       ? NukeExplosionAttributesSchema
-      : effectType === "structures" || effectType === "warship"
-        ? StructuresEffectAttributesSchema
-        : TrailEffectAttributesSchema;
+      : isTrailEffectType(effectType)
+        ? TrailEffectAttributesSchema
+        : StructuresEffectAttributesSchema;
   const parsed = schema.safeParse(candidate);
   if (!parsed.success) return null;
   return parsed.data as EffectAttributesFor<EffectType>;

--- a/src/client/render/gl/passes/RailroadPass.ts
+++ b/src/client/render/gl/passes/RailroadPass.ts
@@ -14,13 +14,18 @@
  *   R8UI terrainTex           → water detection for bridge rendering (shader neighbor lookup)
  *   R16UI tileTex (shared)   → owner lookup for rail color
  *   RGBA32F paletteTex        → player color lookup
+ *   RGBA32F effectTex (shared) → per-owner railroad cosmetic effect
  */
 
 import type { GhostPreviewData, TerrainRect } from "../../types";
 import type { RenderSettings } from "../RenderSettings";
 import overlayVertSrc from "../shaders/map-overlay/overlay.vert.glsl?raw";
 import railroadFragSrc from "../shaders/railroad/railroad.frag.glsl?raw";
-import { getPaletteSize } from "../utils/ColorUtils";
+import {
+  getPaletteSize,
+  MAX_TRAIL_COLORS,
+  RAILROAD_EFFECT_BLOCK,
+} from "../utils/ColorUtils";
 import {
   createMapQuad,
   createProgram,
@@ -90,12 +95,14 @@ export class RailroadPass {
   private ghostRailTex: WebGLTexture;
   private tileTex: WebGLTexture;
   private paletteTex: WebGLTexture;
+  private effectTex: WebGLTexture;
   private terrainTex: WebGLTexture;
   private vao: WebGLVertexArrayObject;
 
   private uCamera: WebGLUniformLocation;
   private uMapSize: WebGLUniformLocation;
   private uZoom: WebGLUniformLocation;
+  private uTime: WebGLUniformLocation;
   private uRailDetailZoom: WebGLUniformLocation;
   private uRailAlpha: WebGLUniformLocation;
   private uRailFade: WebGLUniformLocation;
@@ -130,12 +137,17 @@ export class RailroadPass {
   private localPlayerID = 0;
   private localRailColor: [number, number, number] = [0.75, 0.75, 0.75];
 
+  /** Wall-clock start, for uTime (seconds) — matches TrailPass so the
+   *  railroad effect animates at the same pace as the trail effects. */
+  private readonly startTime = performance.now();
+
   constructor(
     private gl: WebGL2RenderingContext,
     mapW: number,
     mapH: number,
     tileTex: WebGLTexture,
     paletteTex: WebGLTexture,
+    effectTex: WebGLTexture,
     terrainBytes: Uint8Array,
     settings: RenderSettings,
   ) {
@@ -143,6 +155,7 @@ export class RailroadPass {
     this.mapH = mapH;
     this.tileTex = tileTex;
     this.paletteTex = paletteTex;
+    this.effectTex = effectTex;
     this.settings = settings;
 
     this.program = createProgram(
@@ -150,6 +163,7 @@ export class RailroadPass {
       overlayVertSrc,
       shaderSrc(railroadFragSrc, {
         PALETTE_SIZE: getPaletteSize(),
+        RAILROAD_EFFECT_ROW_BASE: RAILROAD_EFFECT_BLOCK * MAX_TRAIL_COLORS,
         ...TILE_DEFINES,
       }),
     );
@@ -157,6 +171,7 @@ export class RailroadPass {
     this.uCamera = gl.getUniformLocation(this.program, "uCamera")!;
     this.uMapSize = gl.getUniformLocation(this.program, "uMapSize")!;
     this.uZoom = gl.getUniformLocation(this.program, "uZoom")!;
+    this.uTime = gl.getUniformLocation(this.program, "uTime")!;
     this.uRailDetailZoom = gl.getUniformLocation(
       this.program,
       "uRailDetailZoom",
@@ -184,6 +199,7 @@ export class RailroadPass {
     gl.uniform1i(gl.getUniformLocation(this.program, "uPalette"), 2);
     gl.uniform1i(gl.getUniformLocation(this.program, "uTerrainTex"), 3);
     gl.uniform1i(gl.getUniformLocation(this.program, "uGhostRailTex"), 4);
+    gl.uniform1i(gl.getUniformLocation(this.program, "uEffect"), 5);
     gl.uniform1f(this.uGhostOwnerID, 0);
 
     // R8UI terrain texture (static, uploaded once for bridge detection)
@@ -348,6 +364,7 @@ export class RailroadPass {
     gl.uniformMatrix3fv(this.uCamera, false, cameraMatrix);
     gl.uniform2f(this.uMapSize, this.mapW, this.mapH);
     gl.uniform1f(this.uZoom, zoom);
+    gl.uniform1f(this.uTime, (performance.now() - this.startTime) / 1000);
     gl.uniform1f(this.uRailDetailZoom, rs.railDetailZoom);
     gl.uniform1f(this.uRailAlpha, rs.railAlpha);
     gl.uniform1f(this.uRailFade, fade);
@@ -361,7 +378,8 @@ export class RailroadPass {
       this.localRailColor[2],
     );
 
-    // Bind textures: 0=railroad, 1=tile, 2=palette, 3=terrain, 4=ghostRail
+    // Bind textures: 0=railroad, 1=tile, 2=palette, 3=terrain, 4=ghostRail,
+    // 5=effect
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.railroadTex);
 
@@ -376,6 +394,9 @@ export class RailroadPass {
 
     gl.activeTexture(gl.TEXTURE4);
     gl.bindTexture(gl.TEXTURE_2D, this.ghostRailTex);
+
+    gl.activeTexture(gl.TEXTURE5);
+    gl.bindTexture(gl.TEXTURE_2D, this.effectTex);
 
     gl.bindVertexArray(this.vao);
     gl.drawArrays(gl.TRIANGLES, 0, 6);
@@ -447,6 +468,6 @@ export class RailroadPass {
     gl.deleteTexture(this.railroadTex);
     gl.deleteTexture(this.ghostRailTex);
     gl.deleteTexture(this.terrainTex);
-    // Don't delete tileTex or paletteTex — shared with other passes
+    // Don't delete tileTex, paletteTex, or effectTex — shared with other passes
   }
 }

--- a/src/client/render/gl/passes/RailroadPass.ts
+++ b/src/client/render/gl/passes/RailroadPass.ts
@@ -110,6 +110,7 @@ export class RailroadPass {
   private uGhostOwnerID: WebGLUniformLocation;
   private uLocalPlayerID: WebGLUniformLocation;
   private uLocalRailColor: WebGLUniformLocation;
+  private uHoverOwner: WebGLUniformLocation;
 
   private mapW: number;
   private mapH: number;
@@ -136,6 +137,8 @@ export class RailroadPass {
 
   private localPlayerID = 0;
   private localRailColor: [number, number, number] = [0.75, 0.75, 0.75];
+  /** Hovered territory's owner (0 = none) — shows that player's railroad effect. */
+  private hoverOwner = 0;
 
   /** Wall-clock start, for uTime (seconds) — matches TrailPass so the
    *  railroad effect animates at the same pace as the trail effects. */
@@ -191,6 +194,7 @@ export class RailroadPass {
       this.program,
       "uLocalRailColor",
     )!;
+    this.uHoverOwner = gl.getUniformLocation(this.program, "uHoverOwner")!;
 
     // Texture unit bindings + ghost defaults
     gl.useProgram(this.program);
@@ -250,6 +254,11 @@ export class RailroadPass {
   /** Rail color for the local player (0–1 RGB). */
   setLocalRailColor(r: number, g: number, b: number): void {
     this.localRailColor = [r, g, b];
+  }
+
+  /** Hovered territory's owner (0 = none) — shows that player's railroad effect. */
+  setHighlightOwner(ownerID: number): void {
+    this.hoverOwner = ownerID;
   }
 
   /**
@@ -371,6 +380,7 @@ export class RailroadPass {
     gl.uniform1f(this.uRailThickness, rs.railThickness);
     gl.uniform1f(this.uGhostOwnerID, this.ghostOwnerID);
     gl.uniform1f(this.uLocalPlayerID, this.localPlayerID);
+    gl.uniform1f(this.uHoverOwner, this.hoverOwner);
     gl.uniform3f(
       this.uLocalRailColor,
       this.localRailColor[0],

--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -56,6 +56,7 @@ import unitVertSrc from "../shaders/unit/unit.vert.glsl?raw";
 import {
   getPaletteSize,
   MAX_TRAIL_COLORS,
+  TRAIN_EFFECT_BLOCK,
   WARSHIP_EFFECT_BLOCK,
 } from "../utils/ColorUtils";
 import { createProgram, shaderSrc } from "../utils/GlUtils";
@@ -93,6 +94,10 @@ const HYDROGEN_BOMB_COL = UNIT_ORDER.indexOf(UT_HYDROGEN_BOMB);
 
 /** Atlas column of the warship — gates the warship cosmetic effect. */
 const WARSHIP_COL = UNIT_ORDER.indexOf(UT_WARSHIP);
+
+/** First atlas column of the train sprites (engine, carriage, loaded
+ *  carriage are contiguous) — gates the train cosmetic effect. */
+const TRAIN_FIRST_COL = UNIT_ORDER.indexOf("TrainEngine");
 
 // ---------------------------------------------------------------------------
 // Instance data layout
@@ -242,7 +247,7 @@ export class UnitPass {
   /** Last game engine tick received for smoothing calculation resets */
   private lastGameTick = -1;
   /** Wall-clock start, for uTime (seconds) — matches StructurePass so the
-   *  warship effect animates at the same pace as the structures effect. */
+   *  warship/train effects animate at the same pace as the structures effect. */
   private startTime = performance.now();
 
   /** unitType string → atlas column (0-11) */
@@ -288,6 +293,8 @@ export class UnitPass {
         ATLAS_COLS,
         WARSHIP_COL,
         WARSHIP_EFFECT_ROW_BASE: WARSHIP_EFFECT_BLOCK * MAX_TRAIL_COLORS,
+        TRAIN_FIRST_COL,
+        TRAIN_EFFECT_ROW_BASE: TRAIN_EFFECT_BLOCK * MAX_TRAIL_COLORS,
       }),
     );
     this.uCamera = gl.getUniformLocation(this.program, "uCamera")!;

--- a/src/client/render/gl/shaders/railroad/railroad.frag.glsl
+++ b/src/client/render/gl/shaders/railroad/railroad.frag.glsl
@@ -25,6 +25,7 @@ uniform float uRailThickness;        // Track width multiplier (1 = default)
 uniform float uGhostOwnerID;         // Player smallID for ghost rail color
 uniform float uLocalPlayerID;        // Local player smallID (0 = none)
 uniform vec3 uLocalRailColor;        // Rail color for the local player's rails
+uniform float uHoverOwner;           // Hovered territory's owner smallID (0 = none)
 
 in vec2 vWorldPos;
 out vec4 fragColor;
@@ -224,9 +225,14 @@ void main() {
         : texture(uPalette, vec2((float(owner) + 0.5) / float(PALETTE_SIZE), 0.75)).rgb);
     // railroad cosmetic: rails are colored by the tile owner, so the owner's
     // railroad effect (raw catalog colors, like trails) replaces that color —
-    // including the local player's white/black rail color.
+    // including the local player's white/black rail color. Like the
+    // structures effect it shows while the owner's territory is hovered, and
+    // always for the local player (touch devices never hover, and buyers
+    // should see what they paid for).
     vec3 effectRGB;
-    if (owner != 0u && railroadEffectColor(int(owner), effectRGB)) {
+    if (owner != 0u &&
+        (owner == uint(uLocalPlayerID) || owner == uint(uHoverOwner + 0.5)) &&
+        railroadEffectColor(int(owner), effectRGB)) {
       railColor = effectRGB;
     }
     // Overlapping railroad highlight — green tint

--- a/src/client/render/gl/shaders/railroad/railroad.frag.glsl
+++ b/src/client/render/gl/shaders/railroad/railroad.frag.glsl
@@ -7,9 +7,17 @@ uniform usampler2D uGhostRailTex;    // R8UI — ghost rail type per tile (0=non
 uniform usampler2D uTileTex;         // R16UI — tile state (for owner lookup)
 uniform sampler2D  uPalette;         // RGBA32F — player colors
 uniform usampler2D uTerrainTex;      // R8UI — terrain bytes (bit 7 = isLand)
+uniform sampler2D  uEffect;          // RGBA32F — shared effect palette, keyed by
+                                     //   ownerID. The railroad block starts at
+                                     //   row RAILROAD_EFFECT_ROW_BASE; same
+                                     //   layout as trail.frag.glsl (row r =
+                                     //   color r's rgb; row 0.a = count,
+                                     //   1.a = styleId, 2.a = scalar0,
+                                     //   3.a = scalar1)
 
 uniform vec2 uMapSize;
 uniform float uZoom;
+uniform float uTime;                 // seconds, for animated effect styles
 uniform float uRailDetailZoom;
 uniform float uRailAlpha;
 uniform float uRailFade;             // Zoom-based fade multiplier (0..1)
@@ -108,6 +116,48 @@ float railLineCoverage(uint rt, vec2 p) {
   return 1.0 - smoothstep(halfW - aa, halfW + aa, railLineDist(rt, p));
 }
 
+// The owner's railroad cosmetic color, if equipped. Reads the railroad block
+// of the shared effect palette with trail semantics (rails are static map
+// geometry like trails): the gradient/transition math mirrors trail.frag.glsl
+// so the same catalog attributes look identical on both. Returns false when
+// the owner has no railroad effect (count 0).
+bool railroadEffectColor(int owner, out vec3 color) {
+  const int rowBase = RAILROAD_EFFECT_ROW_BASE;
+  int count = int(texelFetch(uEffect, ivec2(owner, rowBase), 0).a + 0.5);
+  if (count <= 0) return false;
+  if (count == 1) {
+    // Single color — flat recolor.
+    color = texelFetch(uEffect, ivec2(owner, rowBase), 0).rgb;
+  } else if (int(texelFetch(uEffect, ivec2(owner, rowBase + 1), 0).a + 0.5) == 1) {
+    // transition — the whole track is one color at a time, cross-fading
+    // through the list. frequency = color changes per second.
+    float frequency = texelFetch(uEffect, ivec2(owner, rowBase + 2), 0).a;
+    float t = uTime * frequency;
+    int i = int(t) % count;
+    int j = (i + 1) % count;
+    vec3 a = texelFetch(uEffect, ivec2(owner, rowBase + i), 0).rgb;
+    vec3 b = texelFetch(uEffect, ivec2(owner, rowBase + j), 0).rgb;
+    color = mix(a, b, fract(t));
+  } else {
+    // gradient — cyclic gradient banded across the map (world-space
+    // diagonal), scrolling over time so the colors travel along the track.
+    // colorSize = band width in tiles; movementSpeed = tiles/sec the bands
+    // travel.
+    float colorSize = max(texelFetch(uEffect, ivec2(owner, rowBase + 2), 0).a, 0.001);
+    float movementSpeed = texelFetch(uEffect, ivec2(owner, rowBase + 3), 0).a;
+    float cycle = colorSize * float(count);
+    float phase =
+      fract((vWorldPos.x + vWorldPos.y - uTime * movementSpeed) / cycle);
+    float f = phase * float(count);
+    int i = int(f) % count;
+    int j = (i + 1) % count;
+    vec3 a = texelFetch(uEffect, ivec2(owner, rowBase + i), 0).rgb;
+    vec3 b = texelFetch(uEffect, ivec2(owner, rowBase + j), 0).rgb;
+    color = mix(a, b, fract(f));
+  }
+  return true;
+}
+
 void main() {
   ivec2 tc = ivec2(floor(vWorldPos));
 
@@ -172,6 +222,13 @@ void main() {
       : (owner == uint(uLocalPlayerID)
         ? uLocalRailColor
         : texture(uPalette, vec2((float(owner) + 0.5) / float(PALETTE_SIZE), 0.75)).rgb);
+    // railroad cosmetic: rails are colored by the tile owner, so the owner's
+    // railroad effect (raw catalog colors, like trails) replaces that color —
+    // including the local player's white/black rail color.
+    vec3 effectRGB;
+    if (owner != 0u && railroadEffectColor(int(owner), effectRGB)) {
+      railColor = effectRGB;
+    }
     // Overlapping railroad highlight — green tint
     if (highlighted) railColor = vec3(0.2, 0.85, 0.3);
     if (hitBridge) {

--- a/src/client/render/gl/shaders/unit/unit.frag.glsl
+++ b/src/client/render/gl/shaders/unit/unit.frag.glsl
@@ -6,10 +6,12 @@ uniform sampler2D uAtlas;
 uniform sampler2D uAffiliation;   // 256×2 RGBA8 — row 1 = unit affiliation
 uniform sampler2D uEffect;        // RGBA32F — shared effect palette, keyed by
                                   //   ownerID. The warship block starts at row
-                                  //   WARSHIP_EFFECT_ROW_BASE; same layout as
-                                  //   structure.frag.glsl (row r = color r's rgb;
-                                  //   row 0.a = count, 1.a = styleId,
-                                  //   2.a = scalar0, 3.a = scalar1)
+                                  //   WARSHIP_EFFECT_ROW_BASE and the train
+                                  //   block at TRAIN_EFFECT_ROW_BASE; same
+                                  //   layout as trail/structure.frag.glsl (row r =
+                                  //   color r's rgb; row 0.a = count,
+                                  //   1.a = styleId, 2.a = scalar0,
+                                  //   3.a = scalar1)
 uniform float uTime;              // seconds, for animated effect styles
 uniform float uTick;
 uniform float uFlickerSpeed;
@@ -22,6 +24,7 @@ uniform float uUntargetableAlpha;
 
 in vec2  vQuadPos;
 in vec2  vCellUV;
+in vec2  vWorldPos;
 flat in float vAtlasCol;
 flat in float vOwnerID;
 flat in float vFlags;
@@ -48,12 +51,16 @@ const vec3 FLICKER_COLORS[4] = vec3[4](
   vec3(1.0, 1.0, 1.0)    // white
 );
 
-// The owner's warship cosmetic color, if equipped. Reads the warship block of
-// the shared effect palette; the gradient/transition math mirrors
-// structure.frag.glsl so the same catalog attributes look identical on both.
-// Returns false when the owner has no warship effect (count 0).
-bool warshipEffectColor(int owner, out vec3 color) {
-  const int rowBase = WARSHIP_EFFECT_ROW_BASE;
+// The owner's sprite cosmetic color, if equipped, from the effect-palette
+// block starting at row rowBase (the warship or train block). Returns false
+// when the owner has no effect in that block (count 0).
+//
+// `coord` positions the gradient: with iconSpace the caller passes the sprite
+// diagonal in 0..1 (the palette spans the sprite once, sliding one cycle every
+// colorSize · count / movementSpeed seconds — structure.frag.glsl semantics);
+// otherwise it passes the world diagonal x + y (colorSize = band width in
+// tiles, movementSpeed = tiles/sec — trail.frag.glsl semantics).
+bool spriteEffectColor(int rowBase, int owner, float coord, bool iconSpace, out vec3 color) {
   int count = int(texelFetch(uEffect, ivec2(owner, rowBase), 0).a + 0.5);
   if (count <= 0) return false;
   if (count == 1) {
@@ -70,15 +77,13 @@ bool warshipEffectColor(int owner, out vec3 color) {
     vec3 b = texelFetch(uEffect, ivec2(owner, rowBase + j), 0).rgb;
     color = mix(a, b, fract(t));
   } else {
-    // gradient — the palette spans the sprite's diagonal once (vCellUV is the
-    // sprite cell, 0..1), sliding one full cycle every
-    // colorSize · count / movementSpeed seconds — the same icon-space
-    // semantics as the structures effect.
+    // gradient — cyclic palette along `coord` (see above), scrolling over
+    // time.
     float colorSize = max(texelFetch(uEffect, ivec2(owner, rowBase + 2), 0).a, 0.001);
     float movementSpeed = texelFetch(uEffect, ivec2(owner, rowBase + 3), 0).a;
-    float dn = (vCellUV.x + vCellUV.y) * 0.5; // sprite diagonal, 0..1
-    float phase =
-      fract(dn - uTime * movementSpeed / (colorSize * float(count)));
+    float cycle = colorSize * float(count);
+    float c = iconSpace ? coord : coord / cycle;
+    float phase = fract(c - uTime * movementSpeed / cycle);
     float f = phase * float(count);
     int i = int(f) % count;
     int j = (i + 1) % count;
@@ -143,8 +148,27 @@ void main() {
   // blink still darkens the center band.
   if (abs(vAtlasCol - float(WARSHIP_COL)) < 0.1) {
     vec3 effectRGB;
-    if (warshipEffectColor(int(vOwnerID + 0.5), effectRGB)) {
+    float dn = (vCellUV.x + vCellUV.y) * 0.5; // sprite diagonal, 0..1
+    if (spriteEffectColor(WARSHIP_EFFECT_ROW_BASE, int(vOwnerID + 0.5), dn, true, effectRGB)) {
       territoryColor = effectRGB;
+    }
+  }
+
+  // train cosmetic: the train sprites (engine, carriage, loaded carriage) are
+  // the last three atlas columns. The engine is drawn entirely in the border
+  // band and the carriages are a border-band frame around a territory-band
+  // fill, so recolor both bands — the border band darkened — to keep that
+  // engine/frame/fill structure while the whole train takes the effect.
+  // The gradient is world-space (like trails and the railroad effect): the
+  // 5×5 train sprites fill only the middle of the 13-tile unit cell, so an
+  // icon-space gradient would show a sliver of the palette per car, whereas a
+  // world-space one runs along the whole train.
+  if (vAtlasCol > float(TRAIN_FIRST_COL) - 0.1) {
+    vec3 effectRGB;
+    float diag = vWorldPos.x + vWorldPos.y;
+    if (spriteEffectColor(TRAIN_EFFECT_ROW_BASE, int(vOwnerID + 0.5), diag, false, effectRGB)) {
+      territoryColor = effectRGB;
+      borderColor = effectRGB * 0.6;
     }
   }
 

--- a/src/client/render/gl/shaders/unit/unit.vert.glsl
+++ b/src/client/render/gl/shaders/unit/unit.vert.glsl
@@ -14,6 +14,7 @@ uniform float uHBombGlowScale; // quad enlargement for the hydrogen bomb glow ha
 
 out vec2  vQuadPos;     // quad coords [0,1] — drives the radial glow falloff
 out vec2  vCellUV;      // sprite cell coords; the central 1/scale region is the sprite
+out vec2  vWorldPos;    // world-space tile coords — drives the train effect's gradient
 flat out float vAtlasCol;
 flat out float vOwnerID;
 flat out float vFlags;  // 0.0 = normal, 1.0 = flicker, 2.0 = angry
@@ -46,6 +47,7 @@ void main() {
 
   vec2 center = vec2(worldX + 0.5, worldY + 0.5);
   vec2 worldPos = center + (aPos - 0.5) * halfSize * 2.0;
+  vWorldPos = worldPos;
 
   vec3 clip = uCamera * vec3(worldPos, 1.0);
   gl_Position = vec4(clip.xy, 0.0, 1.0);

--- a/src/client/render/gl/utils/ColorUtils.ts
+++ b/src/client/render/gl/utils/ColorUtils.ts
@@ -28,17 +28,24 @@ export const MAX_TRAIL_COLORS = 8;
  * The effect-palette texture stacks one MAX_TRAIL_COLORS-row block per
  * trail-styled effectType: block 0 = transportShipTrail, block 1 = nukeTrail
  * (matching the nuke bit in trail.frag.glsl), block 2 = structures (read by
- * structure.frag.glsl), block 3 = warship (read by unit.frag.glsl). Bump this
+ * structure.frag.glsl), block 3 = warship and block 4 = train (both read by
+ * unit.frag.glsl), block 5 = railroad (read by railroad.frag.glsl). Bump this
  * if another trail-styled effectType is added (and give its consumer shader
  * the new rowBase).
  */
-export const EFFECT_PALETTE_BLOCKS = 4;
+export const EFFECT_PALETTE_BLOCKS = 6;
 
 /** Block index of the structures effect within the effect-palette texture. */
 export const STRUCTURES_EFFECT_BLOCK = 2;
 
 /** Block index of the warship effect within the effect-palette texture. */
 export const WARSHIP_EFFECT_BLOCK = 3;
+
+/** Block index of the train effect within the effect-palette texture. */
+export const TRAIN_EFFECT_BLOCK = 4;
+
+/** Block index of the railroad effect within the effect-palette texture. */
+export const RAILROAD_EFFECT_BLOCK = 5;
 
 // ---------- Terrain ----------
 

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -337,6 +337,8 @@ export const RailroadEffectAttributesSchema = StructuresEffectAttributesSchema;
 
 // Recolors railroad tracks on the owner's territory with gradient / transition
 // styles (rails are colored by the tile owner, so the effect follows that).
+// Like the structures effect, shown while the owner's territory is hovered
+// and always for the local player.
 const RailroadEffectSchema = CosmeticSchema.extend({
   effectType: z.literal("railroad"),
   attributes: RailroadEffectAttributesSchema,

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -15,8 +15,8 @@ export type CosmeticPack = z.infer<typeof CosmeticPackSchema>;
 export type CosmeticPackItem = z.infer<typeof CosmeticPackItemSchema>;
 export type Subscription = z.infer<typeof SubscriptionSchema>;
 // An effect cosmetic of any type — discriminated on effectType (today
-// transportShipTrail + nukeTrail + nukeExplosion + structures + warship;
-// gains a member per effectType).
+// transportShipTrail + nukeTrail + nukeExplosion + structures + warship +
+// train + railroad; gains a member per effectType).
 export type Effect = z.infer<typeof EffectSchema>;
 export type EffectType = z.infer<typeof EffectTypeSchema>;
 /** The catalog attribute shape of effects of the given effectType. */
@@ -37,6 +37,12 @@ export type StructuresEffectAttributes = z.infer<
 // Attributes of a warship effect (recolors warship sprites, not a trail).
 export type WarshipEffectAttributes = z.infer<
   typeof WarshipEffectAttributesSchema
+>;
+// Attributes of a train effect (recolors train sprites, not a trail).
+export type TrainEffectAttributes = z.infer<typeof TrainEffectAttributesSchema>;
+// Attributes of a railroad effect (recolors railroad tracks, not a trail).
+export type RailroadEffectAttributes = z.infer<
+  typeof RailroadEffectAttributesSchema
 >;
 export type PatternName = z.infer<typeof CosmeticNameSchema>;
 export type Product = z.infer<typeof ProductSchema>;
@@ -131,6 +137,8 @@ export const EFFECT_TYPES = [
   "nukeExplosion",
   "structures",
   "warship",
+  "train",
+  "railroad",
 ] as const;
 export const EffectTypeSchema = z.enum(EFFECT_TYPES);
 
@@ -303,6 +311,38 @@ const WarshipEffectSchema = CosmeticSchema.extend({
   url: z.string().optional(),
 });
 
+// Train-effect attributes: the same gradient/transition shapes as the trail
+// effects, with trail (world-space) semantics — a train is a line of tiny
+// sprites, so "gradient" bands the map like a trail (colorSize = band width in
+// tiles, movementSpeed = tiles/sec) and runs along the whole train;
+// "transition" cross-fades every car.
+export const TrainEffectAttributesSchema = StructuresEffectAttributesSchema;
+
+// Recolors the owner's trains (engine and carriages) with gradient /
+// transition styles. Always visible, like the warship effect. Train sprites
+// are tiny and the engine is drawn entirely in the border band, so the effect
+// recolors both bands (border band darkened) rather than just the fill.
+const TrainEffectSchema = CosmeticSchema.extend({
+  effectType: z.literal("train"),
+  attributes: TrainEffectAttributesSchema,
+  url: z.string().optional(),
+});
+
+// Railroad-effect attributes: the same gradient/transition shapes as the
+// trail effects, with trail (world-space) semantics — rails are static map
+// geometry, so "gradient" bands the map like a trail (colorSize = band width
+// in tiles, movementSpeed = tiles/sec) and "transition" cross-fades the
+// whole track.
+export const RailroadEffectAttributesSchema = StructuresEffectAttributesSchema;
+
+// Recolors railroad tracks on the owner's territory with gradient / transition
+// styles (rails are colored by the tile owner, so the effect follows that).
+const RailroadEffectSchema = CosmeticSchema.extend({
+  effectType: z.literal("railroad"),
+  attributes: RailroadEffectAttributesSchema,
+  url: z.string().optional(),
+});
+
 // Any catalog effect, discriminated on effectType. Add a member per effectType.
 export const EffectSchema = z.discriminatedUnion("effectType", [
   TransportShipTrailEffectSchema,
@@ -310,6 +350,8 @@ export const EffectSchema = z.discriminatedUnion("effectType", [
   NukeExplosionEffectSchema,
   StructuresEffectSchema,
   WarshipEffectSchema,
+  TrainEffectSchema,
+  RailroadEffectSchema,
 ]);
 
 /**
@@ -333,8 +375,8 @@ export function isNukeExplosionEffect(
 
 /**
  * A player selects one effect per "slot". A slot is the effectType itself for
- * per-type effects (transportShipTrail, nukeTrail, structures, warship) and the
- * nukeType for nuke explosions (atom, hydro, mirvWarhead) — so a player can
+ * per-type effects (transportShipTrail, nukeTrail, structures, warship, train,
+ * railroad) and the nukeType for nuke explosions (atom, hydro, mirvWarhead) — so a player can
  * equip a distinct explosion per bomb. Returns the effectType a slot resolves
  * to for catalog lookup, or undefined for an unknown/stale slot (e.g. a bare
  * "nukeExplosion" key from before the per-nukeType split).
@@ -481,6 +523,8 @@ export const CosmeticsSchema = z.object({
       nukeExplosion: lenientRecord(NukeExplosionEffectSchema).optional(),
       structures: lenientRecord(StructuresEffectSchema).optional(),
       warship: lenientRecord(WarshipEffectSchema).optional(),
+      train: lenientRecord(TrainEffectSchema).optional(),
+      railroad: lenientRecord(RailroadEffectSchema).optional(),
     })
     .optional(),
   currencyPacks: z.record(z.string(), PackSchema).optional(),

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -857,6 +857,174 @@ describe("warship effects", () => {
   });
 });
 
+describe("train effects", () => {
+  const gradient = {
+    name: "train_gradient",
+    effectType: "train",
+    attributes: {
+      type: "gradient",
+      colors: ["#ff0000", "#0000ff"],
+      colorSize: 2,
+      movementSpeed: 1,
+    },
+    affiliateCode: null,
+    product: null,
+    priceHard: 10,
+    rarity: "common",
+  };
+  const transition = {
+    name: "train_transition",
+    effectType: "train",
+    attributes: {
+      type: "transition",
+      colors: ["#ff0000", "#ffffff", "#00ff88"],
+      frequency: 3,
+    },
+    affiliateCode: null,
+    product: null,
+    rarity: "common",
+  };
+
+  it("parses the gradient and transition catalog entries", () => {
+    const result = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: {
+        train: {
+          train_gradient: gradient,
+          train_transition: transition,
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.effects?.train?.train_gradient?.attributes.type).toBe(
+        "gradient",
+      );
+      expect(
+        result.data.effects?.train?.train_transition?.attributes.type,
+      ).toBe("transition");
+    }
+  });
+
+  it("resolves the train slot (slot = effectType)", () => {
+    expect(effectTypeForSlot("train")).toBe("train");
+    const parsed = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: { train: { train_gradient: gradient } },
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(
+      findEffectForSlot(parsed.data, "train", "train_gradient")?.name,
+    ).toBe("train_gradient");
+  });
+
+  it("shares trail attribute shapes but is not a trail effect", () => {
+    const eff = EffectSchema.parse(gradient);
+    // Renders through the train palette block, not a trail block.
+    expect(isTrailEffect(eff)).toBe(false);
+    expect(effectMatchesSlot(eff, "train")).toBe(true);
+    expect(effectMatchesSlot(eff, "warship")).toBe(false);
+    expect(effectMatchesSlot(eff, "structures")).toBe(false);
+    expect(effectMatchesSlot(eff, "transportShipTrail")).toBe(false);
+  });
+
+  it("rejects a train effect with an unknown attribute type", () => {
+    expect(
+      EffectSchema.safeParse({
+        ...gradient,
+        attributes: { type: "sparkle", colors: [] },
+      }).success,
+    ).toBe(false);
+  });
+});
+
+describe("railroad effects", () => {
+  const gradient = {
+    name: "railroad_gradient",
+    effectType: "railroad",
+    attributes: {
+      type: "gradient",
+      colors: ["#ff0000", "#0000ff"],
+      colorSize: 2,
+      movementSpeed: 1,
+    },
+    affiliateCode: null,
+    product: null,
+    priceHard: 10,
+    rarity: "common",
+  };
+  const transition = {
+    name: "railroad_transition",
+    effectType: "railroad",
+    attributes: {
+      type: "transition",
+      colors: ["#ff0000", "#ffffff", "#00ff88"],
+      frequency: 3,
+    },
+    affiliateCode: null,
+    product: null,
+    rarity: "common",
+  };
+
+  it("parses the gradient and transition catalog entries", () => {
+    const result = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: {
+        railroad: {
+          railroad_gradient: gradient,
+          railroad_transition: transition,
+        },
+      },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(
+        result.data.effects?.railroad?.railroad_gradient?.attributes.type,
+      ).toBe("gradient");
+      expect(
+        result.data.effects?.railroad?.railroad_transition?.attributes.type,
+      ).toBe("transition");
+    }
+  });
+
+  it("resolves the railroad slot (slot = effectType)", () => {
+    expect(effectTypeForSlot("railroad")).toBe("railroad");
+    const parsed = CosmeticsSchema.safeParse({
+      patterns: {},
+      flags: {},
+      effects: { railroad: { railroad_gradient: gradient } },
+    });
+    expect(parsed.success).toBe(true);
+    if (!parsed.success) return;
+    expect(
+      findEffectForSlot(parsed.data, "railroad", "railroad_gradient")?.name,
+    ).toBe("railroad_gradient");
+  });
+
+  it("shares trail attribute shapes but is not a trail effect", () => {
+    const eff = EffectSchema.parse(gradient);
+    // Renders through the railroad palette block, not a trail block.
+    expect(isTrailEffect(eff)).toBe(false);
+    expect(effectMatchesSlot(eff, "railroad")).toBe(true);
+    expect(effectMatchesSlot(eff, "warship")).toBe(false);
+    expect(effectMatchesSlot(eff, "structures")).toBe(false);
+    expect(effectMatchesSlot(eff, "transportShipTrail")).toBe(false);
+  });
+
+  it("rejects a railroad effect with an unknown attribute type", () => {
+    expect(
+      EffectSchema.safeParse({
+        ...gradient,
+        attributes: { type: "sparkle", colors: [] },
+      }).success,
+    ).toBe(false);
+  });
+});
+
 describe("isTrailEffect", () => {
   it("is true for a trail effect and false for a nukeExplosion", () => {
     const trail = EffectSchema.parse({

--- a/tests/EffectEditorState.test.ts
+++ b/tests/EffectEditorState.test.ts
@@ -77,6 +77,24 @@ describe("EFFECT_EDITOR_TYPES", () => {
   test("only nuke trails offer the spiral vortex", () => {
     expect(EFFECT_EDITOR_TYPES.nukeTrail).toContain("spiral");
     expect(EFFECT_EDITOR_TYPES.transportShipTrail).not.toContain("spiral");
+    expect(EFFECT_EDITOR_TYPES.train).not.toContain("spiral");
+    expect(EFFECT_EDITOR_TYPES.railroad).not.toContain("spiral");
+  });
+
+  test("train and railroad slots validate through the structures-shaped schema", () => {
+    for (const effectType of ["train", "railroad"] as const) {
+      const s = { ...defaultSlotState(effectType), type: "gradient" };
+      expect(slotAttributes(effectType, s)).toEqual({
+        type: "gradient",
+        colors: s.colors.slice(0, s.colorCount),
+        colorSize: s.colorSize,
+        movementSpeed: s.movementSpeed,
+      });
+      expect(slotAttributes(effectType, { ...s, type: "spiral" })).toBe(null);
+      expect(JSON.parse(catalogSnippet(effectType, s)!).effectType).toBe(
+        effectType,
+      );
+    }
   });
 });
 

--- a/tests/WebGLFrameBuilder.effectOverrides.test.ts
+++ b/tests/WebGLFrameBuilder.effectOverrides.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from "vitest";
 import { WebGLFrameBuilder } from "../src/client/WebGLFrameBuilder";
 import {
   MAX_TRAIL_COLORS,
+  RAILROAD_EFFECT_BLOCK,
   STRUCTURES_EFFECT_BLOCK,
+  TRAIN_EFFECT_BLOCK,
 } from "../src/client/render/gl/utils/ColorUtils";
 
 const PALETTE_SIZE = 4096;
@@ -28,12 +30,10 @@ function setup() {
     setNukeTrailSpiral: () => {},
     clearNukeTrailSpiral: () => {},
   };
-  const countOf = (p: Float32Array) =>
-    p[
-      (STRUCTURES_EFFECT_BLOCK * MAX_TRAIL_COLORS * PALETTE_SIZE + LOCAL) * 4 +
-        3
-    ];
-  return { builder, gameView, uploads, countOf };
+  const countIn = (p: Float32Array, block: number) =>
+    p[(block * MAX_TRAIL_COLORS * PALETTE_SIZE + LOCAL) * 4 + 3];
+  const countOf = (p: Float32Array) => countIn(p, STRUCTURES_EFFECT_BLOCK);
+  return { builder, gameView, uploads, countOf, countIn };
 }
 
 describe("WebGLFrameBuilder effect overrides", () => {
@@ -75,6 +75,26 @@ describe("WebGLFrameBuilder effect overrides", () => {
     builder.syncPlayerEffects(gameView);
     expect(uploads).toHaveLength(2);
     expect(countOf(uploads[1])).toBe(3);
+  });
+
+  it("writes train and railroad overrides into their own palette blocks", () => {
+    const { builder, gameView, uploads, countIn } = setup();
+    builder.setEffectOverride("train", {
+      type: "gradient",
+      colors: ["#ff0000", "#ffffff", "#0000ff"],
+      colorSize: 5,
+      movementSpeed: 10,
+    });
+    builder.setEffectOverride("railroad", {
+      type: "transition",
+      colors: ["#ff0000", "#ffff00"],
+      frequency: 2,
+    });
+    builder.syncPlayerEffects(gameView);
+    expect(uploads).toHaveLength(1);
+    expect(countIn(uploads[0], TRAIN_EFFECT_BLOCK)).toBe(3);
+    expect(countIn(uploads[0], RAILROAD_EFFECT_BLOCK)).toBe(2);
+    expect(countIn(uploads[0], STRUCTURES_EFFECT_BLOCK)).toBe(0);
   });
 
   it("keeps an override-only player unresolved until the catalog loads", () => {


### PR DESCRIPTION
## Summary

Client side of the `train` and `railroad` effect types added by openfrontio/infra#576, mirroring the warship effect (#4694). Catalog entries with gradient/transition attributes recolor the owner's trains and railroad tracks. Rebased on the Effect Editor (#5137), which gains **Train** and **Railroad** slots.

- **CosmeticSchemas**: `train` and `railroad` in `EFFECT_TYPES`, catalog keys and effect schemas (attributes shared with structures/warship). Slot machinery, server privilege checks, store/inventory tabs pick them up generically.
- **Effect palette** grows to 6 blocks (`TRAIN_EFFECT_BLOCK = 4`, `RAILROAD_EFFECT_BLOCK = 5`); `WebGLFrameBuilder` resolves both (catalog or Effect Editor override), with build-time guards on the shader-coupled block order.
- **Trains** (`UnitPass` / `unit.frag.glsl`): the warship helper became `spriteEffectColor(rowBase, owner, coord, iconSpace)` (warship math unchanged). Trains use *world-space* gradient math (trail semantics: `colorSize` in tiles, `movementSpeed` in tiles/s) via a new `vWorldPos` varying — the 5×5 train sprites only cover the middle of the 13-tile unit cell, so a sprite-diagonal gradient showed a sliver of the palette per car. This is a shader formula on the fragment's world coordinate, not per-tile storage. Both gray bands are recolored (border band = effect × 0.6) because `trainEngine.png` is entirely border-gray; this keeps the engine/frame/fill contrast.
- **Railroads** (`RailroadPass` / `railroad.frag.glsl`): binds the shared effect texture + `uTime`; the effect follows the *tile owner* (how rails are colored today), overrides the local player's white/black rail color, and the green overlap highlight still wins. Gated like the structures effect: shown while the owner's territory is hovered and always for the local player (`RailroadPass.setHighlightOwner`, fanned out from `Renderer.setHighlightOwner`). Ghost rails are untouched. No new per-tile memory — the pass already owned its rail/tile textures.
- **Effect Editor**: Train and Railroad sub-folders (gradient / transition), validated through the structures-shaped schema and applied through `setEffectOverride` like the other palette slots.
- `effects.type.train` / `effects.type.railroad` labels in `en.json`.

## Test plan

- [x] Schema tests mirroring the warship suite for both types: catalog parse, slot resolution, not-a-trail narrowing, unknown-attribute rejection (`tests/CosmeticSchemas.test.ts`)
- [x] Effect Editor: both slots validate for every offered type, reject `spiral`, emit catalog snippets (`tests/EffectEditorState.test.ts`); overrides land in palette blocks 4 and 5 (`tests/WebGLFrameBuilder.effectOverrides.test.ts`)
- [x] `tsc --noEmit`, eslint, prettier clean; `tests/client` passes (the 3 files that fail when the whole dir runs together — CosmeticPurchaseCompletion, StoreModal, UsernameInput.steam — are pre-existing order pollution and pass in isolation on `main` too)
- [x] Verified in a real game (headless Chromium, dev server, catalog served via route interception): built a city + factory, a 7-car train spawned — the train shows a red→white→blue gradient along its cars and the track a red/yellow/cyan gradient in both the detailed and line rail LOD modes; no GL/shader errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
