### PR TITLE
feat(client): draw effect previews as in-game scenes

### DIFF
--- a/src/client/components/CosmeticPreview.ts
+++ b/src/client/components/CosmeticPreview.ts
@@ -102,10 +102,10 @@ export class CosmeticPreview extends LitElement {
           .explosion=${cosmetic.attributes}
         ></shockwave-swatch>`;
       }
-      return html`<trail-swatch
+      return html`<effect-scene
         class="block w-full h-full"
-        .trail=${cosmetic.attributes}
-      ></trail-swatch>`;
+        .effect=${cosmetic}
+      ></effect-scene>`;
     }
 
     if (this.resolved.type === "crown") {

--- a/src/client/components/EffectPreview.ts
+++ b/src/client/components/EffectPreview.ts
@@ -1,67 +1,597 @@
-import { html, LitElement, svg, TemplateResult } from "lit";
+import { colord } from "colord";
+import {
+  html,
+  LitElement,
+  nothing,
+  svg,
+  SVGTemplateResult,
+  TemplateResult,
+} from "lit";
 import { customElement, property } from "lit/decorators.js";
 import {
+  Effect,
   NukeExplosionAttributes,
   StructuresEffectAttributes,
   TrailEffectAttributes,
 } from "../../core/CosmeticSchemas";
 
-// Neutral fallback when a trail has no usable colors.
-const EMPTY_BG = "#444";
-// Spiral swatch backdrop — the app's recessed-surface navy (bg-surface); the
-// glow reads as emitted light only against a dark ground.
-const SPIRAL_BG = "#082f49";
+// ---------------------------------------------------------------------------
+// Scene previews — a tiny slice of the map, in tile units, drawn the way the
+// GL passes draw it: pixel sprites recolored by band, trails stamped one tile
+// wide, rails on the 3×3 sub-grid, the city as the structure pass's ringed
+// circle with its glyph. The effect paints exactly what it paints in game
+// (trail / structure fill / warship light band / both train bands / rails),
+// with the same gradient geometry and timing as the shaders.
+// ---------------------------------------------------------------------------
 
-// Spiral swatch geometry: sine strands across a 100×48 viewBox, two full
-// waves wide, sampled every 4 units. Like in game, the strands converge into
-// the nuke: amplitude tapers to 0 at the right edge (the missile's side) over
-// the last SPIRAL_TAPER_W units.
-const SPIRAL_VIEW_W = 100;
-const SPIRAL_VIEW_H = 48;
-const SPIRAL_AMPLITUDE = 16;
-const SPIRAL_WAVELENGTH = 50;
-const SPIRAL_TAPER_W = 40;
+/** Any effect that previews as a scene (nuke explosions have their own swatches). */
+export type SceneEffect = Exclude<Effect, { effectType: "nukeExplosion" }>;
 
-/** Polyline path of one sine strand at the given phase offset (radians). */
-function spiralStrandPath(phase: number): string {
+// The preview's stand-in for "you": a default-theme human color
+// (default-theme.json) with the theme's border rule (borderDarken 0.125).
+const PLAYER = colord("#4ade80");
+const PLAYER_COLOR = PLAYER.toHex();
+const BORDER_COLOR = PLAYER.darken(0.125).toHex();
+// Terrain (render-settings.json): deep water and plains.
+const WATER = "#4785b5";
+const PLAINS = "#bedc8a";
+// Territory and trails paint over terrain at mapOverlay.territoryAlpha /
+// trailAlpha.
+const TERRITORY_ALPHA = 0.588;
+const TRAIL_ALPHA = 0.588;
+// The local player's rails take the theme's focused-border color (white).
+const RAIL_COLOR = "#ffffff";
+// The structure pass darkens the player color for the icon fill and border
+// (HSV value × fillDarken / borderDarken); the local player's border starts
+// from the territory color.
+const STRUCTURE_FILL = scaleValue(PLAYER_COLOR, 0.65);
+const STRUCTURE_BORDER = scaleValue(PLAYER_COLOR, 0.1);
+// Nukes flicker through unit.frag.glsl's hot colors (light band) with the
+// mid band halfway to the color two steps on. In game this cycles every few
+// frames; the preview flickers at a pace that doesn't strobe a card grid.
+const FLICKER = ["#ff0000", "#ff8000", "#ffff00", "#ffffff"];
+const FLICKER_MID = FLICKER.map((c, i) => mixRgb(c, FLICKER[(i + 2) % 4]));
+const FLICKER_DUR_S = 1.2;
+// Gradient scroll periods are clamped so extreme catalog values still
+// visibly move (and don't blur).
+const MIN_PERIOD_S = 0.8;
+const MAX_PERIOD_S = 6;
+
+// City glyph from resources/images/CityIcon.svg (24×24 viewBox), as baked
+// into the structure icon atlas.
+const CITY_GLYPH =
+  "M13 9a1 1 0 0 0-1-1H3a1 1 0 0 0-1 1v13h11zM6 20H4v-2h2zm0-4H4v-2h2zm0-4H4v-2h2zm5 8H8v-2h3zm0-4H8v-2h3zm0-4H8v-2h3zm3.5-6H6V3a1 1 0 0 1 1-1h10a1 1 0 0 1 1 1v7h-3V6.5a.5.5 0 0 0-.5-.5zm7.5 7v9h-2.5v-4h-2v4H15v-9a1 1 0 0 1 1-1h5a1 1 0 0 1 1 1z";
+
+// Grayscale sprite templates from resources/sprites, by unit.frag.glsl band:
+// L = 180 (light → territory color), M = 130 (mid → spawn color),
+// D = 70 (dark → border color). One character per tile.
+type Band = "L" | "M" | "D";
+const TRANSPORT_SHIP = ["..D..", ".DLD.", "DLLLD", ".DLD.", "..D.."];
+const WARSHIP = [
+  ".....L.....",
+  "..LLLDLLL..",
+  ".LLLDDDLLL.",
+  ".LLDDDDDLL.",
+  ".LDDDLDDDL.",
+  "LDDDLLLDDDL",
+  ".LDDDLDDDL.",
+  ".LLDDDDDLL.",
+  ".LLLDDDLLL.",
+  "..LLLDLLL..",
+  ".....L.....",
+];
+const TRAIN_ENGINE = [".....", "..D..", ".DDD.", "..D..", "....."];
+const TRAIN_CARRIAGE = [".....", ".LLL.", ".LDL.", ".LLL.", "....."];
+const ATOM_BOMB = [
+  "....M....",
+  "..MMMMM..",
+  ".MMMLMMM.",
+  ".MMLLLMM.",
+  "MMLLLLLMM",
+  ".MMLLLMM.",
+  ".MMMLMMM.",
+  "..MMMMM..",
+  "....M....",
+];
+
+// Rail types (RailroadPass texture values) drawn in the scenes.
+const RAIL_VERTICAL = 1;
+const RAIL_HORIZONTAL = 2;
+const RAIL_TOP_RIGHT = 4;
+
+function scaleValue(hex: string, k: number): string {
+  const hsv = colord(hex).toHsv();
+  return colord({ h: hsv.h, s: hsv.s, v: hsv.v * k }).toHex();
+}
+
+function mixRgb(a: string, b: string, t = 0.5): string {
+  const ca = colord(a).toRgb();
+  const cb = colord(b).toRgb();
+  return colord({
+    r: ca.r + (cb.r - ca.r) * t,
+    g: ca.g + (cb.g - ca.g) * t,
+    b: ca.b + (cb.b - ca.b) * t,
+  }).toHex();
+}
+
+/** Catalog colors the renderer would keep (it drops any it can't parse). */
+function validColors(colors: readonly string[]): string[] {
+  return colors
+    .filter((c) => colord(c).isValid())
+    .map((c) => colord(c).toHex());
+}
+
+// ---------------------------------------------------------------------------
+// Paints — a fill plus (optionally) the SMIL animation that drives it. The
+// animation element goes inside the painted element; gradients go in <defs>.
+// ---------------------------------------------------------------------------
+
+interface Paint {
+  fill: string;
+  anim: SVGTemplateResult | typeof nothing;
+}
+
+const solid = (fill: string): Paint => ({ fill, anim: nothing });
+
+/**
+ * Where a gradient effect's palette cycle sits in the scene:
+ * - world: trail semantics (trail/railroad/train shaders) — the palette
+ *   repeats along the map diagonal x + y, colorSize tiles per color,
+ *   scrolling movementSpeed tiles/s.
+ * - icon: sprite semantics (structure/warship shaders) — the palette spans
+ *   the sprite's diagonal once (the whole gradient is visible on the shape),
+ *   sliding one cycle every colorSize · count / movementSpeed seconds.
+ */
+type GradientSpace =
+  | { space: "world" }
+  | { space: "icon"; x: number; y: number; size: number };
+
+/**
+ * The effect's paint for one recolored band, mirroring the shaders: a single
+ * color is flat; spiral paints flat in its first color (the vortex is drawn
+ * separately); transition cross-fades the whole band through the list, each
+ * step lasting 1/frequency s; gradient is a repeating linear gradient in the
+ * given space, scrolled by translating it one cycle per period (positive
+ * movementSpeed toward +x+y, negative reversed; 0 static).
+ */
+function effectPaint(
+  id: string,
+  attrs: TrailEffectAttributes | StructuresEffectAttributes,
+  colors: readonly string[],
+  space: GradientSpace,
+): { paint: Paint; defs: SVGTemplateResult | typeof nothing } {
+  const n = colors.length;
+  if (n === 1 || attrs.type === "spiral") {
+    return { paint: solid(colors[0]), defs: nothing };
+  }
+  if (attrs.type === "transition") {
+    const anim =
+      attrs.frequency > 0
+        ? svg`<animate
+            attributeName="fill"
+            values=${[...colors, colors[0]].join(";")}
+            dur="${n / attrs.frequency}s"
+            repeatCount="indefinite"
+          ></animate>`
+        : nothing;
+    return { paint: { fill: colors[0], anim }, defs: nothing };
+  }
+  // gradient — one palette cycle is colorSize · count (tiles of x + y in
+  // world space; the sprite diagonal in icon space). Both scroll one cycle
+  // every cycle / |movementSpeed| seconds.
+  const cycle = Math.max(attrs.colorSize, 0.001) * n;
+  const [x1, y1, dx, dy] =
+    space.space === "world"
+      ? [0, 0, cycle / 2, cycle / 2]
+      : [space.x, space.y, space.size, space.size];
+  const speed = attrs.movementSpeed;
+  const scroll =
+    speed === 0
+      ? nothing
+      : svg`<animateTransform
+          attributeName="gradientTransform"
+          type="translate"
+          from="0 0"
+          to="${Math.sign(speed) * dx} ${Math.sign(speed) * dy}"
+          dur="${Math.min(Math.max(cycle / Math.abs(speed), MIN_PERIOD_S), MAX_PERIOD_S)}s"
+          repeatCount="indefinite"
+        ></animateTransform>`;
+  const defs = svg`<linearGradient
+    id=${id}
+    gradientUnits="userSpaceOnUse"
+    spreadMethod="repeat"
+    x1=${x1}
+    y1=${y1}
+    x2=${x1 + dx}
+    y2=${y1 + dy}
+  >
+    ${colors.map((c, i) => svg`<stop offset=${i / n} stop-color=${c}></stop>`)}
+    <stop offset="1" stop-color=${colors[0]}></stop>
+    ${scroll}
+  </linearGradient>`;
+  return { paint: solid(`url(#${id})`), defs };
+}
+
+// ---------------------------------------------------------------------------
+// Geometry helpers
+// ---------------------------------------------------------------------------
+
+/** Path of unit squares for every `band` pixel of a sprite placed at (ox, oy). */
+function pixelPath(
+  rows: readonly string[],
+  band: Band,
+  ox: number,
+  oy: number,
+): string {
+  let d = "";
+  rows.forEach((row, y) => {
+    for (let x = 0; x < row.length; x++) {
+      if (row[x] === band) d += `M${ox + x} ${oy + y}h1v1h-1z`;
+    }
+  });
+  return d;
+}
+
+/** A sprite centered on tile (cx, cy), one path per band. */
+function sprite(
+  rows: readonly string[],
+  cx: number,
+  cy: number,
+  paints: Partial<Record<Band, Paint>>,
+): SVGTemplateResult {
+  const ox = cx - Math.floor(rows[0].length / 2);
+  const oy = cy - Math.floor(rows.length / 2);
+  return svg`<g shape-rendering="crispEdges">
+    ${(Object.keys(paints) as Band[]).map((band) => {
+      const paint = paints[band]!;
+      return svg`<path d=${pixelPath(rows, band, ox, oy)} fill=${paint.fill}>
+        ${paint.anim}
+      </path>`;
+    })}
+  </g>`;
+}
+
+/** Path of unit squares along the bresenham line through the waypoints (the
+ *  TrailManager stamp). */
+function stampPath(points: readonly [number, number][]): string {
+  let d = "";
+  for (let p = 1; p < points.length; p++) {
+    let [x0, y0] = points[p - 1];
+    const [x1, y1] = points[p];
+    const dx = Math.abs(x1 - x0);
+    const dy = -Math.abs(y1 - y0);
+    const sx = x0 < x1 ? 1 : -1;
+    const sy = y0 < y1 ? 1 : -1;
+    let err = dx + dy;
+    for (;;) {
+      d += `M${x0} ${y0}h1v1h-1z`;
+      if (x0 === x1 && y0 === y1) break;
+      const e2 = 2 * err;
+      if (e2 >= dy) {
+        err += dy;
+        x0 += sx;
+      }
+      if (e2 <= dx) {
+        err += dx;
+        y0 += sy;
+      }
+    }
+  }
+  return d;
+}
+
+/** Detailed-zoom rail tile (railroad.frag.glsl railDetailCoverage): the two
+ *  edge bands of the tile's 3×3 sub-grid the track runs along, plus the
+ *  center tie. */
+function railTilePath(rt: number, x: number, y: number): string {
+  const T = 1 / 3;
+  let d = "";
+  for (let j = 0; j < 3; j++) {
+    for (let i = 0; i < 3; i++) {
+      let hit = i === 1 && j === 1;
+      if (rt === RAIL_VERTICAL) hit ||= i === 0 || i === 2;
+      else if (rt === RAIL_HORIZONTAL) hit ||= j === 0 || j === 2;
+      else if (rt === RAIL_TOP_RIGHT) hit ||= j === 0 || i === 2;
+      if (hit) {
+        d += `M${(x + i * T).toFixed(4)} ${(y + j * T).toFixed(4)}h${T.toFixed(4)}v${T.toFixed(4)}h-${T.toFixed(4)}z`;
+      }
+    }
+  }
+  return d;
+}
+
+/** Polyline of a spiral strand: a sine wave around the trail's centerline
+ *  (the helix seen side-on) that flares from the nuke's side over `taperW`
+ *  tiles to full amplitude, like the in-game vortex emerging from the unit. */
+function strandPath(
+  x0: number,
+  x1: number,
+  cy: number,
+  amplitude: number,
+  wavelength: number,
+  taperW: number,
+  phase: number,
+): string {
   const pts: string[] = [];
-  for (let x = 0; x <= SPIRAL_VIEW_W; x += 4) {
-    const taper = Math.min((SPIRAL_VIEW_W - x) / SPIRAL_TAPER_W, 1);
+  for (let x = x0; x <= x1; x += 0.5) {
+    const taper = Math.min((x1 - x) / taperW, 1);
     const y =
-      SPIRAL_VIEW_H / 2 +
-      SPIRAL_AMPLITUDE *
+      cy +
+      amplitude *
         Math.sin((Math.PI / 2) * taper) *
-        Math.sin((x / SPIRAL_WAVELENGTH) * 2 * Math.PI + phase);
-    pts.push(`${x} ${y.toFixed(1)}`);
+        Math.sin((x / wavelength) * 2 * Math.PI + phase);
+    pts.push(`${x} ${y.toFixed(2)}`);
   }
   return `M ${pts.join(" L ")}`;
 }
 
-/**
- * Swatch preview of a trail-styled effect (trails and the structures effect
- * share the same gradient/transition/spiral attribute shapes), filling its
- * container.
- *
- * - gradient: a left-to-right wrapped palette cycle that scrolls at the
- *   in-game pace (one cycle per colorSize · count / movementSpeed seconds,
- *   clamped watchable; movementSpeed 0 stays static). Single color: a flat
- *   static swatch.
- * - transition: cross-fades through the colors over time, mirroring the trail
- *   (each color step lasts 1/frequency seconds, matching the shader).
- * - spiral: neon sine strands on a dark backdrop (the helix seen side-on)
- *   tapering into the nuke's side. Mirrors the in-game glow split: a wide
- *   screen-blended blur (the additive halo), a crisp colored core, and a
- *   white-hot center line that only shows while the strand faces the viewer.
- *   Strands dim toward the backdrop and back in phase order, once per
- *   revolution (2π/rotationSpeed s) — the depth-shaded spin.
- */
-@customElement("trail-swatch")
-export class TrailSwatch extends LitElement {
-  // Named `trail` (not `attributes`) to avoid clashing with Element.attributes.
-  @property({ attribute: false })
-  trail: TrailEffectAttributes | StructuresEffectAttributes | null = null;
+function scene(
+  size: number,
+  defs: unknown,
+  body: SVGTemplateResult,
+): TemplateResult {
+  return html`<svg
+    class="block w-full h-full"
+    viewBox="0 0 ${size} ${size}"
+    preserveAspectRatio="xMidYMid slice"
+  >
+    <defs>${defs}</defs>
+    ${body}
+  </svg>`;
+}
 
-  private animations: Animation[] = [];
+const water = (size: number) =>
+  svg`<rect width=${size} height=${size} fill=${WATER}></rect>`;
+const territory = (size: number) =>
+  svg`<rect width=${size} height=${size} fill=${PLAINS}></rect>
+    <rect width=${size} height=${size} fill=${PLAYER_COLOR} fill-opacity=${TERRITORY_ALPHA}></rect>`;
+
+// ---------------------------------------------------------------------------
+// Scenes
+// ---------------------------------------------------------------------------
+
+/** A transport ship in the player's colors with its trail stamped behind it
+ *  across the water; the trail takes the effect (territory color without one). */
+function transportShipTrailScene(
+  id: string,
+  attrs: TrailEffectAttributes,
+  colors: string[],
+): TemplateResult {
+  const S = 24;
+  const path: [number, number][] = [
+    [1, 21],
+    [7, 16],
+    [12, 13],
+    [18, 8],
+  ];
+  const { paint, defs } =
+    colors.length > 0
+      ? effectPaint(id, attrs, colors, { space: "world" })
+      : { paint: solid(PLAYER_COLOR), defs: nothing };
+  return scene(
+    S,
+    defs,
+    svg`${water(S)}
+      <path data-trail d=${stampPath(path)} fill=${paint.fill} opacity=${TRAIL_ALPHA} shape-rendering="crispEdges">
+        ${paint.anim}
+      </path>
+      ${sprite(TRANSPORT_SHIP, 18, 8, { L: solid(PLAYER_COLOR), D: solid(BORDER_COLOR) })}`,
+  );
+}
+
+/** A flickering atom bomb with its trail behind it. A spiral effect adds the
+ *  vortex: neon strands (halo + core + white-hot center, like the in-game
+ *  bloom split) tapering into the missile, dimming in phase order once per
+ *  revolution (the depth-shaded spin), over the flat first-color spine. */
+function nukeTrailScene(
+  id: string,
+  attrs: TrailEffectAttributes,
+  colors: string[],
+): TemplateResult {
+  const S = 24;
+  const cx = 17;
+  const cy = 12;
+  const { paint, defs } =
+    colors.length > 0
+      ? effectPaint(id, attrs, colors, { space: "world" })
+      : { paint: solid(PLAYER_COLOR), defs: nothing };
+  let strands: SVGTemplateResult | typeof nothing = nothing;
+  if (attrs.type === "spiral" && colors.length > 0) {
+    // Strand count mirrors the in-game clamp (max 8); the amplitude is the
+    // helix radius in tiles, kept inside the scene.
+    const count = Math.min(Math.max(Math.round(attrs.strands), 1), 8);
+    const amplitude = Math.min(Math.max(attrs.radius, 1), 8);
+    const periodS =
+      attrs.rotationSpeed > 0 ? (2 * Math.PI) / attrs.rotationSpeed : 0;
+    strands = svg`<g data-spiral fill="none" stroke-linecap="round">
+      ${Array.from({ length: count }, (_, s) => {
+        const d = strandPath(
+          0,
+          cx,
+          cy + 0.5,
+          amplitude,
+          10,
+          8,
+          (s * 2 * Math.PI) / count,
+        );
+        const color = colors[s % colors.length];
+        const delay = (-s * periodS) / count;
+        const spin = (values: string) =>
+          periodS > 0
+            ? svg`<animate attributeName="opacity" values=${values} dur="${periodS}s" begin="${delay}s" repeatCount="indefinite"></animate>`
+            : nothing;
+        return svg`<g data-strand>
+          ${spin("1;0.35;1")}
+          <path d=${d} stroke=${color} stroke-width="2.4" opacity="0.55" style="filter:blur(0.6px);mix-blend-mode:screen"></path>
+          <path d=${d} stroke=${color} stroke-width="0.9"></path>
+          <path d=${d} stroke="#fff" stroke-width="0.35" opacity="0.9">
+            ${spin("0.9;0;0.9")}
+          </path>
+        </g>`;
+      })}
+    </g>`;
+  }
+  const flicker = (values: readonly string[]): Paint => ({
+    fill: values[0],
+    anim: svg`<animate attributeName="fill" values=${values.join(";")} dur="${FLICKER_DUR_S}s" calcMode="discrete" repeatCount="indefinite"></animate>`,
+  });
+  return scene(
+    S,
+    defs,
+    svg`${water(S)}
+      <path data-trail d=${stampPath([
+        [0, cy],
+        [cx, cy],
+      ])} fill=${paint.fill} opacity=${TRAIL_ALPHA} shape-rendering="crispEdges">
+        ${paint.anim}
+      </path>
+      ${strands}
+      ${sprite(ATOM_BOMB, cx, cy, { L: flicker(FLICKER), M: flicker(FLICKER_MID) })}`,
+  );
+}
+
+/** A city on the player's territory, drawn like the structure pass: a ringed
+ *  circle (border in the darkened player color) around the fill — the
+ *  effect, or the darkened player color — with the white city glyph. */
+function structuresScene(
+  id: string,
+  attrs: StructuresEffectAttributes,
+  colors: string[],
+): TemplateResult {
+  // The gradient spans the icon's diagonal once; the shader anchors the
+  // palette to the icon center (dn = 0 there), so the cycle starts half a
+  // cell before the top-left corner.
+  const { paint, defs } =
+    colors.length > 0
+      ? effectPaint(id, attrs, colors, {
+          space: "icon",
+          x: -0.5,
+          y: -0.5,
+          size: 1,
+        })
+      : { paint: solid(STRUCTURE_FILL), defs: nothing };
+  const glyphSize = 0.59;
+  return scene(
+    1,
+    svg`${defs}
+      <clipPath id="${id}-fill"><circle cx="0.5" cy="0.5" r="0.39"></circle></clipPath>`,
+    svg`${territory(1)}
+      <circle cx="0.5" cy="0.5" r="0.45" fill=${STRUCTURE_BORDER}></circle>
+      <circle data-fill cx="0.5" cy="0.5" r="0.39" fill=${paint.fill}>${paint.anim}</circle>
+      <g clip-path="url(#${id}-fill)">
+        <g
+          transform="translate(${(1 - glyphSize) / 2} ${(1 - glyphSize) / 2}) scale(${glyphSize / 24})"
+        >
+          <path data-glyph d=${CITY_GLYPH} fill="#fff"></path>
+        </g>
+      </g>`,
+  );
+}
+
+/** A warship on the water: the effect recolors its light band (the hull
+ *  ring), the dark band keeps the player's border color. */
+function warshipScene(
+  id: string,
+  attrs: StructuresEffectAttributes,
+  colors: string[],
+): TemplateResult {
+  const S = 15;
+  const { paint, defs } =
+    colors.length > 0
+      ? effectPaint(id, attrs, colors, { space: "icon", x: 2, y: 2, size: 11 })
+      : { paint: solid(PLAYER_COLOR), defs: nothing };
+  return scene(
+    S,
+    defs,
+    svg`${water(S)}
+      ${sprite(WARSHIP, 7, 7, { L: paint, D: solid(BORDER_COLOR) })}`,
+  );
+}
+
+/** An engine and three carriages on a track across the player's territory.
+ *  The effect recolors both sprite bands (the dark band at 60%) with
+ *  world-space gradient bands running along the whole train. */
+function trainScene(
+  id: string,
+  attrs: StructuresEffectAttributes,
+  colors: string[],
+): TemplateResult {
+  const S = 24;
+  const row = 11;
+  const light =
+    colors.length > 0
+      ? effectPaint(id, attrs, colors, { space: "world" })
+      : { paint: solid(PLAYER_COLOR), defs: nothing };
+  const dark =
+    colors.length > 0
+      ? effectPaint(
+          `${id}-dark`,
+          attrs,
+          colors.map((c) => scaleRgb(c, 0.6)),
+          { space: "world" },
+        )
+      : { paint: solid(BORDER_COLOR), defs: nothing };
+  let track = "";
+  for (let x = 0; x < S; x++) track += railTilePath(RAIL_HORIZONTAL, x, row);
+  return scene(
+    S,
+    svg`${light.defs}${dark.defs}`,
+    svg`${territory(S)}
+      <path data-rails d=${track} fill=${RAIL_COLOR}></path>
+      ${[13, 15, 17].map((x) =>
+        sprite(TRAIN_CARRIAGE, x, row, { L: light.paint, D: dark.paint }),
+      )}
+      ${sprite(TRAIN_ENGINE, 19, row, { D: dark.paint })}`,
+  );
+}
+
+function scaleRgb(hex: string, k: number): string {
+  const c = colord(hex).toRgb();
+  return colord({ r: c.r * k, g: c.g * k, b: c.b * k }).toHex();
+}
+
+/** A track with a corner across the player's territory; the effect replaces
+ *  the rail color with world-space bands traveling along the track. */
+function railroadScene(
+  id: string,
+  attrs: StructuresEffectAttributes,
+  colors: string[],
+): TemplateResult {
+  const S = 24;
+  const row = 8;
+  const col = 15;
+  const { paint, defs } =
+    colors.length > 0
+      ? effectPaint(id, attrs, colors, { space: "world" })
+      : { paint: solid(RAIL_COLOR), defs: nothing };
+  let track = "";
+  for (let x = 0; x < col; x++) track += railTilePath(RAIL_HORIZONTAL, x, row);
+  track += railTilePath(RAIL_TOP_RIGHT, col, row);
+  for (let y = row + 1; y < S; y++)
+    track += railTilePath(RAIL_VERTICAL, col, y);
+  return scene(
+    S,
+    defs,
+    svg`${territory(S)}
+      <path data-rails d=${track} fill=${paint.fill}>${paint.anim}</path>`,
+  );
+}
+
+let sceneCount = 0;
+
+/**
+ * Scene preview of a trail-style effect (transport-ship trail, nuke trail,
+ * structures, warship, train, railroad), filling its container. Each scene
+ * shows the effect on the thing it recolors in game. Animation is SMIL inside
+ * the SVG, so there is nothing to start or cancel.
+ */
+@customElement("effect-scene")
+export class EffectScene extends LitElement {
+  @property({ attribute: false })
+  effect: SceneEffect | null = null;
+
+  // Gradient/clip ids must be unique per instance — cards render many at once.
+  private readonly uid = `effect-scene-${++sceneCount}`;
 
   // Light DOM so the shared Tailwind classes apply.
   createRenderRoot(): HTMLElement {
@@ -69,171 +599,36 @@ export class TrailSwatch extends LitElement {
   }
 
   render(): TemplateResult {
-    const colors = this.trail?.colors ?? [];
-    if (this.trail?.type === "spiral" && colors.length > 0) {
-      // Strand count mirrors the in-game clamp (max 8).
-      const strands = Math.min(Math.max(Math.round(this.trail.strands), 1), 8);
-      return html`<div
-        class="w-full h-full rounded-md overflow-hidden"
-        style="background:${SPIRAL_BG};"
-      >
-        <svg
-          class="w-full h-full"
-          viewBox="0 0 ${SPIRAL_VIEW_W} ${SPIRAL_VIEW_H}"
-          preserveAspectRatio="none"
-        >
-          ${Array.from({ length: strands }, (_, s) => {
-            const d = spiralStrandPath((s * 2 * Math.PI) / strands);
-            const color = colors[s % colors.length];
-            // Glow halo (screen ≈ additive light) under a crisp core under a
-            // white-hot center — the in-game bloom split.
-            return svg`<g data-strand>
-              <path
-                d="${d}"
-                fill="none"
-                stroke="${color}"
-                stroke-width="10"
-                stroke-linecap="round"
-                opacity="0.55"
-                style="filter:blur(3px);mix-blend-mode:screen"
-              />
-              <path
-                d="${d}"
-                fill="none"
-                stroke="${color}"
-                stroke-width="3.5"
-                stroke-linecap="round"
-              />
-              <path
-                data-hot
-                d="${d}"
-                fill="none"
-                stroke="#fff"
-                stroke-width="1.4"
-                stroke-linecap="round"
-                opacity="0.9"
-                style="filter:blur(0.3px)"
-              />
-            </g>`;
-          })}
-        </svg>
-      </div>`;
-    }
-    let background: string;
-    let backgroundSize = "";
-    if (colors.length === 0) {
-      background = EMPTY_BG;
-    } else if (this.trail?.type === "transition") {
-      // The animation (see updated) cross-fades from here through the list.
-      background = colors[0];
-    } else if (colors.length === 1) {
-      background = colors[0];
-    } else {
-      // The palette cycle doubled + wrapped at background-size 200%: the
-      // visible half is one full wrapped cycle, and the scroll animation (see
-      // updated) can slide a whole cycle before looping seamlessly.
-      background = `linear-gradient(90deg,${[...colors, ...colors, colors[0]].join(",")})`;
-      backgroundSize = "background-size:200% 100%;";
+    const effect = this.effect;
+    if (effect === null) return html``;
+    const colors = validColors(effect.attributes.colors);
+    let body: TemplateResult;
+    switch (effect.effectType) {
+      case "transportShipTrail":
+        body = transportShipTrailScene(this.uid, effect.attributes, colors);
+        break;
+      case "nukeTrail":
+        body = nukeTrailScene(this.uid, effect.attributes, colors);
+        break;
+      case "structures":
+        body = structuresScene(this.uid, effect.attributes, colors);
+        break;
+      case "warship":
+        body = warshipScene(this.uid, effect.attributes, colors);
+        break;
+      case "train":
+        body = trainScene(this.uid, effect.attributes, colors);
+        break;
+      case "railroad":
+        body = railroadScene(this.uid, effect.attributes, colors);
+        break;
     }
     return html`<div
-      class="w-full h-full rounded-md"
-      style="background:${background};${backgroundSize}"
-    ></div>`;
-  }
-
-  updated(changed: Map<string, unknown>): void {
-    if (!changed.has("trail")) return;
-    for (const a of this.animations) a.cancel();
-    this.animations = [];
-
-    const attrs = this.trail;
-    if (attrs?.type === "transition") {
-      const colors = attrs.colors;
-      if (colors.length < 2 || attrs.frequency <= 0) return;
-
-      const fill = this.querySelector<HTMLElement>("div");
-      if (!fill) return;
-
-      // Cross-fade color0 → color1 → … → color0; each step lasts 1/frequency s,
-      // matching the shader's i = floor(uTime * frequency) mod count.
-      const keyframes = [...colors, colors[0]].map((c) => ({
-        backgroundColor: c,
-      }));
-      this.animations.push(
-        fill.animate(keyframes, {
-          duration: (colors.length / attrs.frequency) * 1000,
-          iterations: Infinity,
-          easing: "linear",
-        }),
-      );
-      return;
-    }
-
-    if (attrs?.type === "gradient") {
-      const colors = attrs.colors;
-      if (colors.length < 2 || attrs.movementSpeed === 0) return;
-
-      const fill = this.querySelector<HTMLElement>("div");
-      if (!fill) return;
-
-      // Slide one full palette cycle per loop (the doubled background in
-      // render makes the wrap seamless) at the in-game pace — one cycle per
-      // colorSize · count / movementSpeed seconds — clamped so extreme
-      // catalog values still visibly move. A positive movementSpeed scrolls
-      // the bands forward (rightward here), negative reverses.
-      const periodS =
-        (attrs.colorSize * colors.length) / Math.abs(attrs.movementSpeed);
-      const durS = Math.min(Math.max(periodS, 0.8), 6);
-      const [from, to] =
-        attrs.movementSpeed > 0 ? ["100% 0%", "0% 0%"] : ["0% 0%", "100% 0%"];
-      this.animations.push(
-        fill.animate(
-          [{ backgroundPosition: from }, { backgroundPosition: to }],
-          { duration: durS * 1000, iterations: Infinity, easing: "linear" },
-        ),
-      );
-      return;
-    }
-
-    if (attrs?.type === "spiral") {
-      if (attrs.rotationSpeed <= 0) return;
-
-      // The vortex spin: each strand group (halo + core + hot line) dims
-      // toward the backdrop and back once per revolution (2π/rotationSpeed
-      // s), phase-offset by its position around the axis, and the white-hot
-      // center vanishes entirely while the strand recedes — facing strands
-      // read white-hot, receding ones dark, like the in-game depth shading.
-      const strandGroups = this.querySelectorAll<SVGGElement>("[data-strand]");
-      const periodMs = ((2 * Math.PI) / attrs.rotationSpeed) * 1000;
-      strandGroups.forEach((group, s) => {
-        const delay = (-s * periodMs) / strandGroups.length;
-        this.animations.push(
-          group.animate([{ opacity: 1 }, { opacity: 0.35 }, { opacity: 1 }], {
-            duration: periodMs,
-            delay,
-            iterations: Infinity,
-            easing: "ease-in-out",
-          }),
-        );
-        const hot = group.querySelector<SVGPathElement>("[data-hot]");
-        if (hot) {
-          this.animations.push(
-            hot.animate([{ opacity: 0.9 }, { opacity: 0 }, { opacity: 0.9 }], {
-              duration: periodMs,
-              delay,
-              iterations: Infinity,
-              easing: "ease-in-out",
-            }),
-          );
-        }
-      });
-    }
-  }
-
-  disconnectedCallback(): void {
-    super.disconnectedCallback();
-    for (const a of this.animations) a.cancel();
-    this.animations = [];
+      data-effect-scene=${effect.effectType}
+      class="w-full h-full rounded-md overflow-hidden"
+    >
+      ${body}
+    </div>`;
   }
 }
 

--- a/src/client/components/EffectPreview.ts
+++ b/src/client/components/EffectPreview.ts
@@ -97,7 +97,8 @@ const ATOM_BOMB = [
 // Rail types (RailroadPass texture values) drawn in the scenes.
 const RAIL_VERTICAL = 1;
 const RAIL_HORIZONTAL = 2;
-const RAIL_TOP_RIGHT = 4;
+// A corner entered from the left and exited downward (RailroadPass railDirection).
+const RAIL_BOTTOM_LEFT = 5;
 
 function scaleValue(hex: string, k: number): string {
   const hsv = colord(hex).toHsv();
@@ -291,7 +292,7 @@ function railTilePath(rt: number, x: number, y: number): string {
       let hit = i === 1 && j === 1;
       if (rt === RAIL_VERTICAL) hit ||= i === 0 || i === 2;
       else if (rt === RAIL_HORIZONTAL) hit ||= j === 0 || j === 2;
-      else if (rt === RAIL_TOP_RIGHT) hit ||= j === 0 || i === 2;
+      else if (rt === RAIL_BOTTOM_LEFT) hit ||= j === 2 || i === 0;
       if (hit) {
         d += `M${(x + i * T).toFixed(4)} ${(y + j * T).toFixed(4)}h${T.toFixed(4)}v${T.toFixed(4)}h-${T.toFixed(4)}z`;
       }
@@ -566,7 +567,7 @@ function railroadScene(
       : { paint: solid(RAIL_COLOR), defs: nothing };
   let track = "";
   for (let x = 0; x < col; x++) track += railTilePath(RAIL_HORIZONTAL, x, row);
-  track += railTilePath(RAIL_TOP_RIGHT, col, row);
+  track += railTilePath(RAIL_BOTTOM_LEFT, col, row);
   for (let y = row + 1; y < S; y++)
     track += railTilePath(RAIL_VERTICAL, col, y);
   return scene(

--- a/tests/client/CosmeticPreview.test.ts
+++ b/tests/client/CosmeticPreview.test.ts
@@ -253,12 +253,15 @@ describe("CosmeticPreview", () => {
     })) as unknown as typeof Element.prototype.animate;
     await render(resolved.transitionEffect as ResolvedCosmetic);
 
-    const trail = preview!.querySelector("trail-swatch")!;
+    const scene = preview!.querySelector("effect-scene")!;
     expect(preview!.classList).toContain("block");
-    expect(trail.classList).toContain("block");
-    expect(trail.querySelector("div")?.getAttribute("style")).toContain(
-      "#ff0000",
-    );
+    expect(scene.classList).toContain("block");
+    // The transition cross-fades the trail through the palette.
+    expect(
+      scene
+        .querySelector("[data-trail] animate[attributeName='fill']")
+        ?.getAttribute("values"),
+    ).toContain("#ff0000");
   });
 
   it("uses the server-provided pack display name", async () => {

--- a/tests/client/EffectScene.test.ts
+++ b/tests/client/EffectScene.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it } from "vitest";
+import "../../src/client/components/EffectPreview";
+import type {
+  EffectScene,
+  SceneEffect,
+} from "../../src/client/components/EffectPreview";
+import type { Effect } from "../../src/core/CosmeticSchemas";
+
+const base = { name: "fx", product: null, rarity: "rare" } as const;
+
+const gradient = {
+  type: "gradient",
+  colors: ["#ff0000", "#00ff00", "#0000ff"],
+  colorSize: 2,
+  movementSpeed: 3,
+} as const;
+
+const transition = {
+  type: "transition",
+  colors: ["#ff0000", "#ffffff"],
+  frequency: 2,
+} as const;
+
+function effect<T extends SceneEffect["effectType"]>(
+  effectType: T,
+  attributes: Extract<Effect, { effectType: T }>["attributes"],
+): SceneEffect {
+  return { ...base, effectType, attributes } as SceneEffect;
+}
+
+describe("EffectScene", () => {
+  let scene: EffectScene | undefined;
+
+  afterEach(() => {
+    scene?.remove();
+    scene = undefined;
+  });
+
+  async function render(fx: SceneEffect): Promise<EffectScene> {
+    scene = document.createElement("effect-scene") as EffectScene;
+    scene.effect = fx;
+    document.body.appendChild(scene);
+    await scene.updateComplete;
+    return scene;
+  }
+
+  it("draws the transport ship trail as stamped tiles behind the ship", async () => {
+    const el = await render(effect("transportShipTrail", gradient));
+    expect(
+      el.querySelector("[data-effect-scene='transportShipTrail']"),
+    ).toBeTruthy();
+    const trail = el.querySelector("[data-trail]")!;
+    // World-space gradient: the trail is filled by a repeating gradient along
+    // the map diagonal, one cycle = colorSize · count tiles of x + y.
+    expect(trail.getAttribute("fill")).toMatch(/^url\(#/);
+    const grad = el.querySelector("linearGradient")!;
+    expect(grad.getAttribute("spreadMethod")).toBe("repeat");
+    expect(grad.getAttribute("gradientUnits")).toBe("userSpaceOnUse");
+    expect(grad.getAttribute("x2")).toBe("3");
+    expect(grad.getAttribute("y2")).toBe("3");
+    expect(
+      [...grad.querySelectorAll("stop")].map((s) =>
+        s.getAttribute("stop-color"),
+      ),
+    ).toEqual(["#ff0000", "#00ff00", "#0000ff", "#ff0000"]);
+    // Scrolls one cycle every colorSize · count / movementSpeed seconds.
+    const scroll = grad.querySelector("animateTransform")!;
+    expect(scroll.getAttribute("dur")).toBe("2s");
+    expect(scroll.getAttribute("to")).toBe("3 3");
+    // The ship itself keeps the player's colors (three paths: trail + 2 bands).
+    expect(el.querySelectorAll("path").length).toBe(3);
+  });
+
+  it("holds a gradient still when movementSpeed is 0 and reverses when negative", async () => {
+    let el = await render(
+      effect("transportShipTrail", { ...gradient, movementSpeed: 0 }),
+    );
+    expect(el.querySelector("animateTransform")).toBeNull();
+    el.remove();
+    el = await render(
+      effect("transportShipTrail", { ...gradient, movementSpeed: -3 }),
+    );
+    expect(el.querySelector("animateTransform")?.getAttribute("to")).toBe(
+      "-3 -3",
+    );
+  });
+
+  it("cross-fades a transition through the palette at 1/frequency per step", async () => {
+    const el = await render(effect("railroad", transition));
+    const rails = el.querySelector("[data-rails]")!;
+    expect(rails.getAttribute("fill")).toBe("#ff0000");
+    const fade = rails.querySelector("animate")!;
+    expect(fade.getAttribute("attributeName")).toBe("fill");
+    expect(fade.getAttribute("values")).toBe("#ff0000;#ffffff;#ff0000");
+    expect(fade.getAttribute("dur")).toBe("1s");
+  });
+
+  it("paints a single color flat and drops colors the renderer can't parse", async () => {
+    const el = await render(
+      effect("warship", { ...gradient, colors: ["nope", "#123456"] }),
+    );
+    expect(el.querySelector("linearGradient")).toBeNull();
+    expect(el.querySelector("path[fill='#123456']")).toBeTruthy();
+  });
+
+  it("falls back to the player's colors when the palette is empty", async () => {
+    const el = await render(effect("structures", { ...gradient, colors: [] }));
+    expect(el.querySelector("linearGradient")).toBeNull();
+    expect(el.querySelector("[data-fill]")?.getAttribute("fill")).toMatch(/^#/);
+  });
+
+  it("spans a structure's gradient across the city icon once", async () => {
+    const el = await render(effect("structures", gradient));
+    expect(el.querySelector("[data-glyph]")).toBeTruthy();
+    expect(el.querySelector("[data-fill]")?.getAttribute("fill")).toMatch(
+      /^url\(#/,
+    );
+    const grad = el.querySelector("linearGradient")!;
+    // Icon space: one palette cycle is the icon diagonal, anchored to center.
+    expect(grad.getAttribute("x1")).toBe("-0.5");
+    expect(grad.getAttribute("x2")).toBe("0.5");
+    expect(grad.querySelector("animateTransform")?.getAttribute("to")).toBe(
+      "1 1",
+    );
+  });
+
+  it("recolors the warship's light band only", async () => {
+    const el = await render(effect("warship", gradient));
+    const paths = [...el.querySelectorAll("path")];
+    expect(
+      paths.filter((p) => p.getAttribute("fill")?.startsWith("url(#")),
+    ).toHaveLength(1);
+    expect(el.querySelector("linearGradient")?.getAttribute("x2")).toBe("13");
+  });
+
+  it("recolors both train bands, the dark band darkened", async () => {
+    const el = await render(effect("train", gradient));
+    const grads = [...el.querySelectorAll("linearGradient")];
+    expect(grads).toHaveLength(2);
+    const darkStops = [...grads[1].querySelectorAll("stop")].map((s) =>
+      s.getAttribute("stop-color"),
+    );
+    expect(darkStops[0]).toBe("#990000");
+    // Engine (1 band) + 3 carriages (2 bands each) + rails.
+    expect(el.querySelectorAll("path")).toHaveLength(8);
+    expect(el.querySelector("[data-rails]")?.getAttribute("fill")).toBe(
+      "#ffffff",
+    );
+  });
+
+  it("winds nuke spiral strands into the missile over a flat spine", async () => {
+    const el = await render(
+      effect("nukeTrail", {
+        type: "spiral",
+        colors: ["#ff00ff", "#00ffff"],
+        radius: 4,
+        strands: 3,
+        rotationSpeed: Math.PI,
+      }),
+    );
+    expect(el.querySelector("[data-trail]")?.getAttribute("fill")).toBe(
+      "#ff00ff",
+    );
+    const strands = [...el.querySelectorAll("[data-strand]")];
+    expect(strands).toHaveLength(3);
+    // Each strand dims once per revolution (2π / rotationSpeed s), phase-offset.
+    const spins = strands.map((s) => s.querySelector("animate")!);
+    expect(spins[0].getAttribute("dur")).toBe("2s");
+    expect(spins[1].getAttribute("begin")).toBe(`${-2 / 3}s`);
+    expect(strands[1].querySelector("path")?.getAttribute("stroke")).toBe(
+      "#00ffff",
+    );
+    // The nuke flickers through the hot colors.
+    const flicker = el.querySelector("animate[calcMode='discrete']")!;
+    expect(flicker.getAttribute("values")).toContain("#ffffff");
+  });
+
+  it("draws a spiral ship trail as a flat line in the first color", async () => {
+    const el = await render(
+      effect("transportShipTrail", {
+        type: "spiral",
+        colors: ["#ff00ff", "#00ffff"],
+        radius: 4,
+        strands: 3,
+        rotationSpeed: 1,
+      }),
+    );
+    expect(el.querySelector("[data-strand]")).toBeNull();
+    expect(el.querySelector("[data-trail]")?.getAttribute("fill")).toBe(
+      "#ff00ff",
+    );
+  });
+
+  it("gives each scene its own gradient ids", async () => {
+    const a = await render(effect("railroad", gradient));
+    const b = document.createElement("effect-scene") as EffectScene;
+    b.effect = effect("railroad", gradient);
+    document.body.appendChild(b);
+    await b.updateComplete;
+    try {
+      expect(a.querySelector("linearGradient")?.id).not.toBe(
+        b.querySelector("linearGradient")?.id,
+      );
+    } finally {
+      b.remove();
+    }
+  });
+});

--- a/tests/client/EffectScene.test.ts
+++ b/tests/client/EffectScene.test.ts
@@ -9,17 +9,17 @@ import type { Effect } from "../../src/core/CosmeticSchemas";
 const base = { name: "fx", product: null, rarity: "rare" } as const;
 
 const gradient = {
-  type: "gradient",
+  type: "gradient" as const,
   colors: ["#ff0000", "#00ff00", "#0000ff"],
   colorSize: 2,
   movementSpeed: 3,
-} as const;
+};
 
 const transition = {
-  type: "transition",
+  type: "transition" as const,
   colors: ["#ff0000", "#ffffff"],
   frequency: 2,
-} as const;
+};
 
 function effect<T extends SceneEffect["effectType"]>(
   effectType: T,


### PR DESCRIPTION
## Summary

The store/inventory previews for trail-style effects were a flat color swatch (`trail-swatch`), which said nothing about what the effect looks like on a ship, a nuke, a city, a warship, a train, or a track. This replaces it with an `<effect-scene>` (`src/client/components/EffectPreview.ts`) — a small SVG slice of the map in tile units, drawn the way the GL passes draw it, with the effect applied to exactly what it recolors in game:

- **Transport ship trail**: the 5×5 transport-ship sprite (player-colored bands from `unit.frag.glsl`'s 180/70 rule) on water, with its trail Bresenham-stamped one tile wide behind it (the `TrailManager` stamp) at `trailAlpha`; the trail takes the effect.
- **Nuke trail**: the 9×9 atom-bomb sprite flickering through the shader's hot colors, trail behind it. A spiral effect adds the vortex strands (halo + core + white-hot center, the in-game bloom split) tapering *into* the missile over the flat first-color spine, dimming in phase order once per revolution (2π/rotationSpeed). A spiral ship trail draws as a flat line in the first color, like in game.
- **Structures**: a city as `structure.frag.glsl` draws it — ringed circle (border = darkened player color), fill = effect (raw catalog colors, no darken), white `CityIcon.svg` glyph — on player territory.
- **Warship**: the 11×11 warship sprite; the effect recolors the light band only, the dark band keeps the border color.
- **Train**: engine + 3 carriages on a detail-zoom track; both bands take the effect, dark band × 0.6, world-space gradient (as in #5135).
- **Railroad**: a track with a corner built from `railDetailCoverage`'s 3×3 sub-grid (rails + ties); the effect replaces the rail color.

Gradient/transition math mirrors the shaders: world-space gradients repeat along the `x + y` diagonal with `colorSize` tiles per color and scroll at `movementSpeed` tiles/s; icon-space gradients (structures/warship) span the sprite diagonal once and slide one cycle per `colorSize · count / movementSpeed` s; transitions cross-fade each step for `1/frequency` s; negative speeds reverse, 0 is static. Unparseable colors are dropped and an empty palette falls back to the player's colors, like the renderer. Animation is SMIL inside the SVG, so there is no animation bookkeeping to start/cancel (the nuke-explosion swatches are unchanged).

`CosmeticPreview` dispatches non-explosion effects to `<effect-scene .effect=${cosmetic}>`.

## Test plan

- [x] New `tests/client/EffectScene.test.ts`: gradient geometry (cycle vector, repeat, stops), scroll period/direction/static, transition values and step duration, single/invalid/empty palettes, structure icon-space anchoring, warship light-band-only, train dual-band darkening, nuke spiral strands + flicker, spiral ship trail, unique gradient ids per instance. `CosmeticPreview.test.ts` updated for the new element.
- [x] `tsc --noEmit`, eslint, oxlint, prettier clean; `tests/client` passes except 3 pattern-swatch tests in `StoreModal`/`InventoryModal` that fail identically on a `main` baseline copy (pre-existing).
- [x] Screenshotted all six scenes × gradient / transition / spiral / single / no-palette in headless Chromium against the dev server; each reads as its in-game counterpart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
