### PR TITLE
feat(client): clan map fullscreen + signed-out clan modal UX

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -369,6 +369,7 @@
     "select_new_leader": "Select a new leader",
     "settings_saved": "Clan settings saved!",
     "sign_in_for_clans": "Sign in to join and manage clans",
+    "sign_in_to_join": "Sign in to join",
     "sort_1v1_losses": "1v1 Losses",
     "sort_1v1_wins": "1v1 Wins",
     "sort_by": "Sort by",

--- a/src/client/ClanModal.ts
+++ b/src/client/ClanModal.ts
@@ -13,6 +13,7 @@ import "./components/clan/ClanGameHistoryView";
 import type { ClanGameHistoryCache } from "./components/clan/ClanGameHistoryView";
 import "./components/clan/ClanManageView";
 import "./components/clan/ClanMapView";
+import type { ClanMapView } from "./components/clan/ClanMapView";
 import "./components/clan/ClanMyRequestsView";
 import "./components/clan/ClanRequestsView";
 import type { ClanRole } from "./components/clan/ClanShared";
@@ -21,6 +22,7 @@ import "./components/ConfirmDialog";
 import "./components/CopyButton";
 import "./components/CurrencyDisplay";
 import { modalHeader } from "./components/ui/ModalHeader";
+import { signedOutNotice } from "./components/ui/SignedOutNotice";
 import { modalRouter } from "./ModalRouter";
 import type { ProfileOrigin } from "./PlayerProfileModal";
 import { translateText } from "./Utils";
@@ -61,6 +63,9 @@ export class ClanModal extends BaseModal {
 
   @state() private view: View = "list";
   @state() private loading = false;
+  // No session: the map and Browse still work; My Clans asks to sign in and
+  // the detail view offers sign-in instead of Join.
+  @state() private signedOut = false;
 
   @state() private myClans: ClanInfo[] = [];
   @state() private myPendingRequests: {
@@ -155,6 +160,8 @@ export class ClanModal extends BaseModal {
           title: translateText("clan_modal.title"),
           onBack: () => this.close(),
           ariaLabel: translateText("common.back"),
+          rightContent:
+            this.activeTab === "map" ? this.fullscreenButton() : undefined,
         })
       : this.renderSubViewHeader();
   }
@@ -181,6 +188,34 @@ export class ClanModal extends BaseModal {
     }
     // Detail tabs: BaseModal already updated activeTab; renderInner reads it.
     // No additional side effects required here.
