### PR TITLE
refactor(server): extract the socket ingress out of GameServer

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -238,10 +238,13 @@ replaced by real joins and observable outcomes. Golden snapshot unchanged.
 
 ## Phase 5 — Message ingress and intent dispatch
 
-- [ ] `ClientSocket.attach(client, { onMessage, onClose })`: decode → validate
-      → rate-limit → spectator-block. The message switch stays in
-      `GameServer.handleClientMessage(client, msg)`. Tests call it directly;
-      keep a few frame-level tests for the decode/kick paths.
+- [x] `SocketIngress.ts` (2026-08-27): `attach(client)` wires the socket
+      listeners; `receive(client, frame)` is decode → validate → rate-limit →
+      spectator-block, then the game's `onMessage`. The message switch is
+      `GameServer.handleClientMessage(client, msg)`. The rate limiter is a
+      constructor parameter, so `SocketIngress.test.ts` drives the limit and
+      kick telemetry paths that `MatchTelemetryIntegration.test.ts` used to
+      reach in for; the frame-level decode / kick tests are unchanged.
 - [ ] `authorizeIntent(intent, actor): IntentOutcome | null` (pure guards,
       table-testable) separated from the effects in `handleIntent`.
 

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -10,7 +10,6 @@ import { GameType, RankedType } from "../core/game/Game";
 import {
   ClientID,
   ClientMessage,
-  ClientMessageSchema,
   ClientSendLiveStatsMessage,
   ClientSendWinnerMessage,
   GameConfig,
@@ -36,14 +35,9 @@ import {
   Turn,
 } from "../core/Schemas";
 import { createPartialGameRecord } from "../core/Util";
-import {
-  createGameWireContext,
-  decodeClientMessageUnvalidated,
-  encodeServerMessage,
-} from "../core/ZbinWire";
+import { createGameWireContext, encodeServerMessage } from "../core/ZbinWire";
 import { archive, finalizeGameRecord } from "./Archive";
 import { Client } from "./Client";
-import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";
 import { applyGameConfigPatch, hostCheatsEnabled } from "./ConfigPatch";
 import { LiveStatsVote, WinnerVote } from "./Consensus";
 import { fetchCustomTribes } from "./CustomTribes";
@@ -53,6 +47,7 @@ import { identityFor, MatchTelemetryRecorder } from "./MatchTelemetryRecorder";
 import { friendsLookup, NameVisibility } from "./NameVisibility";
 import { Roster } from "./Roster";
 import { ServerEnv } from "./ServerEnv";
+import { SocketIngress } from "./SocketIngress";
 import {
   noopMatchTelemetryEmitter,
   type MatchTelemetryEmitter,
@@ -89,18 +84,6 @@ const KICK_REASON_LOBBY_CREATOR = "kick_reason.lobby_creator";
 const KICK_REASON_ADMIN = "kick_reason.admin";
 const KICK_REASON_HOST_LEFT = "kick_reason.host_left";
 const KICK_REASON_MATCH_CANCELLED = "kick_reason.match_cancelled";
-const KICK_REASON_TOO_MUCH_DATA = "kick_reason.too_much_data";
-
-// Messages that speak for a player in the simulation, so a spectator may not
-// send them — including hash, which feeds desync agreement. Ping and rejoin
-// remain connection housekeeping.
-const SPECTATOR_BLOCKED_MESSAGES = new Set([
-  "intent",
-  "winner",
-  "live_stats",
-  "hash",
-]);
-const KICK_REASON_INVALID_MESSAGE = "kick_reason.invalid_message";
 
 export interface GameServerOptions {
   id: string;
@@ -148,7 +131,9 @@ export class GameServer {
   // is told once and its votes are ignored from then on.
   private readonly desync = new DesyncDetector();
 
-  private intentRateLimiter = new ClientMsgRateLimiter();
+  // Socket listeners and the decode / validate / rate-limit / spectator-block
+  // pipeline every frame goes through before handleClientMessage.
+  private readonly ingress: SocketIngress;
 
   private maxGameDuration = 3 * 60 * 60 * 1000; // 3 hours
 
@@ -249,6 +234,13 @@ export class GameServer {
       teamIndex: (c) => this.matchmakingTeamIndex(c),
     });
     this.log = opts.log.child({ gameID: opts.id });
+    this.ingress = new SocketIngress(this.log, this.telemetry, {
+      zbinCtx: () => this.zbinCtx,
+      serverTick: () => this.turns.length,
+      onMessage: (client, msg) => this.handleClientMessage(client, msg),
+      onClose: (client) => this.handleClientDisconnect(client),
+      kick: (clientID, reasonKey) => this.kickClient(clientID, reasonKey),
+    });
     if (opts.startsAt !== undefined) {
       this.visibleAt = Date.now();
     }
@@ -640,7 +632,7 @@ export class GameServer {
       },
       this.turns.length,
     );
-    this.addListeners(client);
+    this.ingress.attach(client);
     this.startLobbyInfoBroadcast();
 
     if (this.playerCount() >= (this.gameConfig.maxPlayers ?? Infinity)) {
@@ -689,7 +681,7 @@ export class GameServer {
     client.lastPing = Date.now();
     this.markClientDisconnected(client.clientID, false);
 
-    this.addListeners(client);
+    this.ingress.attach(client);
     this.startLobbyInfoBroadcast();
 
     if (this._hasStarted) {
@@ -698,187 +690,62 @@ export class GameServer {
     return true;
   }
 
-  private addListeners(client: Client) {
-    client.ws.removeAllListeners("message");
-    client.ws.on("message", async (message: Buffer) => {
-      try {
-        // Decode and validate in two steps (instead of one parseBytes) so a
-        // message that is structurally sound but fails validation — the
-        // signature of a buggy or cheating client — can still be attributed
-        // to its intent in telemetry, exactly like the JSON path did.
-        let raw: ClientMessage;
-        try {
-          // A Buffer is a Uint8Array and zbin honours its byteOffset.
-          raw = decodeClientMessageUnvalidated(message, this.zbinCtx);
-        } catch (e) {
-          // Corrupt bytes: no readable type, nothing to attribute.
-          this.log.warn(`Failed to decode client message, kicking`, {
-            clientID: client.clientID,
-            error: String(e),
-          });
-          this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
-          return;
+  // A validated message from a connected client, after SocketIngress has
+  // applied the rate limit and the spectator block.
+  private handleClientMessage(client: Client, clientMsg: ClientMessage) {
+    switch (clientMsg.type) {
+      case "rejoin": {
+        // Client is already connected, no auth required, send start game message if game has started
+        if (this._hasStarted) {
+          this.sendStartGameMsg(client.ws, clientMsg.lastTurn);
         }
-        const parsed = ClientMessageSchema.safeParse(raw);
-        if (!parsed.success) {
-          const reasonDetail = z.prettifyError(parsed.error);
-          if (raw.type === "intent") {
-            this.telemetry.intentObserved(
-              client,
-              raw.intent,
-              typeof raw.intent?.type === "string" ? raw.intent.type : null,
-              "rejected",
-              this.turns.length,
-              KICK_REASON_INVALID_MESSAGE,
-              reasonDetail,
-            );
-          }
-          this.log.warn(`Failed to parse client message, kicking`, {
-            clientID: client.clientID,
-            error: reasonDetail,
-          });
-          this.kickClient(client.clientID, KICK_REASON_INVALID_MESSAGE);
-          return;
-        }
-        const clientMsg = parsed.data;
-        const bytes = message.length;
-        const rateResult = this.intentRateLimiter.check(
-          client.clientID,
-          clientMsg.type,
-          bytes,
-        );
-        if (rateResult === "kick") {
-          if (clientMsg.type === "intent") {
-            this.telemetry.intentObserved(
-              client,
-              { ...clientMsg.intent, clientID: client.clientID },
-              clientMsg.intent.type,
-              "rejected",
-              this.turns.length,
-              KICK_REASON_TOO_MUCH_DATA,
-            );
-          }
-          this.log.warn(`Client rate limit exceeded, kicking`, {
-            clientID: client.clientID,
-            type: clientMsg.type,
-          });
-          this.kickClient(client.clientID, KICK_REASON_TOO_MUCH_DATA);
-          return;
-        }
-        if (rateResult === "limit") {
-          if (clientMsg.type === "intent") {
-            this.telemetry.intentObserved(
-              client,
-              { ...clientMsg.intent, clientID: client.clientID },
-              clientMsg.intent.type,
-              "rejected",
-              this.turns.length,
-              "limit",
-            );
-          }
-          this.log.warn(`Client message rate limit exceeded, dropping`, {
-            clientID: client.clientID,
-            type: clientMsg.type,
-          });
-          return;
-        }
-        // A spectator is not in the simulation, so none of what it sends can be
-        // game state. Without this, claiming to spectate is a way past the lobby
-        // cap and into the intent stream.
-        if (
-          client.spectator &&
-          SPECTATOR_BLOCKED_MESSAGES.has(clientMsg.type)
-        ) {
-          this.log.warn(`dropping ${clientMsg.type} from spectator`, {
-            clientID: client.clientID,
-          });
-          return;
-        }
-        switch (clientMsg.type) {
-          case "rejoin": {
-            // Client is already connected, no auth required, send start game message if game has started
-            if (this._hasStarted) {
-              this.sendStartGameMsg(client.ws, clientMsg.lastTurn);
-            }
-            break;
-          }
-          case "intent": {
-            // Server stamps clientID from the authenticated connection.
-            const outcome = this.handleIntent(clientMsg.intent, {
-              clientID: client.clientID,
-              isLobbyCreator: client.clientID === this.lobbyCreatorID,
-              isAdmin: isAdminRole(client.role),
-              isAdminBot: false,
-            });
-            if (outcome.status !== 200) {
-              this.log.warn(`intent rejected`, {
-                type: clientMsg.intent.type,
-                clientID: client.clientID,
-                gameID: this.id,
-                reason: outcome.error,
-              });
-            }
-            break;
-          }
-          case "ping": {
-            this.lastPingUpdate = Date.now();
-            client.lastPing = Date.now();
-            break;
-          }
-          case "hash": {
-            client.hashes.set(clientMsg.turnNumber, clientMsg.hash);
-            break;
-          }
-          case "spectate": {
-            this.setSpectator(client, clientMsg.spectator);
-            break;
-          }
-          case "winner": {
-            this.handleWinner(client, clientMsg);
-            break;
-          }
-          case "live_stats": {
-            this.handleLiveStats(client, clientMsg);
-            break;
-          }
-          default: {
-            this.log.warn(`Unknown message type: ${(clientMsg as any).type}`, {
-              clientID: client.clientID,
-            });
-            break;
-          }
-        }
-      } catch (error) {
-        this.log.info(
-          `error handling websocket request in game server: ${error}`,
-          {
-            clientID: client.clientID,
-          },
-        );
+        break;
       }
-    });
-    client.ws.on("close", () => {
-      this.log.info("client disconnected", {
-        clientID: client.clientID,
-        persistentID: client.persistentID,
-      });
-      this.handleClientDisconnect(client);
-    });
-    client.ws.on("error", (error: Error) => {
-      if ((error as any).code === "WS_ERR_UNEXPECTED_RSV_1") {
-        client.ws.close(1002, "WS_ERR_UNEXPECTED_RSV_1");
+      case "intent": {
+        // Server stamps clientID from the authenticated connection.
+        const outcome = this.handleIntent(clientMsg.intent, {
+          clientID: client.clientID,
+          isLobbyCreator: client.clientID === this.lobbyCreatorID,
+          isAdmin: isAdminRole(client.role),
+          isAdminBot: false,
+        });
+        if (outcome.status !== 200) {
+          this.log.warn(`intent rejected`, {
+            type: clientMsg.intent.type,
+            clientID: client.clientID,
+            gameID: this.id,
+            reason: outcome.error,
+          });
+        }
+        break;
       }
-    });
-
-    // Check if WebSocket already closed before we added the listener (race
-    // condition) — the 'close' event has already fired, so the handler above
-    // will never run for this client.
-    if (client.ws.readyState >= 2) {
-      this.log.info("client WebSocket already closing/closed, removing", {
-        clientID: client.clientID,
-        readyState: client.ws.readyState,
-      });
-      this.handleClientDisconnect(client);
+      case "ping": {
+        this.lastPingUpdate = Date.now();
+        client.lastPing = Date.now();
+        break;
+      }
+      case "hash": {
+        client.hashes.set(clientMsg.turnNumber, clientMsg.hash);
+        break;
+      }
+      case "spectate": {
+        this.setSpectator(client, clientMsg.spectator);
+        break;
+      }
+      case "winner": {
+        this.handleWinner(client, clientMsg);
+        break;
+      }
+      case "live_stats": {
+        this.handleLiveStats(client, clientMsg);
+        break;
+      }
+      default: {
+        this.log.warn(`Unknown message type: ${(clientMsg as any).type}`, {
+          clientID: client.clientID,
+        });
+        break;
+      }
     }
   }
 

--- a/src/server/SocketIngress.ts
+++ b/src/server/SocketIngress.ts
@@ -1,0 +1,184 @@
+import { Logger } from "winston";
+import { z } from "zod";
+import { ZbContext } from "../../zbin";
+import { ClientID, ClientMessage, ClientMessageSchema } from "../core/Schemas";
+import { decodeClientMessageUnvalidated } from "../core/ZbinWire";
+import { Client } from "./Client";
+import { ClientMsgRateLimiter } from "./ClientMsgRateLimiter";
+import { MatchTelemetryRecorder } from "./MatchTelemetryRecorder";
+
+export const KICK_REASON_TOO_MUCH_DATA = "kick_reason.too_much_data";
+export const KICK_REASON_INVALID_MESSAGE = "kick_reason.invalid_message";
+
+// Messages that speak for a player in the simulation, so a spectator may not
+// send them — including hash, which feeds desync agreement. Ping and rejoin
+// remain connection housekeeping.
+const SPECTATOR_BLOCKED_MESSAGES = new Set([
+  "intent",
+  "winner",
+  "live_stats",
+  "hash",
+]);
+
+// What the ingress needs from the game it feeds.
+export interface SocketIngressView {
+  // The wire dictionary, once the game has started (see GameServer.zbinCtx).
+  zbinCtx: () => ZbContext | undefined;
+  serverTick: () => number;
+  // A message that passed decoding, validation, rate limiting and the
+  // spectator block.
+  onMessage: (client: Client, msg: ClientMessage) => void;
+  onClose: (client: Client) => void;
+  kick: (clientID: ClientID, reasonKey: string) => void;
+}
+
+// The socket side of a game: attaches the listeners to a client's socket and
+// runs every incoming frame through decode -> validate -> rate-limit ->
+// spectator-block before the game sees it. A frame that fails is dropped or
+// gets its sender kicked here; what a valid message does is
+// GameServer.handleClientMessage.
+export class SocketIngress {
+  constructor(
+    private readonly log: Logger,
+    private readonly telemetry: MatchTelemetryRecorder,
+    private readonly view: SocketIngressView,
+    private readonly rateLimiter: Pick<
+      ClientMsgRateLimiter,
+      "check"
+    > = new ClientMsgRateLimiter(),
+  ) {}
+
+  attach(client: Client): void {
+    client.ws.removeAllListeners("message");
+    client.ws.on("message", async (message: Buffer) => {
+      try {
+        this.receive(client, message);
+      } catch (error) {
+        this.log.info(
+          `error handling websocket request in game server: ${error}`,
+          {
+            clientID: client.clientID,
+          },
+        );
+      }
+    });
+    client.ws.on("close", () => {
+      this.log.info("client disconnected", {
+        clientID: client.clientID,
+        persistentID: client.persistentID,
+      });
+      this.view.onClose(client);
+    });
+    client.ws.on("error", (error: Error) => {
+      if ((error as any).code === "WS_ERR_UNEXPECTED_RSV_1") {
+        client.ws.close(1002, "WS_ERR_UNEXPECTED_RSV_1");
+      }
+    });
+
+    // Check if WebSocket already closed before we added the listener (race
+    // condition) — the 'close' event has already fired, so the handler above
+    // will never run for this client.
+    if (client.ws.readyState >= 2) {
+      this.log.info("client WebSocket already closing/closed, removing", {
+        clientID: client.clientID,
+        readyState: client.ws.readyState,
+      });
+      this.view.onClose(client);
+    }
+  }
+
+  // One frame off a client's socket. Public so the pipeline can be driven
+  // without a socket.
+  receive(client: Client, message: Buffer): void {
+    // Decode and validate in two steps (instead of one parseBytes) so a
+    // message that is structurally sound but fails validation — the
+    // signature of a buggy or cheating client — can still be attributed
+    // to its intent in telemetry, exactly like the JSON path did.
+    let raw: ClientMessage;
+    try {
+      // A Buffer is a Uint8Array and zbin honours its byteOffset.
+      raw = decodeClientMessageUnvalidated(message, this.view.zbinCtx());
+    } catch (e) {
+      // Corrupt bytes: no readable type, nothing to attribute.
+      this.log.warn(`Failed to decode client message, kicking`, {
+        clientID: client.clientID,
+        error: String(e),
+      });
+      this.view.kick(client.clientID, KICK_REASON_INVALID_MESSAGE);
+      return;
+    }
+    const parsed = ClientMessageSchema.safeParse(raw);
+    if (!parsed.success) {
+      const reasonDetail = z.prettifyError(parsed.error);
+      if (raw.type === "intent") {
+        this.telemetry.intentObserved(
+          client,
+          raw.intent,
+          typeof raw.intent?.type === "string" ? raw.intent.type : null,
+          "rejected",
+          this.view.serverTick(),
+          KICK_REASON_INVALID_MESSAGE,
+          reasonDetail,
+        );
+      }
+      this.log.warn(`Failed to parse client message, kicking`, {
+        clientID: client.clientID,
+        error: reasonDetail,
+      });
+      this.view.kick(client.clientID, KICK_REASON_INVALID_MESSAGE);
+      return;
+    }
+    const clientMsg = parsed.data;
+    const bytes = message.length;
+    const rateResult = this.rateLimiter.check(
+      client.clientID,
+      clientMsg.type,
+      bytes,
+    );
+    if (rateResult === "kick") {
+      if (clientMsg.type === "intent") {
+        this.telemetry.intentObserved(
+          client,
+          { ...clientMsg.intent, clientID: client.clientID },
+          clientMsg.intent.type,
+          "rejected",
+          this.view.serverTick(),
+          KICK_REASON_TOO_MUCH_DATA,
+        );
+      }
+      this.log.warn(`Client rate limit exceeded, kicking`, {
+        clientID: client.clientID,
+        type: clientMsg.type,
+      });
+      this.view.kick(client.clientID, KICK_REASON_TOO_MUCH_DATA);
+      return;
+    }
+    if (rateResult === "limit") {
+      if (clientMsg.type === "intent") {
+        this.telemetry.intentObserved(
+          client,
+          { ...clientMsg.intent, clientID: client.clientID },
+          clientMsg.intent.type,
+          "rejected",
+          this.view.serverTick(),
+          "limit",
+        );
+      }
+      this.log.warn(`Client message rate limit exceeded, dropping`, {
+        clientID: client.clientID,
+        type: clientMsg.type,
+      });
+      return;
+    }
+    // A spectator is not in the simulation, so none of what it sends can be
+    // game state. Without this, claiming to spectate is a way past the lobby
+    // cap and into the intent stream.
+    if (client.spectator && SPECTATOR_BLOCKED_MESSAGES.has(clientMsg.type)) {
+      this.log.warn(`dropping ${clientMsg.type} from spectator`, {
+        clientID: client.clientID,
+      });
+      return;
+    }
+    this.view.onMessage(client, clientMsg);
+  }
+}

--- a/tests/server/MatchTelemetryIntegration.test.ts
+++ b/tests/server/MatchTelemetryIntegration.test.ts
@@ -257,60 +257,6 @@ describe("GameServer match telemetry", () => {
     ).toHaveLength(0);
   });
 
-  it.each([
-    ["limit", "limit"],
-    ["kick", "kick_reason.too_much_data"],
-  ] as const)(
-    "captures the existing %s rate-limiter outcome",
-    async (rateResult, reasonCode) => {
-      const game = makeGame();
-      (game as any).intentRateLimiter = { check: () => rateResult };
-      const { client, ws } = makeClient();
-      game.joinClient(client);
-      const intentsBefore = [...(game as any).intents];
-      expect(intentsBefore).toEqual([
-        {
-          type: "mark_disconnected",
-          clientID: "clientAB",
-          isDisconnected: false,
-        },
-      ]);
-      await ws.trigger(
-        "message",
-        clientFrame({ type: "intent", intent: { type: "spawn", tile: 1 } }),
-      );
-      const observed = telemetry.events.find(
-        (event) => event.type === "intent_observed",
-      );
-      expect(observed).toMatchObject({
-        payload: {
-          outcome: "rejected",
-          reasonCode,
-          intentType: "spawn",
-        },
-      });
-      expect(observed?.type).toBe("intent_observed");
-      if (observed?.type !== "intent_observed") {
-        throw new Error("expected intent_observed telemetry");
-      }
-      expect(observed.payload.identity).toEqual({
-        clientId: "clientAB",
-        publicId: "publicABC",
-      });
-      expect(observed.payload.intent).toEqual({
-        type: "spawn",
-        tile: 1,
-        clientID: "clientAB",
-      });
-      expect((game as any).intents).toEqual(intentsBefore);
-      if (rateResult === "kick") {
-        expect(ws.close).toHaveBeenCalledOnce();
-      } else {
-        expect(ws.close).not.toHaveBeenCalled();
-      }
-    },
-  );
-
   it("emits a turn marker after all intent decisions for that tick", async () => {
     const game = makeGame();
     const { client, ws } = makeClient();

--- a/tests/server/SocketIngress.test.ts
+++ b/tests/server/SocketIngress.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MatchTelemetryRecorder } from "../../src/server/MatchTelemetryRecorder";
+import {
+  KICK_REASON_INVALID_MESSAGE,
+  KICK_REASON_TOO_MUCH_DATA,
+  SocketIngress,
+  SocketIngressView,
+} from "../../src/server/SocketIngress";
+import type {
+  MatchTelemetryCounters,
+  MatchTelemetryEmitter,
+  MatchTelemetryEvent,
+} from "../../src/server/telemetry/MatchTelemetry";
+import {
+  cid,
+  makeClient,
+  mockLogger,
+  mockWsOf,
+} from "../util/GameServerHarness";
+import { clientFrame } from "../util/Wire";
+
+// The ingress pipeline on its own, with a stubbed rate limiter: what reaches
+// the game, what is dropped, who gets kicked, and how a rejected intent is
+// attributed in telemetry. What a delivered message then does is GameServer's
+// handleClientMessage, covered by the frame-level tests (GameServerWire,
+// GameServerJoin, MatchTelemetryIntegration).
+
+class RecordingEmitter implements MatchTelemetryEmitter {
+  events: MatchTelemetryEvent[] = [];
+  emit(event: MatchTelemetryEvent) {
+    this.events.push(event);
+    return "enqueued" as const;
+  }
+  counters(): MatchTelemetryCounters {
+    throw new Error("not used");
+  }
+  stop() {}
+}
+
+type Rate = "ok" | "limit" | "kick";
+
+function setup(rate: Rate = "ok") {
+  const emitter = new RecordingEmitter();
+  const view: SocketIngressView = {
+    zbinCtx: () => undefined,
+    serverTick: () => 7,
+    onMessage: vi.fn(),
+    onClose: vi.fn(),
+    kick: vi.fn(),
+  };
+  const check = vi.fn((): Rate => rate);
+  const ingress = new SocketIngress(
+    mockLogger(),
+    new MatchTelemetryRecorder(emitter, cid("match"), "build-1"),
+    view,
+    { check },
+  );
+  const observed = () =>
+    emitter.events
+      .filter((e) => e.type === "intent_observed")
+      .map((e) => e.payload);
+  return { ingress, view, check, observed };
+}
+
+const P1 = cid("p1");
+const spawn = () =>
+  clientFrame({ type: "intent", intent: { type: "spawn", tile: 1 } });
+
+describe("SocketIngress.receive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_700_000_000_000);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("hands a valid message to the game after charging it to the rate limiter", () => {
+    const { ingress, view, check, observed } = setup();
+    const client = makeClient({ clientID: P1 });
+    const frame = clientFrame({ type: "ping" });
+
+    ingress.receive(client, frame);
+
+    expect(check).toHaveBeenCalledWith(P1, "ping", frame.length);
+    expect(view.onMessage).toHaveBeenCalledWith(client, { type: "ping" });
+    expect(view.kick).not.toHaveBeenCalled();
+    expect(observed()).toEqual([]);
+  });
+
+  it("kicks corrupt bytes as invalid_message, with nothing to attribute", () => {
+    const { ingress, view, check, observed } = setup();
+    const client = makeClient({ clientID: P1 });
+
+    ingress.receive(client, Buffer.from([0xff, 0xff, 0xff, 0xff]));
+
+    expect(view.kick).toHaveBeenCalledWith(P1, KICK_REASON_INVALID_MESSAGE);
+    expect(view.onMessage).not.toHaveBeenCalled();
+    expect(check).not.toHaveBeenCalled();
+    expect(observed()).toEqual([]);
+  });
+
+  it("kicks a schema-invalid intent and attributes its raw payload first", () => {
+    const { ingress, view, observed } = setup();
+    const client = makeClient({ clientID: P1, publicId: "p1-pub" });
+
+    // Decodes (the target is a plain string on the wire) but fails zod.
+    ingress.receive(
+      client,
+      clientFrame({
+        type: "intent",
+        intent: { type: "targetPlayer", target: "not a client id" },
+      }),
+    );
+
+    expect(observed()).toMatchObject([
+      {
+        identity: { clientId: P1, publicId: "p1-pub" },
+        intentType: "targetPlayer",
+        outcome: "rejected",
+        reasonCode: KICK_REASON_INVALID_MESSAGE,
+        reasonDetail: expect.stringContaining("target"),
+        intent: { type: "targetPlayer", target: "not a client id" },
+      },
+    ]);
+    expect(view.kick).toHaveBeenCalledWith(P1, KICK_REASON_INVALID_MESSAGE);
+    expect(view.onMessage).not.toHaveBeenCalled();
+  });
+
+  it("kicks a schema-invalid non-intent without attributing anything", () => {
+    const { ingress, view, observed } = setup();
+    const client = makeClient({ clientID: P1 });
+
+    ingress.receive(
+      client,
+      clientFrame({
+        type: "rejoin",
+        gameID: "not a game id",
+        lastTurn: 0,
+        token: "secret",
+      }),
+    );
+
+    expect(view.kick).toHaveBeenCalledWith(P1, KICK_REASON_INVALID_MESSAGE);
+    expect(observed()).toEqual([]);
+  });
+
+  it.each([
+    ["limit", "limit", false],
+    ["kick", KICK_REASON_TOO_MUCH_DATA, true],
+  ] as const)(
+    "on a rate-limiter %s, attributes the intent as rejected and keeps it from the game",
+    (rate, reasonCode, kicked) => {
+      const { ingress, view, observed } = setup(rate);
+      const client = makeClient({ clientID: P1, publicId: "p1-pub" });
+
+      ingress.receive(client, spawn());
+
+      expect(observed()).toMatchObject([
+        {
+          identity: { clientId: P1, publicId: "p1-pub" },
+          intentType: "spawn",
+          outcome: "rejected",
+          reasonCode,
+          intent: { type: "spawn", tile: 1, clientID: P1 },
+        },
+      ]);
+      expect(view.onMessage).not.toHaveBeenCalled();
+      if (kicked) {
+        expect(view.kick).toHaveBeenCalledWith(P1, KICK_REASON_TOO_MUCH_DATA);
+      } else {
+        expect(view.kick).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("drops a rate-limited non-intent quietly", () => {
+    const { ingress, view, observed } = setup("limit");
+    ingress.receive(
+      makeClient({ clientID: P1 }),
+      clientFrame({ type: "ping" }),
+    );
+    expect(view.onMessage).not.toHaveBeenCalled();
+    expect(view.kick).not.toHaveBeenCalled();
+    expect(observed()).toEqual([]);
+  });
+
+  it("drops what a spectator sends for the simulation, but not housekeeping", () => {
+    const { ingress, view, observed } = setup();
+    const spectator = makeClient({ clientID: P1, spectator: true });
+
+    ingress.receive(spectator, spawn());
+    ingress.receive(
+      spectator,
+      clientFrame({ type: "hash", turnNumber: 0, hash: 1 }),
+    );
+    expect(view.onMessage).not.toHaveBeenCalled();
+    // Not a rejection of the intent, just a drop: nothing to attribute.
+    expect(observed()).toEqual([]);
+
+    ingress.receive(spectator, clientFrame({ type: "ping" }));
+    expect(view.onMessage).toHaveBeenCalledWith(spectator, { type: "ping" });
+  });
+});
+
+describe("SocketIngress.attach", () => {
+  it("routes the socket's frames through receive and its close to the game", async () => {
+    const { ingress, view } = setup();
+    const client = makeClient({ clientID: P1 });
+    ingress.attach(client);
+
+    await mockWsOf(client).trigger("message", clientFrame({ type: "ping" }));
+    expect(view.onMessage).toHaveBeenCalledWith(client, { type: "ping" });
+
+    await mockWsOf(client).trigger("close");
+    expect(view.onClose).toHaveBeenCalledWith(client);
+  });
+
+  it("reports a socket that closed before it was attached", () => {
+    const { ingress, view } = setup();
+    const client = makeClient({ clientID: P1 });
+    mockWsOf(client).readyState = 3;
+    ingress.attach(client);
+    expect(view.onClose).toHaveBeenCalledWith(client);
+  });
+
+  it("keeps an error thrown by the game from escaping the socket handler", async () => {
+    const { ingress, view } = setup();
+    (view.onMessage as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const client = makeClient({ clientID: P1 });
+    ingress.attach(client);
+    await expect(
+      mockWsOf(client).trigger("message", clientFrame({ type: "ping" })),
+    ).resolves.toBeUndefined();
+    expect(view.kick).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

First half of Phase 5 of `docs/GameServerRefactor.md` (Phases 0–4 are merged, #5146 was Phase 4). The plan's second Phase 5 item, `authorizeIntent`, follows as its own PR.

- **`src/server/SocketIngress.ts`** (new): the socket listeners and the per-frame pipeline move out of `GameServer.addListeners`. `attach(client)` wires `message`/`close`/`error` and keeps the closed-before-attach race check; `receive(client, frame)` is decode → validate → rate-limit → spectator-block, with the three telemetry attributions for a rejected intent exactly as before, then hands the validated `ClientMessage` to the game. The game is reached through a small `SocketIngressView` (`zbinCtx`, `serverTick`, `onMessage`, `onClose`, `kick`). The two kick-reason constants and `SPECTATOR_BLOCKED_MESSAGES` move with it.
- **`GameServer.ts`**: the message switch stays, unchanged, as `handleClientMessage(client, msg)`; `intentRateLimiter` and three now-unused imports are gone. 1,888 → 1,755 lines.
- The rate limiter is a constructor parameter of the ingress (`Pick<ClientMsgRateLimiter, "check">`, defaulting to the real one), so the two stubbed-limiter cases in `MatchTelemetryIntegration.test.ts` that reached in to replace it move to **`SocketIngress.test.ts`** with the same telemetry assertions. That file also covers the valid pass-through (and the byte charge to the limiter), corrupt bytes, schema-invalid intent and non-intent, the spectator block, and `attach` (close, closed-before-attach, an error thrown by the game not escaping the handler). `(game as any)` reach-ins 29 → 26.

Pure move, no behaviour change: the frame-level decode / kick / spectator tests through `GameServer` are untouched and the golden wire transcript (`GameServerWire.test.ts.snap`) is byte-identical.

## Test plan

- `npx vitest tests/server --run`: 54 files / 540 tests pass (was 53 / 531); snapshot unchanged
- `npx tsc --noEmit`, `npm run lint` (oxlint + eslint), `prettier --check`: clean
- Mutation spot-check: disabling the spectator block fails 6 tests across 3 files (`SocketIngress`, `SpectatorJoin`, the golden `GameServerWire`), restored
- Full `npm test`: 31 failed files / 379 failed tests — identical to pristine `origin/main` (pre-existing client `localStorage` failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)