### PR TITLE
fix(net): cover worker-prefixed paths in the game-server CORS grant

### DIFF
--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -40,6 +40,7 @@ import { createMatchTelemetryEmitter } from "./telemetry/BufferedMatchTelemetryE
 import { MAX_WEBSOCKET_PAYLOAD_BYTES } from "./telemetry/MatchTelemetryConfig";
 import { WorkerLobbyService } from "./WorkerLobbyService";
 import { initWorkerMetrics } from "./WorkerMetrics";
+import { stripWorkerPrefix } from "./WorkerPathPrefix";
 
 const workerId = ServerEnv.workerId() ?? 0;
 const log = logger.child({ comp: `w_${workerId}` });
@@ -94,30 +95,15 @@ export async function startWorker() {
   );
   privilegeRefresher.start();
 
-  // Middleware to handle /wX path prefix
-  app.use((req, res, next) => {
-    // Extract the original path without the worker prefix
-    const originalPath = req.url;
-    const match = originalPath.match(/^\/w(\d+)(.*)$/);
+  // Ahead of everything that can reject a request — the worker-prefix check
+  // below and the rate limiter further down — so that a 404 or a 429 still
+  // carries the CORS headers. Without them the desktop client sees an opaque
+  // CORS failure instead of the real status, which hides the actual fault.
+  // Matches both URL shapes because it runs before the prefix is stripped,
+  // including a prefix naming a different worker.
+  app.use(["/api", /^\/w\d+\/api/], gameApiCors);
 
-    if (match) {
-      const pathWorkerId = parseInt(match[1]);
-      const actualPath = match[2] || "/";
-
-      // Verify this request is for the correct worker
-      if (pathWorkerId !== workerId) {
-        return res.status(404).json({
-          error: "Worker mismatch",
-          message: `This is worker ${workerId}, but you requested worker ${pathWorkerId}`,
-        });
-      }
-
-      // Update the URL to remove the worker prefix
-      req.url = actualPath;
-    }
-
-    next();
-  });
+  app.use(stripWorkerPrefix(workerId));
 
   app.set("trust proxy", 3);
   app.use(compression());
@@ -143,12 +129,6 @@ export async function startWorker() {
       },
     }),
   );
