### PR TITLE
refactor(server): extract the client roster out of GameServer

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -215,15 +215,26 @@ left reaches for `intents`, `isPaused`, `_hasStarted`, `websockets` and
 
 ## Phase 4 — Roster
 
-- [ ] `Roster.ts` collapsing the seven collections: `add`, `reconnect`,
-      `markLeft`, `kick`, `pruneStale(now)`, `active()`, `players()`,
-      `byPersistentId()`, `votingUniqueIPs()`, `wasAdmitted()`, `isKicked()`.
-- [ ] `GameServer` keeps the _policy_ (allowlist, IP cap, dup-session,
-      host-left) and delegates bookkeeping.
-- [ ] Make `activeClients` private; `GameManager.activeClients()` uses
+- [x] `Roster.ts` (2026-08-27) collapsing the seven collections: `add`,
+      `reconnect` (also swaps in the new socket and closes the old one),
+      `markLeft`, `forgetReconnect` (the lobby-phase seat release), `kick`,
+      `pruneStale`, `closeAll`, `active()`, `players()`, `all()`, `get()`,
+      `byPersistentId()` (raw: the kicked check is the caller's policy),
+      `votingUniqueIPs()`, `wasAdmitted()`, `isKicked()`, `isDisconnected()`
+      and `setDisconnected()`.
+- [x] `GameServer` keeps the _policy_ (allowlist, IP cap, dup-session,
+      host-left, the kicked checks on join and reconnect) and delegates the
+      bookkeeping to `this.clients` — `roster()` is already a public method.
+- [x] `activeClients` is no longer public; `GameManager.activeClients()` uses
       `numClients()`.
 
 Only after Phases 1–3: every roster path then has a test.
+
+Status (2026-08-27): done. `Roster.test.ts` covers the bookkeeping; the
+`websockets`, `allClients`, `kickedPersistentIds` and `activeClients`
+reach-ins in `GameServerRejoin.test.ts` and `AdminBotIntent.test.ts` are
+replaced by real joins and observable outcomes. Golden snapshot unchanged.
+`GameServer.ts` is 1888 lines; reach-ins 29.
 
 ## Phase 5 — Message ingress and intent dispatch
 

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -128,7 +128,7 @@ export class GameManager {
   activeClients(): number {
     let totalClients = 0;
     this.games.forEach((game: GameServer) => {
-      totalClients += game.activeClients.length;
+      totalClients += game.numClients();
     });
     return totalClients;
   }

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -51,6 +51,7 @@ import { DesyncDetector } from "./DesyncDetector";
 import { ListingState } from "./ListingState";
 import { identityFor, MatchTelemetryRecorder } from "./MatchTelemetryRecorder";
 import { friendsLookup, NameVisibility } from "./NameVisibility";
+import { Roster } from "./Roster";
 import { ServerEnv } from "./ServerEnv";
 import {
   noopMatchTelemetryEmitter,
@@ -155,16 +156,9 @@ export class GameServer {
 
   private turns: Turn[] = [];
   private intents: StampedIntent[] = [];
-  public activeClients: Client[] = [];
-  private allClients: Map<ClientID, Client> = new Map();
-  // Map persistentID to clientID for reconnection lookup
-  private persistentIdToClientId: Map<string, ClientID> = new Map();
-  // persistentIDs that have passed authorization (incl. Turnstile) for this
-  // game at least once. Survives lobby-phase disconnects, unlike
-  // persistentIdToClientId (which is cleared to free up player slots). Lets a
-  // reconnecting player skip the single-use Turnstile re-check.
-  private admittedPersistentIds: Set<string> = new Set();
-  private clientsDisconnectedStatus: Map<ClientID, boolean> = new Map();
+  // Who joined, who is connected, and the per-account reconnect, admission
+  // and kick flags (see Roster.ts). The join policy stays here.
+  private readonly clients = new Roster();
   private _hasStarted = false;
   private _startTime: number | null = null;
   private hasReachedMaxPlayerCount: boolean = false;
@@ -194,11 +188,7 @@ export class GameServer {
   // fetch lands (undefined until then / on fetch failure / non-public games).
   private tribes?: Tribe[];
 
-  private kickedPersistentIds: Set<string> = new Set();
-
   private isPaused = false;
-
-  private websockets: Set<WebSocket> = new Set();
 
   // The end-of-game winner vote and the running live-stats vote: both
   // IP-weighted majorities among the players (see Consensus.ts).
@@ -255,7 +245,7 @@ export class GameServer {
     this.names = new NameVisibility({
       gameID: opts.id,
       config: () => this.gameConfig,
-      clients: () => this.allClients,
+      clients: () => this.clients.all(),
       teamIndex: (c) => this.matchmakingTeamIndex(c),
     });
     this.log = opts.log.child({ gameID: opts.id });
@@ -279,7 +269,7 @@ export class GameServer {
 
   private get lobbyCreatorID(): ClientID | undefined {
     return this.creatorPersistentID
-      ? this.persistentIdToClientId.get(this.creatorPersistentID)
+      ? this.clients.byPersistentId(this.creatorPersistentID)?.clientID
       : undefined;
   }
 
@@ -309,7 +299,7 @@ export class GameServer {
       acceptedReasonCode?: string,
     ): IntentOutcome => {
       if (!actor.isAdminBot) {
-        const client = this.allClients.get(actor.clientID);
+        const client = this.clients.get(actor.clientID);
         if (client !== undefined) {
           const accepted = outcome.status === 200;
           this.telemetry.intentObserved(
@@ -359,12 +349,13 @@ export class GameServer {
           });
         }
         // Resolve the target to a clientID: an explicit clientID, or an account
-        // publicId matched against allClients (a superset of activeClients that
-        // retains disconnected players), so a disconnected account can still be
-        // kicked — its persistentID is banned, blocking rejoin/reconnect.
+        // publicId matched against everyone who ever joined (a superset of the
+        // connected that retains disconnected players), so a disconnected
+        // account can still be kicked — its persistentID is banned, blocking
+        // rejoin/reconnect.
         let target = stamped.targetClientID;
         if (target === undefined && stamped.targetPublicID !== undefined) {
-          target = [...this.allClients.values()].find(
+          target = [...this.clients.all().values()].find(
             (c) => c.publicId === stamped.targetPublicID,
           )?.clientID;
         }
@@ -496,18 +487,14 @@ export class GameServer {
   }
 
   private isKicked(clientID: ClientID): boolean {
-    const persistentID = this.allClients.get(clientID)?.persistentID;
-    return (
-      persistentID !== undefined && this.kickedPersistentIds.has(persistentID)
-    );
+    const persistentID = this.clients.get(clientID)?.persistentID;
+    return persistentID !== undefined && this.clients.isKicked(persistentID);
   }
 
   // Get existing clientID for this persistentID, or null if new player
   public getClientIdForPersistentId(persistentID: string): ClientID | null {
-    const clientID = this.persistentIdToClientId.get(persistentID);
-    if (!clientID) return null;
-    if (this.kickedPersistentIds.has(persistentID)) return null;
-    return clientID;
+    if (this.clients.isKicked(persistentID)) return null;
+    return this.clients.byPersistentId(persistentID)?.clientID ?? null;
   }
 
   // Whether this persistentID has already been admitted (passed Turnstile and
@@ -515,8 +502,7 @@ export class GameServer {
   // Turnstile re-check when an already-admitted player reconnects. Kicked
   // players are excluded so a kick still forces them back through the gate.
   public wasAdmitted(persistentID: string): boolean {
-    if (this.kickedPersistentIds.has(persistentID)) return false;
-    return this.admittedPersistentIds.has(persistentID);
+    return this.clients.wasAdmitted(persistentID);
   }
 
   // Screened identity stored for this player's client record, or null if
@@ -527,7 +513,7 @@ export class GameServer {
   ): { username: string; clanTag: string | null } | null {
     const clientID = this.getClientIdForPersistentId(persistentID);
     if (clientID === null) return null;
-    const client = this.allClients.get(clientID);
+    const client = this.clients.get(clientID);
     if (client === undefined) return null;
     return { username: client.username, clanTag: client.clanTag };
   }
@@ -540,7 +526,7 @@ export class GameServer {
     if (this._hasEnded) {
       return "rejected";
     }
-    if (this.kickedPersistentIds.has(client.persistentID)) {
+    if (this.clients.isKicked(client.persistentID)) {
       return "kicked";
     }
 
@@ -602,9 +588,10 @@ export class GameServer {
     if (
       this.deps.env() !== GameEnv.Dev &&
       this.gameConfig.gameType === GameType.Public &&
-      this.activeClients.filter(
-        (c) => c.ip === client.ip && c.clientID !== client.clientID,
-      ).length >= 3
+      this.clients
+        .active()
+        .filter((c) => c.ip === client.ip && c.clientID !== client.clientID)
+        .length >= 3
     ) {
       this.log.warn("cannot add client, already have 3 ips", {
         clientID: client.clientID,
@@ -615,11 +602,13 @@ export class GameServer {
 
     if (this.deps.env() === GameEnv.Prod) {
       // Prevent multiple clients from using the same account in prod
-      const conflicting = this.activeClients.find(
-        (c) =>
-          c.persistentID === client.persistentID &&
-          c.clientID !== client.clientID,
-      );
+      const conflicting = this.clients
+        .active()
+        .find(
+          (c) =>
+            c.persistentID === client.persistentID &&
+            c.clientID !== client.clientID,
+        );
       if (conflicting !== undefined) {
         this.log.warn("client ids do not match", {
           clientID: client.clientID,
@@ -634,15 +623,11 @@ export class GameServer {
       }
     }
 
-    // Client connection accepted
-    this.websockets.add(client.ws);
-    this.persistentIdToClientId.set(client.persistentID, client.clientID);
-    this.admittedPersistentIds.add(client.persistentID);
-    this.activeClients.push(client);
+    // Client connection accepted. Added before the first
+    // markClientDisconnected: that call consults the roster to tell a
+    // spectator from a player.
+    this.clients.add(client);
     client.lastPing = Date.now();
-    // Registered before the first markClientDisconnected: that call consults the
-    // registry to tell a spectator from a player.
-    this.allClients.set(client.clientID, client);
     this.markClientDisconnected(client.clientID, false);
     this.telemetry.emit(
       "player_joined",
@@ -682,23 +667,12 @@ export class GameServer {
   ): boolean {
     const clientID = this.getClientIdForPersistentId(persistentID);
     if (!clientID) return false;
-    const client = this.allClients.get(clientID);
+    const client = this.clients.get(clientID);
     if (!client) return false;
 
-    this.websockets.add(ws);
     this.log.info("client rejoining", { clientID, lastTurn });
-
-    // Close old WebSocket to prevent resource leaks
-    if (client.ws !== ws) {
-      this.websockets.delete(client.ws);
-      client.ws.removeAllListeners();
-      client.ws.close();
-    }
-
-    this.activeClients = this.activeClients.filter(
-      (c) => c.clientID !== client.clientID,
-    );
-    this.activeClients.push(client);
+    // Also closes the old WebSocket, to prevent resource leaks.
+    this.clients.reconnect(client, ws);
     if (identityUpdate && !this.hasStarted()) {
       // The verified badge vouches for the exact join name — a pre-start
       // identity change under it must drop the badge (the rejoin path skips
@@ -715,7 +689,6 @@ export class GameServer {
     client.lastPing = Date.now();
     this.markClientDisconnected(client.clientID, false);
 
-    client.ws = ws;
     this.addListeners(client);
     this.startLobbyInfoBroadcast();
 
@@ -910,10 +883,7 @@ export class GameServer {
   }
 
   private handleClientDisconnect(client: Client) {
-    this.websockets.delete(client.ws);
-    this.activeClients = this.activeClients.filter(
-      (c) => c.clientID !== client.clientID,
-    );
+    this.clients.markLeft(client);
     this.checkWinnerAfterElectorateShrink();
 
     // hasStarted() includes prestart: during the lobby -> game transition
@@ -923,7 +893,7 @@ export class GameServer {
       return;
     }
     // Remove persistentId if the game has not started to prevent going over max players
-    this.persistentIdToClientId.delete(client.persistentID);
+    this.clients.forgetReconnect(client);
     // Close lobby when host leaves before game starts: without a host it can
     // never start, and a listed one would haunt the lobby browser and hold
     // the creator's one-listing quota. phase() reports Finished once ended,
@@ -932,7 +902,7 @@ export class GameServer {
       this.log.info("Host left, closing lobby", {
         gameID: this.id,
       });
-      for (const c of [...this.activeClients]) {
+      for (const c of [...this.clients.active()]) {
         this.kickClient(c.clientID, KICK_REASON_HOST_LEFT);
       }
       this._hasEnded = true;
@@ -946,7 +916,7 @@ export class GameServer {
   }
 
   public numClients(): number {
-    return this.activeClients.length;
+    return this.clients.active().length;
   }
 
   public numDesyncedClients(): number {
@@ -977,7 +947,7 @@ export class GameServer {
       connected: this.playerCount(),
       expected,
     });
-    for (const c of [...this.activeClients]) {
+    for (const c of [...this.clients.active()]) {
       this.kickClient(c.clientID, KICK_REASON_MATCH_CANCELLED);
     }
     // phase() reports Finished once ended, so GameManager's next tick prunes.
@@ -1006,7 +976,7 @@ export class GameServer {
     }
 
     const msg = encodeServerMessage(prestartMsg.data, this.zbinCtx);
-    this.activeClients.forEach((c) => {
+    this.clients.active().forEach((c) => {
       this.log.info("sending prestart message", {
         clientID: c.clientID,
         persistentID: c.persistentID,
@@ -1026,11 +996,13 @@ export class GameServer {
       return;
     }
     // Logged-in humans only — guests can't own tribe names.
-    const players = this.activeClients.flatMap((c) =>
-      c.publicId !== undefined
-        ? [{ clientId: c.clientID, publicId: c.publicId }]
-        : [],
-    );
+    const players = this.clients
+      .active()
+      .flatMap((c) =>
+        c.publicId !== undefined
+          ? [{ clientId: c.clientID, publicId: c.publicId }]
+          : [],
+      );
     this.deps
       .fetchTribes(players)
       .then((tribes) => {
@@ -1058,7 +1030,7 @@ export class GameServer {
       if (
         this._hasStarted ||
         this._hasEnded ||
-        this.activeClients.length === 0
+        this.clients.active().length === 0
       ) {
         this.stopLobbyInfoBroadcast();
         return;
@@ -1078,7 +1050,7 @@ export class GameServer {
   private broadcastLobbyInfo() {
     // Off: same payload for everyone (build once). On: per-recipient.
     const shared = this.gameConfig.anonymizeNames ? null : this.gameInfo();
-    this.activeClients.forEach((c) => {
+    this.clients.active().forEach((c) => {
       if (c.ws.readyState === WebSocket.OPEN) {
         const msg = encodeServerMessage(
           {
@@ -1118,7 +1090,7 @@ export class GameServer {
       } satisfies ServerNewLobbyMessage,
       this.zbinCtx,
     );
-    this.activeClients.forEach((c) => {
+    this.clients.active().forEach((c) => {
       if (c.ws.readyState === WebSocket.OPEN) {
         c.ws.send(msg);
       }
@@ -1135,7 +1107,7 @@ export class GameServer {
     // if no client connects/pings.
     this.lastPingUpdate = Date.now();
 
-    const friendsFor = friendsLookup(this.activeClients);
+    const friendsFor = friendsLookup(this.clients.active());
 
     // allowedPublicIds / nameRevealPublicIds hold account publicIds and are
     // enforced server-side against this.gameConfig (joinClient / seesReal).
@@ -1150,17 +1122,15 @@ export class GameServer {
       lobbyCreatedAt: this.createdAt,
       visibleAt: this.visibleAt,
       config,
-      players: this.activeClients
-        .filter((c) => !c.spectator)
-        .map((c) => ({
-          username: c.username,
-          clanTag: c.clanTag ?? null,
-          clientID: c.clientID,
-          cosmetics: c.cosmetics,
-          isLobbyCreator: this.lobbyCreatorID === c.clientID,
-          friends: friendsFor(c),
-          teamIndex: this.matchmakingTeamIndex(c),
-        })),
+      players: this.clients.players().map((c) => ({
+        username: c.username,
+        clanTag: c.clanTag ?? null,
+        clientID: c.clientID,
+        cosmetics: c.cosmetics,
+        isLobbyCreator: this.lobbyCreatorID === c.clientID,
+        friends: friendsFor(c),
+        teamIndex: this.matchmakingTeamIndex(c),
+      })),
       tribes: this.tribes,
     });
     if (!result.success) {
@@ -1200,7 +1170,7 @@ export class GameServer {
       () => this.endTurn(),
       this.deps.turnIntervalMs(),
     );
-    this.activeClients.forEach((c) => {
+    this.clients.active().forEach((c) => {
       this.log.info("sending start message", {
         clientID: c.clientID,
         persistentID: c.persistentID,
@@ -1212,7 +1182,7 @@ export class GameServer {
   // Connected clients who will actually play. Spectators are excluded
   // everywhere a "player" is meant: the lobby cap, and gameStartInfo.
   private playerCount(): number {
-    return this.activeClients.filter((c) => !c.spectator).length;
+    return this.clients.players().length;
   }
 
   // ONE definition of who the allowlist admits, shared by every path that can
@@ -1253,17 +1223,6 @@ export class GameServer {
     // The lobby list is derived from this flag, so everyone's view of who is
     // playing has to be refreshed rather than waiting out the next tick.
     this.broadcastLobbyInfo();
-  }
-
-  // The electorate for the winner and live-stats votes. Spectators run the
-  // simulation but may not vote, so counting them would raise the bar for a
-  // majority without anyone able to meet it: five spectators watching four
-  // players make a strict majority of nine unreachable, and the game would
-  // never reach consensus, never archive, and never be scored.
-  private votingUniqueIPs(): number {
-    return new Set(
-      this.activeClients.filter((c) => !c.spectator).map((c) => c.ip),
-    ).size;
   }
 
   // Pin a publicId to a team slot after the lobby exists, so a lobby that fills
@@ -1323,7 +1282,7 @@ export class GameServer {
 
   private sendStartGameMsg(ws: WebSocket, lastTurn: number) {
     // Find which client this websocket belongs to
-    const client = this.activeClients.find((c) => c.ws === ws);
+    const client = this.clients.active().find((c) => c.ws === ws);
     if (!client) {
       this.log.warn("Could not find client for websocket in sendStartGameMsg");
       return;
@@ -1401,7 +1360,7 @@ export class GameServer {
       } satisfies ServerTurnMessage,
       this.zbinCtx,
     );
-    this.activeClients.forEach((c) => {
+    this.clients.active().forEach((c) => {
       if (c.ws.readyState === c.ws.OPEN) {
         c.ws.send(msg);
       }
@@ -1415,11 +1374,7 @@ export class GameServer {
       clearInterval(this.endTurnIntervalID);
       this.endTurnIntervalID = undefined;
     }
-    this.websockets.forEach((ws) => {
-      if (ws.readyState === WebSocket.OPEN) {
-        ws.close(1000, "game has ended");
-      }
-    });
+    this.clients.closeAll("game has ended");
     if (!this._hasPrestarted && !this._hasStarted) {
       this.log.info(`game not started, not archiving game`);
       this.telemetry.matchFinished(this.turns.length);
@@ -1427,7 +1382,7 @@ export class GameServer {
     }
     this.log.info(`ending game with ${this.turns.length} turns`);
     try {
-      if (this.allClients.size === 0) {
+      if (this.clients.all().size === 0) {
         this.log.info("no clients joined, not archiving game", {
           gameID: this.id,
         });
@@ -1473,25 +1428,19 @@ export class GameServer {
       return GamePhase.Finished;
     }
     const now = Date.now();
-    const alive: Client[] = [];
-    for (const client of this.activeClients) {
-      if (now - client.lastPing > 60_000) {
-        this.log.info("no pings received, terminating connection", {
-          clientID: client.clientID,
-          persistentID: client.persistentID,
-        });
-        if (client.ws.readyState === WebSocket.OPEN) {
-          client.ws.close(1000, "no heartbeats received, closing connection");
-        }
-      } else {
-        alive.push(client);
+    const stale = this.clients.pruneStale(now, 60_000);
+    for (const client of stale) {
+      this.log.info("no pings received, terminating connection", {
+        clientID: client.clientID,
+        persistentID: client.persistentID,
+      });
+      if (client.ws.readyState === WebSocket.OPEN) {
+        client.ws.close(1000, "no heartbeats received, closing connection");
       }
     }
     // On an abrupt network drop the ws 'close' event can lag far behind this
     // ping prune, so re-check the winner vote here too.
-    const pruned = alive.length < this.activeClients.length;
-    this.activeClients = alive;
-    if (pruned) {
+    if (stale.length > 0) {
       this.checkWinnerAfterElectorateShrink();
     }
     if (now > this.createdAt + this.maxGameDuration) {
@@ -1502,7 +1451,7 @@ export class GameServer {
     }
 
     const noRecentPings = now > this.lastPingUpdate + 20 * 1000;
-    const noActive = this.activeClients.length === 0;
+    const noActive = this.clients.active().length === 0;
 
     const lessThanLifetime = this.startsAt ? Date.now() < this.startsAt : true;
     if (
@@ -1529,7 +1478,7 @@ export class GameServer {
   public gameInfo(viewer?: ClientID): GameInfo {
     return {
       gameID: this.id,
-      clients: this.names.lobbyClients(viewer, this.activeClients),
+      clients: this.names.lobbyClients(viewer, this.clients.active()),
       lobbyCreatorClientID: this.lobbyCreatorID,
       gameConfig: this.gameConfig,
       startsAt: this.startsAt,
@@ -1558,14 +1507,14 @@ export class GameServer {
    *  people played and identify none of them. Restricted to lobbies the admin bot
    *  created — never a public or matchmade game.
    *
-   *  allClients, not activeClients: someone who joined and left still appears in
-   *  the record the host has to reconcile against. */
+   *  Everyone who joined, not only the connected: someone who joined and left
+   *  still appears in the record the host has to reconcile against. */
   public roster(): {
     clientID: ClientID;
     publicId: string | undefined;
     username: string;
   }[] {
-    return [...this.allClients.values()].map((c) => ({
+    return [...this.clients.all().values()].map((c) => ({
       clientID: c.clientID,
       publicId: c.publicId,
       username: c.username,
@@ -1656,8 +1605,8 @@ export class GameServer {
       return;
     }
 
-    const clientToKick = this.allClients.get(clientID);
-    if (!clientToKick) {
+    const client = this.clients.get(clientID);
+    if (!client) {
       this.log.warn(`cannot kick client, not found in game`, {
         clientID,
         reasonKey,
@@ -1665,10 +1614,9 @@ export class GameServer {
       return;
     }
 
-    this.kickedPersistentIds.add(clientToKick.persistentID);
-
-    const client = this.activeClients.find((c) => c.clientID === clientID);
-    if (client) {
+    // The persistentID is banned whether or not the client is still
+    // connected; only a connected one is told and cut off.
+    if (this.clients.kick(client)) {
       this.log.info("Kicking client from game", {
         clientID: client.clientID,
         persistentID: client.persistentID,
@@ -1686,9 +1634,6 @@ export class GameServer {
         );
         client.ws.close(1000, reasonKey);
       }
-      this.activeClients = this.activeClients.filter(
-        (c) => c.clientID !== clientID,
-      );
     } else {
       this.log.warn(`cannot kick client, not found in game`, {
         clientID,
@@ -1703,7 +1648,7 @@ export class GameServer {
     }
 
     const now = Date.now();
-    for (const [clientID, client] of this.allClients) {
+    for (const [clientID, client] of this.clients.all()) {
       const isDisconnected = this.isClientDisconnected(clientID);
       if (!isDisconnected && now - client.lastPing > this.disconnectedTimeout) {
         this.markClientDisconnected(clientID, true);
@@ -1717,16 +1662,16 @@ export class GameServer {
   }
 
   public isClientDisconnected(clientID: string): boolean {
-    return this.clientsDisconnectedStatus.get(clientID) ?? true;
+    return this.clients.isDisconnected(clientID);
   }
 
   private markClientDisconnected(clientID: string, isDisconnected: boolean) {
-    this.clientsDisconnectedStatus.set(clientID, isDisconnected);
+    this.clients.setDisconnected(clientID, isDisconnected);
     // Connection status is tracked for every client, but only a player's reaches
     // the simulation: a spectator has no entry in gameStartInfo.players, so an
     // intent naming them refers to nobody — and it is kept in the archived turn
     // log, where readers take mark_disconnected as a player having dropped.
-    if (this.allClients.get(clientID)?.spectator) return;
+    if (this.clients.get(clientID)?.spectator) return;
     this.addIntent({
       type: "mark_disconnected",
       clientID: clientID,
@@ -1752,8 +1697,7 @@ export class GameServer {
           clientID: player.clientID,
           username: player.username,
           clanTag: player.clanTag,
-          persistentID:
-            this.allClients.get(player.clientID)?.persistentID ?? "",
+          persistentID: this.clients.get(player.clientID)?.persistentID ?? "",
           stats,
           cosmetics: player.cosmetics,
           // Simulation inputs: teamIndex pins matchmade teams, friends bias
@@ -1784,7 +1728,7 @@ export class GameServer {
   }
 
   private handleSynchronization() {
-    const check = this.desync.check(this.turns.length, this.activeClients);
+    const check = this.desync.check(this.turns.length, this.clients.active());
     if (check === null) {
       return;
     }
@@ -1800,8 +1744,8 @@ export class GameServer {
       turn,
       correctHash: mostCommonHash,
       clientsWithCorrectHash:
-        this.activeClients.length - outOfSyncClients.length,
-      totalActiveClients: this.activeClients.length,
+        this.clients.active().length - outOfSyncClients.length,
+      totalActiveClients: this.clients.active().length,
     });
     if (!serverDesync.success) {
       this.log.warn("failed to create desync message", {
@@ -1835,7 +1779,7 @@ export class GameServer {
     }
     client.reportedWinner = clientMsg.winner;
 
-    const activeUniqueIPs = this.votingUniqueIPs();
+    const activeUniqueIPs = this.clients.votingUniqueIPs();
     const { key: winnerKey, votes } = this.winnerVote.cast(
       clientMsg,
       client.ip,
@@ -1874,7 +1818,7 @@ export class GameServer {
     if (this.winnerVote.winner() !== null || this._hasEnded) {
       return;
     }
-    const activeIPs = new Set(this.activeClients.map((c) => c.ip));
+    const activeIPs = new Set(this.clients.active().map((c) => c.ip));
     const result = this.winnerVote.tallyAmong(activeIPs);
     if (result === null) {
       return;
@@ -1903,7 +1847,7 @@ export class GameServer {
       client.clientID,
       client.ip,
       clientMsg.stats,
-      this.votingUniqueIPs(),
+      this.clients.votingUniqueIPs(),
     );
   }
 
@@ -1931,7 +1875,7 @@ export class GameServer {
       turn: latest.turn,
       winner: w?.[0] === "player" ? w[1] : null,
       players: latest.players.map((p) => {
-        const client = this.allClients.get(p.clientID);
+        const client = this.clients.get(p.clientID);
         return {
           ...p,
           username: client?.username ?? null,

--- a/src/server/Roster.ts
+++ b/src/server/Roster.ts
@@ -1,0 +1,155 @@
+import WebSocket from "ws";
+import { ClientID } from "../core/Schemas";
+import { Client } from "./Client";
+
+// Who is in the game: everyone who ever joined, who is connected right now,
+// the socket each connection holds, and the per-account flags a returning
+// player is judged by (may they reconnect, were they admitted, were they
+// kicked). Bookkeeping only — the join policy (allowlist, IP cap, duplicate
+// sessions, host-left) stays in GameServer, which decides what to call.
+export class Roster {
+  // Connected clients in join order; a reconnect moves the client to the end.
+  private connected: Client[] = [];
+  // Every client that ever joined, by clientID. Never shrinks: someone who
+  // joined and left keeps their record, so they can still be kicked and
+  // still appear in the host's post-game reconciliation.
+  private everyone = new Map<ClientID, Client>();
+  private sockets = new Set<WebSocket>();
+  // persistentID -> clientID for reconnection. Cleared by forgetReconnect (a
+  // lobby-phase leave) so the seat is free again.
+  private reconnectable = new Map<string, ClientID>();
+  // persistentIDs that have passed join authorization (incl. Turnstile) for
+  // this game at least once. Survives forgetReconnect, unlike the reconnect
+  // mapping, so a returning player can skip the single-use Turnstile re-check.
+  private admitted = new Set<string>();
+  private kicked = new Set<string>();
+  private disconnected = new Map<ClientID, boolean>();
+
+  add(client: Client): void {
+    this.sockets.add(client.ws);
+    this.reconnectable.set(client.persistentID, client.clientID);
+    this.admitted.add(client.persistentID);
+    this.connected.push(client);
+    this.everyone.set(client.clientID, client);
+  }
+
+  // Hands the client a new socket. The old one is closed and forgotten, and
+  // the client moves to the end of the connected order.
+  reconnect(client: Client, ws: WebSocket): void {
+    this.sockets.add(ws);
+    if (client.ws !== ws) {
+      this.sockets.delete(client.ws);
+      client.ws.removeAllListeners();
+      client.ws.close();
+    }
+    client.ws = ws;
+    this.connected = this.connected.filter(
+      (c) => c.clientID !== client.clientID,
+    );
+    this.connected.push(client);
+  }
+
+  // The client's socket went away. Their record and reconnect mapping stay.
+  markLeft(client: Client): void {
+    this.sockets.delete(client.ws);
+    this.connected = this.connected.filter(
+      (c) => c.clientID !== client.clientID,
+    );
+  }
+
+  // Drops the reconnect mapping, so the persistentID comes back through the
+  // full join path and its seat counts as free. Admission is kept.
+  forgetReconnect(client: Client): void {
+    this.reconnectable.delete(client.persistentID);
+  }
+
+  // Bans the persistentID (no rejoin, no reconnect, no admission) whether or
+  // not the client is still connected, and drops it from the connected list.
+  // Returns whether it was connected.
+  kick(client: Client): boolean {
+    this.kicked.add(client.persistentID);
+    const wasConnected = this.connected.some(
+      (c) => c.clientID === client.clientID,
+    );
+    this.connected = this.connected.filter(
+      (c) => c.clientID !== client.clientID,
+    );
+    return wasConnected;
+  }
+
+  // Removes and returns the connected clients that have not pinged for more
+  // than `maxSilenceMs` as of `now`.
+  pruneStale(now: number, maxSilenceMs: number): Client[] {
+    const stale: Client[] = [];
+    const alive: Client[] = [];
+    for (const client of this.connected) {
+      (now - client.lastPing > maxSilenceMs ? stale : alive).push(client);
+    }
+    this.connected = alive;
+    return stale;
+  }
+
+  // Closes every socket still open.
+  closeAll(reason: string): void {
+    this.sockets.forEach((ws) => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.close(1000, reason);
+      }
+    });
+  }
+
+  active(): readonly Client[] {
+    return this.connected;
+  }
+
+  // Connected clients who will actually play. Spectators are excluded
+  // everywhere a "player" is meant: the lobby cap, gameStartInfo, the votes.
+  players(): Client[] {
+    return this.connected.filter((c) => !c.spectator);
+  }
+
+  all(): ReadonlyMap<ClientID, Client> {
+    return this.everyone;
+  }
+
+  get(clientID: ClientID): Client | undefined {
+    return this.everyone.get(clientID);
+  }
+
+  // The client this persistentID may reconnect as, if the mapping is still
+  // held. Does not consult the kick list: that is the caller's policy.
+  byPersistentId(persistentID: string): Client | undefined {
+    const clientID = this.reconnectable.get(persistentID);
+    return clientID === undefined ? undefined : this.everyone.get(clientID);
+  }
+
+  isKicked(persistentID: string): boolean {
+    return this.kicked.has(persistentID);
+  }
+
+  // Whether this persistentID has already been admitted (passed Turnstile and
+  // other join authorization) for this game. Kicked players are excluded so
+  // a kick still forces them back through the gate.
+  wasAdmitted(persistentID: string): boolean {
+    if (this.kicked.has(persistentID)) return false;
+    return this.admitted.has(persistentID);
+  }
+
+  // Unknown clients count as disconnected.
+  isDisconnected(clientID: ClientID): boolean {
+    return this.disconnected.get(clientID) ?? true;
+  }
+
+  setDisconnected(clientID: ClientID, isDisconnected: boolean): void {
+    this.disconnected.set(clientID, isDisconnected);
+  }
+
+  // The electorate for the winner and live-stats votes. Spectators run the
+  // simulation but may not vote, so counting them would raise the bar for a
+  // majority without anyone able to meet it: five spectators watching four
+  // players make a strict majority of nine unreachable, and the game would
+  // never reach consensus, never archive, and never be scored.
+  votingUniqueIPs(): number {
+    return new Set(this.players().map((c) => c.ip)).size;
+  }
+}

--- a/tests/server/AdminBotIntent.test.ts
+++ b/tests/server/AdminBotIntent.test.ts
@@ -2,6 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GameType } from "../../src/core/game/Game";
 import { ADMIN_BOT_CLIENT_ID } from "../../src/core/Schemas";
 import { GameServer } from "../../src/server/GameServer";
+import {
+  makeClient,
+  makeGame as makeJoinableGame,
+  mockWsOf,
+} from "../util/GameServerHarness";
 
 describe("GameServer.handleIntent (admin bot)", () => {
   let mockLogger: any;
@@ -134,11 +139,10 @@ describe("GameServer.handleIntent (admin bot)", () => {
     });
 
     it("resolves a publicID target to a connected client's clientID", () => {
-      const game = makeGame();
-      // A connected client is in both lists; allClients is the superset we match on.
-      const connected = { clientID: "liveCID1", publicId: "pubABCD1" };
-      (game as any).activeClients.push(connected);
-      (game as any).allClients.set("liveCID1", connected);
+      const game = makeJoinableGame();
+      game.joinClient(
+        makeClient({ clientID: "liveCID1", publicId: "pubABCD1" }),
+      );
       const spy = vi.spyOn(game, "kickClient").mockImplementation(() => {});
       const result = apply(game, {
         type: "kick_player",
@@ -148,24 +152,31 @@ describe("GameServer.handleIntent (admin bot)", () => {
       expect(spy).toHaveBeenCalledWith("liveCID1", expect.any(String));
     });
 
-    it("kicks a disconnected account by publicID via allClients (bans its persistentID)", () => {
-      const game = makeGame();
-      // Disconnected: still known to the game (allClients) but already dropped
-      // from activeClients on socket close. Must stay kickable so the
-      // persistentID ban fires and blocks a rejoin/reconnect.
-      (game as any).allClients.set("goneCID1", {
+    it("kicks a disconnected account by publicID (bans its persistentID)", async () => {
+      const game = makeJoinableGame();
+      // Disconnected: still known to the game but no longer connected after
+      // the socket close. Must stay kickable so the persistentID ban fires
+      // and blocks a rejoin/reconnect.
+      const gone = makeClient({
         clientID: "goneCID1",
         publicId: "pubGONE1",
         persistentID: "persist-gone-1",
       });
+      game.joinClient(gone);
+      await mockWsOf(gone).trigger("close");
+      expect(game.numClients()).toBe(0);
+
       const result = apply(game, {
         type: "kick_player",
         targetPublicID: "pubGONE1",
       } as any);
       expect(result.status).toBe(200);
-      expect((game as any).kickedPersistentIds.has("persist-gone-1")).toBe(
-        true,
-      );
+      expect(game.wasAdmitted("persist-gone-1")).toBe(false);
+      expect(
+        game.joinClient(
+          makeClient({ clientID: "goneCID2", persistentID: "persist-gone-1" }),
+        ),
+      ).toBe("kicked");
     });
 
     it("404s when no client matches the publicID", () => {

--- a/tests/server/GameServerRejoin.test.ts
+++ b/tests/server/GameServerRejoin.test.ts
@@ -44,8 +44,6 @@ describe("GameServer.rejoinClient", () => {
     expect(client.ws).toBe(newWs);
     // One seat, not two.
     expect(game.numClients()).toBe(1);
-    // Only the current socket should remain strongly referenced by the game.
-    expect((game as any).websockets.size).toBe(1);
     // Lobby traffic now reaches the new socket.
     vi.advanceTimersByTime(1000);
     expect(newWs.sent().map((m) => m.type)).toContain("lobby_info");
@@ -195,13 +193,11 @@ describe("GameServer.rejoinClient", () => {
       const { game, client, ctx } = playedGame(2);
       await mockWsOf(client).trigger("close");
       expect(game.numClients()).toBe(0);
-      expect((game as any).websockets.size).toBe(0);
       expect(game.getClientIdForPersistentId("p1-pid")).toBe(P1);
 
       const newWs = makeMockWs();
       expect(game.rejoinClient(newWs as any, "p1-pid", 0)).toBe(true);
       expect(game.numClients()).toBe(1);
-      expect((game as any).websockets.size).toBe(1);
       expect(startFrameOn(newWs, ctx).turns).toHaveLength(2);
     });
   });

--- a/tests/server/Roster.test.ts
+++ b/tests/server/Roster.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Roster } from "../../src/server/Roster";
+import {
+  cid,
+  makeClient,
+  makeMockWs,
+  mockWsOf,
+} from "../util/GameServerHarness";
+
+// The roster bookkeeping on its own. The policy that decides what to call —
+// allowlist, IP cap, duplicate sessions, host-left, the kicked checks on
+// join and reconnect — is covered through GameServer in GameServerJoin,
+// GameServerRejoin and AdminBotIntent.
+
+const T0 = 1_700_000_000_000;
+
+describe("Roster", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adds a client as connected, known, admitted and reconnectable", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1"), persistentID: "p1-pid" });
+    const p2 = makeClient({ clientID: cid("p2") });
+    roster.add(p1);
+    roster.add(p2);
+
+    expect(roster.active()).toEqual([p1, p2]);
+    expect(roster.all().size).toBe(2);
+    expect(roster.get(cid("p1"))).toBe(p1);
+    expect(roster.byPersistentId("p1-pid")).toBe(p1);
+    expect(roster.wasAdmitted("p1-pid")).toBe(true);
+    expect(roster.isKicked("p1-pid")).toBe(false);
+    expect(roster.byPersistentId("nobody")).toBeUndefined();
+    expect(roster.wasAdmitted("nobody")).toBe(false);
+  });
+
+  it("moves a reconnecting client to the end, on the new socket, and drops the old one", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1") });
+    const p2 = makeClient({ clientID: cid("p2") });
+    roster.add(p1);
+    roster.add(p2);
+    const oldWs = mockWsOf(p1);
+    const newWs = makeMockWs();
+
+    roster.reconnect(p1, newWs as any);
+
+    expect(roster.active()).toEqual([p2, p1]);
+    expect(p1.ws).toBe(newWs);
+    expect(oldWs.close).toHaveBeenCalledOnce();
+    // Forgotten, not just closed: even reopened it is no longer the game's
+    // to close.
+    oldWs.readyState = 1;
+    roster.closeAll("bye");
+    expect(oldWs.close).toHaveBeenCalledOnce();
+    expect(newWs.close).toHaveBeenCalledWith(1000, "bye");
+  });
+
+  it("keeps the socket when a client reconnects on the one it already has", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1") });
+    roster.add(p1);
+    roster.reconnect(p1, p1.ws);
+    expect(mockWsOf(p1).close).not.toHaveBeenCalled();
+    expect(roster.active()).toEqual([p1]);
+  });
+
+  it("keeps the record and the reconnect mapping of a client who left", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1"), persistentID: "p1-pid" });
+    roster.add(p1);
+    roster.markLeft(p1);
+
+    expect(roster.active()).toEqual([]);
+    expect(roster.get(cid("p1"))).toBe(p1);
+    expect(roster.byPersistentId("p1-pid")).toBe(p1);
+    expect(roster.wasAdmitted("p1-pid")).toBe(true);
+    // Their socket is no longer the game's to close.
+    roster.closeAll("bye");
+    expect(mockWsOf(p1).close).not.toHaveBeenCalled();
+  });
+
+  it("frees the seat on forgetReconnect but keeps the admission", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1"), persistentID: "p1-pid" });
+    roster.add(p1);
+    roster.markLeft(p1);
+    roster.forgetReconnect(p1);
+
+    expect(roster.byPersistentId("p1-pid")).toBeUndefined();
+    expect(roster.wasAdmitted("p1-pid")).toBe(true);
+    expect(roster.get(cid("p1"))).toBe(p1);
+  });
+
+  it("bans a kicked account whether or not it is connected", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1"), persistentID: "p1-pid" });
+    const p2 = makeClient({ clientID: cid("p2"), persistentID: "p2-pid" });
+    roster.add(p1);
+    roster.add(p2);
+
+    expect(roster.kick(p1)).toBe(true);
+    expect(roster.active()).toEqual([p2]);
+    expect(roster.isKicked("p1-pid")).toBe(true);
+    expect(roster.wasAdmitted("p1-pid")).toBe(false);
+    // The reconnect mapping is raw; refusing a kicked account is the
+    // caller's check.
+    expect(roster.byPersistentId("p1-pid")).toBe(p1);
+
+    roster.markLeft(p2);
+    expect(roster.kick(p2)).toBe(false);
+    expect(roster.isKicked("p2-pid")).toBe(true);
+  });
+
+  it("prunes clients silent for longer than the limit and hands them back", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1") });
+    const p2 = makeClient({ clientID: cid("p2") });
+    const p3 = makeClient({ clientID: cid("p3") });
+    roster.add(p1);
+    roster.add(p2);
+    roster.add(p3);
+    p2.lastPing = T0 - 60_001;
+    // Exactly at the limit is not yet stale.
+    p3.lastPing = T0 - 60_000;
+
+    expect(roster.pruneStale(T0, 60_000)).toEqual([p2]);
+    expect(roster.active()).toEqual([p1, p3]);
+    expect(roster.pruneStale(T0, 60_000)).toEqual([]);
+  });
+
+  it("leaves spectators out of the players and counts each voting IP once", () => {
+    const roster = new Roster();
+    const p1 = makeClient({ clientID: cid("p1"), ip: "1.1.1.1" });
+    const p2 = makeClient({ clientID: cid("p2"), ip: "1.1.1.1" });
+    const p3 = makeClient({ clientID: cid("p3"), ip: "2.2.2.2" });
+    const s1 = makeClient({
+      clientID: cid("s1"),
+      ip: "3.3.3.3",
+      spectator: true,
+    });
+    for (const c of [p1, p2, p3, s1]) roster.add(c);
+
+    expect(roster.active()).toHaveLength(4);
+    expect(roster.players()).toEqual([p1, p2, p3]);
+    expect(roster.votingUniqueIPs()).toBe(2);
+  });
+
+  it("treats a client as disconnected until told otherwise", () => {
+    const roster = new Roster();
+    expect(roster.isDisconnected(cid("p1"))).toBe(true);
+    roster.setDisconnected(cid("p1"), false);
+    expect(roster.isDisconnected(cid("p1"))).toBe(false);
+    roster.setDisconnected(cid("p1"), true);
+    expect(roster.isDisconnected(cid("p1"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Phase 4 of `docs/GameServerRefactor.md` (the plan checked in by #5114; Phases 0–3 are merged, #5145 was the last Phase 3 module).

- **`src/server/Roster.ts`** (new): the seven parallel client collections in `GameServer` — `activeClients`, `allClients`, `websockets`, `persistentIdToClientId`, `admittedPersistentIds`, `kickedPersistentIds`, `clientsDisconnectedStatus` — become one object. Bookkeeping: `add`, `reconnect` (also swaps in the new socket and closes the old one, which `rejoinClient` did by hand), `markLeft`, `forgetReconnect` (the lobby-phase seat release), `kick`, `pruneStale`, `closeAll`. Reads: `active()` (readonly, join order kept — `gameStartInfo.players` depends on it), `players()`, `all()`, `get()`, `byPersistentId()`, `isKicked`, `wasAdmitted`, `isDisconnected`/`setDisconnected`, `votingUniqueIPs` (moved with its spectator-electorate comment).
- **`GameServer.ts`** keeps every policy decision — allowlist, IP cap, duplicate sessions, host-left, the kicked checks on join and reconnect — and delegates the bookkeeping through `this.clients` (`roster()` is already a public method, hence the field name). `byPersistentId()` is deliberately raw so `lobbyCreatorID` resolves exactly as before; the kicked exclusion stays in `getClientIdForPersistentId`. 1,944 → 1,888 lines.
- `activeClients` is no longer public; `GameManager.activeClients()` sums `numClients()`.
- **Tests:** `Roster.test.ts` (9 tests) covers the bookkeeping on its own. The seven roster reach-ins in `GameServerRejoin.test.ts` and `AdminBotIntent.test.ts` are replaced by real joins and observable outcomes (`wasAdmitted(...)` false, a re-join returning `"kicked"`). `(game as any)` reach-ins 36 → 29; what remains is lifecycle/ingress state for Phases 5–6.

Pure move, no behaviour change: the golden wire transcript (`GameServerWire.test.ts.snap`) is byte-identical.

## Test plan

- `npx vitest tests/server --run`: 53 files / 531 tests pass (was 52 / 522); snapshot unchanged
- `npx tsc --noEmit`, `npm run lint` (oxlint + eslint), `prettier --check`: clean
- Mutation spot-check: dropping the kicked exclusion from `Roster.wasAdmitted` fails 4 tests across 4 files (`Roster`, `AdminBotIntent`, `GameServerJoin`, `GameServerRejoin`), restored
- Full `npm test`: 31 failed files / 379 failed tests — identical to pristine `origin/main` (pre-existing client `localStorage` failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)