### PR TITLE
Let bundle pattern items name the colour palette they grant

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -672,6 +672,8 @@ const PACK_UNAVAILABLE_REASONS = [
   "Pack is not for sale",
   "Pack not available for hard currency",
   "Pack has no items",
+  // A pattern item predating pack colours; an admin has to pick one.
+  "Pack item is missing its color palette",
 ];
 
 // POST /shop/purchase/pack — buy a cosmetic pack (see CosmeticPackSchema) for

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -321,9 +321,12 @@ async function purchasePack(
   }
 }
 
-/** The translated name of the cosmetic a flare ("<type>:<name>") refers to. */
+/**
+ * The translated name of the cosmetic a flare refers to: "<type>:<name>",
+ * or "pattern:<name>:<palette>" for a coloured pattern ("Camo (Crimson)").
+ */
 function flareDisplayName(flare: string): string {
-  const [type, name] = flare.split(":", 2);
+  const [type, name, palette] = flare.split(":");
   const prefix = {
     pattern: "territory_patterns.pattern",
     skin: "territory_patterns.pattern",
@@ -331,7 +334,13 @@ function flareDisplayName(flare: string): string {
     crown: "crowns",
     effect: "effects",
   }[type];
-  return prefix && name ? translateCosmetic(prefix, name) : flare;
+  if (!prefix || !name) return flare;
+  const displayName = translateCosmetic(prefix, name);
+  if (!palette) return displayName;
+  return translateText("inventory.selected_cosmetic_variant", {
+    name: displayName,
+    variant: translateCosmetic("territory_patterns.color_palette", palette),
+  });
 }
 
 function simpleHash(str: string): string {
@@ -551,9 +560,29 @@ export function effectRelationship(
   );
 }
 
-/** The flare a pack item's purchase grants, e.g. "pattern:camo". */
+/** The flare a pack item's purchase grants, e.g. "pattern:camo:red". */
 export function packItemFlare(item: CosmeticPackItem): string {
-  return `${item.type}:${item.name}`;
+  const base = `${item.type}:${item.name}`;
+  return item.colorPalette ? `${base}:${item.colorPalette}` : base;
+}
+
+/**
+ * The resolved entry a pack item refers to, or undefined if its cosmetic is
+ * no longer in the catalog. A pattern item is the entry for its palette —
+ * the "pattern:<key>:<palette>" one, or the uncoloured "pattern:<key>" one
+ * when the item names no palette — since that is the flare the pack grants.
+ */
+export function findPackItem(
+  item: CosmeticPackItem,
+  candidates: readonly ResolvedCosmetic[],
+): ResolvedCosmetic | undefined {
+  return candidates.find(
+    (r) =>
+      r.type === item.type &&
+      r.cosmetic?.name === item.name &&
+      (item.type !== "pattern" ||
+        r.key.split(":")[2] === (item.colorPalette ?? undefined)),
+  );
 }
 
 /**
@@ -735,17 +764,10 @@ export function resolveCosmetics(
     });
   }
 
-  // Cosmetic packs. Items reference cosmetics resolved above by (type, name);
-  // a pattern item is its uncoloured entry — the "pattern:<key>" one, with
-  // no palette segment — since the pack grants "pattern:<name>".
+  // Cosmetic packs. Items reference cosmetics resolved above (findPackItem).
   for (const [packKey, pack] of Object.entries(cosmetics.packs ?? {})) {
     const packItems = pack.items.flatMap((item) => {
-      const found = result.find(
-        (r) =>
-          r.type === item.type &&
-          r.cosmetic?.name === item.name &&
-          (item.type !== "pattern" || r.key.split(":").length === 2),
-      );
+      const found = findPackItem(item, result);
       return found ? [found] : [];
     });
     result.push({

--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -5,10 +5,7 @@ import { UserMeResponse } from "../core/ApiSchemas";
 import { CosmeticPack, Cosmetics, Product } from "../core/CosmeticSchemas";
 import { BaseModal } from "./components/BaseModal";
 import "./components/CosmeticCard";
-import {
-  cosmeticDisplayName,
-  cosmeticSelectionLabel,
-} from "./components/CosmeticPresentation";
+import { cosmeticSelectionLabel } from "./components/CosmeticPresentation";
 import "./components/CurrencyDisplay";
 import "./components/CustomCurrencyCard";
 import "./components/EffectsGrid";
@@ -20,6 +17,7 @@ import "./components/TribesPanel";
 import { modalHeader } from "./components/ui/ModalHeader";
 import {
   fetchCosmetics,
+  findPackItem,
   groupCosmeticVariants,
   ownedPackItems,
   purchaseCosmetic,
@@ -281,10 +279,8 @@ export class StoreModal extends BaseModal {
       resolved.cosmetic as CosmeticPack,
       this.userMeResponse,
     ).map((item) => {
-      const found = resolved.packItems?.find(
-        (r) => r.type === item.type && r.cosmetic?.name === item.name,
-      );
-      return found ? cosmeticDisplayName(found) : item.name;
+      const found = findPackItem(item, resolved.packItems ?? []);
+      return found ? cosmeticSelectionLabel(found) : item.name;
     });
   }
 

--- a/src/client/components/CosmeticCard.ts
+++ b/src/client/components/CosmeticCard.ts
@@ -4,7 +4,11 @@ import { Subscription } from "../../core/CosmeticSchemas";
 import { ResolvedCosmetic, translateCosmetic } from "../Cosmetics";
 import { translateText } from "../Utils";
 import "./CosmeticInfo";
-import { cosmeticDisplayName, cosmeticRarity } from "./CosmeticPresentation";
+import {
+  cosmeticDisplayName,
+  cosmeticRarity,
+  cosmeticSelectionLabel,
+} from "./CosmeticPresentation";
 import "./CosmeticPreview";
 
 const COSMETIC_CARD_STYLE_ID = "cosmetic-card-styles";
@@ -485,7 +489,7 @@ export class CosmeticCard extends LitElement {
               .showAdFree=${active.relationship === "purchasable"}
               .usdValue=${usdValue}
               .perks=${this.subscriptionPerks()}
-              .items=${(active.packItems ?? []).map(cosmeticDisplayName)}
+              .items=${(active.packItems ?? []).map(cosmeticSelectionLabel)}
             ></cosmetic-info>`
           : nothing}
       </div>

--- a/src/client/components/PackContentsDialog.ts
+++ b/src/client/components/PackContentsDialog.ts
@@ -9,7 +9,10 @@ import { customElement, property } from "lit/decorators.js";
 import { CosmeticPack } from "../../core/CosmeticSchemas";
 import { ResolvedCosmetic } from "../Cosmetics";
 import { translateText } from "../Utils";
-import { cosmeticDisplayName, cosmeticTypeLabel } from "./CosmeticPresentation";
+import {
+  cosmeticSelectionLabel,
+  cosmeticTypeLabel,
+} from "./CosmeticPresentation";
 import "./CosmeticPreview";
 
 /**
@@ -117,7 +120,7 @@ export class PackContentsDialog extends LitElement {
                     </div>
                     <span
                       class="w-full break-words text-center text-sm font-bold leading-tight text-white"
-                      >${cosmeticDisplayName(item)}</span
+                      >${cosmeticSelectionLabel(item)}</span
                     >
                     <span
                       data-pack-contents-type

--- a/src/core/CosmeticSchemas.ts
+++ b/src/core/CosmeticSchemas.ts
@@ -412,12 +412,16 @@ export const PackSchema = CosmeticSchema.extend({
 // One member of a cosmetic pack: a reference to a cosmetic elsewhere in the
 // same catalog by (type, name). patterns/flags/skins/crowns live in
 // `<type>s[name]`; an effect is found by name across effects[*] (the item
-// does not carry its effectType). The referenced cosmetic may be absent (it
-// was deleted after the listing was cached) or not sold on its own — the
-// pack is rendered from its items, never gated on the item's own price.
+// does not carry its effectType). A pattern item names the colour palette
+// it grants ("pattern:<name>:<palette>", the same flare a single purchase
+// grants); without one it is the legacy uncoloured variant. The referenced
+// cosmetic may be absent (it was deleted after the listing was cached) or
+// not sold on its own — the pack is rendered from its items, never gated on
+// the item's own price.
 export const CosmeticPackItemSchema = z.object({
   type: z.enum(["pattern", "flag", "skin", "crown", "effect"]),
   name: CosmeticNameSchema,
+  colorPalette: z.string().optional(),
 });
 
 // A bundle of cosmetics bought in one hard-currency transaction

--- a/tests/CosmeticSchemas.test.ts
+++ b/tests/CosmeticSchemas.test.ts
@@ -1,4 +1,5 @@
 import {
+  CosmeticPackItemSchema,
   CosmeticPackSchema,
   Cosmetics,
   CosmeticsSchema,
@@ -1213,6 +1214,15 @@ describe("Cosmetic pack schemas", () => {
   it("parses packs keyed by slug with their items in order", () => {
     const parsed = CosmeticsSchema.parse({ ...base, packs: { starter } });
     expect(parsed.packs).toEqual({ starter });
+  });
+
+  it("lets a pattern item name its colour palette", () => {
+    const item = { type: "pattern", name: "camo", colorPalette: "red" };
+    expect(CosmeticPackItemSchema.parse(item)).toEqual(item);
+    // Legacy: a pattern item without a palette is the uncoloured variant.
+    expect(
+      CosmeticPackItemSchema.parse({ type: "pattern", name: "camo" }),
+    ).toEqual({ type: "pattern", name: "camo" });
   });
 
   it("is optional — an older catalog without packs still parses", () => {

--- a/tests/ResolveCosmetics.test.ts
+++ b/tests/ResolveCosmetics.test.ts
@@ -607,5 +607,66 @@ describe("resolveCosmetics cosmetic packs", () => {
     expect(packItemFlare({ type: "effect", name: "ship_trail_gradient" })).toBe(
       "effect:ship_trail_gradient",
     );
+    expect(
+      packItemFlare({ type: "pattern", name: "camo", colorPalette: "red" }),
+    ).toBe("pattern:camo:red");
+  });
+
+  describe("pattern items with a colour palette", () => {
+    const coloured = {
+      ...starter,
+      items: [{ type: "pattern" as const, name: "camo", colorPalette: "red" }],
+    };
+    const catalogWith = (packs: Record<string, typeof coloured>) =>
+      makeCosmetics({
+        patterns: { camo: camo as any },
+        colorPalettes: {
+          red: { name: "red", primaryColor: "#f00", secondaryColor: "#000" },
+        },
+        packs,
+      });
+
+    test("resolve to that palette's entry, the one the granted flare unlocks", () => {
+      const resolved = packOf(
+        resolveCosmetics(
+          catalogWith({ starter: coloured }),
+          makeUserMe(),
+          null,
+        ),
+      );
+      expect(resolved.packItems?.map((item) => item.key)).toEqual([
+        "pattern:camo:red",
+      ]);
+      expect(resolved.packItems?.[0].colorPalette?.name).toBe("red");
+    });
+
+    test("are owned by the palette flare, not the bare pattern flare", () => {
+      const cosmetics = catalogWith({ starter: coloured });
+      expect(
+        packOf(resolveCosmetics(cosmetics, makeUserMe(["pattern:camo"]), null))
+          .relationship,
+      ).toBe("purchasable");
+      expect(
+        packOf(
+          resolveCosmetics(cosmetics, makeUserMe(["pattern:camo:red"]), null),
+        ).relationship,
+      ).toBe("owned");
+    });
+
+    test("skip a palette the pattern no longer offers", () => {
+      const resolved = packOf(
+        resolveCosmetics(
+          catalogWith({
+            starter: {
+              ...coloured,
+              items: [{ type: "pattern", name: "camo", colorPalette: "gone" }],
+            },
+          }),
+          makeUserMe(),
+          null,
+        ),
+      );
+      expect(resolved.packItems).toEqual([]);
+    });
   });
 });

--- a/tests/client/CosmeticPackPurchase.test.ts
+++ b/tests/client/CosmeticPackPurchase.test.ts
@@ -17,6 +17,8 @@ const { getUserMe, invalidateUserMe, purchaseCosmeticPack } =
 const translations = {
   "cosmetics.hard": "plutonium",
   "flags.pirate": "Jolly Roger",
+  "inventory.selected_cosmetic_variant": "{name} ({variant})",
+  "territory_patterns.color_palette.red": "Crimson",
   "store.login_required": "log in",
   "store.pack_already_owned": "already own {items}",
   "store.pack_debt": "debt {debt}",
@@ -138,13 +140,16 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
     vi.mocked(purchaseCosmeticPack).mockResolvedValue({
       ok: false,
       code: "already_owned",
-      ownedFlareNames: ["flag:pirate", "pattern:camo"],
+      ownedFlareNames: ["flag:pirate", "pattern:camo:red"],
     });
 
     await purchaseCosmetic(starter, "hard");
 
-    // Translated where a name exists, title-cased otherwise.
-    expect(alertMock).toHaveBeenCalledWith("already own Jolly Roger, Camo");
+    // Translated where a name exists, title-cased otherwise; a coloured
+    // pattern names its colour.
+    expect(alertMock).toHaveBeenCalledWith(
+      "already own Jolly Roger, Camo (Crimson)",
+    );
     expect(invalidateUserMe).toHaveBeenCalled();
     expect(reloadMock).toHaveBeenCalled();
   });

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -91,6 +91,7 @@ describe("purchaseCosmeticPack", () => {
       "Pack is not for sale",
       "Pack not available for hard currency",
       "Pack has no items",
+      "Pack item is missing its color palette",
     ]) {
       respond(400, { error: "Bad request", reason });
       expect(await purchaseCosmeticPack("starter")).toEqual({

--- a/tests/client/StoreModal.test.ts
+++ b/tests/client/StoreModal.test.ts
@@ -199,14 +199,14 @@ const starterBundle: ResolvedCosmetic = {
     priceHard: 250,
     rarity: "epic",
     items: [
-      { type: "pattern", name: "stripes" },
+      { type: "pattern", name: "stripes", colorPalette: "red" },
       { type: "flag", name: "aurora" },
     ],
   },
   colorPalette: null,
   relationship: "purchasable",
   key: "cosmeticPack:starter",
-  packItems: [{ ...red, colorPalette: null, key: "pattern:stripes" }, flag],
+  packItems: [red, flag],
 };
 
 const affiliatePattern: ResolvedCosmetic = {
@@ -666,7 +666,7 @@ describe("StoreModal cosmetic browser", () => {
       card(modal, starterBundle.key)?.querySelector(
         "[data-cosmetic-info-items]",
       )?.textContent,
-    ).toContain("Stripes, Aurora");
+    ).toContain("inventory.selected_cosmetic_variant, Aurora");
 
     await clickHardPurchase(modal);
     expect(purchaseCosmetic).toHaveBeenCalledWith(starterBundle, "hard");
@@ -693,7 +693,7 @@ describe("StoreModal cosmetic browser", () => {
     const items = [...dialog.querySelectorAll("[data-pack-contents-item]")];
     expect(
       items.map((item) => item.getAttribute("data-pack-contents-item")),
-    ).toEqual(["pattern:stripes", "flag:aurora"]);
+    ).toEqual(["pattern:stripes:red", "flag:aurora"]);
     expect(items[1].querySelector("cosmetic-preview")).toBeTruthy();
     expect(items[1].textContent).toContain("Aurora");
     // Each item says what kind of cosmetic it is.


### PR DESCRIPTION
## Summary
- Client half of the pack-palette change (server side: infra #582, merged and deployed). A pattern item in a bundle now carries `colorPalette` and grants `pattern:<name>:<palette>` — the same flare a single purchase of that colour grants — instead of the bare `pattern:<name>` flare, which is the legacy uncoloured variant the store never sells.
- `CosmeticPackItemSchema` gains optional `colorPalette`; `packItemFlare` includes it; a new `findPackItem()` resolves a pattern item to *that palette's* entry (`pattern:camo:red`) for both `resolveCosmetics` and the Store's "Already own …" naming. A palette the pattern no longer offers is skipped like a deleted item; a palette-less item still falls back to the uncoloured entry so an older listing keeps rendering.
- Card tile, "Includes:" tooltip, dialog names, and the 409 "already owned" message use the colour-qualified label ("Camo (Crimson)") via `cosmeticSelectionLabel`.
- The server's new 400 reason for a legacy palette-less pattern item (`"Pack item is missing its color palette"`) maps to the "bundle unavailable" outcome.

## Test plan
- `npx tsc --noEmit`, ESLint, Prettier clean.
- New/updated tests in `tests/CosmeticSchemas.test.ts`, `tests/ResolveCosmetics.test.ts` (palette entry resolution, palette-flare ownership, stale palette skipped), `tests/client/CosmeticPackPurchase.test.ts` (409 names the colour), `tests/client/PurchaseCosmeticPack.test.ts` (new 400 reason), `tests/client/StoreModal.test.ts` — all passing.
- Rebased onto `main` after #5118 was squash-merged, so the diff is only these two commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)