### PR TITLE
fix(client): scroll inside inline page modals again, not the document

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,6 +58,12 @@
         flex-basis: 100%;
         width: 100%;
       }
+      /* body is a column while an inline page is open (see styles.css):
+         size the slot to its content there, not to 100% of the height. */
+      body.page-open #pw-oop-flex_container {
+        flex-basis: auto;
+        flex-shrink: 0;
+      }
 
       /* Google Funding Choices CCPA link override */
       .fc-dns-link,
@@ -234,7 +240,7 @@
 
     <!-- MAIN CONTENT AREA -->
     <div
-      class="in-[.in-game]:hidden flex-1 basis-full min-w-0 min-h-dvh relative pt-[var(--top-ad-pad,0px)] transition-[margin] duration-500 ease-out will-change-[margin-left] flex flex-col"
+      class="in-[.in-game]:hidden flex-1 basis-full min-w-0 min-h-dvh in-[.page-open]:min-h-0 in-[.page-open]:overflow-hidden relative pt-[var(--top-ad-pad,0px)] transition-[margin] duration-500 ease-out will-change-[margin-left] flex flex-col"
     >
       <!-- Desktop Top Bar (sticky so it stays visible while the page scrolls,
            offset below the header ad when one is showing) -->

--- a/src/client/Navigation.ts
+++ b/src/client/Navigation.ts
@@ -15,6 +15,8 @@ export function closeMobileSidebar() {
 export function initNavigation() {
   const showPage = (pageId: string) => {
     window.currentPageId = pageId;
+    // Inline pages scroll inside their modal, not the document (see styles.css)
+    document.body.classList.toggle("page-open", pageId !== "page-play");
 
     // Close mobile sidebar if a nav item was clicked
     closeMobileSidebar();

--- a/src/client/Navigation.ts
+++ b/src/client/Navigation.ts
@@ -15,8 +15,6 @@ export function closeMobileSidebar() {
 export function initNavigation() {
   const showPage = (pageId: string) => {
     window.currentPageId = pageId;
-    // Inline pages scroll inside their modal, not the document (see styles.css)
-    document.body.classList.toggle("page-open", pageId !== "page-play");
 
     // Close mobile sidebar if a nav item was clicked
     closeMobileSidebar();
@@ -36,6 +34,11 @@ export function initNavigation() {
         visibleModal.classList.remove("block");
       }
     }
+
+    // Inline pages scroll inside their modal, not the document (see
+    // styles.css). Set after closing the previous modal: an inline modal's
+    // close() re-enters showPage("page-play"), which would clear this.
+    document.body.classList.toggle("page-open", pageId !== "page-play");
 
     // Handle page-play separately (it's not a page-content element)
     const pagePlayEl = document.getElementById("page-play");

--- a/src/client/components/MainLayout.ts
+++ b/src/client/components/MainLayout.ts
@@ -19,10 +19,10 @@ export class MainLayout extends LitElement {
   render() {
     return html`
       <main
-        class="relative [.in-game_&]:hidden flex flex-col flex-1 w-full px-0 lg:px-[clamp(1.5rem,3vw,3rem)] pt-0 lg:pt-[clamp(0.75rem,1.5vw,1.5rem)] pb-0 lg:pb-[clamp(0.375rem,0.75vw,0.75rem)]"
+        class="relative [.in-game_&]:hidden flex flex-col flex-1 min-h-0 w-full px-0 lg:px-[clamp(1.5rem,3vw,3rem)] pt-0 lg:pt-[clamp(0.75rem,1.5vw,1.5rem)] pb-0 lg:pb-[clamp(0.375rem,0.75vw,0.75rem)]"
       >
         <div
-          class="w-full lg:max-w-[20cm] 2xl:max-w-[24cm] mx-auto flex flex-col flex-1 gap-0 lg:gap-[clamp(1.5rem,3vw,3rem)] overflow-x-clip sm:px-4 lg:px-0"
+          class="w-full lg:max-w-[20cm] 2xl:max-w-[24cm] mx-auto flex flex-col flex-1 min-h-0 gap-0 lg:gap-[clamp(1.5rem,3vw,3rem)] overflow-x-clip sm:px-4 lg:px-0"
         >
           ${this._initialChildren}
         </div>

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -101,6 +101,17 @@ body.in-game {
   overflow: hidden;
 }
 
+/* An inline page (store, settings, leaderboard, ...) is a modal rendered in
+   the content area: lock the document so it scrolls inside the modal, and
+   stack body children in a column so the content area gets the height left
+   under the header-ad slot. */
+body.page-open {
+  height: 100%;
+  overflow: hidden;
+  flex-direction: column;
+  flex-wrap: nowrap;
+}
+
 * {
   -webkit-box-sizing: border-box;
   -moz-box-sizing: border-box;


### PR DESCRIPTION
Regression fix for #5009 (`7ae09256b`). No approved issue — reporting and fixing in one go.

## Description:

Since #5009, opening an inline page modal (Store, Settings, Leaderboard, Help, ...) scrolls the **whole document** instead of scrolling inside the modal.

**Cause.** Those modals are the `.page-content` elements in `index.html`, sized `w-full h-full`. They used to get a bounded height from the locked chain #5009 removed: `body h-full overflow-hidden` → content div `h-full overflow-hidden` → `main-layout`'s `overflow-y-auto`. Unbounding that chain is correct for the homepage (document-level scrolling, needed for ad viewability), but it also let the page modals grow to their full content height, so `o-modal`'s `[data-modal-scroll]` container had nothing left to scroll. Measured at `main` with Help open: document `scrollHeight` 7353px, modal container `clientHeight == scrollHeight == 7034`.

**Fix.** Re-lock the layout *only* while an inline page is open, keyed off a `page-open` body class — the same pattern as the existing `in-game` class:

- `src/client/Navigation.ts` — `showPage()` toggles `body.page-open`. It's the single place page visibility changes; `BaseModal.open()/close()` for inline modals route through it.
- `src/client/styles.css` — `body.page-open { height: 100%; overflow: hidden; flex-direction: column; flex-wrap: nowrap }`. The column matters: #5009 made body a wrapping flex row so the Playwire header-ad slot (`#pw-oop-flex_container`) gets its own full-width line. A column lets the content area take the height *remaining* under that slot rather than overflowing by its height.
- `index.html` — content area gets `in-[.page-open]:min-h-0 in-[.page-open]:overflow-hidden`; the ad slot gets `flex-basis: auto; flex-shrink: 0` under `body.page-open`, since its usual `flex-basis: 100%` would mean 100% *height* in a column.
- `src/client/components/MainLayout.ts` — `min-h-0` on `main` and the inner column so they can shrink to the bounded height. This is what the removed `overflow-hidden` / `overflow-y-auto` implicitly gave them; inert on the homepage, whose chain is auto-height.

The homepage keeps scrolling at the document level exactly as #5009 intends — the class is only present while a page modal is open.

## Verification

Headless Chromium against the dev server, at 1400×900 and 390×844:

- **Repro at `main`:** Help open → document `scrollHeight` 7353 / 10470, `window.scrollTo(0, 5000)` moves the page, modal container doesn't scroll.
- **With this PR:** Help open → `scrollHeight == innerHeight` (900 / 844), `window.scrollTo` doesn't move, modal container scrolls (7034px of content in a 581px box; 10284 in 658 on mobile), footer pinned at the viewport bottom.
- **Back to Play:** class removed, document scrolls again.
- **Header ad interaction:** simulated a 250px `#pw-oop-flex` unit in its slot with a page open → slot occupies 0–250, nav sits at 250, the modal's scroll box shrinks to 331px and still scrolls, footer still at the viewport bottom, no document scroll.
- 10 navigation-related client test files (72 tests) pass; Prettier + ESLint clean.

Not covered: the real Playwire creative (RAMP won't initialize headless). The simulation above reproduces the geometry #5009 describes, but a headed pass with ads live is worth a glance.

## Please complete the following:

- [x] I have added screenshots for all UI updates — no visual change; the fix is scroll behavior, which the measurements above capture
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — N/A, no user-visible text
- [x] I have added relevant tests to the test directory — N/A, pure CSS/layout behavior; verified e2e as above

## Please put your Discord username so you can be contacted if a bug or regression is found:

evanpelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)