### PR TITLE
Tell signed-out players to sign in when blocked from a trusted lobby

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1546,6 +1546,7 @@
     "teams_hvn_detailed": "{num} Humans vs {num} Nations",
     "title": "Waiting for Game Start...",
     "trust_required_body": "You must have a trusted account to join this game. Please play more games or make any purchase to become trusted.",
+    "trust_required_body_signed_out": "You must sign in and play more games to join this game. Sign in to your account, then play more games or make any purchase to become trusted.",
     "trust_required_ok": "OK",
     "trust_required_title": "Trusted account required",
     "trusted_locked": "Trusted accounts only. Your account isn't trusted yet.",

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -11,15 +11,16 @@ import {
   Trios,
 } from "../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
-import { hasLinkedAccount } from "./Api";
 import "./components/IOSAddToHomeScreenBanner";
 import {
   canJoinTrustedLobby,
   lobbyCard,
   mapAspectRatios,
   trustRequiredDialog,
+  viewerIsSignedIn,
   viewerIsTrusted,
 } from "./components/LobbyCard";
+import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { multiplayerAllowed, type DesktopUpdateState } from "./DesktopShell";
 import { HostLobbyModal } from "./HostLobbyModal";
 import { JoinLobbyModal } from "./JoinLobbyModal";
