### PR TITLE
refactor(server): extract the winner and live-stats votes out of GameServer

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -132,10 +132,9 @@ spy `ServerEnv`, and a throw inside `handleWinner`'s catch silently drops the
 archive. The harness `makeGame` defaults `archive` and `fetchTribes` to inert
 spies; pass `deps: { archive }` to read the record. Golden frames unchanged
 (the snapshot lost only the three deployment stamps). No `vi.mock` of
-`Archive`/`CustomTribes` remains. `archiveGame` is still spied in
-`WinnerVoteRetally` and `ArchivePlayerRecord`, which assemble game state by
-hand rather than joining and starting; they move with Phase 3's `Consensus`
-extraction and a wire/record-based rewrite.
+`Archive`/`CustomTribes` remains. (`archiveGame` stayed spied in
+`WinnerVoteRetally` and `ArchivePlayerRecord` until Phase 3's `Consensus`
+extraction rewrote them through real joins and starts.)
 
 ## Phase 3 — Extract pure modules (lowest risk first)
 
@@ -186,7 +185,14 @@ Status:
       vote guards read the detector. The tally tests moved from
       `GameServerDesync.test.ts` to `DesyncDetector.test.ts` (plus cadence and
       record tests); the turn-loop tests stay through `GameServer`.
-- [ ] `Consensus.ts`
+- [x] `Consensus.ts` (2026-08-26): `WinnerVote` (`cast`, `tally`,
+      `tallyAmong`, decided once) and `LiveStatsVote` (`cast` per client per
+      turn with the twenty-round window, `latest`). `GameServer` keeps the
+      desync / kick guards, `reportedWinner`, the electorate, the logging and
+      `archiveGame`, in the original order. The last two `archiveGame` spies
+      are gone: `WinnerVoteRetally`, the `GameServer` half of `LiveStats` and
+      `ArchivePlayerRecord` now join real clients, start, vote over the wire
+      and read the record off the injected `archive`. Reach-ins 68 → 36.
 - [ ] `ListingState.ts`
 - [ ] `MatchTelemetryRecorder.ts`
 

