### PR TITLE
Make public lobby listing one-way for the host

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -143,9 +143,9 @@ export class HostLobbyModal extends BaseModal {
     if (lobby.clients) {
       this.clients = lobby.clients;
     }
-    // The server can delist on its own (join whitelist enabled, duplicate
-    // creator resolved by the master); follow its state unless our own
-    // toggle request is mid-flight.
+    // The server can delist on its own (duplicate creator / cap overflow
+    // resolved by the master); follow its state unless our own toggle
+    // request is mid-flight.
     if (!this.listingRequestInFlight && lobby.listed !== undefined) {
       this.publiclyListed = lobby.listed;
     }
@@ -232,7 +232,9 @@ export class HostLobbyModal extends BaseModal {
 
   // Private/Public segmented toggle in the header. Shown to everyone;
   // non-subscribers get a subscription-required dialog instead of a listing
-  // request (the server re-checks the subscription regardless).
+  // request (the server re-checks the subscription regardless). Listing is
+  // one-way (the server rejects unlisting), so the Private segment goes away
+  // once the lobby is listed.
   private renderVisibilityToggle() {
     const segment = (labelKey: string, isPublic: boolean) => html`
       <button
@@ -249,7 +251,9 @@ export class HostLobbyModal extends BaseModal {
       <div
         class="flex items-center rounded-full border border-white/10 bg-white/5 p-0.5 shrink-0"
       >
-        ${segment("host_modal.visibility_private", false)}
+        ${this.publiclyListed
+          ? nothing
+          : segment("host_modal.visibility_private", false)}
         ${segment("host_modal.visibility_public", true)}
       </div>
       ${this.renderAutoStartTimer()}

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -265,16 +265,6 @@ export class GameServer {
 
   public updateGameConfig(gameConfig: Partial<GameConfig>): void {
     applyGameConfigPatch(this.gameConfig, gameConfig);
-    // A join whitelist and public listing are mutually exclusive: a listed
-    // lobby must be joinable by anyone who finds it in the lobby browser.
-    if (
-      gameConfig.allowedPublicIds !== undefined &&
-      this.listing.isListed() &&
-      this.hasJoinWhitelist()
-    ) {
-      this.setListed(false);
-      this.log.info("delisted lobby: join whitelist enabled");
-    }
   }
 
   // Dispatch a control/gameplay intent from either a websocket client or the

--- a/src/server/IntentAuthorization.ts
+++ b/src/server/IntentAuthorization.ts
@@ -88,6 +88,15 @@ export function authorizeIntent(
           error: "cannot enable host cheats in a publicly listed lobby",
         };
       }
+      // Likewise a join whitelist: a listed lobby must stay joinable by
+      // anyone who finds it, and listing is permanent, so the whitelist is
+      // rejected rather than delisting the lobby.
+      if (game.isListed && (intent.config.allowedPublicIds?.length ?? 0) > 0) {
+        return {
+          status: 409,
+          error: "cannot enable a join whitelist in a publicly listed lobby",
+        };
+      }
       return null;
 
     case "toggle_game_start_timer":

--- a/src/server/Worker.ts
+++ b/src/server/Worker.ts
@@ -278,6 +278,12 @@ export async function startWorker() {
     if (game.isPublic() || game.hasStarted()) {
       return res.status(409).json({ error: "Game cannot be listed" });
     }
+    // Listing is one-way for the host: players recruited from the lobby
+    // browser must not lose the lobby they joined. Only the master delists
+    // (duplicate creator / cap overflow).
+    if (!listed && game.isListed()) {
+      return res.status(409).json({ error: "listing_permanent" });
+    }
 
     if (listed) {
       // A whitelisted lobby would be advertised to everyone yet reject every

--- a/tests/server/HostedLobbyListing.test.ts
+++ b/tests/server/HostedLobbyListing.test.ts
@@ -130,17 +130,6 @@ describe("GameServer listing", () => {
     ).toBe(true);
   });
 
-  it("delists when a join whitelist is added via config update", () => {
-    const game = makeGame();
-    game.setListed(true);
-
-    game.updateGameConfig({ allowedPublicIds: [] });
-    expect(game.isListed()).toBe(true);
-
-    game.updateGameConfig({ allowedPublicIds: ["p1"] });
-    expect(game.isListed()).toBe(false);
-  });
-
   it("exposes the listed flag in gameInfo for private lobbies only", () => {
     const game = makeGame();
     expect(game.gameInfo().listed).toBe(false);
@@ -437,6 +426,26 @@ describe("listed lobby host powers", () => {
         asAdmin,
       ).status,
     ).toBe(200);
+  });
+
+  it("rejects a join whitelist while listed instead of delisting", () => {
+    const game = makeGame();
+    game.setListed(true);
+
+    const empty = {
+      type: "update_game_config",
+      config: { allowedPublicIds: [] },
+    } as any;
+    expect(game.handleIntent(empty, asHost).status).toBe(200);
+    expect(game.isListed()).toBe(true);
+
+    const whitelist = {
+      type: "update_game_config",
+      config: { allowedPublicIds: ["p1"] },
+    } as any;
+    expect(game.handleIntent(whitelist, asHost).status).toBe(409);
+    expect(game.isListed()).toBe(true);
+    expect(game.hasJoinWhitelist()).toBe(false);
   });
 
   it("rejects enabling host cheats while listed", () => {

--- a/tests/server/ListingState.test.ts
+++ b/tests/server/ListingState.test.ts
@@ -6,9 +6,9 @@ import {
 } from "../../src/core/Schemas";
 import { ListingState } from "../../src/server/ListingState";
 
-// The listing state on its own. How the game acts on it — delisting when a
-// whitelist appears, arming the start countdown at the deadline, what the
-// lobby browser is told — is covered through GameServer in
+// The listing state on its own. How the game acts on it — rejecting a
+// whitelist while listed, arming the start countdown at the deadline, what
+// the lobby browser is told — is covered through GameServer in
 // HostedLobbyListing.test.ts.
 
 const T0 = 1_700_000_000_000;


### PR DESCRIPTION
## Summary
- Once a private lobby is publicly listed, the host can no longer unlist it: `POST /api/game/:id/listing` with `listed: false` now returns `409 listing_permanent`.
- Enabling a join whitelist on a listed lobby is rejected in `IntentAuthorization` (409, same pattern as host cheats) instead of `GameServer.updateGameConfig` silently delisting the lobby; that auto-delist branch is removed.
- The host modal hides the "Private" segment of the visibility toggle once the lobby is listed (whitelist and host-cheat cards were already hidden while listed).
- The master's enforcement delist (duplicate creator / `MAX_HOSTED_LOBBIES` overflow) and phase-based removal on start/fill/host-leave are unchanged.

## Test plan
- Replaced the "delists when a join whitelist is added" test with one asserting the whitelist intent is rejected and the lobby stays listed (`tests/server/HostedLobbyListing.test.ts`).
- `npx vitest tests/server tests/client --run`: 171 files, 1875 tests pass.
- `tsc --noEmit`, oxlint and Prettier clean.
- Note: there is no HTTP-level test for the listing endpoint, so the `listing_permanent` 409 is not covered by a test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)