### PR TITLE
refactor(server): extract the intent guards out of GameServer.handleIntent

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -245,8 +245,17 @@ replaced by real joins and observable outcomes. Golden snapshot unchanged.
       constructor parameter, so `SocketIngress.test.ts` drives the limit and
       kick telemetry paths that `MatchTelemetryIntegration.test.ts` used to
       reach in for; the frame-level decode / kick tests are unchanged.
-- [ ] `authorizeIntent(intent, actor): IntentOutcome | null` (pure guards,
-      table-testable) separated from the effects in `handleIntent`.
+- [x] `IntentAuthorization.ts` (2026-08-27): `authorizeIntent` takes the
+      intent, the actor and the game state and is every actor / game-state
+      guard of `handleIntent`, in order, returning the first refusal or null;
+      `IntentActor` and `IntentOutcome` live there too. `handleIntent` keeps
+      what needs the roster (resolving a kick target) and the effects.
+      `IntentAuthorization.test.ts` is the table.
+
+Phase 5 complete (2026-08-27): two PRs, golden snapshot unchanged.
+`GameServer.ts` is 1663 lines (from 1,888); reach-ins 26. What is left
+reaches for `intents`, `isPaused`, `_hasStarted`, `_hasEnded`,
+`_hasPrestarted` and `startsAt` — the lifecycle state of Phase 6.
 
 ## Phase 6 — Lifecycle state machine
 

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -42,6 +42,11 @@ import { applyGameConfigPatch, hostCheatsEnabled } from "./ConfigPatch";
 import { LiveStatsVote, WinnerVote } from "./Consensus";
 import { fetchCustomTribes } from "./CustomTribes";
 import { DesyncDetector } from "./DesyncDetector";
+import {
+  authorizeIntent,
+  IntentActor,
+  IntentOutcome,
+} from "./IntentAuthorization";
 import { ListingState } from "./ListingState";
 import { identityFor, MatchTelemetryRecorder } from "./MatchTelemetryRecorder";
 import { friendsLookup, NameVisibility } from "./NameVisibility";
