### PR TITLE
Color trade ships in alt view by self/ally involvement on either end

### DIFF
--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -211,6 +211,8 @@ export class UnitPass {
   private uFlickerSpeed: WebGLUniformLocation;
   private uAngryColor: WebGLUniformLocation;
   private uAltView: WebGLUniformLocation;
+  private uSelfColor: WebGLUniformLocation;
+  private uAllyColor: WebGLUniformLocation;
   private uHBombGlowScale: WebGLUniformLocation;
   private uHBombGlowColor: WebGLUniformLocation;
   private uHBombGlowStrength: WebGLUniformLocation;
@@ -306,6 +308,8 @@ export class UnitPass {
     this.uAngryColor = gl.getUniformLocation(this.program, "uAngryColor")!;
 
     this.uAltView = gl.getUniformLocation(this.program, "uAltView")!;
+    this.uSelfColor = gl.getUniformLocation(this.program, "uSelfColor")!;
+    this.uAllyColor = gl.getUniformLocation(this.program, "uAllyColor")!;
     this.uHBombGlowScale = gl.getUniformLocation(
       this.program,
       "uHBombGlowScale",
@@ -593,6 +597,9 @@ export class UnitPass {
     gl.uniform1f(this.uFlickerSpeed, us.flickerSpeed);
     gl.uniform3f(this.uAngryColor, us.angryR, us.angryG, us.angryB);
     gl.uniform1i(this.uAltView, this.altView ? 1 : 0);
+    const af = this.settings.affiliation;
+    gl.uniform3f(this.uSelfColor, af.selfR, af.selfG, af.selfB);
+    gl.uniform3f(this.uAllyColor, af.allyR, af.allyG, af.allyB);
     gl.uniform1f(this.uHBombGlowScale, us.hBombGlowScale);
     gl.uniform3f(
       this.uHBombGlowColor,

--- a/src/client/render/gl/passes/UnitPass.ts
+++ b/src/client/render/gl/passes/UnitPass.ts
@@ -121,6 +121,7 @@ const FLAG_ANGRY = 2;
 const FLAG_TRADE_FRIENDLY = 3;
 const FLAG_RETREATING = 4;
 const FLAG_FLICKER_UNTARGETABLE = 5;
+const FLAG_TRADE_SELF = 6;
 
 /** Atlas column indices for train sub-types (resolved from trainType + loaded) */
 const TRAIN_ENGINE_COL = UNIT_ORDER.indexOf("TrainEngine");
@@ -475,9 +476,11 @@ export class UnitPass {
         unit.unitType === UT_WARSHIP && unit.targetUnitId !== null;
       const isFlicker = FLICKER_TYPES.has(unit.unitType);
 
-      // Enemy trade ships heading to a self/allied port get FLAG_TRADE_FRIENDLY
-      // so alt-view renders them yellow instead of red.
-      let isTradeFriendly = false;
+      // Alt-view trade ship color from owner + destination port owner:
+      //   self involved on either end        -> green  (FLAG_TRADE_SELF)
+      //   ally/teammate involved on either end -> yellow (FLAG_TRADE_FRIENDLY)
+      //   otherwise                          -> red    (owner affiliation)
+      let tradeFlag = FLAG_NORMAL;
       if (
         unit.unitType === UT_TRADE_SHIP &&
         unit.targetUnitId !== null &&
@@ -486,20 +489,23 @@ export class UnitPass {
         const targetPort = this.structures.get(unit.targetUnitId);
         if (targetPort) {
           const portOwner = targetPort.ownerID;
-          // Only recolor enemy-owned ships: a self/allied ship already renders
-          // green/yellow via its affiliation color (e.g. a captured trade ship
-          // heading to our port is ours and must stay green, not yellow).
-          isTradeFriendly =
-            unit.ownerID !== this.localPlayerID &&
-            !this.friendlyOwners.has(unit.ownerID) &&
-            (portOwner === this.localPlayerID ||
-              this.friendlyOwners.has(portOwner));
+          if (
+            unit.ownerID === this.localPlayerID ||
+            portOwner === this.localPlayerID
+          ) {
+            tradeFlag = FLAG_TRADE_SELF;
+          } else if (
+            this.friendlyOwners.has(unit.ownerID) ||
+            this.friendlyOwners.has(portOwner)
+          ) {
+            tradeFlag = FLAG_TRADE_FRIENDLY;
+          }
         }
       }
 
       let flags = FLAG_NORMAL;
-      if (isTradeFriendly) {
-        flags = FLAG_TRADE_FRIENDLY;
+      if (tradeFlag !== FLAG_NORMAL) {
+        flags = tradeFlag;
       } else if (isRetreatingWarship) {
         flags = FLAG_RETREATING;
       } else if (isAngryWarship) {

--- a/src/client/render/gl/shaders/unit/unit.frag.glsl
+++ b/src/client/render/gl/shaders/unit/unit.frag.glsl
@@ -39,8 +39,10 @@ const float FLAG_ANGRY          = 2.0;
 const float FLAG_TRADE_FRIENDLY = 3.0;
 const float FLAG_RETREATING     = 4.0;
 const float FLAG_FLICKER_UNTARGETABLE = 5.0; // nuke out of SAM range — dimmed
+const float FLAG_TRADE_SELF     = 6.0;
 
-// Ally color for trade-friendly override (yellow — matches affiliation.ts ALLY)
+// Trade ship alt-view overrides (match affiliation.ts SELF / ALLY)
+const vec3 SELF_COLOR = vec3(0.0, 1.0, 0.0);
 const vec3 ALLY_COLOR = vec3(1.0, 1.0, 0.0);
 
 // Flicker hot colors: red → orange → yellow → white
@@ -128,10 +130,12 @@ void main() {
 
   // Alt-view: solid affiliation color, no gray-replacement bands
   if (uAltView != 0) {
-    // Enemy trade ships heading to a self/allied port render as yellow (ally)
-    vec3 ac = abs(vFlags - FLAG_TRADE_FRIENDLY) < 0.1
-      ? ALLY_COLOR
-      : texelFetch(uAffiliation, ivec2(int(vOwnerID), 1), 0).rgb;
+    // Trade ships: green if self is on either end, yellow if an ally is
+    vec3 ac = abs(vFlags - FLAG_TRADE_SELF) < 0.1
+      ? SELF_COLOR
+      : abs(vFlags - FLAG_TRADE_FRIENDLY) < 0.1
+        ? ALLY_COLOR
+        : texelFetch(uAffiliation, ivec2(int(vOwnerID), 1), 0).rgb;
     fragColor = vec4(ac, texel.a * alphaMul);
     return;
   }

--- a/src/client/render/gl/shaders/unit/unit.frag.glsl
+++ b/src/client/render/gl/shaders/unit/unit.frag.glsl
@@ -17,6 +17,8 @@ uniform float uTick;
 uniform float uFlickerSpeed;
 uniform vec3  uAngryColor;
 uniform int   uAltView;
+uniform vec3  uSelfColor;         // affiliation self/ally colors (alt-view trade ships)
+uniform vec3  uAllyColor;
 uniform vec3  uHBombGlowColor;
 uniform float uHBombGlowStrength;
 uniform float uHBombGlowInner;
@@ -40,10 +42,6 @@ const float FLAG_TRADE_FRIENDLY = 3.0;
 const float FLAG_RETREATING     = 4.0;
 const float FLAG_FLICKER_UNTARGETABLE = 5.0; // nuke out of SAM range — dimmed
 const float FLAG_TRADE_SELF     = 6.0;
-
-// Trade ship alt-view overrides (match affiliation.ts SELF / ALLY)
-const vec3 SELF_COLOR = vec3(0.0, 1.0, 0.0);
-const vec3 ALLY_COLOR = vec3(1.0, 1.0, 0.0);
 
 // Flicker hot colors: red → orange → yellow → white
 const vec3 FLICKER_COLORS[4] = vec3[4](
@@ -132,9 +130,9 @@ void main() {
   if (uAltView != 0) {
     // Trade ships: green if self is on either end, yellow if an ally is
     vec3 ac = abs(vFlags - FLAG_TRADE_SELF) < 0.1
-      ? SELF_COLOR
+      ? uSelfColor
       : abs(vFlags - FLAG_TRADE_FRIENDLY) < 0.1
-        ? ALLY_COLOR
+        ? uAllyColor
         : texelFetch(uAffiliation, ivec2(int(vOwnerID), 1), 0).rgb;
     fragColor = vec4(ac, texel.a * alphaMul);
     return;


### PR DESCRIPTION
## Summary
- Alt view (space-hold) previously colored trade ships by owner affiliation, with one override: enemy ships heading to a self/ally port became yellow. This replaces that with a single priority rule on the ship's owner and its destination port's owner.
- Green if the local player owns the ship **or** the destination port; yellow if an ally/teammate is on either end; red otherwise (enemy → enemy).
- Teams need no special handling: the existing `friendlyOwners` set already merges alliances and teammates.
- Adds `FLAG_TRADE_SELF` (CPU + shader) and a hardcoded `SELF_COLOR` in `unit.frag.glsl` alongside the existing `ALLY_COLOR`.

## Test plan
- `npx tsc --noEmit`, Prettier, and ESLint pass on the changed files.
- Not verified in-game (shader only runs under WebGL; no existing UnitPass tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)