+  }
+
+  private fullscreenButton() {
+    const label = translateText("fullscreen.enter");
+    return html`<button
+      type="button"
+      data-testid="map-fullscreen"
+      title=${label}
+      aria-label=${label}
+      class="flex items-center justify-center w-10 h-10 rounded-full shrink-0 bg-white/5 hover:bg-white/10 transition-all border border-white/10 text-white/70 hover:text-white"
+      @click=${() =>
+        this.querySelector<ClanMapView>("clan-map-view")?.enterFullscreen()}
+    >
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        class="w-5 h-5"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        stroke-width="2"
+      >
+        <path
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4"
+        />
+      </svg>
+    </button>`;
   }
 
   private tagPill(tag: string) {
@@ -299,7 +334,7 @@ export class ClanModal extends BaseModal {
     if (targetTag) {
       this.openDetail(targetTag.toUpperCase());
     }
-    this.loadMyClans({ allowGuest: Boolean(targetTag) });
+    this.loadMyClans();
   }
 
   protected onClose(): void {
@@ -319,36 +354,20 @@ export class ClanModal extends BaseModal {
     this.returningFromModalHandoff = false;
   }
 
-  private async loadMyClans(opts: { allowGuest?: boolean } = {}) {
+  private async loadMyClans() {
     this.loading = true;
     try {
       const me = await getUserMe();
       if (!this.isModalOpen) return;
       if (!me || Object.keys(me.user).length === 0) {
-        // The map is public (read-only without a token). Checked once the
-        // response is in, not when it was requested: the router opens inline
-        // modals arg-less first and only then with the URL's tab, so a guest
-        // deep-linked to `#modal=clan&tab=map` has reached the map by now.
-        if (opts.allowGuest || this.activeTab === "map") {
-          this.myPublicId = null;
-          this.myPendingRequests = [];
-          this.myClanRoles = new Map();
-          this.myClans = [];
-          return;
-        }
-        window.dispatchEvent(
-          new CustomEvent("show-message", {
-            detail: {
-              message: translateText("clan_modal.sign_in_for_clans"),
-              color: "red",
-              duration: 3000,
-            },
-          }),
-        );
-        this.close();
-        window.showPage?.("page-account");
+        this.signedOut = true;
+        this.myPublicId = null;
+        this.myPendingRequests = [];
+        this.myClanRoles = new Map();
+        this.myClans = [];
         return;
       }
+      this.signedOut = false;
       this.myPublicId = me.player.publicId;
       this.myPendingRequests = me.player.clanRequests ?? [];
       const roles = new Map<string, ClanRole>();
@@ -745,6 +764,12 @@ export class ClanModal extends BaseModal {
   }
 
   private renderMyClans() {
+    if (this.signedOut) {
+      return signedOutNotice(() => {
+        this.close();
+        window.showPage?.("page-account");
+      }, translateText("clan_modal.sign_in_for_clans"));
+    }
     const hasClans = this.myClans.length > 0;
     const hasRequests = this.myPendingRequests.length > 0;
 

--- a/src/client/ClanModal.ts
+++ b/src/client/ClanModal.ts
@@ -167,9 +167,11 @@ export class ClanModal extends BaseModal {
   }
 
   protected renderBody() {
-    // The map fills the content box edge to edge; everything else is padded.
+    // The map fills the content box edge to edge and exactly to its height
+    // (the modal is an inline page, so the scroll area has a fixed height and
+    // anything taller scrolls); everything else is padded.
     const onMap = this.onListView && this.activeTab === "map";
-    return html`<div class=${onMap ? "" : "p-4 lg:p-[1.4rem]"}>
+    return html`<div class=${onMap ? "h-full" : "p-4 lg:p-[1.4rem]"}>
       ${this.renderInner()}
     </div>`;
   }
@@ -619,7 +621,9 @@ export class ClanModal extends BaseModal {
     // List view (map / my clans / browse) — header + tabs are rendered by o-modal
     if (this.activeTab === "map") {
       // Mounted only while open: the page polls its API while framed.
-      return this.isModalOpen ? html`<clan-map-view></clan-map-view>` : html``;
+      return this.isModalOpen
+        ? html`<clan-map-view class="block h-full"></clan-map-view>`
+        : html``;
     }
     return html`
       ${this.activeTab === "my-clans"

--- a/src/client/components/clan/ClanDetailView.ts
+++ b/src/client/components/clan/ClanDetailView.ts
@@ -781,7 +781,18 @@ export class ClanDetailView extends LitElement {
     clan: ClanInfo,
   ) {
     const buttons: ReturnType<typeof html>[] = [];
-    if (!isMember && hasPendingRequest) {
+    if (!isMember && this.myPublicId === null) {
+      // Signed out: hand off to sign-in instead of sending a join that
+      // would only come back 401.
+      buttons.push(html`
+        <button
+          @click=${() => window.showPage?.("page-account")}
+          class="flex-1 px-6 py-3 text-sm font-bold text-white uppercase tracking-wider bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 rounded-xl transition-all"
+        >
+          ${translateText("clan_modal.sign_in_to_join")}
+        </button>
+      `);
+    } else if (!isMember && hasPendingRequest) {
       buttons.push(html`
         <button
           disabled

--- a/src/client/components/clan/ClanMapView.ts
+++ b/src/client/components/clan/ClanMapView.ts
@@ -48,6 +48,12 @@ export class ClanMapView extends LitElement {
     target.postMessage({ type: "clanmap:auth", jwt: auth.jwt }, origin);
   };
 
+  // Fullscreens the frame element itself, so it works from the parent
+  // without any cooperation from the page (which also has its own button).
+  public enterFullscreen(): void {
+    void this.frame?.requestFullscreen?.().catch(() => {});
+  }
+
   render() {
     // The page sizes its canvas to the frame and re-fits on resize, so the
     // frame just needs a real height: the modal is content-sized on desktop.

--- a/src/client/components/clan/ClanMapView.ts
+++ b/src/client/components/clan/ClanMapView.ts
@@ -55,15 +55,15 @@ export class ClanMapView extends LitElement {
   }
 
   render() {
-    // The page sizes its canvas to the frame and re-fits on resize, so the
-    // frame just needs a real height: the modal is content-sized on desktop.
-    // `allow="fullscreen"` is what makes the page's Fullscreen button appear.
+    // The page sizes its canvas to the frame and re-fits on resize; the host
+    // gives the frame its height. `allow="fullscreen"` is what makes the
+    // page's Fullscreen button appear.
     return html`<iframe
       src=${clanMapOrigin() + "/"}
       title=${translateText("clan_modal.map_frame_title")}
       allow="fullscreen"
       allowfullscreen
-      class="block w-full h-[calc(100vh-16rem)] min-h-[320px] border-0 bg-[#0e1116]"
+      class="block w-full h-full border-0 bg-[#0e1116]"
     ></iframe>`;
   }
 }

--- a/src/client/components/ui/SignedOutNotice.ts
+++ b/src/client/components/ui/SignedOutNotice.ts
@@ -7,14 +7,15 @@ import "../baseComponents/Button";
  * subscription) when there is no signed-in session: explain why the modal is
  * empty and hand off to the account modal's sign-in options.
  */
-export const signedOutNotice = (onSignIn: () => void): TemplateResult => html`
+export const signedOutNotice = (
+  onSignIn: () => void,
+  message: string = translateText("account_modal.sign_in_desc"),
+): TemplateResult => html`
   <div class="p-6">
     <div
       class="bg-white/5 rounded-xl border border-white/10 p-8 text-center flex flex-col items-center gap-4"
     >
-      <p class="text-white/60 text-sm">
-        ${translateText("account_modal.sign_in_desc")}
-      </p>
+      <p class="text-white/60 text-sm">${message}</p>
       <o-button
         variant="primary"
         size="md"

--- a/tests/client/clan/ClanMapView.test.ts
+++ b/tests/client/clan/ClanMapView.test.ts
@@ -114,6 +114,15 @@ describe("ClanMapView", () => {
     expect(postMessage).not.toHaveBeenCalled();
   });
 
+  it("fullscreens the frame element on request", () => {
+    const request = vi.fn(() => Promise.resolve());
+    frame.requestFullscreen = request as never;
+
+    view.enterFullscreen();
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+
   it("stops listening once removed", async () => {
     view.remove();
     ready();

--- a/tests/client/clan/ClanModal.handlers.test.ts
+++ b/tests/client/clan/ClanModal.handlers.test.ts
@@ -596,6 +596,9 @@ describe("ClanModal — handlers", () => {
 
       setState(modal, "selectedClanTag" as keyof ClanModal, "TST" as never);
       setState(modal, "myClanRoles" as keyof ClanModal, new Map() as never);
+      // Signed in but not a member; without an id the detail view offers
+      // sign-in instead of Join.
+      setState(modal, "myPublicId" as keyof ClanModal, "test-player" as never);
       setState(modal, "view" as keyof ClanModal, "detail" as never);
       await waitForSubComponent(modal, "clan-detail-view");
     });

--- a/tests/client/clan/ClanModalGuest.test.ts
+++ b/tests/client/clan/ClanModalGuest.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  apiMockFactory,
+  authMockFactory,
+  clanApiMockFactory,
+  crazyGamesSdkMockFactory,
+  flushAsync,
+  getElState,
+  stubLocalStorage,
+  utilsMockFactory,
+  virtualizerMockFactory,
+  waitForSubComponent,
+} from "./ClanModalTestUtils";
+
+vi.mock("@lit-labs/virtualizer/virtualize.js", () => virtualizerMockFactory());
+vi.mock("../../../src/client/Api", () => apiMockFactory());
+vi.mock("../../../src/client/ClanApi", () => clanApiMockFactory());
+vi.mock("../../../src/client/Utils", () => utilsMockFactory());
+vi.mock("../../../src/client/Auth", () => authMockFactory());
+vi.mock("../../../src/client/CrazyGamesSDK", () => crazyGamesSdkMockFactory());
+
+stubLocalStorage();
+
+import { getUserMe } from "../../../src/client/Api";
+import { joinClan } from "../../../src/client/ClanApi";
+import { ClanModal } from "../../../src/client/ClanModal";
+
+const asMock = (fn: unknown) => fn as ReturnType<typeof vi.fn>;
+
+// Signed out: the map and Browse are public, My Clans asks to sign in, and
+// nothing routes the visitor to a 401.
+describe("ClanModal — signed out", () => {
+  let modal: ClanModal;
+  let showPage: ReturnType<typeof vi.fn<(pageId: string) => void>>;
+
+  beforeEach(async () => {
+    if (!customElements.get("clan-modal")) {
+      customElements.define("clan-modal", ClanModal);
+    }
+    asMock(getUserMe).mockResolvedValue({ user: {}, player: {} } as never);
+    showPage = vi.fn<(pageId: string) => void>();
+    window.showPage = showPage;
+
+    modal = document.createElement("clan-modal") as ClanModal;
+    modal.setAttribute("inline", "");
+    document.body.appendChild(modal);
+    await modal.updateComplete;
+  });
+
+  afterEach(() => {
+    modal.remove();
+    delete window.showPage;
+    vi.clearAllMocks();
+    // Back to the factory's signed-in leader.
+    asMock(getUserMe).mockReset();
+  });
+
+  function buttonWithText(text: string): HTMLButtonElement | undefined {
+    return Array.from(modal.querySelectorAll("button")).find(
+      (b) => b.textContent?.trim() === text,
+    );
+  }
+
+  it("stays open on My Clans and offers to sign in", async () => {
+    modal.open();
+    await flushAsync(modal);
+
+    expect(modal.isOpen()).toBe(true);
+    expect(getElState(modal, "activeTab")).toBe("my-clans");
+    expect(modal.textContent).toContain("clan_modal.sign_in_for_clans");
+    expect(showPage).not.toHaveBeenCalled();
+
+    modal.querySelector<HTMLElement>("o-button")!.click();
+    await flushAsync(modal);
+
+    expect(modal.isOpen()).toBe(false);
+    expect(showPage).toHaveBeenCalledWith("page-account");
+  });
+
+  it("lets a signed-out viewer deep-link to the map", async () => {
+    // The router's sequence for `#modal=clan&tab=map`: showPage() opens the
+    // inline modal without args, then the URL's args arrive.
+    modal.open();
+    modal.open({ tab: "map" });
+    await flushAsync(modal);
+
+    expect(modal.isOpen()).toBe(true);
+    expect(getElState(modal, "activeTab")).toBe("map");
+    expect(modal.querySelector("clan-map-view")).not.toBeNull();
+  });
+
+  it("lets a signed-out viewer browse clans", async () => {
+    modal.open({ tab: "browse" });
+    await flushAsync(modal);
+
+    expect(modal.isOpen()).toBe(true);
+    expect(modal.querySelector("clan-browse-view")).not.toBeNull();
+  });
+
+  it("offers sign-in instead of Join on a clan's detail", async () => {
+    modal.open({ clan: "TST" });
+    await waitForSubComponent(modal, "clan-detail-view");
+    await flushAsync(modal, modal.querySelector("clan-detail-view"));
+
+    expect(buttonWithText("clan_modal.join_clan")).toBeUndefined();
+    const signIn = buttonWithText("clan_modal.sign_in_to_join");
+    expect(signIn).toBeDefined();
+
+    signIn!.click();
+    await flushAsync(modal);
+
+    expect(joinClan).not.toHaveBeenCalled();
+    expect(showPage).toHaveBeenCalledWith("page-account");
+  });
+});
+
+describe("ClanModal — map fullscreen button", () => {
+  let modal: ClanModal;
+
+  beforeEach(async () => {
+    if (!customElements.get("clan-modal")) {
+      customElements.define("clan-modal", ClanModal);
+    }
+    modal = document.createElement("clan-modal") as ClanModal;
+    modal.setAttribute("inline", "");
+    document.body.appendChild(modal);
+    await modal.updateComplete;
+  });
+
+  afterEach(() => {
+    modal.remove();
+    vi.clearAllMocks();
+  });
+
+  const fullscreenButton = () =>
+    modal.querySelector<HTMLButtonElement>('[data-testid="map-fullscreen"]');
+
+  it("shows only on the Map tab and fullscreens the map frame", async () => {
+    modal.open();
+    await flushAsync(modal);
+    expect(fullscreenButton()).toBeNull();
+
+    modal.setActiveTab("map");
+    await flushAsync(modal);
+    const mapView = await waitForSubComponent(modal, "clan-map-view");
+    const request = vi.fn(() => Promise.resolve());
+    mapView.querySelector("iframe")!.requestFullscreen = request as never;
+
+    fullscreenButton()!.click();
+
+    expect(request).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/client/clan/ClanModalProfileHandoff.test.ts
+++ b/tests/client/clan/ClanModalProfileHandoff.test.ts
@@ -39,7 +39,6 @@ class FakeIntersectionObserver {
 }
 vi.stubGlobal("IntersectionObserver", FakeIntersectionObserver);
 
-import { getUserMe } from "../../../src/client/Api";
 import type { ClanInfo } from "../../../src/client/ClanApi";
 import { fetchClanDetail } from "../../../src/client/ClanApi";
 import { ClanModal } from "../../../src/client/ClanModal";
@@ -92,8 +91,6 @@ describe("ClanModal — player-profile handoff", () => {
     modal.remove();
     profileModal.remove();
     vi.clearAllMocks();
-    // Back to the factory's signed-in leader after the guest tests below.
-    asMock(getUserMe).mockReset();
   });
 
   function detailView(): HTMLElement {
@@ -273,30 +270,6 @@ describe("ClanModal — player-profile handoff", () => {
     await flushAsync(modal);
     expect(modal.querySelector("clan-map-view")).toBeNull();
     expect(getElState(modal, "activeTab")).toBe("my-clans");
-  });
-
-  it("lets a signed-out viewer deep-link to the map", async () => {
-    asMock(getUserMe).mockResolvedValue({ user: {}, player: {} } as never);
-
-    // The router's sequence for `#modal=clan&tab=map`: showPage() opens the
-    // inline modal without args, then the URL's args arrive. The guest
-    // decision must not have been taken on that first, tab-less open.
-    modal.open();
-    modal.open({ tab: "map" });
-    await flushAsync(modal);
-
-    expect(modal.isOpen()).toBe(true);
-    expect(getElState(modal, "activeTab")).toBe("map");
-    expect(modal.querySelector("clan-map-view")).not.toBeNull();
-  });
-
-  it("still sends a signed-out viewer to sign in on the clan list", async () => {
-    asMock(getUserMe).mockResolvedValue({ user: {}, player: {} } as never);
-
-    modal.open();
-    await flushAsync(modal);
-
-    expect(modal.isOpen()).toBe(false);
   });
 
   it("offers a Donations tab on the clan detail", async () => {


### PR DESCRIPTION
## Summary
- **Fullscreen button** for the clan map: a ⛶ button in the clan modal header while the Map tab is active. It calls `ClanMapView.enterFullscreen()`, which fullscreens the iframe element from the parent — independent of the map page (whose own HUD button still works).
- **Signed-out UX** — no bounce, no 401s: opening Clans without a session now stays open. **My Clans** renders the shared `signedOutNotice` ("Sign in to join and manage clans" + Sign in → account page); **Map** and **Browse** just work. A clan's detail shows a single **"Sign in to join"** button instead of Join / Request invite, so no join is sent without a session (the 401 branch in `handleJoin` remains as a safety net). Donate/Leave/Manage were already member-only and the History/Donations tabs already show "members only" notices.
- `signedOutNotice` gains an optional message parameter (default unchanged). New key `clan_modal.sign_in_to_join`.
- Removes the `loadMyClans` toast + redirect to the account page, so the signed-out state is now a first-class render path (`signedOut` state).

Pairs with the infra PR making `GET /clans` and `GET /clans/:clanTag` public (`noAuthWrapper`) — until that deploys, a signed-out Browse shows the existing "Failed to load" state.

## Test plan
- [x] `NODE_OPTIONS=--localstorage-file=... npx vitest tests/EnJsonSorted.test.ts tests/client/clan tests/client/PlayerProfileModal.test.ts tests/client/ClanGameStatsNavigation.test.ts tests/client/PlayerProfileClansTab.test.ts --run` — 19 files, 374 tests (new `ClanModalGuest.test.ts` ×5: stays open + sign-in handoff, map deep link, browse, "Sign in to join" never calls `joinClan`, fullscreen button only on Map tab; `ClanMapView.test.ts` fullscreen)
- [x] `npx tsc --noEmit`, `npm run lint`, prettier
- [x] Dev server as a signed-out visitor: My Clans shows the notice + Sign in, Browse opens, Map tab shows the "Enter fullscreen" button
- [ ] Staging once the infra change is deployed: signed-out Browse lists clans and a clan page shows "Sign in to join"

🤖 Generated with [Claude Code](https://claude.com/claude-code)