@@ -60,21 +65,6 @@ export enum GamePhase {
 
 // Identity + authority for an intent, supplied by whoever dispatched it: a
 // per-connection websocket client, or the trusted admin-bot HTTP API.
-export interface IntentActor {
-  clientID: ClientID; // stamped onto the intent
-  isLobbyCreator: boolean;
-  isAdmin: boolean; // role-based admin/root (also true for the admin bot)
-  isAdminBot: boolean; // the trusted admin-bot HTTP API
-}
-
-// Outcome of dispatching an intent. `status` is an HTTP-style code: 200 on
-// success. The admin-bot route maps a non-200 straight to its response; the
-// websocket path logs it and drops the message.
-export interface IntentOutcome {
-  status: number;
-  error?: string;
-}
-
 export function hashPersistentID(persistentID: string): string {
   return createHash("sha256").update(persistentID).digest("hex");
 }
@@ -280,9 +270,10 @@ export class GameServer {
   }
 
   // Dispatch a control/gameplay intent from either a websocket client or the
-  // trusted admin-bot HTTP API. `actor` carries the authority; the per-intent
-  // actions and game-state guards live here. Returns an HTTP-style outcome the
-  // caller maps (the bot route -> response, the websocket path -> a log).
+  // trusted admin-bot HTTP API. `actor` carries the authority; the guards are
+  // authorizeIntent, the per-intent actions live here. Returns an HTTP-style
+  // outcome the caller maps (the bot route -> response, the websocket path ->
+  // a log).
   public handleIntent(intent: Intent, actor: IntentActor): IntentOutcome {
     const serverTick = this.turns.length;
     const stamped: StampedIntent = { ...intent, clientID: actor.clientID };
@@ -308,38 +299,17 @@ export class GameServer {
       return outcome;
     };
 
-    // The admin bot only manages private games.
-    if (actor.isAdminBot && this.isPublic()) {
-      return finish({
-        status: 403,
-        error: "admin bot cannot act on public games",
-      });
+    const denied = authorizeIntent(intent, actor, {
+      isPublic: this.isPublic(),
+      isListed: this.isListed(),
+      hasStarted: this.hasStarted(),
+    });
+    if (denied !== null) {
+      return finish(denied);
     }
 
     switch (stamped.type) {
-      case "mark_disconnected":
-        return finish({
-          status: 400,
-          error: "mark_disconnected is server-internal",
-        });
-
       case "kick_player": {
-        if (!actor.isLobbyCreator && !actor.isAdmin) {
-          return finish({
-            status: 403,
-            error: "only the lobby creator or an admin can kick players",
-          });
-        }
-        // A listed lobby recruits strangers from the public browser; letting
-        // the host kick them is a griefing vector. Admins keep the power for
-        // moderation. The listed flag survives game start on purpose, so a
-        // publicly recruited game stays kick-free like a real public game.
-        if (this.isListed() && !actor.isAdmin) {
-          return finish({
-            status: 403,
-            error: "the host cannot kick players in a publicly listed lobby",
-          });
-        }
         // Resolve the target to a clientID: an explicit clientID, or an account
         // publicId matched against everyone who ever joined (a superset of the
         // connected that retains disconnected players), so a disconnected
@@ -373,51 +343,11 @@ export class GameServer {
       }
 
       case "update_game_config": {
-        if (!actor.isLobbyCreator && !actor.isAdminBot) {
-          return finish({
-            status: 403,
-            error: "only the lobby creator can update game config",
-          });
-        }
-        if (this.isPublic()) {
-          return finish({ status: 403, error: "cannot update a public game" });
-        }
-        if (this.hasStarted()) {
-          return finish({ status: 409, error: "game already started" });
-        }
-        if (stamped.config.gameType === GameType.Public) {
-          return finish({
-            status: 400,
-            error: "cannot change a game to public",
-          });
-        }
-        // Host cheats give the host an asymmetric advantage over players
-        // recruited from the lobby browser. Listing is likewise rejected
-        // while cheats are on (Worker's listing endpoint), so a listed
-        // lobby can never have them.
-        if (this.isListed() && hostCheatsEnabled(stamped.config.hostCheats)) {
-          return finish({
-            status: 409,
-            error: "cannot enable host cheats in a publicly listed lobby",
-          });
-        }
         this.updateGameConfig(stamped.config);
         return finish({ status: 200 });
       }
 
       case "toggle_game_start_timer": {
-        if (!actor.isLobbyCreator && !actor.isAdminBot) {
-          return finish({
-            status: 403,
-            error: "only the lobby creator can start",
-          });
-        }
-        if (this.isPublic()) {
-          return finish({ status: 403, error: "cannot start a public game" });
-        }
-        if (this.hasStarted()) {
-          return finish({ status: 409, error: "game already started" });
-        }
         if (this.startsAt) {
           this.startsAt = undefined;
         } else {
@@ -429,22 +359,6 @@ export class GameServer {
       }
 
       case "toggle_pause": {
-        if (!actor.isLobbyCreator && !actor.isAdminBot) {
-          return finish({
-            status: 403,
-            error: "only the lobby creator can pause",
-          });
-        }
-        if (this.isListed() && !actor.isAdminBot) {
-          return finish({
-            status: 403,
-            error: "the host cannot pause a publicly listed game",
-          });
-        }
-        // Pausing only makes sense once the game is running.
-        if (!this.hasStarted()) {
-          return finish({ status: 409, error: "game not started" });
-        }
         const outcome = finish({ status: 200 });
         // Pausing: flush the intent into a turn before isPaused short-circuits
         // endTurn(). Unpausing: clear the flag first so the next turn runs.
@@ -461,13 +375,7 @@ export class GameServer {
       }
 
       default: {
-        // Gameplay intents: websocket players only, into the turn queue.
-        if (actor.isAdminBot) {
-          return finish({
-            status: 400,
-            error: "intent not permitted for admin bot",
-          });
-        }
+        // Gameplay intents, into the turn queue.
         // While paused the intent is accepted at ingress but not queued into a
         // turn; tag it so telemetry can tell it apart from a queued intent.
         const paused = this.isPaused;

--- a/src/server/IntentAuthorization.ts
+++ b/src/server/IntentAuthorization.ts
@@ -1,0 +1,128 @@
+import { GameType } from "../core/game/Game";
+import { ClientID, Intent } from "../core/Schemas";
+import { hostCheatsEnabled } from "./ConfigPatch";
+
+export interface IntentActor {
+  clientID: ClientID; // stamped onto the intent
+  isLobbyCreator: boolean;
+  isAdmin: boolean; // role-based admin/root (also true for the admin bot)
+  isAdminBot: boolean; // the trusted admin-bot HTTP API
+}
+
+// Outcome of dispatching an intent. `status` is an HTTP-style code: 200 on
+// success. The admin-bot route maps a non-200 straight to its response; the
+// websocket path logs it and drops the message.
+export interface IntentOutcome {
+  status: number;
+  error?: string;
+}
+
+// The game state the guards read.
+export interface IntentGameState {
+  isPublic: boolean;
+  isListed: boolean;
+  hasStarted: boolean;
+}
+
+// The actor and game-state guards of GameServer.handleIntent, in the order
+// it applies them: the first that fails is the outcome; null means the
+// intent may go ahead. Pure, so every combination is table-testable. What
+// needs the roster (resolving a kick target) or changes the game stays in
+// handleIntent.
+export function authorizeIntent(
+  intent: Intent,
+  actor: IntentActor,
+  game: IntentGameState,
+): IntentOutcome | null {
+  // The admin bot only manages private games.
+  if (actor.isAdminBot && game.isPublic) {
+    return { status: 403, error: "admin bot cannot act on public games" };
+  }
+
+  switch (intent.type) {
+    case "mark_disconnected":
+      return { status: 400, error: "mark_disconnected is server-internal" };
+
+    case "kick_player":
+      if (!actor.isLobbyCreator && !actor.isAdmin) {
+        return {
+          status: 403,
+          error: "only the lobby creator or an admin can kick players",
+        };
+      }
+      // A listed lobby recruits strangers from the public browser; letting
+      // the host kick them is a griefing vector. Admins keep the power for
+      // moderation. The listed flag survives game start on purpose, so a
+      // publicly recruited game stays kick-free like a real public game.
+      if (game.isListed && !actor.isAdmin) {
+        return {
+          status: 403,
+          error: "the host cannot kick players in a publicly listed lobby",
+        };
+      }
+      return null;
+
+    case "update_game_config":
+      if (!actor.isLobbyCreator && !actor.isAdminBot) {
+        return {
+          status: 403,
+          error: "only the lobby creator can update game config",
+        };
+      }
+      if (game.isPublic) {
+        return { status: 403, error: "cannot update a public game" };
+      }
+      if (game.hasStarted) {
+        return { status: 409, error: "game already started" };
+      }
+      if (intent.config.gameType === GameType.Public) {
+        return { status: 400, error: "cannot change a game to public" };
+      }
+      // Host cheats give the host an asymmetric advantage over players
+      // recruited from the lobby browser. Listing is likewise rejected
+      // while cheats are on (Worker's listing endpoint), so a listed
+      // lobby can never have them.
+      if (game.isListed && hostCheatsEnabled(intent.config.hostCheats)) {
+        return {
+          status: 409,
+          error: "cannot enable host cheats in a publicly listed lobby",
+        };
+      }
+      return null;
+
+    case "toggle_game_start_timer":
+      if (!actor.isLobbyCreator && !actor.isAdminBot) {
+        return { status: 403, error: "only the lobby creator can start" };
+      }
+      if (game.isPublic) {
+        return { status: 403, error: "cannot start a public game" };
+      }
+      if (game.hasStarted) {
+        return { status: 409, error: "game already started" };
+      }
+      return null;
+
+    case "toggle_pause":
+      if (!actor.isLobbyCreator && !actor.isAdminBot) {
+        return { status: 403, error: "only the lobby creator can pause" };
+      }
+      if (game.isListed && !actor.isAdminBot) {
+        return {
+          status: 403,
+          error: "the host cannot pause a publicly listed game",
+        };
+      }
+      // Pausing only makes sense once the game is running.
+      if (!game.hasStarted) {
+        return { status: 409, error: "game not started" };
+      }
+      return null;
+
+    default:
+      // Gameplay intents: websocket players only.
+      if (actor.isAdminBot) {
+        return { status: 400, error: "intent not permitted for admin bot" };
+      }
+      return null;
+  }
+}

--- a/tests/server/IntentAuthorization.test.ts
+++ b/tests/server/IntentAuthorization.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, it } from "vitest";
+import { GameType } from "../../src/core/game/Game";
+import { GameConfig, Intent } from "../../src/core/Schemas";
+import {
+  authorizeIntent,
+  IntentActor,
+  IntentGameState,
+} from "../../src/server/IntentAuthorization";
+import { cid } from "../util/GameServerHarness";
+
+// The guards on their own, as a table. What an authorized intent then does —
+// kicking, config patching, the start timer, pausing, queueing — is covered
+// through GameServer in AdminBotIntent, HostedLobbyListing and the golden
+// transcript.
+
+const actor = (over: Partial<IntentActor> = {}): IntentActor => ({
+  clientID: cid("p1"),
+  isLobbyCreator: false,
+  isAdmin: false,
+  isAdminBot: false,
+  ...over,
+});
+const player = actor();
+const host = actor({ isLobbyCreator: true });
+const admin = actor({ isAdmin: true });
+const bot = actor({ isAdmin: true, isAdminBot: true });
+
+const lobby = (over: Partial<IntentGameState> = {}): IntentGameState => ({
+  isPublic: false,
+  isListed: false,
+  hasStarted: false,
+  ...over,
+});
+
+const kick: Intent = { type: "kick_player", targetClientID: cid("p2") };
+const config = (c: Partial<GameConfig>): Intent => ({
+  type: "update_game_config",
+  config: c,
+});
+const timer: Intent = { type: "toggle_game_start_timer" };
+const pause: Intent = { type: "toggle_pause", paused: true };
+const spawn: Intent = { type: "spawn", tile: 1 };
+
+describe("authorizeIntent", () => {
+  it.each<[string, Intent, IntentActor, IntentGameState, number | null]>([
+    // The admin bot is refused any intent on a public game, before anything
+    // else is considered.
+    ["bot on a public game", spawn, bot, lobby({ isPublic: true }), 403],
+    ["bot kick on a public game", kick, bot, lobby({ isPublic: true }), 403],
+
+    [
+      "mark_disconnected from anyone",
+      { type: "mark_disconnected", isDisconnected: true },
+      host,
+      lobby(),
+      400,
+    ],
+
+    ["kick by a player", kick, player, lobby(), 403],
+    ["kick by the host", kick, host, lobby(), null],
+    [
+      "kick by the host of a listed lobby",
+      kick,
+      host,
+      lobby({ isListed: true }),
+      403,
+    ],
+    [
+      "kick by an admin in a listed lobby",
+      kick,
+      admin,
+      lobby({ isListed: true }),
+      null,
+    ],
+    [
+      "kick by the bot in a listed lobby",
+      kick,
+      bot,
+      lobby({ isListed: true }),
+      null,
+    ],
+    [
+      "kick by the host of a listed game that started",
+      kick,
+      host,
+      lobby({ isListed: true, hasStarted: true }),
+      403,
+    ],
+
+    ["config by a player", config({ bots: 1 }), player, lobby(), 403],
+    [
+      "config by an admin who is not the host",
+      config({ bots: 1 }),
+      admin,
+      lobby(),
+      403,
+    ],
+    ["config by the host", config({ bots: 1 }), host, lobby(), null],
+    ["config by the bot", config({ bots: 1 }), bot, lobby(), null],
+    [
+      "config on a public game",
+      config({ bots: 1 }),
+      host,
+      lobby({ isPublic: true }),
+      403,
+    ],
+    [
+      "config after the start",
+      config({ bots: 1 }),
+      host,
+      lobby({ hasStarted: true }),
+      409,
+    ],
+    [
+      "config promoting the game to public",
+      config({ gameType: GameType.Public }),
+      host,
+      lobby(),
+      400,
+    ],
+    [
+      "config enabling host cheats in a listed lobby",
+      config({ hostCheats: { infiniteGold: true } }),
+      host,
+      lobby({ isListed: true }),
+      409,
+    ],
+    [
+      "config without cheats in a listed lobby",
+      config({ bots: 1 }),
+      host,
+      lobby({ isListed: true }),
+      null,
+    ],
+
+    ["start timer by a player", timer, player, lobby(), 403],
+    ["start timer by the host", timer, host, lobby(), null],
+    ["start timer by the bot", timer, bot, lobby(), null],
+    [
+      "start timer on a public game",
+      timer,
+      host,
+      lobby({ isPublic: true }),
+      403,
+    ],
+    [
+      "start timer after the start",
+      timer,
+      host,
+      lobby({ hasStarted: true }),
+      409,
+    ],
+
+    ["pause by a player", pause, player, lobby({ hasStarted: true }), 403],
+    ["pause by the host", pause, host, lobby({ hasStarted: true }), null],
+    [
+      "pause by the host of a listed game",
+      pause,
+      host,
+      lobby({ isListed: true, hasStarted: true }),
+      403,
+    ],
+    [
+      "pause by the bot in a listed game",
+      pause,
+      bot,
+      lobby({ isListed: true, hasStarted: true }),
+      null,
+    ],
+    ["pause before the start", pause, host, lobby(), 409],
+
+    ["gameplay by a player", spawn, player, lobby(), null],
+    [
+      "gameplay by a player in a public game",
+      spawn,
+      player,
+      lobby({ isPublic: true }),
+      null,
+    ],
+    ["gameplay by an admin", spawn, admin, lobby(), null],
+    ["gameplay by the bot", spawn, bot, lobby(), 400],
+  ])("%s", (_name, intent, who, game, status) => {
+    const outcome = authorizeIntent(intent, who, game);
+    if (status === null) {
+      expect(outcome).toBeNull();
+    } else {
+      expect(outcome).toMatchObject({ status, error: expect.any(String) });
+    }
+  });
+
+  it("names the reason", () => {
+    expect(authorizeIntent(kick, host, lobby({ isListed: true }))).toEqual({
+      status: 403,
+      error: "the host cannot kick players in a publicly listed lobby",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Second half of Phase 5 of `docs/GameServerRefactor.md` (#5149 was the first half; Phases 0–4 are merged). This completes Phase 5.

- **`src/server/IntentAuthorization.ts`** (new): `authorizeIntent(intent, actor, game)` is every actor and game-state guard of `handleIntent` — the admin bot on a public game, `mark_disconnected`, and the per-intent checks for `kick_player`, `update_game_config`, `toggle_game_start_timer`, `toggle_pause` and gameplay intents — in the same order, with the same status codes and messages, as a pure function over `{ isPublic, isListed, hasStarted }`. It returns the first refusal or `null`. `IntentActor` and `IntentOutcome` move with it (they had no consumers outside `GameServer.ts`); the guard comments (listed-lobby kick griefing, host cheats) move with their guards.
- **`GameServer.ts`**: `handleIntent` applies `authorizeIntent` first and keeps only what needs the roster (resolving a kick target by publicId, the self-kick check) and the effects. 1,755 → 1,663 lines. `hostCheatsEnabled` stays imported for `hasHostCheats()`.
- **`tests/server/IntentAuthorization.test.ts`**: a 34-row `it.each` table over player / host / admin / bot × lobby state × intent, including the ordering (the bot is refused on a public game before any per-intent check) and the refusal text. The existing tests through `GameServer` (`AdminBotIntent`, `HostedLobbyListing`, the golden transcript) are unchanged.

Pure move, no behaviour change: the golden wire transcript (`GameServerWire.test.ts.snap`) is byte-identical. `(game as any)` reach-ins stay at 26 — everything left is lifecycle state, Phase 6's target.

## Test plan

- `npx vitest tests/server --run`: 55 files / 573 tests pass (was 54 / 540); snapshot unchanged
- `npx tsc --noEmit`, `npm run lint` (oxlint + eslint), `prettier --check`: clean
- Mutation spot-check: disabling the listed-lobby kick guard fails 4 tests across 2 files (`IntentAuthorization`, `HostedLobbyListing`), restored
- Full `npm test`: 31 failed files / 379 failed tests — identical to pristine `origin/main` (pre-existing client `localStorage` failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)