--- a/src/server/Consensus.ts
+++ b/src/server/Consensus.ts
@@ -1,0 +1,133 @@
+import { ClientID, ClientSendWinnerMessage, LiveStats } from "../core/Schemas";
+import { VoteRound } from "./VoteTally";
+
+// The simulation runs on the clients, so the outcomes the server has to
+// report — who won, and what the board looks like right now — exist only as
+// claims from clients. Both are settled by the same IP-weighted majority
+// vote (VoteTally.ts); these two classes keep the per-game state around it.
+// Who is allowed to vote (not a spectator, not desynced, not kicked) and
+// what happens once a vote settles are the game's business, not theirs.
+
+export interface VoteOutcome<T> {
+  value: T;
+  votes: number;
+}
+
+// The end-of-game winner vote. Decided once; the game guards against votes
+// arriving after that.
+export class WinnerVote {
+  private readonly round = new VoteRound<ClientSendWinnerMessage>();
+  private decided: ClientSendWinnerMessage | null = null;
+
+  // The winning message once a majority has backed one, else null.
+  winner(): ClientSendWinnerMessage | null {
+    return this.decided;
+  }
+
+  // Records a vote from `ip`. Returns the candidate's key and how many unique
+  // IPs back it after this vote.
+  cast(
+    msg: ClientSendWinnerMessage,
+    ip: string,
+  ): { key: string; votes: number } {
+    // A cancelled match ends with winner omitted; JSON.stringify(undefined)
+    // is not a string, so key those votes as "null".
+    const key = JSON.stringify(msg.winner ?? null);
+    return { key, votes: this.round.add(key, msg, ip) };
+  }
+
+  // Decides the vote if some candidate holds a strict majority of an
+  // electorate of `electorate` unique IPs.
+  tally(electorate: number): VoteOutcome<ClientSendWinnerMessage> | null {
+    const result = this.round.result(electorate);
+    if (result !== null) {
+      this.decided = result.value;
+    }
+    return result;
+  }
+
+  // Re-tally against a shrunken electorate: only votes from `activeIPs`
+  // count, and only against `activeIPs.size` (see VoteRound.resultAmong).
+  tallyAmong(
+    activeIPs: Set<string>,
+  ): VoteOutcome<ClientSendWinnerMessage> | null {
+    const result = this.round.resultAmong(activeIPs);
+    if (result !== null) {
+      this.decided = result.value;
+    }
+    return result;
+  }
+}
+
+// The running live-stats vote. Clients each send a snapshot every ~10s
+// tagged with the turn it was taken at; in-sync clients produce an identical
+// snapshot for a given turn, so a majority settles it and the latest settled
+// snapshot is what the admin bot reads.
+export class LiveStatsVote {
+  // Bound on the pending rounds in case consensus is never reached for some
+  // turns (e.g. a persistent desync). Maps iterate in insertion order and
+  // turns arrive ascending, so pruning drops the oldest pending rounds.
+  private static readonly MAX_PENDING_ROUNDS = 20;
+
+  // Tallies keyed by turn number; an entry is removed once consensus is
+  // reached for that turn (or a later one) so the map stays small.
+  private readonly rounds: Map<
+    number,
+    { round: VoteRound<LiveStats>; voters: Set<ClientID> }
+  > = new Map();
+  private settled: LiveStats | null = null;
+
+  // The latest snapshot a majority agreed on, or null before the first.
+  latest(): LiveStats | null {
+    return this.settled;
+  }
+
+  // Records a client's snapshot, one vote per client per turn, against an
+  // electorate of `electorate` unique IPs. Returns whether this vote settled
+  // its turn. Turns at or before the latest settled one are ignored.
+  cast(
+    clientID: ClientID,
+    ip: string,
+    stats: LiveStats,
+    electorate: number,
+  ): boolean {
+    const turn = stats.turn;
+    if (this.settled !== null && turn <= this.settled.turn) {
+      return false;
+    }
+
+    let entry = this.rounds.get(turn);
+    if (entry === undefined) {
+      entry = { round: new VoteRound<LiveStats>(), voters: new Set() };
+      this.rounds.set(turn, entry);
+      this.prune();
+    }
+    if (entry.voters.has(clientID)) {
+      return false;
+    }
+    entry.voters.add(clientID);
+
+    entry.round.add(JSON.stringify(stats), stats, ip);
+    const result = entry.round.result(electorate);
+    if (result === null) {
+      return false;
+    }
+
+    this.settled = result.value;
+    // This turn (and any older still-pending ones) are now settled.
+    for (const t of this.rounds.keys()) {
+      if (t <= turn) {
+        this.rounds.delete(t);
+      }
+    }
+    return true;
+  }
+
+  private prune(): void {
+    while (this.rounds.size > LiveStatsVote.MAX_PENDING_ROUNDS) {
+      const oldest = this.rounds.keys().next().value;
+      if (oldest === undefined) break;
+      this.rounds.delete(oldest);
+    }
+  }
+}

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -21,7 +21,6 @@ import {
   GameStartInfoSchema,
   HOSTED_LOBBY_AUTO_START_MS,
   Intent,
-  LiveStats,
   LobbyAccent,
   PartialGameRecord,
   PlayerLiveStats,
@@ -48,6 +47,7 @@ import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
 import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";
 import { applyGameConfigPatch, hostCheatsEnabled } from "./ConfigPatch";
+import { LiveStatsVote, WinnerVote } from "./Consensus";
 import { fetchCustomTribes } from "./CustomTribes";
 import { DesyncDetector } from "./DesyncDetector";
 import { friendsLookup, NameVisibility } from "./NameVisibility";
@@ -60,7 +60,6 @@ import {
   type MatchTelemetryType,
   type TelemetryPlayerIdentity,
 } from "./telemetry/MatchTelemetry";
-import { VoteRound } from "./VoteTally";
 export enum GamePhase {
   Lobby = "LOBBY",
   Active = "ACTIVE",
@@ -178,8 +177,6 @@ export class GameServer {
 
   private lastPingUpdate = 0;
 
-  private winner: ClientSendWinnerMessage | null = null;
-
   // Note: This can be undefined if accessed before the game starts.
   private gameStartInfo!: GameStartInfo;
   // Wire-only copy of gameStartInfo sent to clients. Identical to
@@ -207,17 +204,10 @@ export class GameServer {
 
   private websockets: Set<WebSocket> = new Set();
 
-  private winnerVotes = new VoteRound<ClientSendWinnerMessage>();
-
-  // Per-turn consensus on the live stats snapshot (see handleLiveStats).
-  // Tallies are keyed by turn number; an entry is removed once consensus is
-  // reached for that turn (or a later one) so the map stays small.
-  private liveStatsVotes: Map<
-    number,
-    { round: VoteRound<LiveStats>; voters: Set<ClientID> }
-  > = new Map();
-  private latestLiveStats: LiveStats | null = null;
-  private static readonly MAX_PENDING_LIVE_STATS_ROUNDS = 20;
+  // The end-of-game winner vote and the running live-stats vote: both
+  // IP-weighted majorities among the players (see Consensus.ts).
+  private readonly winnerVote = new WinnerVote();
+  private readonly liveStatsVote = new LiveStatsVote();
 
   private _hasEnded = false;
 
@@ -1523,7 +1513,7 @@ export class GameServer {
         this.log.info("no clients joined, not archiving game", {
           gameID: this.id,
         });
-      } else if (this.winner !== null) {
+      } else if (this.winnerVote.winner() !== null) {
         this.log.info("game already archived", {
           gameID: this.id,
         });
@@ -1844,15 +1834,16 @@ export class GameServer {
   }
 
   private archiveGame() {
+    const winner = this.winnerVote.winner();
     this.log.info("archiving game", {
       gameID: this.id,
-      winner: this.winner?.winner,
+      winner: winner?.winner,
     });
 
     // Players must stay in the same order as the game start info.
     const playerRecords: PlayerRecord[] = this.gameStartInfo.players.map(
       (player) => {
-        const stats = this.winner?.allPlayersStats[player.clientID];
+        const stats = winner?.allPlayersStats[player.clientID];
         if (stats === undefined) {
           this.log.warn(`Unable to find stats for clientID ${player.clientID}`);
         }
@@ -1883,7 +1874,7 @@ export class GameServer {
         this.turns,
         this._startTime ?? 0,
         Date.now(),
-        this.winner?.winner,
+        winner?.winner,
         this.createdAt,
         this.visibleAt,
         this.gameStartInfo.tribes,
@@ -1936,18 +1927,18 @@ export class GameServer {
     if (
       this.desync.isDesynced(client.clientID) ||
       this.isKicked(client.clientID) ||
-      this.winner !== null ||
+      this.winnerVote.winner() !== null ||
       client.reportedWinner !== null
     ) {
       return;
     }
     client.reportedWinner = clientMsg.winner;
 
-    // Add client vote. A cancelled match ends with winner omitted;
-    // JSON.stringify(undefined) is not a string, so key those votes as "null".
-    const winnerKey = JSON.stringify(clientMsg.winner ?? null);
     const activeUniqueIPs = this.votingUniqueIPs();
-    const votes = this.winnerVotes.add(winnerKey, clientMsg, client.ip);
+    const { key: winnerKey, votes } = this.winnerVote.cast(
+      clientMsg,
+      client.ip,
+    );
 
     this.log.info(
       `received winner vote ${clientMsg.winner}, ${votes}/${activeUniqueIPs} votes for this winner`,
@@ -1956,13 +1947,12 @@ export class GameServer {
       },
     );
 
-    const result = this.winnerVotes.result(activeUniqueIPs);
+    const result = this.winnerVote.tally(activeUniqueIPs);
     if (result === null) {
       return;
     }
 
     // Vote succeeded
-    this.winner = result.value;
     this.log.info(
       `Winner determined by ${result.votes}/${activeUniqueIPs} active IPs`,
       {
@@ -1980,15 +1970,14 @@ export class GameServer {
   // winnerless (e.g. game s5bcKtj8). Re-tally whenever the electorate
   // shrinks, counting only votes from still-active IPs (see resultAmong).
   private checkWinnerAfterElectorateShrink() {
-    if (this.winner !== null || this._hasEnded) {
+    if (this.winnerVote.winner() !== null || this._hasEnded) {
       return;
     }
     const activeIPs = new Set(this.activeClients.map((c) => c.ip));
-    const result = this.winnerVotes.resultAmong(activeIPs);
+    const result = this.winnerVote.tallyAmong(activeIPs);
     if (result === null) {
       return;
     }
-    this.winner = result.value;
     this.log.info(
       `Winner determined by ${result.votes}/${activeIPs.size} active IPs after electorate shrank`,
     );
@@ -2009,52 +1998,12 @@ export class GameServer {
     ) {
       return;
     }
-    const stats = clientMsg.stats;
-    const turn = stats.turn;
-    // Ignore turns we've already reached consensus on (or older ones).
-    if (this.latestLiveStats !== null && turn <= this.latestLiveStats.turn) {
-      return;
-    }
-
-    let entry = this.liveStatsVotes.get(turn);
-    if (entry === undefined) {
-      entry = { round: new VoteRound<LiveStats>(), voters: new Set() };
-      this.liveStatsVotes.set(turn, entry);
-      this.pruneLiveStatsVotes();
-    }
-    // One vote per client per turn.
-    if (entry.voters.has(client.clientID)) {
-      return;
-    }
-    entry.voters.add(client.clientID);
-
-    const activeUniqueIPs = this.votingUniqueIPs();
-    entry.round.add(JSON.stringify(stats), stats, client.ip);
-    const result = entry.round.result(activeUniqueIPs);
-    if (result === null) {
-      return;
-    }
-
-    this.latestLiveStats = result.value;
-    // This turn (and any older still-pending ones) are now settled.
-    for (const t of this.liveStatsVotes.keys()) {
-      if (t <= turn) {
-        this.liveStatsVotes.delete(t);
-      }
-    }
-  }
-
-  // Bound the pending-vote map in case consensus is never reached for some
-  // turns (e.g. a persistent desync). Maps iterate in insertion order and turns
-  // arrive ascending, so this drops the oldest pending rounds.
-  private pruneLiveStatsVotes() {
-    while (
-      this.liveStatsVotes.size > GameServer.MAX_PENDING_LIVE_STATS_ROUNDS
-    ) {
-      const oldest = this.liveStatsVotes.keys().next().value;
-      if (oldest === undefined) break;
-      this.liveStatsVotes.delete(oldest);
-    }
+    this.liveStatsVote.cast(
+      client.clientID,
+      client.ip,
+      clientMsg.stats,
+      this.votingUniqueIPs(),
+    );
   }
 
   // Latest majority-agreed live stats snapshot, with players enriched with
@@ -2072,14 +2021,15 @@ export class GameServer {
       connected: boolean;
     })[];
   } | null {
-    if (this.latestLiveStats === null) {
+    const latest = this.liveStatsVote.latest();
+    if (latest === null) {
       return null;
     }
-    const w = this.winner?.winner;
+    const w = this.winnerVote.winner()?.winner;
     return {
-      turn: this.latestLiveStats.turn,
+      turn: latest.turn,
       winner: w?.[0] === "player" ? w[1] : null,
-      players: this.latestLiveStats.players.map((p) => {
+      players: latest.players.map((p) => {
         const client = this.allClients.get(p.clientID);
         return {
           ...p,

--- a/tests/server/ArchivePlayerRecord.test.ts
+++ b/tests/server/ArchivePlayerRecord.test.ts
@@ -1,137 +1,139 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
-
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameType } from "../../src/core/game/Game";
 import { PartialGameRecord } from "../../src/core/Schemas";
-import { GameServer } from "../../src/server/GameServer";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
 
-// The upload the game hands its finished record to.
-const archive = vi.fn(async (_record: PartialGameRecord) => {});
+// What the game writes into the record it archives, driven through real
+// joins and starts and read off the injected archive.
 
-describe("archiveGame player records", () => {
-  let mockLogger: any;
+// Lets the fetchTribes .then/.catch chain settle.
+async function flushMicrotasks() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
+describe("archived game records", () => {
+  let archive: ReturnType<
+    typeof vi.fn<(r: PartialGameRecord) => Promise<void>>
+  >;
 
   beforeEach(() => {
-    vi.clearAllMocks();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    vi.useFakeTimers();
+    archive = vi.fn(async () => {});
   });
 
-  it("preserves simulation inputs (teamIndex, friends, isLobbyCreator) so replays stay in sync", () => {
-    const game = new GameServer(
-      {
-        id: "test-game",
-        log: mockLogger,
-        createdAt: Date.now(),
-        gameConfig: { gameType: GameType.Public } as any,
-      },
-      { archive },
-    );
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
 
+  const archived = () => archive.mock.calls[0][0];
+
+  it("preserves simulation inputs (teamIndex, friends, isLobbyCreator) so replays stay in sync", async () => {
     // Matchmade 2v2: the server stamps teamIndex on the game start info and
     // every client pins teams from it. The archived record is replayed
     // through the same team assignment, so these fields must survive
     // archiving — dropping them makes replays re-derive different teams and
     // desync from the recorded hashes.
-    (game as any).gameStartInfo = {
-      gameID: "test-game",
-      lobbyCreatedAt: 0,
+    const ALICE = cid("alice");
+    const BOB = cid("bob");
+    const game = makeGame({
       config: { gameType: GameType.Public },
-      players: [
-        {
-          clientID: "clientAAA",
-          username: "alice",
-          clanTag: "AA",
-          cosmetics: {},
-          isLobbyCreator: true,
-          friends: ["clientBBB"],
-          teamIndex: 0,
-        },
-        {
-          clientID: "clientBBB",
-          username: "bob",
-          clanTag: null,
-          cosmetics: {},
-          isLobbyCreator: false,
-          friends: [],
-          teamIndex: 1,
-        },
-      ],
-    };
+      creatorPersistentID: "alice-pid",
+      matchmakingTeams: [["alice-pub"], ["bob-pub"]],
+      deps: { archive },
+    });
+    const alice = makeClient({
+      clientID: ALICE,
+      persistentID: "alice-pid",
+      username: "alice",
+      clanTag: "AA",
+      publicId: "alice-pub",
+      friends: ["bob-pub"],
+      ip: "1.1.1.1",
+    });
+    const bob = makeClient({
+      clientID: BOB,
+      persistentID: "bob-pid",
+      username: "bob",
+      publicId: "bob-pub",
+      ip: "2.2.2.2",
+    });
+    game.joinClient(alice);
+    game.joinClient(bob);
+    startGame(game);
 
-    (game as any).archiveGame();
+    // Both back the same winner: 2 of 2 IPs archives the game.
+    for (const c of [alice, bob]) {
+      await mockWsOf(c).emit({
+        type: "winner",
+        winner: ["player", ALICE],
+        allPlayersStats: {},
+      });
+    }
 
     expect(archive).toHaveBeenCalledTimes(1);
-    const record = vi.mocked(archive).mock.calls[0][0] as any;
-    const [alice, bob] = record.info.players;
-
-    expect(alice).toMatchObject({
-      clientID: "clientAAA",
+    const [a, b] = archived().info.players;
+    expect(a).toMatchObject({
+      clientID: ALICE,
+      username: "alice",
+      clanTag: "AA",
+      persistentID: "alice-pid",
       teamIndex: 0,
-      friends: ["clientBBB"],
+      friends: [BOB],
       isLobbyCreator: true,
     });
-    expect(bob).toMatchObject({
-      clientID: "clientBBB",
+    expect(b).toMatchObject({
+      clientID: BOB,
       teamIndex: 1,
-      friends: [],
       isLobbyCreator: false,
     });
+    // No friends in the game is recorded as the field being absent.
+    expect(b.friends).toBeUndefined();
+    expect(archived().info.winner).toEqual(["player", ALICE]);
   });
 
-  it("carries custom tribe names into the archived record for infra ingest and replays", () => {
-    const game = new GameServer(
-      {
-        id: "test-game",
-        log: mockLogger,
-        createdAt: Date.now(),
-        gameConfig: { gameType: GameType.Public } as any,
-      },
-      { archive },
-    );
+  it("carries custom tribe names into the archived record for infra ingest and replays", async () => {
+    const fetchTribes = vi.fn(async () => [
+      { name: "Dragon Riders" },
+      { name: "Night Wolves" },
+    ]);
+    const game = makeGame({
+      config: { gameType: GameType.Public, bots: 2 },
+      deps: { archive, fetchTribes },
+    });
+    game.joinClient(makeClient({ publicId: "someone-pub" }));
 
-    (game as any).gameStartInfo = {
-      gameID: "test-game",
-      lobbyCreatedAt: 0,
-      config: { gameType: GameType.Public },
-      players: [],
-      tribes: [{ name: "Dragon Riders" }, { name: "Night Wolves" }],
-    };
-
-    (game as any).archiveGame();
+    game.prestart();
+    await flushMicrotasks();
+    game.start();
+    // Ending an unfinished game archives it as it stands.
+    await game.end();
 
     expect(archive).toHaveBeenCalledTimes(1);
-    const record = vi.mocked(archive).mock.calls[0][0] as any;
-    expect(record.info.tribes).toEqual([
+    expect(archived().info.tribes).toEqual([
       { name: "Dragon Riders" },
       { name: "Night Wolves" },
     ]);
   });
 
-  it("omits tribes from the archived record when none were fetched", () => {
-    const game = new GameServer(
-      {
-        id: "test-game",
-        log: mockLogger,
-        createdAt: Date.now(),
-        gameConfig: { gameType: GameType.Public } as any,
-      },
-      { archive },
-    );
+  it("omits tribes from the archived record when none were fetched", async () => {
+    const game = makeGame({
+      config: { gameType: GameType.Public, bots: 2 },
+      deps: { archive },
+    });
+    game.joinClient(makeClient());
 
-    (game as any).gameStartInfo = {
-      gameID: "test-game",
-      lobbyCreatedAt: 0,
-      config: { gameType: GameType.Public },
-      players: [],
-    };
+    startGame(game);
+    await game.end();
 
-    (game as any).archiveGame();
-
-    const record = vi.mocked(archive).mock.calls[0][0] as any;
-    expect(record.info.tribes).toBeUndefined();
+    expect(archive).toHaveBeenCalledTimes(1);
+    expect(archived().info.tribes).toBeUndefined();
   });
 });

--- a/tests/server/Consensus.test.ts
+++ b/tests/server/Consensus.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from "vitest";
+import { ClientSendWinnerMessage, LiveStats } from "../../src/core/Schemas";
+import { LiveStatsVote, WinnerVote } from "../../src/server/Consensus";
+import { cid } from "../util/GameServerHarness";
+
+// The two vote objects on their own. Who may vote and what a settled vote
+// triggers are GameServer's business, covered in WinnerVoteRetally.test.ts
+// and LiveStats.test.ts.
+
+const P1 = cid("p1");
+const P2 = cid("p2");
+
+const winnerMsg = (
+  winner: ClientSendWinnerMessage["winner"],
+): ClientSendWinnerMessage => ({ type: "winner", winner, allPlayersStats: {} });
+
+describe("WinnerVote", () => {
+  it("decides once a candidate holds a strict majority of the electorate", () => {
+    const vote = new WinnerVote();
+    expect(vote.cast(winnerMsg(["player", P1]), "1.1.1.1").votes).toBe(1);
+    // 1 of 2 is a tie, not a majority.
+    expect(vote.tally(2)).toBeNull();
+    expect(vote.winner()).toBeNull();
+
+    expect(vote.cast(winnerMsg(["player", P1]), "2.2.2.2").votes).toBe(2);
+    expect(vote.tally(2)).toEqual({
+      value: winnerMsg(["player", P1]),
+      votes: 2,
+    });
+    expect(vote.winner()?.winner).toEqual(["player", P1]);
+  });
+
+  it("counts one vote per IP per candidate", () => {
+    const vote = new WinnerVote();
+    vote.cast(winnerMsg(["player", P1]), "1.1.1.1");
+    expect(vote.cast(winnerMsg(["player", P1]), "1.1.1.1").votes).toBe(1);
+    expect(vote.tally(2)).toBeNull();
+  });
+
+  it("keys a cancelled match (no winner) as null so those votes can agree", () => {
+    const vote = new WinnerVote();
+    expect(vote.cast(winnerMsg(undefined), "1.1.1.1").key).toBe("null");
+    vote.cast(winnerMsg(undefined), "2.2.2.2");
+    expect(vote.tally(2)?.value.winner).toBeUndefined();
+  });
+
+  it("re-tallies among the IPs still present, ignoring the departed", () => {
+    const vote = new WinnerVote();
+    vote.cast(winnerMsg(["player", P1]), "1.1.1.1");
+    vote.cast(winnerMsg(["player", P2]), "2.2.2.2");
+    expect(vote.tally(2)).toBeNull();
+
+    // 2.2.2.2 left: their vote no longer counts, and the electorate is one.
+    expect(vote.tallyAmong(new Set(["1.1.1.1"]))).toEqual({
+      value: winnerMsg(["player", P1]),
+      votes: 1,
+    });
+    expect(vote.winner()?.winner).toEqual(["player", P1]);
+  });
+
+  it("does not let a departed voter's own vote decide anything", () => {
+    const vote = new WinnerVote();
+    vote.cast(winnerMsg(["player", P2]), "2.2.2.2");
+    expect(vote.tallyAmong(new Set(["1.1.1.1"]))).toBeNull();
+    expect(vote.winner()).toBeNull();
+  });
+});
+
+describe("LiveStatsVote", () => {
+  const stats = (turn: number, tilesOwned: number): LiveStats => ({
+    turn,
+    players: [
+      {
+        clientID: P1,
+        tilesOwned,
+        troops: 5,
+        gold: "100",
+        isAlive: true,
+        team: null,
+        killedBy: null,
+        deathPosition: null,
+      },
+    ],
+  });
+
+  it("settles a turn at a strict majority of the electorate", () => {
+    const vote = new LiveStatsVote();
+    expect(vote.cast("c1", "1.1.1.1", stats(100, 10), 3)).toBe(false);
+    expect(vote.latest()).toBeNull();
+    expect(vote.cast("c2", "2.2.2.2", stats(100, 10), 3)).toBe(true);
+    expect(vote.latest()).toEqual(stats(100, 10));
+  });
+
+  it("does not settle when the snapshots disagree", () => {
+    const vote = new LiveStatsVote();
+    vote.cast("c1", "1.1.1.1", stats(100, 10), 3);
+    vote.cast("c2", "2.2.2.2", stats(100, 20), 3);
+    expect(vote.cast("c3", "3.3.3.3", stats(100, 30), 3)).toBe(false);
+    expect(vote.latest()).toBeNull();
+  });
+
+  it("takes one vote per client per turn", () => {
+    const vote = new LiveStatsVote();
+    vote.cast("c1", "1.1.1.1", stats(100, 10), 3);
+    // The same client backing a different snapshot is ignored, so neither
+    // candidate can reach a majority from this one client.
+    expect(vote.cast("c1", "1.1.1.1", stats(100, 20), 3)).toBe(false);
+    expect(vote.cast("c2", "2.2.2.2", stats(100, 20), 3)).toBe(false);
+    expect(vote.latest()).toBeNull();
+  });
+
+  it("ignores turns at or before the latest settled one", () => {
+    const vote = new LiveStatsVote();
+    vote.cast("c1", "1.1.1.1", stats(100, 10), 3);
+    vote.cast("c2", "2.2.2.2", stats(100, 10), 3);
+    expect(vote.cast("c1", "1.1.1.1", stats(50, 99), 3)).toBe(false);
+    expect(vote.cast("c2", "2.2.2.2", stats(50, 99), 3)).toBe(false);
+    expect(vote.latest()?.turn).toBe(100);
+  });
+
+  it("advances to a newer turn once it settles", () => {
+    const vote = new LiveStatsVote();
+    vote.cast("c1", "1.1.1.1", stats(100, 10), 3);
+    vote.cast("c2", "2.2.2.2", stats(100, 10), 3);
+    vote.cast("c1", "1.1.1.1", stats(200, 42), 3);
+    expect(vote.cast("c2", "2.2.2.2", stats(200, 42), 3)).toBe(true);
+    expect(vote.latest()).toEqual(stats(200, 42));
+  });
+
+  it("drops the oldest pending turn once more than twenty are waiting", () => {
+    const vote = new LiveStatsVote();
+    // c1 alone cannot settle anything against an electorate of five...
+    vote.cast("c1", "1.1.1.1", stats(0, 1), 5);
+    // ...and twenty newer pending turns push turn 0 out of the window.
+    for (let turn = 1; turn <= 20; turn++) {
+      vote.cast("c1", "1.1.1.1", stats(turn, 1), 5);
+    }
+    // Turn 0's round is gone, so c1 is no longer a recorded voter for it and
+    // a fresh vote is accepted; alone against an electorate of one it wins.
+    expect(vote.cast("c1", "1.1.1.1", stats(0, 1), 1)).toBe(true);
+    expect(vote.latest()?.turn).toBe(0);
+  });
+
+  it("keeps a pending turn that is still within the window", () => {
+    const vote = new LiveStatsVote();
+    vote.cast("c1", "1.1.1.1", stats(0, 1), 5);
+    for (let turn = 1; turn <= 19; turn++) {
+      vote.cast("c1", "1.1.1.1", stats(turn, 1), 5);
+    }
+    // Twenty pending in total: turn 0 is still there, so c1's repeat vote
+    // for it is a duplicate and is ignored.
+    expect(vote.cast("c1", "1.1.1.1", stats(0, 1), 1)).toBe(false);
+    expect(vote.latest()).toBeNull();
+  });
+});

--- a/tests/server/LiveStats.test.ts
+++ b/tests/server/LiveStats.test.ts
@@ -1,60 +1,53 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { GameType } from "../../src/core/game/Game";
 import { PlayerLiveStats } from "../../src/core/Schemas";
 import { registerAdminBotRoutes } from "../../src/server/AdminBotRoutes";
-import { GameServer } from "../../src/server/GameServer";
+import { Client } from "../../src/server/Client";
 import { ServerEnv } from "../../src/server/ServerEnv";
+import {
+  makeClient,
+  makeGame,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
+
+const TURN_MS = 100;
 
 describe("GameServer.handleLiveStats", () => {
-  let mockLogger: any;
-
   beforeEach(() => {
     vi.useFakeTimers();
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    vi.setSystemTime(1_700_000_000_000);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllTimers();
+    vi.useRealTimers();
   });
 
-  function makeClient(clientID: string, ip: string, username: string) {
-    return {
-      clientID,
-      ip,
-      persistentID: `pid-${clientID}`,
-      username,
-      publicId: clientID.replace("client", "public"), // 8-char ID, e.g. public01
-    } as any;
-  }
-
-  // A GameServer with three distinct-IP active clients wired up.
+  // A game with three distinct-IP players in the lobby.
   function gameWithClients() {
-    const game = new GameServer({
-      id: "test-game",
-      log: mockLogger,
-      createdAt: Date.now(),
-      gameConfig: { gameType: GameType.Private } as any,
-    });
+    const game = makeGame();
     const clients = [
-      makeClient("client01", "1.1.1.1", "Alice"),
-      makeClient("client02", "2.2.2.2", "Bob"),
-      makeClient("client03", "3.3.3.3", "Carol"),
+      makeClient({
+        clientID: "client01",
+        ip: "1.1.1.1",
+        username: "Alice",
+        publicId: "public01",
+      }),
+      makeClient({
+        clientID: "client02",
+        ip: "2.2.2.2",
+        username: "Bob",
+        publicId: "public02",
+      }),
+      makeClient({
+        clientID: "client03",
+        ip: "3.3.3.3",
+        username: "Carol",
+        publicId: "public03",
+      }),
     ];
-    (game as any).activeClients = clients;
-    const allClients = new Map<string, unknown>();
-    const disconnected = new Map<string, boolean>();
-    for (const c of clients) {
-      allClients.set(c.clientID, c);
-      disconnected.set(c.clientID, false); // all connected
-    }
-    (game as any).allClients = allClients;
-    (game as any).clientsDisconnectedStatus = disconnected;
+    for (const c of clients) game.joinClient(c);
     return { game, clients };
   }
 
@@ -71,26 +64,19 @@ describe("GameServer.handleLiveStats", () => {
     },
   ];
 
-  const report = (
-    game: GameServer,
-    client: any,
-    turn: number,
-    players: PlayerLiveStats[],
-  ) =>
-    (game as any).handleLiveStats(client, {
-      type: "live_stats",
-      stats: { turn, players },
-    });
+  // What a client does every ~10s: send its snapshot of the board.
+  const report = (client: Client, turn: number, players: PlayerLiveStats[]) =>
+    mockWsOf(client).emit({ type: "live_stats", stats: { turn, players } });
 
-  it("reaches consensus at a strict majority and enriches usernames", () => {
+  it("reaches consensus at a strict majority and enriches usernames", async () => {
     const { game, clients } = gameWithClients();
     const players = snapshot(10);
 
-    report(game, clients[0], 100, players);
+    await report(clients[0], 100, players);
     // 1 of 3 IPs -> not yet.
     expect(game.liveStats()).toBeNull();
 
-    report(game, clients[1], 100, players);
+    await report(clients[1], 100, players);
     // 2 of 3 IPs -> consensus.
     expect(game.liveStats()).toEqual({
       turn: 100,
@@ -106,55 +92,60 @@ describe("GameServer.handleLiveStats", () => {
     });
   });
 
-  it("reports server-side connection status per player", () => {
+  it("reports server-side connection status per player", async () => {
     const { game, clients } = gameWithClients();
-    // client01 (the only player in the snapshot) has dropped.
-    (game as any).clientsDisconnectedStatus.set("client01", true);
+    startGame(game);
+    // client01 (the only player in the snapshot) went quiet: the turn loop
+    // marks them disconnected at the next 5-turn boundary.
+    clients[0].lastPing = Date.now() - 31_000;
+    vi.advanceTimersByTime(5 * TURN_MS);
+    expect(game.isClientDisconnected("client01")).toBe(true);
+
     const players = snapshot(10);
-    report(game, clients[0], 100, players);
-    report(game, clients[1], 100, players);
+    await report(clients[0], 100, players);
+    await report(clients[1], 100, players);
     expect(game.liveStats()?.players[0].connected).toBe(false);
   });
 
-  it("does not reach consensus when clients disagree", () => {
+  it("does not reach consensus when clients disagree", async () => {
     const { game, clients } = gameWithClients();
-    report(game, clients[0], 100, snapshot(10));
-    report(game, clients[1], 100, snapshot(20));
-    report(game, clients[2], 100, snapshot(30));
+    await report(clients[0], 100, snapshot(10));
+    await report(clients[1], 100, snapshot(20));
+    await report(clients[2], 100, snapshot(30));
     expect(game.liveStats()).toBeNull();
   });
 
-  it("ignores a second vote from the same client in a turn", () => {
+  it("ignores a second vote from the same client in a turn", async () => {
     const { game, clients } = gameWithClients();
-    report(game, clients[0], 100, snapshot(10));
+    await report(clients[0], 100, snapshot(10));
     // Same client trying to back a different snapshot is ignored, so neither
     // candidate can reach a majority from this one client.
-    report(game, clients[0], 100, snapshot(20));
-    report(game, clients[1], 100, snapshot(20));
+    await report(clients[0], 100, snapshot(20));
+    await report(clients[1], 100, snapshot(20));
     expect(game.liveStats()).toBeNull();
   });
 
-  it("ignores stats for a turn already settled", () => {
+  it("ignores stats for a turn already settled", async () => {
     const { game, clients } = gameWithClients();
     const players = snapshot(10);
-    report(game, clients[0], 100, players);
-    report(game, clients[1], 100, players);
+    await report(clients[0], 100, players);
+    await report(clients[1], 100, players);
     expect(game.liveStats()?.turn).toBe(100);
 
     // Late/old turns must not overwrite the latest snapshot.
-    report(game, clients[0], 50, snapshot(99));
-    report(game, clients[1], 50, snapshot(99));
+    await report(clients[0], 50, snapshot(99));
+    await report(clients[1], 50, snapshot(99));
     expect(game.liveStats()?.turn).toBe(100);
   });
 
-  it("advances to a newer turn once it reaches consensus", () => {
+  it("advances to a newer turn once it reaches consensus", async () => {
     const { game, clients } = gameWithClients();
-    report(game, clients[0], 100, snapshot(10));
-    report(game, clients[1], 100, snapshot(10));
+    await report(clients[0], 100, snapshot(10));
+    await report(clients[1], 100, snapshot(10));
     expect(game.liveStats()?.turn).toBe(100);
 
-    report(game, clients[0], 200, snapshot(42));
-    report(game, clients[1], 200, snapshot(42));
+    await report(clients[0], 200, snapshot(42));
+    await report(clients[1], 200, snapshot(42));
     expect(game.liveStats()).toEqual({
       turn: 200,
       winner: null,
@@ -169,11 +160,19 @@ describe("GameServer.handleLiveStats", () => {
     });
   });
 
-  it("ignores out-of-sync clients", () => {
+  it("ignores out-of-sync clients", async () => {
     const { game, clients } = gameWithClients();
-    (game as any).desync.record([clients[0]]);
-    report(game, clients[0], 100, snapshot(10));
-    report(game, clients[1], 100, snapshot(10));
+    startGame(game);
+    // client01 reports a different hash for turn 0 than the other two; the
+    // check ten turns later marks them desynced.
+    await mockWsOf(clients[0]).emit({ type: "hash", hash: 1, turnNumber: 0 });
+    await mockWsOf(clients[1]).emit({ type: "hash", hash: 2, turnNumber: 0 });
+    await mockWsOf(clients[2]).emit({ type: "hash", hash: 2, turnNumber: 0 });
+    vi.advanceTimersByTime(10 * TURN_MS);
+    expect(game.numDesyncedClients()).toBe(1);
+
+    await report(clients[0], 100, snapshot(10));
+    await report(clients[1], 100, snapshot(10));
     // Only client02's vote counted (1 of 3) -> no consensus.
     expect(game.liveStats()).toBeNull();
   });

--- a/tests/server/WinnerVoteRetally.test.ts
+++ b/tests/server/WinnerVoteRetally.test.ts
@@ -1,111 +1,109 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameType } from "../../src/core/game/Game";
-import { GameServer } from "../../src/server/GameServer";
+import { PartialGameRecord, Winner } from "../../src/core/Schemas";
+import { Client } from "../../src/server/Client";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
 
 // Regression tests for game s5bcKtj8: in a 1v1 the loser disconnected within
 // a second of being eliminated, before their client simulated the win tick
 // and voted. The winner's vote sat at 1 of 2 active IPs and was never
 // re-evaluated, so the game archived winnerless. The electorate shrinking
 // must now trigger a re-tally.
+//
+// Driven through the real game: two players join and start, votes arrive as
+// winner messages on their sockets, and the outcome is whatever record the
+// game hands to the archive.
 describe("winner vote re-tally when the electorate shrinks", () => {
-  let mockLogger: any;
+  const WINNER = cid("winner");
+  const LOSER = cid("loser");
+  let archive: ReturnType<
+    typeof vi.fn<(r: PartialGameRecord) => Promise<void>>
+  >;
 
   beforeEach(() => {
-    mockLogger = {
-      child: vi.fn().mockReturnThis(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+    archive = vi.fn(async () => {});
   });
 
-  function makeClient(clientID: string, ip: string) {
-    return {
-      clientID,
-      ip,
-      persistentID: `pid-${clientID}`,
-      username: clientID,
-      reportedWinner: null,
-      hashes: new Map(),
-      lastPing: Date.now(),
-      ws: { readyState: 3, close: vi.fn(), OPEN: 1 },
-    } as any;
-  }
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
 
   function game1v1() {
-    const game = new GameServer({
-      id: "test-game",
-      log: mockLogger,
-      createdAt: Date.now(),
-      gameConfig: { gameType: GameType.Public } as any,
+    const game = makeGame({
+      config: { gameType: GameType.Public },
+      deps: { archive },
     });
-    const winner = makeClient("client01", "1.1.1.1");
-    const loser = makeClient("client02", "2.2.2.2");
-    (game as any).activeClients = [winner, loser];
-    (game as any).allClients = new Map([
-      ["client01", winner],
-      ["client02", loser],
-    ]);
-    (game as any)._hasStarted = true;
-    (game as any).archiveGame = vi.fn();
+    const winner = makeClient({ clientID: WINNER, ip: "1.1.1.1" });
+    const loser = makeClient({ clientID: LOSER, ip: "2.2.2.2" });
+    game.joinClient(winner);
+    game.joinClient(loser);
+    startGame(game);
     return { game, winner, loser };
   }
 
-  const vote = (game: GameServer, client: any, winner: any) =>
-    (game as any).handleWinner(client, {
-      type: "winner",
-      winner,
-      allPlayersStats: {},
-    });
+  const vote = (client: Client, winner: Winner) =>
+    mockWsOf(client).emit({ type: "winner", winner, allPlayersStats: {} });
+  const disconnect = (client: Client) => mockWsOf(client).trigger("close");
+  // The winner in each record the game archived, in order.
+  const archivedWinners = () =>
+    archive.mock.calls.map(([record]) => record.info.winner);
 
-  it("resolves a wedged 1v1 vote when the non-voting loser disconnects", () => {
-    const { game, winner, loser } = game1v1();
-    vote(game, winner, ["player", "client01"]);
+  it("resolves a wedged 1v1 vote when the non-voting loser disconnects", async () => {
+    const { winner, loser } = game1v1();
+    await vote(winner, ["player", WINNER]);
     // 1 of 2 active IPs is not a strict majority: nothing archived yet.
-    expect((game as any).winner).toBeNull();
-    expect((game as any).archiveGame).not.toHaveBeenCalled();
+    expect(archive).not.toHaveBeenCalled();
 
-    (game as any).handleClientDisconnect(loser);
+    await disconnect(loser);
 
-    expect((game as any).winner?.winner).toEqual(["player", "client01"]);
-    expect((game as any).archiveGame).toHaveBeenCalledTimes(1);
+    expect(archivedWinners()).toEqual([["player", WINNER]]);
   });
 
-  it("does not crown a player who votes for themselves and disconnects", () => {
-    const { game, loser: cheater } = game1v1();
-    vote(game, cheater, ["player", "client02"]);
-    (game as any).handleClientDisconnect(cheater);
+  it("does not crown a player who votes for themselves and disconnects", async () => {
+    const { loser: cheater } = game1v1();
+    await vote(cheater, ["player", LOSER]);
+    await disconnect(cheater);
     // The departed cheater's vote must not count against the shrunken
     // electorate (#4136).
-    expect((game as any).winner).toBeNull();
-    expect((game as any).archiveGame).not.toHaveBeenCalled();
+    expect(archive).not.toHaveBeenCalled();
   });
 
-  it("stays winnerless when everyone leaves without any votes", () => {
-    const { game, winner, loser } = game1v1();
-    (game as any).handleClientDisconnect(loser);
-    (game as any).handleClientDisconnect(winner);
-    expect((game as any).winner).toBeNull();
-    expect((game as any).archiveGame).not.toHaveBeenCalled();
+  it("stays winnerless when everyone leaves without any votes", async () => {
+    const { winner, loser } = game1v1();
+    await disconnect(loser);
+    await disconnect(winner);
+    expect(archive).not.toHaveBeenCalled();
   });
 
-  it("does not archive again after the game already ended", () => {
+  it("does not archive a winner after the game already ended", async () => {
     const { game, winner, loser } = game1v1();
-    vote(game, winner, ["player", "client01"]);
-    (game as any)._hasEnded = true;
-    (game as any).handleClientDisconnect(loser);
-    expect((game as any).winner).toBeNull();
-    expect((game as any).archiveGame).not.toHaveBeenCalled();
+    await vote(winner, ["player", WINNER]);
+    // Ending archives the game as it stands: winnerless.
+    await game.end();
+    expect(archivedWinners()).toEqual([undefined]);
+
+    // The loser's socket closing afterwards must not re-tally and archive a
+    // second, contradicting record.
+    await disconnect(loser);
+    expect(archivedWinners()).toEqual([undefined]);
   });
 
-  it("re-tallies when the ping prune in phase() drops a stale client", () => {
+  it("re-tallies when the ping prune in phase() drops a stale client", async () => {
     const { game, winner, loser } = game1v1();
-    vote(game, winner, ["player", "client01"]);
+    await vote(winner, ["player", WINNER]);
     // The loser's connection dropped without a ws close event: pings stop,
     // and only the 60s prune in phase() removes them from activeClients.
     loser.lastPing = Date.now() - 61_000;
     game.phase();
-    expect((game as any).winner?.winner).toEqual(["player", "client01"]);
-    expect((game as any).archiveGame).toHaveBeenCalledTimes(1);
+    expect(archivedWinners()).toEqual([["player", WINNER]]);
   });
 });


### PR DESCRIPTION
## Summary

Phase 3 of `docs/GameServerRefactor.md`, fourth of six module extractions (previous: #5114, #5116, #5117, #5122, #5124, #5126). A pure move with no behaviour change — the golden wire snapshot is untouched.

- **`src/server/Consensus.ts`** (new): the two IP-weighted majority votes the game runs over client claims. `WinnerVote` — `cast(msg, ip)` keys the vote (a cancelled match's missing winner as `"null"`), `tally(electorate)` / `tallyAmong(activeIPs)` decide and remember it. `LiveStatsVote` — `cast(clientID, ip, stats, electorate)` takes one vote per client per turn, ignores turns at or before the latest settled one, keeps at most twenty pending rounds, and reports whether the turn settled.
- **`GameServer`** keeps what is the game's business, in the original order: the desync / kick guards, `reportedWinner`, the electorate (`votingUniqueIPs`, and the plain active-IP set for the shrink re-tally — preserved as-is), the logging and `archiveGame`. Net −50 lines.
- **Tests — the point of this PR:** the last two `archiveGame` spies are gone. `WinnerVoteRetally.test.ts`, the `GameServer` half of `LiveStats.test.ts`, and `ArchivePlayerRecord.test.ts` no longer poke `activeClients` / `allClients` / `gameStartInfo` / `_hasStarted` into the server; they join real clients, start, vote over the wire (or go quiet, or desync via real hash reports) and read the record off the injected `archive`. `Consensus.test.ts` covers both votes directly, including the twenty-round window. Repo-wide `(game as any)` reach-ins 68 → 36 (from ~150 when this series began).

## Test plan

- `npx vitest tests/server --run`: 50 files / 509 tests green (was 47 / 487).
- Golden snapshot (`GameServerWire.test.ts.snap`): unchanged.
- Mutation checks: dropping the live-stats one-vote-per-client guard fails 3 tests; making the shrink re-tally count departed voters (`result` instead of `resultAmong`) fails 2, including the #4136 cheater case. Both restored.
- Full `npm test`: 31 failing files / 379 tests — identical to a pristine `origin/main` run (the pre-existing `localStorage` client failures); +12 passing.
- `tsc --noEmit`, prettier, oxlint, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)