### PR TITLE
refactor(server): extract the lobby listing state out of GameServer

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -193,7 +193,12 @@ Status:
       are gone: `WinnerVoteRetally`, the `GameServer` half of `LiveStats` and
       `ArchivePlayerRecord` now join real clients, start, vote over the wire
       and read the record off the injected `archive`. Reach-ins 68 → 36.
-- [ ] `ListingState.ts`
+- [x] `ListingState.ts` (2026-08-27): the listed / listedAt / label / accent /
+      featured fields, the duplicate-toggle rule and the auto-start deadline.
+      `GameServer` keeps thin public delegates (Worker, AdminBotRoutes and
+      WorkerLobbyService call them) and `maybeAutoStartListed`, which is
+      lifecycle. `ListingState.test.ts` covers the deadline rules and label
+      sanitisation; `HostedLobbyListing.test.ts` is unchanged.
 - [ ] `MatchTelemetryRecorder.ts`
 
 ## Phase 4 — Roster

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -13,13 +13,11 @@ import {
   ClientMessageSchema,
   ClientSendLiveStatsMessage,
   ClientSendWinnerMessage,
-  FEATURED_LOBBY_AUTO_START_MS,
   GameConfig,
   GameID,
   GameInfo,
   GameStartInfo,
   GameStartInfoSchema,
-  HOSTED_LOBBY_AUTO_START_MS,
   Intent,
   LobbyAccent,
   PartialGameRecord,
@@ -37,7 +35,7 @@ import {
   Tribe,
   Turn,
 } from "../core/Schemas";
-import { createPartialGameRecord, sanitizeLobbyLabel } from "../core/Util";
+import { createPartialGameRecord } from "../core/Util";
 import {
   createGameWireContext,
   decodeClientMessageUnvalidated,
@@ -50,6 +48,7 @@ import { applyGameConfigPatch, hostCheatsEnabled } from "./ConfigPatch";
 import { LiveStatsVote, WinnerVote } from "./Consensus";
 import { fetchCustomTribes } from "./CustomTribes";
 import { DesyncDetector } from "./DesyncDetector";
+import { ListingState } from "./ListingState";
 import { friendsLookup, NameVisibility } from "./NameVisibility";
 import { ServerEnv } from "./ServerEnv";
 import {
@@ -211,22 +210,9 @@ export class GameServer {
 
   private _hasEnded = false;
 
-  // Whether this private lobby is visible in the public lobby browser.
-  // Deliberately kept out of gameConfig so update_game_config can't set it;
-  // only the authenticated /api/game/:id/listing endpoint may (it verifies
-  // the creator's subscription).
-  private listed = false;
-  // When the lobby was listed; drives the auto-start deadline. Cleared on
-  // delist, so relisting starts a fresh deadline.
-  private listedAt?: number;
-
-  // Featured lobbies: a label shown instead of the map name, an accent for the
-  // row, and a longer auto-start deadline. Set once at create_game by an
-  // authenticated admin bot; deliberately unreachable from update_game_config,
-  // like `listed` itself.
-  private label?: string;
-  private accent?: LobbyAccent;
-  private featured = false;
+  // This private lobby's presence in the public lobby browser (see
+  // ListingState.ts).
+  private readonly listing = new ListingState();
 
   private lobbyInfoIntervalId: ReturnType<typeof setInterval> | null = null;
 
@@ -374,7 +360,7 @@ export class GameServer {
     // lobby must be joinable by anyone who finds it in the lobby browser.
     if (
       gameConfig.allowedPublicIds !== undefined &&
-      this.listed &&
+      this.listing.isListed() &&
       this.hasJoinWhitelist()
     ) {
       this.setListed(false);
@@ -1258,7 +1244,7 @@ export class GameServer {
     });
     const wireGameStartInfo = {
       ...this.gameStartInfo,
-      listed: this.listed,
+      listed: this.listing.isListed(),
     };
     this.wireGameStartInfo = this.gameConfig.disableClanTags
       ? {
@@ -1617,11 +1603,11 @@ export class GameServer {
       startsAt: this.startsAt,
       serverTime: Date.now(),
       publicGameType: this.publicGameType,
-      listed: this.isPublic() ? undefined : this.listed,
-      autoStartAt: this.autoStartAt(),
-      label: this.label,
-      accent: this.accent,
-      featured: this.featured ? true : undefined,
+      listed: this.isPublic() ? undefined : this.listing.isListed(),
+      autoStartAt: this.listing.autoStartAt(),
+      label: this.listing.lobbyLabel(),
+      accent: this.listing.lobbyAccent(),
+      featured: this.listing.isFeatured() ? true : undefined,
     };
   }
 
@@ -1630,7 +1616,7 @@ export class GameServer {
   }
 
   public isListed(): boolean {
-    return this.listed;
+    return this.listing.isListed();
   }
 
   /** Who joined, and the account behind each one.
@@ -1655,45 +1641,28 @@ export class GameServer {
   }
 
   public setListed(listed: boolean): void {
-    if (this.listed === listed) {
-      // Duplicate toggles must not extend the auto-start deadline.
-      return;
-    }
-    this.listed = listed;
-    this.listedAt = listed ? Date.now() : undefined;
+    this.listing.setListed(listed);
   }
 
-  // Deadline after which a listed lobby starts automatically, so hosts
-  // can't sit on a public listing indefinitely.
   public autoStartAt(): number | undefined {
-    if (!this.listed || this.listedAt === undefined) return undefined;
-    return (
-      this.listedAt +
-      (this.featured
-        ? FEATURED_LOBBY_AUTO_START_MS
-        : HOSTED_LOBBY_AUTO_START_MS)
-    );
+    return this.listing.autoStartAt();
   }
 
   public isFeatured(): boolean {
-    return this.featured;
+    return this.listing.isFeatured();
   }
 
   public lobbyLabel(): string | undefined {
-    return this.label;
+    return this.listing.lobbyLabel();
   }
 
   public lobbyAccent(): LobbyAccent | undefined {
-    return this.accent;
+    return this.listing.lobbyAccent();
   }
 
-  // Only create_game calls this. A label is sanitised at the boundary so no
-  // unsanitised text can exist on a GameServer at all.
+  // Only create_game calls this.
   public setFeatured(opts: { label?: string; accent?: LobbyAccent }): void {
-    this.featured = true;
-    const label = opts.label ? sanitizeLobbyLabel(opts.label) : "";
-    this.label = label.length > 0 ? label : undefined;
-    this.accent = opts.accent;
+    this.listing.setFeatured(opts);
   }
 
   // Called from GameManager's tick while in the Lobby phase: once the
@@ -1704,7 +1673,7 @@ export class GameServer {
     if (this.hasStarted() || this.startsAt !== undefined) {
       return;
     }
-    const deadline = this.autoStartAt();
+    const deadline = this.listing.autoStartAt();
     if (deadline === undefined || Date.now() < deadline) {
       return;
     }

--- a/src/server/ListingState.ts
+++ b/src/server/ListingState.ts
@@ -1,0 +1,70 @@
+import {
+  FEATURED_LOBBY_AUTO_START_MS,
+  HOSTED_LOBBY_AUTO_START_MS,
+  LobbyAccent,
+} from "../core/Schemas";
+import { sanitizeLobbyLabel } from "../core/Util";
+
+// A private lobby's presence in the public lobby browser: whether it is
+// listed, since when (which drives the auto-start deadline), and the
+// featured dressing an admin bot can give it. Deliberately kept out of
+// GameConfig so update_game_config can't set any of it; only the
+// authenticated listing endpoint (which verifies the creator's
+// subscription) and create_game may.
+export class ListingState {
+  private listed = false;
+  // When the lobby was listed. Cleared on delist, so relisting starts a
+  // fresh deadline.
+  private listedAt?: number;
+  // Featured lobbies: a label shown instead of the map name, an accent for
+  // the row, and a longer auto-start deadline.
+  private label?: string;
+  private accent?: LobbyAccent;
+  private featured = false;
+
+  isListed(): boolean {
+    return this.listed;
+  }
+
+  setListed(listed: boolean): void {
+    if (this.listed === listed) {
+      // Duplicate toggles must not extend the auto-start deadline.
+      return;
+    }
+    this.listed = listed;
+    this.listedAt = listed ? Date.now() : undefined;
+  }
+
+  // Deadline after which a listed lobby starts automatically, so hosts
+  // can't sit on a public listing indefinitely.
+  autoStartAt(): number | undefined {
+    if (!this.listed || this.listedAt === undefined) return undefined;
+    return (
+      this.listedAt +
+      (this.featured
+        ? FEATURED_LOBBY_AUTO_START_MS
+        : HOSTED_LOBBY_AUTO_START_MS)
+    );
+  }
+
+  isFeatured(): boolean {
+    return this.featured;
+  }
+
+  lobbyLabel(): string | undefined {
+    return this.label;
+  }
+
+  lobbyAccent(): LobbyAccent | undefined {
+    return this.accent;
+  }
+
+  // Only create_game calls this. A label is sanitised at the boundary so no
+  // unsanitised text can exist on a game at all.
+  setFeatured(opts: { label?: string; accent?: LobbyAccent }): void {
+    this.featured = true;
+    const label = opts.label ? sanitizeLobbyLabel(opts.label) : "";
+    this.label = label.length > 0 ? label : undefined;
+    this.accent = opts.accent;
+  }
+}

--- a/tests/server/ListingState.test.ts
+++ b/tests/server/ListingState.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FEATURED_LOBBY_AUTO_START_MS,
+  HOSTED_LOBBY_AUTO_START_MS,
+  LobbyLabelSchema,
+} from "../../src/core/Schemas";
+import { ListingState } from "../../src/server/ListingState";
+
+// The listing state on its own. How the game acts on it — delisting when a
+// whitelist appears, arming the start countdown at the deadline, what the
+// lobby browser is told — is covered through GameServer in
+// HostedLobbyListing.test.ts.
+
+const T0 = 1_700_000_000_000;
+
+describe("ListingState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("starts unlisted, unfeatured and undressed", () => {
+    const listing = new ListingState();
+    expect(listing.isListed()).toBe(false);
+    expect(listing.autoStartAt()).toBeUndefined();
+    expect(listing.isFeatured()).toBe(false);
+    expect(listing.lobbyLabel()).toBeUndefined();
+    expect(listing.lobbyAccent()).toBeUndefined();
+  });
+
+  it("dates the auto-start deadline from the moment of listing", () => {
+    const listing = new ListingState();
+    listing.setListed(true);
+    expect(listing.autoStartAt()).toBe(T0 + HOSTED_LOBBY_AUTO_START_MS);
+  });
+
+  it("does not let a repeated listing push the deadline back", () => {
+    const listing = new ListingState();
+    listing.setListed(true);
+    vi.setSystemTime(T0 + 60_000);
+    listing.setListed(true);
+    expect(listing.autoStartAt()).toBe(T0 + HOSTED_LOBBY_AUTO_START_MS);
+  });
+
+  it("drops the deadline on delist and starts a fresh one on relist", () => {
+    const listing = new ListingState();
+    listing.setListed(true);
+    listing.setListed(false);
+    expect(listing.isListed()).toBe(false);
+    expect(listing.autoStartAt()).toBeUndefined();
+
+    vi.setSystemTime(T0 + 60_000);
+    listing.setListed(true);
+    expect(listing.autoStartAt()).toBe(
+      T0 + 60_000 + HOSTED_LOBBY_AUTO_START_MS,
+    );
+  });
+
+  it("gives a featured lobby the longer deadline", () => {
+    const listing = new ListingState();
+    listing.setFeatured({});
+    listing.setListed(true);
+    expect(listing.isFeatured()).toBe(true);
+    expect(listing.autoStartAt()).toBe(T0 + FEATURED_LOBBY_AUTO_START_MS);
+  });
+
+  it("keeps the featured dressing, with the label sanitised at the boundary", () => {
+    const listing = new ListingState();
+    // Control characters go, whitespace runs collapse; the label is rendered
+    // as text, so markup-looking characters are just characters.
+    listing.setFeatured({
+      label: "  Friday \t Night\u0007 <Cup>  ",
+      accent: "gold",
+    });
+    expect(listing.lobbyLabel()).toBe("Friday Night <Cup>");
+    expect(LobbyLabelSchema.safeParse(listing.lobbyLabel()).success).toBe(true);
+    expect(listing.lobbyAccent()).toBe("gold");
+  });
+
+  it("stores no label when the given one sanitises to nothing", () => {
+    const listing = new ListingState();
+    listing.setFeatured({ label: "   " });
+    expect(listing.isFeatured()).toBe(true);
+    expect(listing.lobbyLabel()).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase 3 of `docs/GameServerRefactor.md`, fifth of six module extractions (previous: #5114, #5116, #5117, #5122, #5124, #5126, #5142). A pure move with no behaviour change — the golden wire snapshot is untouched and `HostedLobbyListing.test.ts` (1,055 lines) passes unmodified.

- **`src/server/ListingState.ts`** (new): a private lobby's presence in the public lobby browser — `listed` / `listedAt` / `label` / `accent` / `featured` — together with the two rules that live on those fields: a repeated listing must not push the auto-start deadline back, and a featured lobby gets the longer deadline. Label sanitisation stays at this boundary, so no unsanitised text can exist on a game.
- **`GameServer`** keeps thin public delegates (`isListed`, `setListed`, `autoStartAt`, `isFeatured`, `lobbyLabel`, `lobbyAccent`, `setFeatured`) since Worker, AdminBotRoutes and WorkerLobbyService call them, and `maybeAutoStartListed`, which is lifecycle. Three read sites re-pointed: `updateGameConfig`'s whitelist → delist check, the wire start info's `listed`, and `gameInfo`. Net −31 lines; three imports pruned.
- **`tests/server/ListingState.test.ts`** (new, 7 tests): deadline dated from the moment of listing, repeat listing doesn't extend it, delist/relist restarts it, featured deadline, label sanitised at the boundary (control characters stripped, whitespace collapsed; the label renders as text so markup-looking characters are kept), empty label stored as absent.

## Test plan

- `npx vitest tests/server --run`: 51 files / 516 tests green (was 50 / 509).
- Golden snapshot (`GameServerWire.test.ts.snap`): unchanged.
- Mutation check: removing the duplicate-toggle guard in `setListed` fails 2 tests (`ListingState` and `HostedLobbyListing`); restored.
- Full `npm test`: 31 failing files / 379 tests — identical to the pristine `origin/main` baseline (the pre-existing `localStorage` client failures); +7 passing.
- `tsc --noEmit`, prettier, oxlint, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)