@@ -121,8 +122,15 @@ export class GameModeSelector extends LitElement {
 
   private onUserMe = (e: Event) => {
     const me = (e as CustomEvent<UserMeResponse | false>).detail;
-    this.viewerSignedIn = hasLinkedAccount(me);
+    this.viewerSignedIn = viewerIsSignedIn(me);
     this.viewerTrusted = viewerIsTrusted(me);
+    // A CrazyGames sign-in surfaces as a userMeResponse without a linked
+    // identity, so re-read the SDK profile alongside it.
+    if (crazyGamesSDK.isOnCrazyGames()) {
+      void crazyGamesSDK.getUserProfile().then((user) => {
+        if (user !== null) this.viewerSignedIn = true;
+      });
+    }
   };
 
   public stop() {

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -53,6 +53,7 @@ export class GameModeSelector extends LitElement {
   @state() private inputValid: boolean = true;
   @state() private desktopUpdateState: DesktopUpdateState | null = null;
   @state() private viewerTrusted: boolean = false;
+  @state() private viewerSignedIn: boolean = false;
   @state() private showTrustRequired: boolean = false;
   private serverTimeOffset: number = 0;
   private defaultLobbyTime: number = 0;
@@ -118,9 +119,9 @@ export class GameModeSelector extends LitElement {
   };
 
   private onUserMe = (e: Event) => {
-    this.viewerTrusted = viewerIsTrusted(
-      (e as CustomEvent<UserMeResponse | false>).detail,
-    );
+    const me = (e as CustomEvent<UserMeResponse | false>).detail;
+    this.viewerSignedIn = me !== false;
+    this.viewerTrusted = viewerIsTrusted(me);
   };
 
   public stop() {
@@ -287,7 +288,10 @@ export class GameModeSelector extends LitElement {
           )}
         </div>
         ${this.showTrustRequired
-          ? trustRequiredDialog(() => (this.showTrustRequired = false))
+          ? trustRequiredDialog(
+              this.viewerSignedIn,
+              () => (this.showTrustRequired = false),
+            )
           : nothing}
       </div>
     `;

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -11,6 +11,7 @@ import {
   Trios,
 } from "../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
+import { hasLinkedAccount } from "./Api";
 import "./components/IOSAddToHomeScreenBanner";
 import {
   canJoinTrustedLobby,
@@ -120,7 +121,7 @@ export class GameModeSelector extends LitElement {
 
   private onUserMe = (e: Event) => {
     const me = (e as CustomEvent<UserMeResponse | false>).detail;
-    this.viewerSignedIn = me !== false;
+    this.viewerSignedIn = hasLinkedAccount(me);
     this.viewerTrusted = viewerIsTrusted(me);
   };
 

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -4,7 +4,7 @@ import { repeat } from "lit/directives/repeat.js";
 import { UserMeResponse } from "../../core/ApiSchemas";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../../core/Schemas";
-import { hasLinkedAccount } from "../Api";
+import { crazyGamesSDK } from "../CrazyGamesSDK";
 import { type DesktopUpdateState } from "../DesktopShell";
 import { shouldBlockMultiplayerAction } from "../GameModeSelector";
 import { JoinLobbyModal } from "../JoinLobbyModal";
@@ -41,6 +41,7 @@ import {
   lobbyCard,
   mapAspectRatios,
   trustRequiredDialog,
+  viewerIsSignedIn,
   viewerIsTrusted,
 } from "./LobbyCard";
 import { modalHeader } from "./ui/ModalHeader";
@@ -189,8 +190,15 @@ export class DetailedGameViewModal extends BaseModal {
 
   private onUserMe = (e: Event) => {
     const me = (e as CustomEvent<UserMeResponse | false>).detail;
-    this.viewerSignedIn = hasLinkedAccount(me);
+    this.viewerSignedIn = viewerIsSignedIn(me);
     this.viewerTrusted = viewerIsTrusted(me);
+    // A CrazyGames sign-in surfaces as a userMeResponse without a linked
+    // identity, so re-read the SDK profile alongside it.
+    if (crazyGamesSDK.isOnCrazyGames()) {
+      void crazyGamesSDK.getUserProfile().then((user) => {
+        if (user !== null) this.viewerSignedIn = true;
+      });
+    }
   };
 
   // ---- Slot animation ----

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -4,6 +4,7 @@ import { repeat } from "lit/directives/repeat.js";
 import { UserMeResponse } from "../../core/ApiSchemas";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../../core/Schemas";
+import { hasLinkedAccount } from "../Api";
 import { type DesktopUpdateState } from "../DesktopShell";
 import { shouldBlockMultiplayerAction } from "../GameModeSelector";
 import { JoinLobbyModal } from "../JoinLobbyModal";
@@ -188,7 +189,7 @@ export class DetailedGameViewModal extends BaseModal {
 
   private onUserMe = (e: Event) => {
     const me = (e as CustomEvent<UserMeResponse | false>).detail;
-    this.viewerSignedIn = me !== false;
+    this.viewerSignedIn = hasLinkedAccount(me);
     this.viewerTrusted = viewerIsTrusted(me);
   };
 

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -108,6 +108,7 @@ export class DetailedGameViewModal extends BaseModal {
   @state() private profileName = "";
   @state() private desktopUpdateState: DesktopUpdateState | null = null;
   @state() private viewerTrusted: boolean = false;
+  @state() private viewerSignedIn: boolean = false;
   @state() private showTrustRequired: boolean = false;
 
   private serverTimeOffset = 0;
@@ -186,9 +187,9 @@ export class DetailedGameViewModal extends BaseModal {
   };
 
   private onUserMe = (e: Event) => {
-    this.viewerTrusted = viewerIsTrusted(
-      (e as CustomEvent<UserMeResponse | false>).detail,
-    );
+    const me = (e as CustomEvent<UserMeResponse | false>).detail;
+    this.viewerSignedIn = me !== false;
+    this.viewerTrusted = viewerIsTrusted(me);
   };
 
   // ---- Slot animation ----
@@ -265,7 +266,10 @@ export class DetailedGameViewModal extends BaseModal {
     return html`
       <div class="custom-scrollbar p-4 lg:p-6 flex flex-col gap-4">
         ${this.showTrustRequired
-          ? trustRequiredDialog(() => (this.showTrustRequired = false))
+          ? trustRequiredDialog(
+              this.viewerSignedIn,
+              () => (this.showTrustRequired = false),
+            )
           : nothing}
         ${this.showFilters ? this.renderFilterPanel() : nothing}
         ${shown.length === 0

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -2,6 +2,7 @@ import { html, svg, TemplateResult } from "lit";
 import { UserMeResponse } from "../../core/ApiSchemas";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo } from "../../core/Schemas";
+import { hasLinkedIdentity } from "../AccountIdentity";
 import { terrainMapFileLoader } from "../TerrainMapFileLoader";
 import { getMapName, getModifierLabels, translateText } from "../Utils";
 import "./ConfirmDialog";
@@ -13,6 +14,16 @@ import "./ConfirmDialog";
  */
 export function viewerIsTrusted(userMe: UserMeResponse | false): boolean {
   return userMe !== false && userMe.player.trustTier === "trusted";
+}
+
+/**
+ * Whether the viewer has an account to become trusted on. A guest session
+ * still resolves to a UserMeResponse, so a linked identity (Discord, Google,
+ * Steam, email) is what counts. Callers on CrazyGames must OR in the SDK
+ * profile themselves; it isn't on the API response.
+ */
+export function viewerIsSignedIn(userMe: UserMeResponse | false): boolean {
+  return userMe !== false && hasLinkedIdentity(userMe.user);
 }
 
 /** Whether the viewer may join `lobby`: it is open, or they are trusted. */

--- a/src/client/components/LobbyCard.ts
+++ b/src/client/components/LobbyCard.ts
@@ -26,12 +26,20 @@ export function canJoinTrustedLobby(
 /**
  * Popup shown instead of attempting to join a trusted-only lobby the viewer
  * can't get into (the server would refuse them anyway). Tells them how to
- * become trusted rather than letting the join fail.
+ * become trusted rather than letting the join fail: a signed-out viewer is
+ * told to sign in first, since trust only attaches to an account.
  */
-export function trustRequiredDialog(onClose: () => void): TemplateResult {
+export function trustRequiredDialog(
+  signedIn: boolean,
+  onClose: () => void,
+): TemplateResult {
   return html`<confirm-dialog
     .heading=${translateText("public_lobby.trust_required_title")}
-    .message=${translateText("public_lobby.trust_required_body")}
+    .message=${translateText(
+      signedIn
+        ? "public_lobby.trust_required_body"
+        : "public_lobby.trust_required_body_signed_out",
+    )}
     variant="warning"
     .showClose=${true}
     .buttons=${"confirmOnly"}

--- a/tests/client/LobbyCardTrust.test.ts
+++ b/tests/client/LobbyCardTrust.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../src/client/Utils", () => ({
 import {
   lobbyCard,
   trustRequiredDialog,
+  viewerIsSignedIn,
   viewerIsTrusted,
 } from "../../src/client/components/LobbyCard";
 
@@ -111,5 +112,20 @@ describe("trustRequiredDialog", () => {
 
   it("tells a signed-out viewer to sign in first", () => {
     expect(message(false)).toBe("public_lobby.trust_required_body_signed_out");
+  });
+});
+
+describe("viewerIsSignedIn", () => {
+  const me = (user: object) => ({ user }) as unknown as UserMeResponse;
+
+  it("counts any linked identity, including Steam-only", () => {
+    expect(viewerIsSignedIn(me({ steam: { id: "1" } }))).toBe(true);
+    expect(viewerIsSignedIn(me({ discord: { id: "1" } }))).toBe(true);
+    expect(viewerIsSignedIn(me({ email: "a@b.c" }))).toBe(true);
+  });
+
+  it("treats a guest session and a failed lookup as signed out", () => {
+    expect(viewerIsSignedIn(me({}))).toBe(false);
+    expect(viewerIsSignedIn(false)).toBe(false);
   });
 });

--- a/tests/client/LobbyCardTrust.test.ts
+++ b/tests/client/LobbyCardTrust.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../src/client/Utils", () => ({
 
 import {
   lobbyCard,
+  trustRequiredDialog,
   viewerIsTrusted,
 } from "../../src/client/components/LobbyCard";
 
@@ -89,5 +90,26 @@ describe("viewerIsTrusted", () => {
     expect(viewerIsTrusted(me(null))).toBe(false);
     expect(viewerIsTrusted(me(undefined))).toBe(false);
     expect(viewerIsTrusted(false)).toBe(false);
+  });
+});
+
+describe("trustRequiredDialog", () => {
+  function message(signedIn: boolean): unknown {
+    const host = document.createElement("div");
+    render(
+      trustRequiredDialog(signedIn, () => {}),
+      host,
+    );
+    return (
+      host.querySelector("confirm-dialog") as unknown as { message: string }
+    ).message;
+  }
+
+  it("tells a signed-in but untrusted viewer to play more games", () => {
+    expect(message(true)).toBe("public_lobby.trust_required_body");
+  });
+
+  it("tells a signed-out viewer to sign in first", () => {
+    expect(message(false)).toBe("public_lobby.trust_required_body_signed_out");
   });
 });


### PR DESCRIPTION
## Summary
- The trusted-only lobby rejection popup told everyone to "play more games or make any purchase", which is a dead end for a player with no linked account — trust only attaches to an account.
- Both places that show the popup (homepage lobby cards in `GameModeSelector` and the More Games browser in `DetailedGameViewModal`) now track whether the viewer is signed in from the `userMeResponse` event (`false` when logged out) and pass it to `trustRequiredDialog`.
- Signed-out viewers get a new `public_lobby.trust_required_body_signed_out` string telling them to sign in first, then play more games or make a purchase. The signed-in message is unchanged.

## Test plan
- `npx vitest tests/client/LobbyCardTrust.test.ts --run` — 6/6 pass, including two new cases asserting which body key the dialog renders for signed-in vs signed-out.
- `npx tsc --noEmit` clean; oxlint + eslint clean on touched files; Prettier applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)