### PR TITLE
refactor(server): take the ping prune out of GameServer.phase()

### DIFF
--- a/docs/GameServerRefactor.md
+++ b/docs/GameServerRefactor.md
@@ -261,9 +261,11 @@ reaches for `intents`, `isPaused`, `_hasStarted`, `_hasEnded`,
 
 - [ ] One `state: "lobby" | "prestart" | "started" | "ended"` plus `paused`
       replaces the booleans. `hasStarted()` becomes `state !== "lobby"`.
-- [ ] Split `phase()` into `pruneStaleClients()` (side effects; called once per
-      `GameManager.tick`) and a pure `phase()`. `publicLobbies()` /
-      `listedLobbies()` stop mutating state.
+- [x] (2026-08-27) `phase()` is a pure read; the 60s ping prune (with its
+      winner re-tally) is `pruneStaleClients()`, which `GameManager.tick`
+      calls just before `phase()` and which is a no-op once the game has
+      ended, as the old early return made it. `publicLobbies()` and
+      `listedLobbies()` no longer close anyone's socket.
 - [ ] Decide whether `end()` should await `archive()` after checking how
       `Archive.ts` handles rejections.
 

--- a/src/server/GameManager.ts
+++ b/src/server/GameManager.ts
@@ -143,6 +143,7 @@ export class GameManager {
   tick() {
     const active = new Map<GameID, GameServer>();
     for (const [id, game] of this.games) {
+      game.pruneStaleClients();
       const phase = game.phase();
       if (phase === GamePhase.Lobby) {
         game.maybeAutoStartListed();

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1194,16 +1194,15 @@ export class GameServer {
     this.telemetry.matchFinished(this.turns.length);
   }
 
-  phase(): GamePhase {
-    // An ended game (e.g. an unstarted lobby whose host left) must report
-    // Finished: GameManager prunes on Finished, and a ghost that kept
-    // reporting Lobby would stay advertised in the lobby browser and hold
-    // the creator's one-listing quota until the max-duration cutoff.
+  // Drops the clients that have not pinged for 60s. GameManager calls this
+  // once per tick, just before phase(); it is the one lifecycle step with a
+  // side effect, and keeping it out of phase() lets the lobby browser read
+  // the phase as often as it likes without closing anyone's socket.
+  public pruneStaleClients(): void {
     if (this._hasEnded) {
-      return GamePhase.Finished;
+      return;
     }
-    const now = Date.now();
-    const stale = this.clients.pruneStale(now, 60_000);
+    const stale = this.clients.pruneStale(Date.now(), 60_000);
     for (const client of stale) {
       this.log.info("no pings received, terminating connection", {
         clientID: client.clientID,
@@ -1218,6 +1217,18 @@ export class GameServer {
     if (stale.length > 0) {
       this.checkWinnerAfterElectorateShrink();
     }
+  }
+
+  // A pure read of the lifecycle; pruneStaleClients() is the side effect.
+  phase(): GamePhase {
+    // An ended game (e.g. an unstarted lobby whose host left) must report
+    // Finished: GameManager prunes on Finished, and a ghost that kept
+    // reporting Lobby would stay advertised in the lobby browser and hold
+    // the creator's one-listing quota until the max-duration cutoff.
+    if (this._hasEnded) {
+      return GamePhase.Finished;
+    }
+    const now = Date.now();
     if (now > this.createdAt + this.maxGameDuration) {
       this.log.warn("game past max duration", {
         gameID: this.id,

--- a/tests/server/GameServerPhase.test.ts
+++ b/tests/server/GameServerPhase.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createGameWireContext } from "../../src/core/ZbinWire";
+import { GameManager } from "../../src/server/GameManager";
 import { GamePhase } from "../../src/server/GameServer";
 import {
   cid,
   makeClient,
   makeGame,
+  mockLogger,
   mockWsOf,
   startGame,
 } from "../util/GameServerHarness";
@@ -82,6 +84,7 @@ describe("GameServer.phase()", () => {
     vi.advanceTimersByTime(60_500);
     await mockWsOf(chatty).emit({ type: "ping" });
 
+    game.pruneStaleClients();
     expect(game.phase()).toBe(GamePhase.Active);
     expect(mockWsOf(quiet).close).toHaveBeenCalledWith(
       1000,
@@ -100,7 +103,70 @@ describe("GameServer.phase()", () => {
 
     // 60s without pings prunes both; the game is then unattended.
     vi.advanceTimersByTime(60_500);
+    game.pruneStaleClients();
     expect(game.phase()).toBe(GamePhase.Finished);
+    expect(game.numClients()).toBe(0);
+  });
+
+  it("reads the phase without pruning; only pruneStaleClients drops anyone", () => {
+    const game = makeGame({ startsAt: T0 + 1000 });
+    const quiet = makeClient({ clientID: cid("quiet") });
+    game.joinClient(quiet);
+    vi.advanceTimersByTime(60_500);
+
+    expect(game.phase()).toBe(GamePhase.Active);
+    expect(mockWsOf(quiet).close).not.toHaveBeenCalled();
+    expect(game.numClients()).toBe(1);
+
+    game.pruneStaleClients();
+    expect(mockWsOf(quiet).close).toHaveBeenCalled();
+    expect(game.numClients()).toBe(0);
+  });
+
+  it("does not prune once the game has ended", async () => {
+    // end() closes the sockets but leaves the roster to the close events;
+    // the prune must not get ahead of them on a game that is already over.
+    const game = makeGame();
+    game.joinClient(makeClient({ clientID: cid("quiet") }));
+    await game.end();
+    vi.advanceTimersByTime(60_500);
+
+    game.pruneStaleClients();
+    expect(game.numClients()).toBe(1);
+  });
+});
+
+describe("GameManager and the ping prune", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("prunes on tick, not on a lobby-browser read", () => {
+    const gm = new GameManager(mockLogger());
+    const game = gm.createGame(cid("game"), undefined, "host-pid")!;
+    game.setListed(true);
+    const quiet = makeClient({
+      clientID: cid("quiet"),
+      persistentID: "host-pid",
+    });
+    game.joinClient(quiet);
+    vi.advanceTimersByTime(60_500);
+
+    expect(gm.listedLobbies()).toEqual([game]);
+    expect(mockWsOf(quiet).close).not.toHaveBeenCalled();
+    expect(game.numClients()).toBe(1);
+
+    gm.tick();
+    expect(mockWsOf(quiet).close).toHaveBeenCalledWith(
+      1000,
+      "no heartbeats received, closing connection",
+    );
     expect(game.numClients()).toBe(0);
   });
 });

--- a/tests/server/WinnerVoteRetally.test.ts
+++ b/tests/server/WinnerVoteRetally.test.ts
@@ -97,13 +97,13 @@ describe("winner vote re-tally when the electorate shrinks", () => {
     expect(archivedWinners()).toEqual([undefined]);
   });
 
-  it("re-tallies when the ping prune in phase() drops a stale client", async () => {
+  it("re-tallies when the ping prune drops a stale client", async () => {
     const { game, winner, loser } = game1v1();
     await vote(winner, ["player", WINNER]);
     // The loser's connection dropped without a ws close event: pings stop,
-    // and only the 60s prune in phase() removes them from activeClients.
+    // and only the 60s prune removes them from the connected clients.
     loser.lastPing = Date.now() - 61_000;
-    game.phase();
+    game.pruneStaleClients();
     expect(archivedWinners()).toEqual([["player", WINNER]]);
   });
 });


### PR DESCRIPTION
## Summary

First part of Phase 6 of `docs/GameServerRefactor.md` (Phases 0–5 are merged; #5150 was the last Phase 5 PR).

- `GameServer.phase()` used to drop clients that had not pinged for 60 s — closing their sockets and re-tallying the winner vote — before reading the lifecycle. So every caller pruned: `GameManager.tick`, but also `publicLobbies()` and `listedLobbies()` on each lobby-browser request via `WorkerLobbyService`.
- The prune is now **`pruneStaleClients()`**, unchanged in what it does (log, close, `checkWinnerAfterElectorateShrink`) and a no-op once the game has ended, exactly as `phase()`'s early return made it. **`GameManager.tick` calls it once, just before `phase()`.** `phase()` is a pure read.
- `GameServerPhase.test.ts` and `WinnerVoteRetally.test.ts` call the prune where they relied on `phase()` for it. Three new tests pin the split down: `phase()` alone drops nobody; `gm.listedLobbies()` does not prune while `gm.tick()` does; the prune is a no-op after `end()` (observed through `numClients()`, since `end()` has already closed the socket).

No behaviour change beyond the timing of the prune (once per tick rather than also on every lobby read); the golden wire transcript (`GameServerWire.test.ts.snap`) is byte-identical.

The rest of Phase 6 — the lifecycle state fields and retiring the remaining `(game as any)` reach-ins — follows as its own PR.

## Test plan

- `npx vitest tests/server --run`: 55 files / 576 tests pass (was 573); snapshot unchanged
- `npx tsc --noEmit`, `npm run lint` (oxlint + eslint), `prettier --check`: clean
- Mutation spot-check: removing the ended guard from `pruneStaleClients()` fails the new no-op test, restored
- Full `npm test`: 31 failed files / 379 failed tests — identical to pristine `origin/main` (pre-existing client `localStorage` failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)