### PR TITLE
Fill territory with translucent relation color in alt-view

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -737,6 +737,8 @@
     "advanced_label": "Advanced settings",
     "alt_view_fill_alpha_desc": "How opaque the relation-colored territory fill is while holding the alt-view key (Space)",
     "alt_view_fill_alpha_label": "Alt-view fill opacity",
+    "alt_view_hover_perspective_desc": "In alt-view (Space), hovering another player shows their allies and embargoes instead of yours",
+    "alt_view_hover_perspective_label": "Alt-view hover perspective",
     "background_color_desc": "Color of the area outside the map and impassable terrain.",
     "background_color_label": "Background color",
     "black": "Black",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -735,6 +735,8 @@
   "graphics_setting": {
     "advanced_desc": "Fine-tune individual graphics options",
     "advanced_label": "Advanced settings",
+    "alt_view_fill_alpha_desc": "How opaque the relation-colored territory fill is while holding the alt-view key (Space)",
+    "alt_view_fill_alpha_label": "Alt-view fill opacity",
     "background_color_desc": "Color of the area outside the map and impassable terrain.",
     "background_color_label": "Background color",
     "black": "Black",

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -318,6 +318,15 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     this.requestUpdate();
   }
 
+  private patchAltView(patch: Partial<GraphicsOverrides["altView"]>) {
+    const current = this.userSettings.graphicsOverrides();
+    this.userSettings.setGraphicsOverrides({
+      ...current,
+      altView: { ...current.altView, ...patch },
+    });
+    this.requestUpdate();
+  }
+
   private patchRailroad(patch: Partial<GraphicsOverrides["railroad"]>) {
     const current = this.userSettings.graphicsOverrides();
     this.userSettings.setGraphicsOverrides({
@@ -410,6 +419,13 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     );
   }
 
+  private currentAltViewFillAlpha(): number {
+    return (
+      this.userSettings.graphicsOverrides().altView?.fillAlpha ??
+      renderDefaults.altView.fillAlpha
+    );
+  }
+
   private currentCoordinateGridOpacity(): number {
     return (
       this.userSettings.graphicsOverrides().mapOverlay?.coordinateGridOpacity ??
@@ -454,6 +470,11 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
   private onTerritoryAlphaChange(event: Event) {
     const value = parseFloat((event.target as HTMLInputElement).value);
     this.patchMapOverlay({ territoryAlpha: value });
+  }
+
+  private onAltViewFillAlphaChange(event: Event) {
+    const value = parseFloat((event.target as HTMLInputElement).value);
+    this.patchAltView({ fillAlpha: value });
   }
 
   private onCoordinateGridOpacityChange(event: Event) {
@@ -969,6 +990,7 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     const highlightThicken = this.currentHighlightThicken();
     const territorySat = this.currentTerritorySat();
     const territoryAlpha = this.currentTerritoryAlpha();
+    const altViewFillAlpha = this.currentAltViewFillAlpha();
     const coordinateGridOpacity = this.currentCoordinateGridOpacity();
     const railDrawDistance = RAIL_ZOOM_MAX - this.currentRailMinZoom();
     const railThickness = this.currentRailThickness();
@@ -1422,6 +1444,31 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
         </div>
         <div class="text-sm text-slate-400 w-12 text-right">
           ${territoryAlpha.toFixed(2)}
+        </div>
+      </div>
+
+      <div
+        class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
+      >
+        <div class="flex-1">
+          <div class="font-medium">
+            ${translateText("graphics_setting.alt_view_fill_alpha_label")}
+          </div>
+          <div class="text-sm text-slate-400">
+            ${translateText("graphics_setting.alt_view_fill_alpha_desc")}
+          </div>
+          <input
+            type="range"
+            min=${TERRITORY_ALPHA_MIN}
+            max=${TERRITORY_ALPHA_MAX}
+            step=${TERRITORY_ALPHA_STEP}
+            .value=${String(altViewFillAlpha)}
+            @input=${this.onAltViewFillAlphaChange}
+            class="w-full border border-slate-500 rounded-lg"
+          />
+        </div>
+        <div class="text-sm text-slate-400 w-12 text-right">
+          ${altViewFillAlpha.toFixed(2)}
         </div>
       </div>
 

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -472,6 +472,19 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     this.patchMapOverlay({ territoryAlpha: value });
   }
 
+  private currentAltViewHoverPerspective(): boolean {
+    return (
+      this.userSettings.graphicsOverrides().altView?.hoverPerspective ??
+      renderDefaults.altView.hoverPerspective
+    );
+  }
+
+  private onToggleAltViewHoverPerspective() {
+    this.patchAltView({
+      hoverPerspective: !this.currentAltViewHoverPerspective(),
+    });
+  }
+
   private onAltViewFillAlphaChange(event: Event) {
     const value = parseFloat((event.target as HTMLInputElement).value);
     this.patchAltView({ fillAlpha: value });
@@ -991,6 +1004,7 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     const territorySat = this.currentTerritorySat();
     const territoryAlpha = this.currentTerritoryAlpha();
     const altViewFillAlpha = this.currentAltViewFillAlpha();
+    const altViewHoverPerspective = this.currentAltViewHoverPerspective();
     const coordinateGridOpacity = this.currentCoordinateGridOpacity();
     const railDrawDistance = RAIL_ZOOM_MAX - this.currentRailMinZoom();
     const railThickness = this.currentRailThickness();
@@ -1471,6 +1485,27 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
           ${altViewFillAlpha.toFixed(2)}
         </div>
       </div>
+
+      <button
+        class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
+        @click=${this.onToggleAltViewHoverPerspective}
+      >
+        <div class="flex-1">
+          <div class="font-medium">
+            ${translateText(
+              "graphics_setting.alt_view_hover_perspective_label",
+            )}
+          </div>
+          <div class="text-sm text-slate-400">
+            ${translateText("graphics_setting.alt_view_hover_perspective_desc")}
+          </div>
+        </div>
+        <div class="text-sm text-slate-400">
+          ${altViewHoverPerspective
+            ? translateText("user_setting.on")
+            : translateText("user_setting.off")}
+        </div>
+      </button>
 
       <div
         class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"

--- a/src/client/render/gl/GraphicsOverrides.ts
+++ b/src/client/render/gl/GraphicsOverrides.ts
@@ -52,6 +52,13 @@ export const GraphicsOverridesSchema = z
         embargoTintRatio: z.number(),
       })
       .partial(),
+    altView: z
+      .object({
+        // Opacity of the translucent relation-colored territory fill shown
+        // while holding the alt-view key (0 = borders only, 1 = opaque).
+        fillAlpha: z.number(),
+      })
+      .partial(),
     affiliation: z
       .object({
         // "#rrggbb" hex strings; alt-view border colors for your own, allied,

--- a/src/client/render/gl/GraphicsOverrides.ts
+++ b/src/client/render/gl/GraphicsOverrides.ts
@@ -57,6 +57,9 @@ export const GraphicsOverridesSchema = z
         // Opacity of the translucent relation-colored territory fill shown
         // while holding the alt-view key (0 = borders only, 1 = opaque).
         fillAlpha: z.number(),
+        // When true, hovering another player's territory shows alt-view from
+        // their diplomacy; false always uses your own.
+        hoverPerspective: z.boolean(),
       })
       .partial(),
     affiliation: z

--- a/src/client/render/gl/RenderOverrides.ts
+++ b/src/client/render/gl/RenderOverrides.ts
@@ -107,6 +107,9 @@ export function applyGraphicsOverrides(
   if (overrides.altView?.fillAlpha !== undefined) {
     settings.altView.fillAlpha = overrides.altView.fillAlpha;
   }
+  if (overrides.altView?.hoverPerspective !== undefined) {
+    settings.altView.hoverPerspective = overrides.altView.hoverPerspective;
+  }
   if (overrides.affiliation?.selfColor !== undefined) {
     applyHexColor(overrides.affiliation.selfColor, (r, g, b) => {
       settings.affiliation.selfR = r;

--- a/src/client/render/gl/RenderOverrides.ts
+++ b/src/client/render/gl/RenderOverrides.ts
@@ -104,6 +104,9 @@ export function applyGraphicsOverrides(
     settings.mapOverlay.embargoTintRatio =
       overrides.mapOverlay.embargoTintRatio;
   }
+  if (overrides.altView?.fillAlpha !== undefined) {
+    settings.altView.fillAlpha = overrides.altView.fillAlpha;
+  }
   if (overrides.affiliation?.selfColor !== undefined) {
     applyHexColor(overrides.affiliation.selfColor, (r, g, b) => {
       settings.affiliation.selfR = r;

--- a/src/client/render/gl/RenderSettings.ts
+++ b/src/client/render/gl/RenderSettings.ts
@@ -408,6 +408,8 @@ export interface RenderSettings {
   altView: {
     gridFontSize: number;
     recolorStructures: boolean;
+    /** Opacity of the translucent affiliation-colored territory fill. */
+    fillAlpha: number;
   };
   tileDrip: {
     /**

--- a/src/client/render/gl/RenderSettings.ts
+++ b/src/client/render/gl/RenderSettings.ts
@@ -410,6 +410,11 @@ export interface RenderSettings {
     recolorStructures: boolean;
     /** Opacity of the translucent affiliation-colored territory fill. */
     fillAlpha: number;
+    /**
+     * When true, hovering another player's territory recolors alt-view from
+     * that player's diplomacy; when false, always use the local player's.
+     */
+    hoverPerspective: boolean;
   };
   tileDrip: {
     /**

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -629,6 +629,7 @@ export class GPURenderer {
     this.affiliationPalette = new AffiliationPalette(gl, this.settings);
     const affTex = this.affiliationPalette.getTexture();
     this.borderStampPass.setAffiliationTex(affTex);
+    this.territoryPass.setAffiliationTex(affTex);
     this.unitPass.setAffiliationTex(affTex);
     this.structurePass.setAffiliationTex(affTex);
     this.trailPass.setAffiliationTex(affTex);

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1095,6 +1095,7 @@ export class GPURenderer {
     this.namePass.setHighlightOwner(ownerID);
     this.structurePass.setHighlightOwner(ownerID);
     this.railroadPass.setHighlightOwner(ownerID);
+    this.affiliationPalette.setHoveredOwner(ownerID);
   }
   setMouseWorldPos(x: number, y: number): void {
     this.namePass.setMouseWorldPos(x, y);

--- a/src/client/render/gl/debug/Layout.ts
+++ b/src/client/render/gl/debug/Layout.ts
@@ -838,6 +838,7 @@ export function buildTree(s: RenderSettings, d: RenderSettings): DebugNode[] {
     folder("Alt View", [
       slider(s.altView, "gridFontSize", d.altView, 6, 32, 1, "Grid Font Size"),
       toggle(s.altView, "recolorStructures", d.altView, "Recolor Structures"),
+      slider(s.altView, "fillAlpha", d.altView, 0, 1, 0.01, "Fill Alpha"),
     ]),
 
     folder(

--- a/src/client/render/gl/debug/Layout.ts
+++ b/src/client/render/gl/debug/Layout.ts
@@ -839,6 +839,7 @@ export function buildTree(s: RenderSettings, d: RenderSettings): DebugNode[] {
       slider(s.altView, "gridFontSize", d.altView, 6, 32, 1, "Grid Font Size"),
       toggle(s.altView, "recolorStructures", d.altView, "Recolor Structures"),
       slider(s.altView, "fillAlpha", d.altView, 0, 1, 0.01, "Fill Alpha"),
+      toggle(s.altView, "hoverPerspective", d.altView, "Hover Perspective"),
     ]),
 
     folder(

--- a/src/client/render/gl/passes/TerritoryPass.ts
+++ b/src/client/render/gl/passes/TerritoryPass.ts
@@ -42,6 +42,7 @@ export class TerritoryPass {
   private uDefenseDarken: WebGLUniformLocation;
   private uSaturation: WebGLUniformLocation;
   private uTerritoryAlpha: WebGLUniformLocation;
+  private uAltFillAlpha: WebGLUniformLocation;
   private highlightOwner = 0;
   private isTeamMode = false;
 
@@ -55,6 +56,7 @@ export class TerritoryPass {
   private skinAnchorTex: WebGLTexture;
   private defenseCoverageTex: WebGLTexture | null = null;
   private borderTex: WebGLTexture | null = null;
+  private affiliationTex: WebGLTexture | null = null;
 
   private altView = false;
   private showPatterns = true;
@@ -180,6 +182,7 @@ export class TerritoryPass {
       this.program,
       "uTerritoryAlpha",
     )!;
+    this.uAltFillAlpha = gl.getUniformLocation(this.program, "uAltFillAlpha")!;
 
     gl.useProgram(this.program);
     gl.uniform1i(gl.getUniformLocation(this.program, "uTileTex"), 0);
@@ -191,6 +194,7 @@ export class TerritoryPass {
     gl.uniform1i(gl.getUniformLocation(this.program, "uSkinAnchor"), 6);
     gl.uniform1i(gl.getUniformLocation(this.program, "uDefenseCoverageTex"), 7);
     gl.uniform1i(gl.getUniformLocation(this.program, "uBorderTex"), 8);
+    gl.uniform1i(gl.getUniformLocation(this.program, "uAffiliation"), 9);
 
     this.vao = createMapQuad(gl, mapW, mapH);
 
@@ -412,6 +416,11 @@ export class TerritoryPass {
     this.borderTex = tex;
   }
 
+  /** Affiliation palette (row 0 = border/relation colors) for the alt-view fill. */
+  setAffiliationTex(tex: WebGLTexture): void {
+    this.affiliationTex = tex;
+  }
+
   /** Draw territory fill + stale-nuke ground. Blending must be enabled by caller. */
   draw(cameraMatrix: Float32Array): void {
     this.flushTileTexture();
@@ -442,6 +451,7 @@ export class TerritoryPass {
     gl.uniform1f(this.uDefenseDarken, mo.territoryDefenseDarken);
     gl.uniform1f(this.uSaturation, mo.territorySaturation);
     gl.uniform1f(this.uTerritoryAlpha, mo.territoryAlpha);
+    gl.uniform1f(this.uAltFillAlpha, this.settings.altView.fillAlpha);
 
     gl.activeTexture(gl.TEXTURE0);
     gl.bindTexture(gl.TEXTURE_2D, this.tileTex);
@@ -464,6 +474,10 @@ export class TerritoryPass {
     if (this.borderTex) {
       gl.activeTexture(gl.TEXTURE8);
       gl.bindTexture(gl.TEXTURE_2D, this.borderTex);
+    }
+    if (this.affiliationTex) {
+      gl.activeTexture(gl.TEXTURE9);
+      gl.bindTexture(gl.TEXTURE_2D, this.affiliationTex);
     }
 
     gl.bindVertexArray(this.vao);

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -346,7 +346,7 @@
   },
   "altView": {
     "gridFontSize": 24,
-    "fillAlpha": 0.35,
+    "fillAlpha": 0.25,
     "recolorStructures": true
   },
   "tileDrip": {

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -346,7 +346,7 @@
   },
   "altView": {
     "gridFontSize": 24,
-    "fillAlpha": 0.25,
+    "fillAlpha": 0.15,
     "recolorStructures": true
   },
   "tileDrip": {

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -347,6 +347,7 @@
   "altView": {
     "gridFontSize": 24,
     "fillAlpha": 0.15,
+    "hoverPerspective": true,
     "recolorStructures": true
   },
   "tileDrip": {

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -346,6 +346,7 @@
   },
   "altView": {
     "gridFontSize": 24,
+    "fillAlpha": 0.35,
     "recolorStructures": true
   },
   "tileDrip": {

--- a/src/client/render/gl/shaders/map-overlay/territory.frag.glsl
+++ b/src/client/render/gl/shaders/map-overlay/territory.frag.glsl
@@ -27,6 +27,8 @@ uniform float uDefenseDarken;      // multiplier applied to fill on defended til
 uniform sampler2D uBorderTex;      // RGBA8 — border flags; R > 0.25 = border tile
 uniform float uSaturation;         // 1 = full color, 0 = grayscale
 uniform float uTerritoryAlpha;     // absolute fill opacity; 1 = fully opaque
+uniform sampler2D uAffiliation;    // RGBA8 — alt-view relation colors (row 0)
+uniform float uAltFillAlpha;       // alt-view translucent fill opacity
 
 in vec2 vWorldPos;
 out vec4 fragColor;
@@ -52,8 +54,13 @@ void main() {
     return;
   }
 
-  // Alt-view: hide owned non-fallout tiles
-  if (uAltView != 0) discard;
+  // Alt-view: translucent fill in the owner's relation color (matches the
+  // border color BorderStampPass draws in alt-view).
+  if (uAltView != 0) {
+    vec3 rel = texelFetch(uAffiliation, ivec2(int(owner), 0), 0).rgb;
+    fragColor = vec4(rel, uAltFillAlpha);
+    return;
+  }
 
   // --- Territory fill (owned, not fallout) ---
   float u = (float(owner) + 0.5) / float(PALETTE_SIZE);

--- a/src/client/render/gl/utils/Affiliation.ts
+++ b/src/client/render/gl/utils/Affiliation.ts
@@ -75,7 +75,9 @@ export class AffiliationPalette {
   }
 
   private perspective(): number {
-    return this.hoveredOwnerID > 0 ? this.hoveredOwnerID : this.localPlayerID;
+    return this.settings.altView.hoverPerspective && this.hoveredOwnerID > 0
+      ? this.hoveredOwnerID
+      : this.localPlayerID;
   }
 
   updateRelations(data: Uint8Array, size: number): void {

--- a/src/client/render/gl/utils/Affiliation.ts
+++ b/src/client/render/gl/utils/Affiliation.ts
@@ -5,7 +5,10 @@
  *   Row 0: border colors (4-state: self/ally/neutral/embargo)
  *   Row 1: unit colors (3-state: self/ally/enemy)
  *
- * Rebuilt when localPlayerID or relationship data changes.
+ * Colors are computed from the perspective of the hovered player when the
+ * cursor is over someone else's territory, otherwise the local player.
+ *
+ * Rebuilt when the perspective or relationship data changes.
  */
 
 import type { RenderSettings } from "../RenderSettings";
@@ -28,6 +31,7 @@ export class AffiliationPalette {
 
   // Cached inputs for rebuilding
   private localPlayerID = 0;
+  private hoveredOwnerID = 0;
   private relationData: Uint8Array | null = null;
   private relationSize = 0;
 
@@ -59,6 +63,21 @@ export class AffiliationPalette {
     this.rebuild();
   }
 
+  /**
+   * Hovered tile owner (0 = none/water). A non-zero owner other than the
+   * local player becomes the perspective the colors are computed from.
+   */
+  setHoveredOwner(id: number): void {
+    if (id === this.hoveredOwnerID) return;
+    const before = this.perspective();
+    this.hoveredOwnerID = id;
+    if (this.perspective() !== before) this.rebuild();
+  }
+
+  private perspective(): number {
+    return this.hoveredOwnerID > 0 ? this.hoveredOwnerID : this.localPlayerID;
+  }
+
   updateRelations(data: Uint8Array, size: number): void {
     this.relationData = data;
     this.relationSize = size;
@@ -86,7 +105,7 @@ export class AffiliationPalette {
 
   private rebuild(): void {
     const d = this.cpuData;
-    const lp = this.localPlayerID;
+    const lp = this.perspective();
     const rel = this.relationData;
     const rs = this.relationSize;
 

--- a/tests/GraphicsOverrides.test.ts
+++ b/tests/GraphicsOverrides.test.ts
@@ -62,6 +62,20 @@ describe("GraphicsOverridesSchema", () => {
     }
   });
 
+  test("accepts partial altView overrides", () => {
+    expect(GraphicsOverridesSchema.safeParse({ altView: {} }).success).toBe(
+      true,
+    );
+    expect(
+      GraphicsOverridesSchema.safeParse({ altView: { fillAlpha: 0.2 } })
+        .success,
+    ).toBe(true);
+    expect(
+      GraphicsOverridesSchema.safeParse({ altView: { fillAlpha: "faint" } })
+        .success,
+    ).toBe(false);
+  });
+
   test("accepts partial railroad overrides", () => {
     const cases = [
       { railroad: {} },
@@ -356,6 +370,14 @@ describe("applyGraphicsOverrides", () => {
     expect(
       gen({ mapOverlay: { territoryAlpha: 0 } }).mapOverlay.territoryAlpha,
     ).toBe(0);
+  });
+
+  test("applies altView.fillAlpha override (including 0)", () => {
+    expect(gen({ altView: { fillAlpha: 0.4 } }).altView.fillAlpha).toBe(0.4);
+    expect(gen({ altView: { fillAlpha: 0 } }).altView.fillAlpha).toBe(0);
+    expect(gen({}).altView.fillAlpha).toBe(
+      createRenderSettings().altView.fillAlpha,
+    );
   });
 
   test("mapOverlay override leaves other mapOverlay fields at defaults", () => {

--- a/tests/GraphicsOverrides.test.ts
+++ b/tests/GraphicsOverrides.test.ts
@@ -74,6 +74,15 @@ describe("GraphicsOverridesSchema", () => {
       GraphicsOverridesSchema.safeParse({ altView: { fillAlpha: "faint" } })
         .success,
     ).toBe(false);
+    expect(
+      GraphicsOverridesSchema.safeParse({
+        altView: { hoverPerspective: false },
+      }).success,
+    ).toBe(true);
+    expect(
+      GraphicsOverridesSchema.safeParse({ altView: { hoverPerspective: "no" } })
+        .success,
+    ).toBe(false);
   });
 
   test("accepts partial railroad overrides", () => {
@@ -378,6 +387,13 @@ describe("applyGraphicsOverrides", () => {
     expect(gen({}).altView.fillAlpha).toBe(
       createRenderSettings().altView.fillAlpha,
     );
+  });
+
+  test("applies altView.hoverPerspective override (default on)", () => {
+    expect(gen({}).altView.hoverPerspective).toBe(true);
+    expect(
+      gen({ altView: { hoverPerspective: false } }).altView.hoverPerspective,
+    ).toBe(false);
   });
 
   test("mapOverlay override leaves other mapOverlay fields at defaults", () => {


### PR DESCRIPTION
## Summary
- Alt-view (hold spacebar) previously hid owned territory and only drew borders in relation colors; owned tiles are now filled with a translucent version of the same self/ally/neutral/embargo color.
- `territory.frag.glsl` samples the shared `AffiliationPalette` texture (row 0, same as `BorderStampPass`) instead of discarding owned tiles; `TerritoryPass` gains `setAffiliationTex()` and a `uAltFillAlpha` uniform, wired in `Renderer`.
- New `altView.fillAlpha` render setting (default `0.15`) with a "Fill Alpha" slider in the debug panel.
- Exposed as a graphics override (`altView.fillAlpha` in `GraphicsOverridesSchema` / `applyGraphicsOverrides`) with an "Alt-view fill opacity" slider in the Graphics Settings modal, so it persists with presets.
- Alt-view colors now follow the hovered player's diplomacy: hovering another player's territory rebuilds the `AffiliationPalette` from their row of the relation matrix (they become "self", their allies/embargoes are colored accordingly); hovering your own territory or water uses your perspective.
- New `altView.hoverPerspective` setting/override (default on) with an "Alt-view hover perspective" toggle in Graphics Settings, so users can switch back to always viewing from their own relations.

## Test plan
- `npx tsc --noEmit`, `npm run lint`: clean.
- `npx vitest --run tests/client` (114 files / 1282 tests) and `tests/GraphicsOverrides.test.ts` / `tests/GraphicsPresets.test.ts` (new schema + apply cases for `fillAlpha` and `hoverPerspective`) pass.
- Not visually verified in a live WebGL session; shader change mirrors the existing `texelFetch(uAffiliation, …)` usage in `border-stamp.frag.glsl`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)