### PR TITLE
Make every 4th scheduled public game trusted-only

### DIFF
--- a/src/server/MapPlaylist.ts
+++ b/src/server/MapPlaylist.ts
@@ -35,10 +35,11 @@ const MAX_PLAYER_COUNT = 125;
 
 // Share of public FFA games that run with overtime enabled.
 const OVERTIME_FFA_CHANCE = 0.25;
-// Share of scheduled public games (FFA, team and special alike) that are
-// trusted-only (GameConfig.trusted): only accounts the API reports as trusted
-// may join. Rolled independently of the map and modifier rolls.
-const TRUSTED_PUBLIC_CHANCE = 1 / 3;
+// Every Nth scheduled public game (FFA, team and special alike, counted in
+// creation order) is trusted-only (GameConfig.trusted): only accounts the API
+// reports as trusted may join. A fixed rotation rather than a roll so the
+// lobbies on offer at any moment are never all locked.
+const TRUSTED_PUBLIC_EVERY = 4;
 
 const TEAM_WEIGHTS: { config: TeamCountConfig; weight: number }[] = [
   { config: 2, weight: 10 },
@@ -145,9 +146,13 @@ export class MapPlaylist {
     team: [],
   };
 
+  // Scheduled public games handed out so far, across all types.
+  private scheduled = 0;
+
   public async gameConfig(type: ScheduledPublicGameType): Promise<GameConfig> {
     const config = await this.rollConfig(type);
-    if (Math.random() < TRUSTED_PUBLIC_CHANCE) {
+    this.scheduled++;
+    if (this.scheduled % TRUSTED_PUBLIC_EVERY === 0) {
       config.trusted = true;
     }
     return config;

--- a/tests/server/MapPlaylistTrusted.test.ts
+++ b/tests/server/MapPlaylistTrusted.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { GameConfigSchema } from "../../src/core/Schemas";
 import { MapPlaylist } from "../../src/server/MapPlaylist";
 
@@ -6,40 +6,59 @@ vi.mock("../../src/server/MapLandTiles", () => ({
   getMapLandTiles: async () => 1_000_000,
 }));
 
-// A third of scheduled public games are trusted-only, whatever their type.
-// The roll is the LAST Math.random() call gameConfig makes, so a spy that
-// answers every earlier roll (map, modifiers) with the same value still
-// decides trust by that value.
+// Every 4th scheduled public game is trusted-only, counted across FFA, team
+// and special in creation order: three open lobbies, then one locked. A
+// rotation, not a roll, so the lobbies on offer are never all locked at once.
 describe("MapPlaylist trusted-only public games", () => {
-  let randomSpy: ReturnType<typeof vi.spyOn>;
-
-  beforeEach(() => {
-    randomSpy = vi.spyOn(Math, "random");
-  });
-
-  afterEach(() => {
-    randomSpy.mockRestore();
-  });
-
-  for (const type of ["ffa", "team", "special"] as const) {
-    it(`marks a ${type} lobby trusted-only on a low roll`, async () => {
-      randomSpy.mockReturnValue(0.1);
-      const config = await new MapPlaylist().gameConfig(type);
-      expect(config.trusted).toBe(true);
+  it("marks every 4th game trusted-only across all types", async () => {
+    const playlist = new MapPlaylist();
+    const types = [
+      "ffa",
+      "team",
+      "special",
+      "ffa",
+      "team",
+      "special",
+      "ffa",
+      "team",
+    ] as const;
+    const trusted: boolean[] = [];
+    for (const type of types) {
+      const config = await playlist.gameConfig(type);
       expect(GameConfigSchema.safeParse(config).success).toBe(true);
-    });
+      trusted.push(config.trusted === true);
+    }
+    expect(trusted).toEqual([
+      false,
+      false,
+      false,
+      true,
+      false,
+      false,
+      false,
+      true,
+    ]);
+  });
 
-    it(`leaves a ${type} lobby open on a high roll`, async () => {
+  it("counts per playlist instance, starting open", async () => {
+    const a = new MapPlaylist();
+    const b = new MapPlaylist();
+    for (let i = 0; i < 3; i++) await a.gameConfig("ffa");
+    expect((await a.gameConfig("ffa")).trusted).toBe(true);
+    // b has its own counter: its first game is open.
+    expect((await b.gameConfig("ffa")).trusted).toBeUndefined();
+  });
+
+  it("does not depend on Math.random", async () => {
+    const randomSpy = vi.spyOn(Math, "random").mockReturnValue(0.1);
+    try {
+      const playlist = new MapPlaylist();
+      expect((await playlist.gameConfig("ffa")).trusted).toBeUndefined();
       randomSpy.mockReturnValue(0.9);
-      const config = await new MapPlaylist().gameConfig(type);
-      expect(config.trusted).toBeUndefined();
-    });
-  }
-
-  it("rolls trust at the one-third threshold", async () => {
-    randomSpy.mockReturnValue(1 / 3 - 0.001);
-    expect((await new MapPlaylist().gameConfig("ffa")).trusted).toBe(true);
-    randomSpy.mockReturnValue(1 / 3 + 0.001);
-    expect((await new MapPlaylist().gameConfig("ffa")).trusted).toBeUndefined();
+      for (let i = 0; i < 2; i++) await playlist.gameConfig("team");
+      expect((await playlist.gameConfig("special")).trusted).toBe(true);
+    } finally {
+      randomSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #5127. Replaces the random 1/3 trusted-only roll with a fixed rotation: `MapPlaylist` counts the scheduled public games it hands out across FFA, team and special (creation order) and marks every 4th one `trusted: true` (`TRUSTED_PUBLIC_EVERY = 4`).
- Why: with a random roll all the lobbies on offer could be locked at the same time. Counting across types guarantees three open lobbies between locked ones, so the three upcoming public lobbies can never all be trusted-only.
- The counter lives on the `MapPlaylist` instance (one per master), so it survives across lobby types and resets only on master restart, starting with open lobbies.

## Test plan
- `tests/server/MapPlaylistTrusted.test.ts` rewritten: an 8-game ffa/team/special sequence is trusted at positions 4 and 8 only; each instance counts on its own and starts open; the result is independent of `Math.random`.
- `npx vitest tests/server --run`: 48 files / 491 tests green; `tsc --noEmit`, eslint, Prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)