-  // Before the rate limiter on purpose: a 429 still has to carry the CORS
-  // headers, or the desktop client sees an opaque CORS failure instead of the
-  // real status. Preflights are answered here and never reach the limiter,
-  // which is fine — they do no work.
-  app.use("/api", gameApiCors);
-
   app.use(
     rateLimit({
       windowMs: 1000, // 1 second

--- a/src/server/WorkerPathPrefix.ts
+++ b/src/server/WorkerPathPrefix.ts
@@ -1,0 +1,37 @@
+import type { NextFunction, Request, RequestHandler, Response } from "express";
+
+/**
+ * Reconcile the two ways a worker is addressed.
+ *
+ * nginx (and the vite dev proxy) route to a worker by URL prefix — /wN/... —
+ * but each worker registers its routes unprefixed, so the prefix is stripped
+ * here before routing. A prefix naming a different worker means the request
+ * was misrouted, or the client computed the wrong worker for a game id, and is
+ * refused rather than silently served by the wrong worker.
+ */
+export function stripWorkerPrefix(workerId: number): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Extract the original path without the worker prefix
+    const originalPath = req.url;
+    const match = originalPath.match(/^\/w(\d+)(.*)$/);
+
+    if (match) {
+      const pathWorkerId = parseInt(match[1]);
+      const actualPath = match[2] || "/";
+
+      // Verify this request is for the correct worker
+      if (pathWorkerId !== workerId) {
+        res.status(404).json({
+          error: "Worker mismatch",
+          message: `This is worker ${workerId}, but you requested worker ${pathWorkerId}`,
+        });
+        return;
+      }
+
+      // Update the URL to remove the worker prefix
+      req.url = actualPath;
+    }
+
+    next();
+  };
+}

--- a/tests/server/GameApiCors.test.ts
+++ b/tests/server/GameApiCors.test.ts
@@ -7,6 +7,7 @@ import {
   applyGameApiCorsHeaders,
   gameApiCors,
 } from "../../src/server/GameApiCors";
+import { stripWorkerPrefix } from "../../src/server/WorkerPathPrefix";
 
 // The game server's /api routes are same-origin for the web client, but the
 // desktop app loads its renderer from app://openfront and so reaches them
@@ -96,7 +97,9 @@ describe("gameApiCors middleware, mounted on a real Express app", () => {
   beforeEach(async () => {
     routeHits = [];
     const app = express();
-    app.use("/api", gameApiCors);
+    // Mirrors Worker.ts: CORS ahead of the prefix check, matching both shapes.
+    app.use(["/api", /^\/w\d+\/api/], gameApiCors);
+    app.use(stripWorkerPrefix(0));
     app.post("/api/create_game", (_req, res) => {
       routeHits.push("create_game");
       res.json({ gameID: "g1" });
@@ -157,15 +160,34 @@ describe("gameApiCors middleware, mounted on a real Express app", () => {
     expect(routeHits).toEqual(["create_game"]);
   });
 
-  test("grants a worker-prefixed GET as well", async () => {
-    const res = await fetch(`${base}/api/game/abcdefgh/exists`, {
+  test("grants a request addressed to this worker's prefix", async () => {
+    // The shape the client actually sends: ClientEnv.workerPath() puts the
+    // worker in the path, and nginx routes on it.
+    const res = await fetch(`${base}/w0/api/game/abcdefgh/exists`, {
       headers: { Origin: DESKTOP_APP_ORIGIN },
     });
 
+    expect(res.status).toBe(200);
     expect(res.headers.get("access-control-allow-origin")).toBe(
       "app://openfront",
     );
     expect(routeHits).toEqual(["exists"]);
+  });
+
+  test("grants a worker-mismatch 404 so the client can read it", async () => {
+    // A client that computes the wrong worker for a game id (e.g. its injected
+    // numWorkers disagrees with the server's) gets this 404. Without the grant
+    // the desktop sees an opaque CORS failure instead, which hides the actual
+    // fault — the same reasoning that puts CORS ahead of the rate limiter.
+    const res = await fetch(`${base}/w7/api/game/abcdefgh/exists`, {
+      headers: { Origin: DESKTOP_APP_ORIGIN },
+    });
+
+    expect(res.status).toBe(404);
+    expect(res.headers.get("access-control-allow-origin")).toBe(
+      "app://openfront",
+    );
+    expect(routeHits).toEqual([]);
   });
 
   test("an error response still carries the grant", async () => {

--- a/tests/server/WorkerPathPrefix.test.ts
+++ b/tests/server/WorkerPathPrefix.test.ts
@@ -1,0 +1,65 @@
+import express from "express";
+import http from "http";
+import type { AddressInfo } from "net";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { stripWorkerPrefix } from "../../src/server/WorkerPathPrefix";
+
+// Each worker is addressed as /wN/... through nginx, but registers its routes
+// unprefixed. This middleware is what reconciles the two, and it is also the
+// gate that rejects a request routed to the wrong worker.
+describe("stripWorkerPrefix", () => {
+  let server: http.Server;
+  let base: string;
+  let seenUrl: string | null;
+
+  beforeEach(async () => {
+    seenUrl = null;
+    const app = express();
+    app.use(stripWorkerPrefix(0));
+    app.get("/api/game/:id/exists", (req, res) => {
+      seenUrl = req.url;
+      res.json({ exists: true });
+    });
+    app.get("/", (req, res) => {
+      seenUrl = req.url;
+      res.json({ root: true });
+    });
+
+    server = http.createServer(app);
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`;
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve())),
+    );
+  });
+
+  test("routes this worker's own prefix to the unprefixed route", async () => {
+    const res = await fetch(`${base}/w0/api/game/abcdefgh/exists`);
+    expect(res.status).toBe(200);
+    expect(seenUrl).toBe("/api/game/abcdefgh/exists");
+  });
+
+  test("leaves an unprefixed request untouched", async () => {
+    const res = await fetch(`${base}/api/game/abcdefgh/exists`);
+    expect(res.status).toBe(200);
+    expect(seenUrl).toBe("/api/game/abcdefgh/exists");
+  });
+
+  test("maps a bare worker prefix to the root", async () => {
+    const res = await fetch(`${base}/w0`);
+    expect(res.status).toBe(200);
+    expect(seenUrl).toBe("/");
+  });
+
+  test("refuses a request routed to a different worker", async () => {
+    const res = await fetch(`${base}/w7/api/game/abcdefgh/exists`);
+    expect(res.status).toBe(404);
+    expect(await res.json()).toMatchObject({ error: "Worker mismatch" });
+    expect(seenUrl).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-up to #5085, which merged before this last commit was pushed — so the
gap below is on `main` today.

## What

#5085 mounted the CORS middleware at `/api`, which sits *behind* the middleware
that strips the `/wN` worker prefix. That covers the prefixed routes in the
normal case, but not when the prefix names a **different** worker: that check
answers `404 Worker mismatch` before the CORS middleware ever runs, so the
response carries no grant and the desktop client sees an opaque CORS failure
instead of the actual status.

That is exactly the case a client hits when its injected `numWorkers` disagrees
with the server's — i.e. when it computes the wrong worker for a game id. The
desktop has had that bug once already (openfront-desktop `0c1679c`, "inject the
game server's real worker count, not 1"), and it was hard to see. It should be
readable, not opaque. Same reasoning that already put the middleware ahead of
the rate limiter.

## How

Mounted on both URL shapes, ahead of the prefix check. Express 5 accepts an
array of paths, so `["/api", /^\/w\d+\/api/]` matches the prefixed form —
including a mismatched prefix — without matching static assets.

The prefix middleware moves to `WorkerPathPrefix.ts` so `Worker.ts` and the
tests exercise the same code rather than a re-implementation of it. It was
inline and had no tests; it has four now.

Credit where due: CodeRabbit caught that the `/w0` test in #5085 was mislabelled
(it requested `/api/...`, not `/w0/api/...`). Writing the honest version is what
surfaced the mismatch case.

## Testing

`tests/server/WorkerPathPrefix.test.ts` (own prefix, unprefixed, bare `/w0`,
mismatch 404) and two new cases in `tests/server/GameApiCors.test.ts`, both
driven over real HTTP against a real Express app.

Verified against a running dev server:

| Request | Result |
|---|---|
| `/w0/api/game/:id/exists` | `200` + grant |
| `/w7/...` (wrong worker) | `404` + grant — previously opaque |
| `OPTIONS /w0/api/create_game` | `204` + grant |
| `/w0/commit.txt` (static) | untouched, no CORS headers |

581 server tests green, `tsc --noEmit` and lint clean.

Note for release: `v33` currently has #5072's client change (calls go
cross-origin) but neither #5085 nor this, so the desktop's `/api` calls fail
there. Both want cherry-picking together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01URxNGKBbPtYSybwfR3Uih1