### PR TITLE
Make Config.attackLogic pure and pin attack balance with golden tests

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -18,7 +18,6 @@ import {
   UnitInfo,
   UnitType,
 } from "../game/Game";
-import { TileRef } from "../game/GameMap";
 import { UserSettings } from "../game/UserSettings";
 import { GameConfig, TeamCountConfig } from "../Schemas";
 import { NukeType } from "../StatsSchemas";
@@ -61,6 +60,31 @@ export function parseGameEnv(value: string | undefined): GameEnv {
   }
 }
 
+export interface AttackLogicInput {
+  terrain: TerrainType;
+  attackTroops: number;
+  attacker: { type: PlayerType; numTiles: number };
+  /** null when attacking terra nullius. */
+  defender: {
+    type: PlayerType;
+    numTiles: number;
+    troops: number;
+    isTraitor: boolean;
+    /** Defender is disconnected and on the attacker's team. */
+    isDisconnectedTeammate: boolean;
+  } | null;
+  /** A defense post owned by the defender is in range of the tile. */
+  defenderHasDefensePost: boolean;
+  /** Fraction of land tiles with fallout, or null if the tile has no fallout. */
+  falloutRatio: number | null;
+}
+
+export interface AttackLogicResult {
+  attackerTroopLoss: number;
+  defenderTroopLoss: number;
+  tilesPerTickUsed: number;
+}
+
 export interface NukeMagnitude {
   inner: number;
   outer: number;
@@ -68,6 +92,30 @@ export interface NukeMagnitude {
 
 const DEFENSE_DEBUFF_MIDPOINT = 150_000;
 const DEFENSE_DEBUFF_DECAY_RATE = Math.LN2 / 50000;
+// attackLogic tunables
+const LARGE_ATTACKER_TILES = 100_000;
+const BOT_DEFENDER_LOSS_MULT = 0.7;
+const TERRA_NULLIUS_COST_SCALE = 2000;
+const TERRA_NULLIUS_MIN_COST = 5;
+const TERRA_NULLIUS_MAX_COST = 100;
+
+function terrainAttackBase(terrain: TerrainType): {
+  mag: number;
+  tileCost: number;
+} {
+  switch (terrain) {
+    case TerrainType.Plains:
+      return { mag: 80, tileCost: 16.5 };
+    case TerrainType.Highland:
+      return { mag: 100, tileCost: 20 };
+    case TerrainType.Mountain:
+      return { mag: 120, tileCost: 25 };
+    case TerrainType.Impassable:
+      throw new Error(`impassable terrain cannot be attacked`);
+    default:
+      throw new Error(`terrain type ${terrain} not supported`);
+  }
+}
 const DEFAULT_SPAWN_IMMUNITY_TICKS = 5 * 10;
 
 export const JwksSchema = z.object({
@@ -690,129 +738,103 @@ export class Config {
     return this.bots();
   }
 
-  attackLogic(
-    gm: Game,
-    attackTroops: number,
-    attacker: Player,
-    defender: Player | TerraNullius,
-    tileToConquer: TileRef,
-  ): {
-    attackerTroopLoss: number;
-    defenderTroopLoss: number;
-    tilesPerTickUsed: number;
-  } {
-    let mag;
-    let speed;
-    const type = gm.terrainType(tileToConquer);
-    switch (type) {
-      case TerrainType.Plains:
-        mag = 80;
-        speed = 16.5;
-        break;
-      case TerrainType.Highland:
-        mag = 100;
-        speed = 20;
-        break;
-      case TerrainType.Mountain:
-        mag = 120;
-        speed = 25;
-        break;
-      case TerrainType.Impassable:
-        throw new Error(`impassable terrain cannot be attacked`);
-      default:
-        throw new Error(`terrain type ${type} not supported`);
+  /**
+   * Per-tile attack outcome. Pure: depends only on the given input and this
+   * config's tunables, never on Game/Player objects. AttackExecution gathers
+   * the input from the simulation.
+   *
+   * Two base values come from the terrain and are scaled by the situation:
+   *  - `mag`: how bloody the tile is (drives attacker troop loss)
+   *  - `tileCost`: how much of the attack's per-tick tile budget the tile
+   *    consumes (higher = slower conquest)
+   */
+  attackLogic(input: AttackLogicInput): AttackLogicResult {
+    const { attackTroops, attacker, defender } = input;
+    let { mag, tileCost } = terrainAttackBase(input.terrain);
+
+    if (defender !== null && input.defenderHasDefensePost) {
+      mag *= this.defensePostDefenseBonus();
+      tileCost *= this.defensePostSpeedBonus();
     }
-    if (defender.isPlayer()) {
-      for (const dp of gm.nearbyUnits(
-        tileToConquer,
-        gm.config().defensePostRange(),
-        UnitType.DefensePost,
-      )) {
-        if (dp.unit.owner() === defender) {
-          mag *= this.defensePostDefenseBonus();
-          speed *= this.defensePostSpeedBonus();
-          break;
-        }
-      }
+    if (input.falloutRatio !== null) {
+      const fallout = this.falloutDefenseModifier(input.falloutRatio);
+      mag *= fallout;
+      tileCost *= fallout;
     }
 
-    if (gm.hasFallout(tileToConquer)) {
-      const falloutRatio = gm.numTilesWithFallout() / gm.numLandTiles();
-      mag *= this.falloutDefenseModifier(falloutRatio);
-      speed *= this.falloutDefenseModifier(falloutRatio);
-    }
-
-    if (attacker.isPlayer() && defender.isPlayer()) {
-      if (defender.isDisconnected() && attacker.isOnSameTeam(defender)) {
-        // No troop loss if defender is disconnected and on same team
-        mag = 0;
-      }
-      if (
-        (attacker.type() === PlayerType.Human ||
-          attacker.type() === PlayerType.Nation) &&
-        defender.type() === PlayerType.Bot
-      ) {
-        mag *= 0.7;
-      }
-    }
-
-    if (defender.isPlayer()) {
-      const defenseSig =
-        1 -
-        sigmoid(
-          defender.numTilesOwned(),
-          DEFENSE_DEBUFF_DECAY_RATE,
-          DEFENSE_DEBUFF_MIDPOINT,
-        );
-
-      const largeDefenderSpeedDebuff = 0.7 + 0.3 * defenseSig;
-      const largeDefenderAttackDebuff = 0.7 + 0.3 * defenseSig;
-
-      let largeAttackBonus = 1;
-      if (attacker.numTilesOwned() > 100_000) {
-        largeAttackBonus = Math.sqrt(100_000 / attacker.numTilesOwned()) ** 0.7;
-      }
-      let largeAttackerSpeedBonus = 1;
-      if (attacker.numTilesOwned() > 100_000) {
-        largeAttackerSpeedBonus = (100_000 / attacker.numTilesOwned()) ** 0.6;
-      }
-
-      const defenderTroopLoss = defender.troops() / defender.numTilesOwned();
-      const traitorMod = defender.isTraitor() ? this.traitorDefenseDebuff() : 1;
-      const currentAttackerLoss =
-        within(defender.troops() / attackTroops, 0.6, 2) *
-        mag *
-        0.8 *
-        largeDefenderAttackDebuff *
-        largeAttackBonus *
-        traitorMod;
-      const altAttackerLoss =
-        1.3 * defenderTroopLoss * (mag / 100) * traitorMod;
-      const attackerTroopLoss =
-        0.6 * currentAttackerLoss + 0.4 * altAttackerLoss;
-
+    if (defender === null) {
       return {
-        attackerTroopLoss,
-        defenderTroopLoss,
-        tilesPerTickUsed:
-          within(defender.troops() / (5 * attackTroops), 0.2, 1.5) *
-          speed *
-          largeDefenderSpeedDebuff *
-          largeAttackerSpeedBonus *
-          (defender.isTraitor() ? this.traitorSpeedDebuff() : 1),
-      };
-    } else {
-      return {
-        attackerTroopLoss:
-          attacker.type() === PlayerType.Bot ? mag / 10 : mag / 5,
+        attackerTroopLoss: mag / (attacker.type === PlayerType.Bot ? 10 : 5),
         defenderTroopLoss: 0,
         tilesPerTickUsed: within(
-          (2000 * Math.max(10, speed)) / attackTroops,
-          5,
-          100,
+          (TERRA_NULLIUS_COST_SCALE * tileCost) / attackTroops,
+          TERRA_NULLIUS_MIN_COST,
+          TERRA_NULLIUS_MAX_COST,
         ),
       };
     }
+
+    if (defender.isDisconnectedTeammate) {
+      // No troop loss if defender is disconnected and on same team
+      mag = 0;
+    }
+    if (
+      (attacker.type === PlayerType.Human ||
+        attacker.type === PlayerType.Nation) &&
+      defender.type === PlayerType.Bot
+    ) {
+      mag *= BOT_DEFENDER_LOSS_MULT;
+    }
+
+    // Big defenders are easier to bite into: both loss and cost scale down
+    // towards 0.7 as the defender's territory grows past the midpoint.
+    const largeDefenderDebuff =
+      0.7 +
+      0.3 *
+        (1 -
+          sigmoid(
+            defender.numTiles,
+            DEFENSE_DEBUFF_DECAY_RATE,
+            DEFENSE_DEBUFF_MIDPOINT,
+          ));
+
+    // Big attackers get cheaper, faster tiles past LARGE_ATTACKER_TILES.
+    let largeAttackerLossBonus = 1;
+    let largeAttackerCostBonus = 1;
+    if (attacker.numTiles > LARGE_ATTACKER_TILES) {
+      const ratio = LARGE_ATTACKER_TILES / attacker.numTiles;
+      largeAttackerLossBonus = Math.sqrt(ratio) ** 0.7;
+      largeAttackerCostBonus = ratio ** 0.6;
+    }
+
+    const traitorLossMod = defender.isTraitor ? this.traitorDefenseDebuff() : 1;
+    const traitorCostMod = defender.isTraitor ? this.traitorSpeedDebuff() : 1;
+
+    // Defender loses its average troops-per-tile.
+    const defenderTroopLoss = defender.troops / defender.numTiles;
+
+    // Attacker loss blends a ratio-driven term (how outnumbered the attack
+    // is, clamped) with a density-driven term (defender troops per tile).
+    const ratioLoss =
+      within(defender.troops / attackTroops, 0.6, 2) *
+      mag *
+      0.8 *
+      largeDefenderDebuff *
+      largeAttackerLossBonus *
+      traitorLossMod;
+    const densityLoss = 1.3 * defenderTroopLoss * (mag / 100) * traitorLossMod;
+    const attackerTroopLoss = 0.6 * ratioLoss + 0.4 * densityLoss;
+
+    return {
+      attackerTroopLoss,
+      defenderTroopLoss,
+      tilesPerTickUsed:
+        within(defender.troops / (5 * attackTroops), 0.2, 1.5) *
+        tileCost *
+        largeDefenderDebuff *
+        largeAttackerCostBonus *
+        traitorCostMod,
+    };
   }
 
   attackTilesPerTick(

--- a/src/core/execution/AttackExecution.ts
+++ b/src/core/execution/AttackExecution.ts
@@ -1,4 +1,5 @@
 import { renderTroops } from "../../client/Utils";
+import { AttackLogicInput } from "../configuration/Config";
 import {
   Attack,
   Difficulty,
@@ -10,6 +11,7 @@ import {
   PlayerType,
   TerrainType,
   TerraNullius,
+  UnitType,
 } from "../game/Game";
 import { GameMap, TileRef } from "../game/GameMap";
 import { PseudoRandom } from "../PseudoRandom";
@@ -309,13 +311,7 @@ export class AttackExecution implements Execution {
       this.addNeighbors(tileToConquer);
       const { attackerTroopLoss, defenderTroopLoss, tilesPerTickUsed } = this.mg
         .config()
-        .attackLogic(
-          this.mg,
-          troopCount,
-          this._owner,
-          this.target,
-          tileToConquer,
-        );
+        .attackLogic(this.attackLogicInput(troopCount, tileToConquer));
       numTilesPerTick -= tilesPerTickUsed;
       troopCount -= attackerTroopLoss;
       this.attack.setTroops(troopCount);
@@ -325,6 +321,49 @@ export class AttackExecution implements Execution {
       this._owner.conquer(tileToConquer);
       this.handleDeadDefender();
     }
+  }
+
+  private attackLogicInput(
+    attackTroops: number,
+    tile: TileRef,
+  ): AttackLogicInput {
+    const defender = this.target.isPlayer() ? this.target : null;
+    let defenderHasDefensePost = false;
+    if (defender !== null) {
+      for (const dp of this.mg.nearbyUnits(
+        tile,
+        this.mg.config().defensePostRange(),
+        UnitType.DefensePost,
+      )) {
+        if (dp.unit.owner() === defender) {
+          defenderHasDefensePost = true;
+          break;
+        }
+      }
+    }
+    return {
+      terrain: this.map.terrainType(tile),
+      attackTroops,
+      attacker: {
+        type: this._owner.type(),
+        numTiles: this._owner.numTilesOwned(),
+      },
+      defender:
+        defender === null
+          ? null
+          : {
+              type: defender.type(),
+              numTiles: defender.numTilesOwned(),
+              troops: defender.troops(),
+              isTraitor: defender.isTraitor(),
+              isDisconnectedTeammate:
+                defender.isDisconnected() && this._owner.isOnSameTeam(defender),
+            },
+      defenderHasDefensePost,
+      falloutRatio: this.mg.hasFallout(tile)
+        ? this.mg.numTilesWithFallout() / this.mg.numLandTiles()
+        : null,
+    };
   }
 
   private rejectIncomingAllianceRequests(target: Player) {

--- a/tests/AttackLogicGolden.test.ts
+++ b/tests/AttackLogicGolden.test.ts
@@ -1,0 +1,207 @@
+/**
+ * Golden-value tests for `Config.attackLogic` / `Config.attackTilesPerTick`.
+ *
+ * These pin the *exact* numeric output of the per-tile attack formula across a
+ * grid of inputs. They exist so the formula can be refactored with confidence
+ * (a pure restructuring must leave the snapshot untouched) and so that any
+ * deliberate balance change shows up as a reviewable diff of numbers rather
+ * than a vague "it feels different".
+ *
+ * This is a test of the formula, not of the simulation. See
+ * AttackScenarios.test.ts for end-to-end numbers on real maps.
+ */
+import { AttackLogicInput, Config } from "../src/core/configuration/Config";
+import {
+  Player,
+  PlayerType,
+  TerrainType,
+  TerraNullius,
+} from "../src/core/game/Game";
+import { UserSettings } from "../src/core/game/UserSettings";
+import { GameConfig } from "../src/core/Schemas";
+
+const config = new Config({} as GameConfig, new UserSettings(), false);
+
+type Defender = NonNullable<AttackLogicInput["defender"]>;
+
+function defender(
+  o: Partial<Defender> & { numTiles: number; troops: number },
+): Defender {
+  return {
+    type: PlayerType.Human,
+    isTraitor: false,
+    isDisconnectedTeammate: false,
+    ...o,
+  };
+}
+
+function round(x: number): number {
+  return Number(x.toPrecision(6));
+}
+
+function run(o: Partial<AttackLogicInput> & { attackTroops: number }) {
+  const r = config.attackLogic({
+    terrain: TerrainType.Plains,
+    attacker: { type: PlayerType.Human, numTiles: 20_000 },
+    defender: null,
+    defenderHasDefensePost: false,
+    falloutRatio: null,
+    ...o,
+  });
+  return {
+    attackerLoss: round(r.attackerTroopLoss),
+    defenderLoss: round(r.defenderTroopLoss),
+    tileCost: round(r.tilesPerTickUsed),
+  };
+}
+
+const TERRAINS = [
+  TerrainType.Plains,
+  TerrainType.Highland,
+  TerrainType.Mountain,
+] as const;
+
+describe("attackLogic golden values", () => {
+  test("player vs player: terrain × territory × troops grid", () => {
+    const attackerTiles = [1_000, 50_000, 200_000];
+    const defenderTiles = [1_000, 50_000, 150_000, 400_000];
+    const defenderTroops = [10_000, 100_000, 1_000_000];
+    const attackTroops = [10_000, 100_000, 1_000_000];
+
+    const table: Record<string, ReturnType<typeof run>> = {};
+    for (const terrain of TERRAINS)
+      for (const at of attackerTiles)
+        for (const dt of defenderTiles)
+          for (const dtr of defenderTroops)
+            for (const atr of attackTroops) {
+              const key = `${TerrainType[terrain]} aTiles=${at} dTiles=${dt} dTroops=${dtr} attack=${atr}`;
+              table[key] = run({
+                terrain,
+                attackTroops: atr,
+                attacker: { type: PlayerType.Human, numTiles: at },
+                defender: defender({ numTiles: dt, troops: dtr }),
+              });
+            }
+    expect(table).toMatchSnapshot();
+  });
+
+  test("player vs player: situational modifiers", () => {
+    const base = { numTiles: 20_000, troops: 100_000 };
+    const pvp = (o: Partial<AttackLogicInput> = {}) =>
+      run({ attackTroops: 100_000, defender: defender(base), ...o });
+    const cases: Record<string, ReturnType<typeof run>> = {
+      baseline: pvp(),
+      "defender has defense post": pvp({ defenderHasDefensePost: true }),
+      "no fallout": pvp({ falloutRatio: null }),
+      "fallout 10%": pvp({ falloutRatio: 0.1 }),
+      "fallout 100%": pvp({ falloutRatio: 1 }),
+      "defender is traitor": pvp({
+        defender: defender({ ...base, isTraitor: true }),
+      }),
+      "human attacks bot": pvp({
+        defender: defender({ ...base, type: PlayerType.Bot }),
+      }),
+      "nation attacks bot": pvp({
+        attacker: { type: PlayerType.Nation, numTiles: 20_000 },
+        defender: defender({ ...base, type: PlayerType.Bot }),
+      }),
+      "bot attacks bot": pvp({
+        attacker: { type: PlayerType.Bot, numTiles: 20_000 },
+        defender: defender({ ...base, type: PlayerType.Bot }),
+      }),
+      "bot attacks human": pvp({
+        attacker: { type: PlayerType.Bot, numTiles: 20_000 },
+      }),
+      "disconnected teammate": pvp({
+        defender: defender({ ...base, isDisconnectedTeammate: true }),
+      }),
+      "defense post + fallout + traitor (stacking)": pvp({
+        terrain: TerrainType.Mountain,
+        defenderHasDefensePost: true,
+        falloutRatio: 0.5,
+        defender: defender({ ...base, isTraitor: true }),
+      }),
+    };
+    expect(cases).toMatchSnapshot();
+  });
+
+  test("player vs player: troop ratio clamps", () => {
+    // defender.troops / attackTroops is clamped to [0.6, 2] for losses and
+    // defender.troops / (5 * attackTroops) to [0.2, 1.5] for tile cost.
+    const ratios = [0.01, 0.1, 0.5, 0.6, 1, 2, 5, 7.5, 10, 100];
+    const table: Record<string, ReturnType<typeof run>> = {};
+    for (const r of ratios) {
+      table[`defenderTroops/attackTroops=${r}`] = run({
+        attackTroops: 100_000 / r,
+        defender: defender({ numTiles: 20_000, troops: 100_000 }),
+      });
+    }
+    expect(table).toMatchSnapshot();
+  });
+
+  test("player vs player: large-territory curves", () => {
+    // Sweep territory size on each side independently to pin the sigmoid
+    // defender debuff and the >100k attacker bonus.
+    const sizes = [
+      1_000, 10_000, 50_000, 100_000, 100_001, 150_000, 200_000, 300_000,
+      500_000, 1_000_000,
+    ];
+    const table: Record<string, ReturnType<typeof run>> = {};
+    for (const s of sizes) {
+      table[`attackerTiles=${s}`] = run({
+        attackTroops: 100_000,
+        attacker: { type: PlayerType.Human, numTiles: s },
+        defender: defender({ numTiles: 20_000, troops: 100_000 }),
+      });
+      table[`defenderTiles=${s}`] = run({
+        attackTroops: 100_000,
+        defender: defender({ numTiles: s, troops: 100_000 }),
+      });
+    }
+    expect(table).toMatchSnapshot();
+  });
+
+  test("player vs terra nullius", () => {
+    const table: Record<string, ReturnType<typeof run>> = {};
+    for (const terrain of TERRAINS)
+      for (const type of [PlayerType.Human, PlayerType.Bot])
+        for (const atr of [100, 1_000, 10_000, 100_000, 1_000_000])
+          for (const fallout of [0, 0.5]) {
+            const key = `${TerrainType[terrain]} ${type} attack=${atr} fallout=${fallout}`;
+            table[key] = run({
+              terrain,
+              attackTroops: atr,
+              attacker: { type, numTiles: 1_000 },
+              falloutRatio: fallout > 0 ? fallout : null,
+            });
+          }
+    expect(table).toMatchSnapshot();
+  });
+
+  test("attackTilesPerTick", () => {
+    const table: Record<string, number> = {};
+    const attacker = {} as Player;
+    const troops = (n: number) =>
+      ({ isPlayer: () => true, troops: () => n }) as unknown as Player;
+    const terraNullius = { isPlayer: () => false } as unknown as TerraNullius;
+    for (const dtr of [1_000, 100_000, 10_000_000])
+      for (const atr of [1_000, 100_000, 10_000_000])
+        for (const border of [1, 10, 100, 1_000]) {
+          table[`dTroops=${dtr} attack=${atr} border=${border}`] = round(
+            config.attackTilesPerTick(atr, attacker, troops(dtr), border),
+          );
+        }
+    for (const border of [1, 10, 100, 1_000]) {
+      table[`terraNullius border=${border}`] = round(
+        config.attackTilesPerTick(1_000, attacker, terraNullius, border),
+      );
+    }
+    expect(table).toMatchSnapshot();
+  });
+
+  test("impassable terrain throws", () => {
+    expect(() =>
+      run({ terrain: TerrainType.Impassable, attackTroops: 1 }),
+    ).toThrow();
+  });
+});

--- a/tests/AttackScenarios.test.ts
+++ b/tests/AttackScenarios.test.ts
@@ -1,0 +1,405 @@
+/**
+ * End-to-end attack benchmarks on real maps.
+ *
+ * Each scenario sets up two territories on a real map, gives each side a
+ * troop count, launches a real AttackExecution with the real attack formula
+ * and runs the simulation until the attack ends (or a
+ * tick cap). The resulting metrics — how long the attack took, tiles taken,
+ * troops lost on each side, and the per-second / per-tile rates — are pinned
+ * in a snapshot.
+ *
+ * Purpose: when the attack meta is changed, the snapshot diff quantifies the
+ * impact in every scenario ("attacking into mountains got 12% slower, troop
+ * loss vs bots unchanged", …). A pure refactor of attackLogic must leave the
+ * snapshot untouched.
+ *
+ * No PlayerExecution is registered, so troops do not regenerate during the
+ * attack; the numbers isolate the attack formula itself.
+ */
+import { Config } from "../src/core/configuration/Config";
+import { AttackExecution } from "../src/core/execution/AttackExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  TerraNullius,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+import { UseRealAttackLogic } from "./util/TestConfig";
+
+/**
+ * UseRealAttackLogic only restores attackLogic; TestConfig also stubs
+ * attackTilesPerTick to 1, which would cap every attack at one tile per tick.
+ * Restore that too so the attack fans out along the border like in production.
+ */
+class RealAttackConfig extends UseRealAttackLogic {
+  attackTilesPerTick(
+    attackTroops: number,
+    attacker: Player,
+    defender: Player | TerraNullius,
+    numAdjacentTilesWithEnemy: number,
+  ): number {
+    return Config.prototype.attackTilesPerTick.call(
+      this,
+      attackTroops,
+      attacker,
+      defender,
+      numAdjacentTilesWithEnemy,
+    );
+  }
+}
+
+interface Rect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+interface Side {
+  rect: Rect;
+  troops: number;
+  type?: PlayerType;
+  traitor?: boolean;
+  /** Defense posts at these coordinates (defender only). */
+  defensePosts?: [number, number][];
+}
+
+interface Scenario {
+  map: string;
+  attacker: Side;
+  /** "terraNullius" attacks unclaimed land inside `defenderRect`. */
+  defender: Side | "terraNullius";
+  attackTroops: number;
+  maxTicks?: number;
+}
+
+interface Metrics {
+  finished: boolean;
+  ticks: number;
+  attackerTiles: number;
+  defenderTiles: number;
+  tilesConquered: number;
+  attackerTroopsLost: number;
+  defenderTroopsLost: number;
+  tilesPerSecond: number;
+  attackerLossPerSecond: number;
+  defenderLossPerSecond: number;
+  attackerLossPerTile: number;
+  defenderLossPerTile: number;
+  defenderEliminated: boolean;
+}
+
+const DEFAULT_MAX_TICKS = 3000; // 5 minutes of game time
+
+/** Conquer every passable land tile in the rect; returns tiles conquered. */
+function conquerRect(game: Game, player: Player, r: Rect): number {
+  const map = game.map();
+  let n = 0;
+  for (let y = r.y; y < r.y + r.h; y++) {
+    for (let x = r.x; x < r.x + r.w; x++) {
+      const t = map.ref(x, y);
+      if (map.isLand(t) && !map.isImpassable(t)) {
+        player.conquer(t);
+        n++;
+      }
+    }
+  }
+  return n;
+}
+
+function sig(x: number): number {
+  return Number(x.toPrecision(4));
+}
+
+async function runScenario(s: Scenario): Promise<Metrics> {
+  const attackerInfo = new PlayerInfo(
+    "attacker",
+    s.attacker.type ?? PlayerType.Human,
+    null,
+    "attacker",
+  );
+  const defenderSide = s.defender === "terraNullius" ? null : s.defender;
+  const defenderInfo = new PlayerInfo(
+    "defender",
+    defenderSide?.type ?? PlayerType.Human,
+    null,
+    "defender",
+  );
+  const game = await setup(
+    s.map,
+    {},
+    [attackerInfo, defenderInfo],
+    undefined,
+    RealAttackConfig,
+  );
+  const attacker = game.player("attacker");
+  const defender = game.player("defender");
+
+  const attackerTiles = conquerRect(game, attacker, s.attacker.rect);
+  attacker.setTroops(s.attacker.troops);
+  if (s.attacker.traitor) attacker.markTraitor();
+
+  let defenderTiles = 0;
+  if (defenderSide !== null) {
+    defenderTiles = conquerRect(game, defender, defenderSide.rect);
+    defender.setTroops(defenderSide.troops);
+    if (defenderSide.traitor) defender.markTraitor();
+    for (const [x, y] of defenderSide.defensePosts ?? []) {
+      defender.buildUnit(UnitType.DefensePost, game.ref(x, y), {});
+    }
+  }
+
+  const targetID =
+    defenderSide === null ? game.terraNullius().id() : defender.id();
+  const attackerTroopsBefore = attacker.troops();
+  const defenderTroopsBefore = defender.troops();
+  const attackerTilesBefore = attacker.numTilesOwned();
+
+  game.addExecution(new AttackExecution(s.attackTroops, attacker, targetID));
+
+  const maxTicks = s.maxTicks ?? DEFAULT_MAX_TICKS;
+  let ticks = 0;
+  do {
+    game.executeNextTick();
+    ticks++;
+  } while (attacker.outgoingAttacks().length > 0 && ticks < maxTicks);
+
+  const inFlight = attacker
+    .outgoingAttacks()
+    .reduce((sum, a) => sum + a.troops(), 0);
+  const attackerTroopsLost =
+    attackerTroopsBefore - attacker.troops() - inFlight;
+  const defenderTroopsLost = defenderTroopsBefore - defender.troops();
+  const tilesConquered = attacker.numTilesOwned() - attackerTilesBefore;
+  const seconds = ticks / 10;
+
+  return {
+    finished: attacker.outgoingAttacks().length === 0,
+    ticks,
+    attackerTiles,
+    defenderTiles,
+    tilesConquered,
+    attackerTroopsLost,
+    defenderTroopsLost,
+    tilesPerSecond: sig(tilesConquered / seconds),
+    attackerLossPerSecond: sig(attackerTroopsLost / seconds),
+    defenderLossPerSecond: sig(defenderTroopsLost / seconds),
+    attackerLossPerTile: sig(
+      tilesConquered === 0 ? 0 : attackerTroopsLost / tilesConquered,
+    ),
+    defenderLossPerTile: sig(
+      tilesConquered === 0 ? 0 : defenderTroopsLost / tilesConquered,
+    ),
+    defenderEliminated: defenderSide !== null && !defender.isAlive(),
+  };
+}
+
+// plains: 100x100, all Plains terrain. Left half vs right half.
+const PLAINS_LEFT: Rect = { x: 0, y: 0, w: 50, h: 100 };
+const PLAINS_RIGHT: Rect = { x: 50, y: 0, w: 50, h: 100 };
+
+// big_plains: 200x200, all Plains terrain.
+const BIG_LEFT: Rect = { x: 0, y: 0, w: 100, h: 200 };
+const BIG_RIGHT: Rect = { x: 100, y: 0, w: 100, h: 200 };
+
+// world: 2000x1000 mixed terrain. These 100x100 blocks are fully land:
+//   (1200,100) mostly Plains, some Highland
+//   (1300,200) Highland + Mountain
+//   (1400,200) mostly Mountain
+function worldBlock(bx: number, by: number): [Rect, Rect] {
+  return [
+    { x: bx, y: by, w: 50, h: 100 },
+    { x: bx + 50, y: by, w: 50, h: 100 },
+  ];
+}
+const [WORLD_PLAINS_L, WORLD_PLAINS_R] = worldBlock(1200, 100);
+const [WORLD_HILLS_L, WORLD_HILLS_R] = worldBlock(1300, 200);
+const [WORLD_MTN_L, WORLD_MTN_R] = worldBlock(1400, 200);
+
+const scenarios: Record<string, Scenario> = {
+  // --- plains, equal territories, vary attack size --------------------------
+  "plains equal 50k vs 50k, attack 10k": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000 },
+    attackTroops: 10_000,
+  },
+  "plains equal 50k vs 50k, attack 25k": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000 },
+    attackTroops: 25_000,
+  },
+  "plains equal 50k vs 50k, attack 50k (all-in)": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000 },
+    attackTroops: 50_000,
+  },
+  // --- plains, troop imbalance ---------------------------------------------
+  "plains overwhelming 200k vs 20k, attack 40k": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 200_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 20_000 },
+    attackTroops: 40_000,
+  },
+  "plains outmatched 20k vs 200k, attack 4k": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 20_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 200_000 },
+    attackTroops: 4_000,
+  },
+  "plains outmatched 20k vs 200k, attack 20k (all-in)": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 20_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 200_000 },
+    attackTroops: 20_000,
+  },
+  // --- plains, territory imbalance -----------------------------------------
+  "plains small attacker (500 tiles) vs big defender (9500 tiles)": {
+    map: "plains",
+    attacker: { rect: { x: 0, y: 0, w: 5, h: 100 }, troops: 50_000 },
+    defender: { rect: { x: 5, y: 0, w: 95, h: 100 }, troops: 50_000 },
+    attackTroops: 10_000,
+  },
+  "plains big attacker (9500 tiles) vs small defender (500 tiles)": {
+    map: "plains",
+    attacker: { rect: { x: 0, y: 0, w: 95, h: 100 }, troops: 50_000 },
+    defender: { rect: { x: 95, y: 0, w: 5, h: 100 }, troops: 50_000 },
+    attackTroops: 10_000,
+  },
+  // --- player types ---------------------------------------------------------
+  "plains human vs bot defender": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000, type: PlayerType.Bot },
+    attackTroops: 10_000,
+  },
+  "plains nation vs bot defender": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000, type: PlayerType.Nation },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000, type: PlayerType.Bot },
+    attackTroops: 10_000,
+  },
+  "plains bot vs human defender": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000, type: PlayerType.Bot },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000 },
+    attackTroops: 10_000,
+  },
+  // --- modifiers ------------------------------------------------------------
+  "plains traitor defender": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000, traitor: true },
+    attackTroops: 10_000,
+  },
+  "plains defender with one defense post at the border": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: {
+      rect: PLAINS_RIGHT,
+      troops: 50_000,
+      defensePosts: [[55, 50]],
+    },
+    attackTroops: 10_000,
+  },
+  "plains defender with defense posts covering the whole border": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: {
+      rect: PLAINS_RIGHT,
+      troops: 50_000,
+      defensePosts: [
+        [55, 10],
+        [55, 50],
+        [55, 90],
+      ],
+    },
+    attackTroops: 10_000,
+  },
+  // --- terra nullius --------------------------------------------------------
+  "plains human vs terra nullius, attack 2k": {
+    map: "plains",
+    attacker: { rect: { x: 0, y: 0, w: 10, h: 100 }, troops: 10_000 },
+    defender: "terraNullius",
+    attackTroops: 2_000,
+  },
+  "plains human vs terra nullius, attack 20k": {
+    map: "plains",
+    attacker: { rect: { x: 0, y: 0, w: 10, h: 100 }, troops: 100_000 },
+    defender: "terraNullius",
+    attackTroops: 20_000,
+  },
+  "plains bot vs terra nullius, attack 2k": {
+    map: "plains",
+    attacker: {
+      rect: { x: 0, y: 0, w: 10, h: 100 },
+      troops: 10_000,
+      type: PlayerType.Bot,
+    },
+    defender: "terraNullius",
+    attackTroops: 2_000,
+  },
+  // --- bigger territories ---------------------------------------------------
+  "big_plains equal 20k tiles each, 200k vs 200k, attack 40k": {
+    map: "big_plains",
+    attacker: { rect: BIG_LEFT, troops: 200_000 },
+    defender: { rect: BIG_RIGHT, troops: 200_000 },
+    attackTroops: 40_000,
+  },
+  "big_plains equal 20k tiles each, 1M vs 1M, attack 200k": {
+    map: "big_plains",
+    attacker: { rect: BIG_LEFT, troops: 1_000_000 },
+    defender: { rect: BIG_RIGHT, troops: 1_000_000 },
+    attackTroops: 200_000,
+  },
+  // --- world map, real terrain ---------------------------------------------
+  "world plains-ish region, 100k vs 100k, attack 20k": {
+    map: "world",
+    attacker: { rect: WORLD_PLAINS_L, troops: 100_000 },
+    defender: { rect: WORLD_PLAINS_R, troops: 100_000 },
+    attackTroops: 20_000,
+  },
+  "world highland/mountain region, 100k vs 100k, attack 20k": {
+    map: "world",
+    attacker: { rect: WORLD_HILLS_L, troops: 100_000 },
+    defender: { rect: WORLD_HILLS_R, troops: 100_000 },
+    attackTroops: 20_000,
+  },
+  "world mountain region, 100k vs 100k, attack 20k": {
+    map: "world",
+    attacker: { rect: WORLD_MTN_L, troops: 100_000 },
+    defender: { rect: WORLD_MTN_R, troops: 100_000 },
+    attackTroops: 20_000,
+  },
+  "world mountain region, human vs terra nullius, attack 20k": {
+    map: "world",
+    attacker: { rect: WORLD_MTN_L, troops: 100_000 },
+    defender: "terraNullius",
+    attackTroops: 20_000,
+  },
+  // Large empires (>100k tiles) trigger the large-attacker/defender curves.
+  "world huge empires (~150k tiles each), 2M vs 2M, attack 400k": {
+    map: "world",
+    attacker: { rect: { x: 800, y: 100, w: 400, h: 400 }, troops: 2_000_000 },
+    defender: { rect: { x: 1200, y: 100, w: 400, h: 400 }, troops: 2_000_000 },
+    attackTroops: 400_000,
+  },
+};
+
+describe("attack scenarios", () => {
+  for (const [name, scenario] of Object.entries(scenarios)) {
+    test(
+      name,
+      async () => {
+        const metrics = await runScenario(scenario);
+        expect(metrics).toMatchSnapshot();
+      },
+      120_000,
+    );
+  }
+});

--- a/tests/__snapshots__/AttackLogicGolden.test.ts.snap
+++ b/tests/__snapshots__/AttackLogicGolden.test.ts.snap
@@ -1,0 +1,2201 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`attackLogic golden values > attackTilesPerTick 1`] = `
+{
+  "dTroops=1000 attack=1000 border=1": 1.5,
+  "dTroops=1000 attack=1000 border=10": 15,
+  "dTroops=1000 attack=1000 border=100": 150,
+  "dTroops=1000 attack=1000 border=1000": 1500,
+  "dTroops=1000 attack=100000 border=1": 1.5,
+  "dTroops=1000 attack=100000 border=10": 15,
+  "dTroops=1000 attack=100000 border=100": 150,
+  "dTroops=1000 attack=100000 border=1000": 1500,
+  "dTroops=1000 attack=10000000 border=1": 1.5,
+  "dTroops=1000 attack=10000000 border=10": 15,
+  "dTroops=1000 attack=10000000 border=100": 150,
+  "dTroops=1000 attack=10000000 border=1000": 1500,
+  "dTroops=100000 attack=1000 border=1": 0.3,
+  "dTroops=100000 attack=1000 border=10": 3,
+  "dTroops=100000 attack=1000 border=100": 30,
+  "dTroops=100000 attack=1000 border=1000": 300,
+  "dTroops=100000 attack=100000 border=1": 1.5,
+  "dTroops=100000 attack=100000 border=10": 15,
+  "dTroops=100000 attack=100000 border=100": 150,
+  "dTroops=100000 attack=100000 border=1000": 1500,
+  "dTroops=100000 attack=10000000 border=1": 1.5,
+  "dTroops=100000 attack=10000000 border=10": 15,
+  "dTroops=100000 attack=10000000 border=100": 150,
+  "dTroops=100000 attack=10000000 border=1000": 1500,
+  "dTroops=10000000 attack=1000 border=1": 0.03,
+  "dTroops=10000000 attack=1000 border=10": 0.3,
+  "dTroops=10000000 attack=1000 border=100": 3,
+  "dTroops=10000000 attack=1000 border=1000": 30,
+  "dTroops=10000000 attack=100000 border=1": 0.3,
+  "dTroops=10000000 attack=100000 border=10": 3,
+  "dTroops=10000000 attack=100000 border=100": 30,
+  "dTroops=10000000 attack=100000 border=1000": 300,
+  "dTroops=10000000 attack=10000000 border=1": 1.5,
+  "dTroops=10000000 attack=10000000 border=10": 15,
+  "dTroops=10000000 attack=10000000 border=100": 150,
+  "dTroops=10000000 attack=10000000 border=1000": 1500,
+  "terraNullius border=1": 2,
+  "terraNullius border=10": 20,
+  "terraNullius border=100": 200,
+  "terraNullius border=1000": 2000,
+}
+`;
+
+exports[`attackLogic golden values > player vs player: large-territory curves 1`] = `
+{
+  "attackerTiles=1000": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "attackerTiles=10000": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "attackerTiles=100000": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "attackerTiles=1000000": {
+    "attackerLoss": 18.5041,
+    "defenderLoss": 5,
+    "tileCost": 0.793713,
+  },
+  "attackerTiles=100001": {
+    "attackerLoss": 38.8488,
+    "defenderLoss": 5,
+    "tileCost": 3.15981,
+  },
+  "attackerTiles=150000": {
+    "attackerLoss": 33.9843,
+    "defenderLoss": 5,
+    "tileCost": 2.47747,
+  },
+  "attackerTiles=200000": {
+    "attackerLoss": 30.9283,
+    "defenderLoss": 5,
+    "tileCost": 2.08471,
+  },
+  "attackerTiles=300000": {
+    "attackerLoss": 27.1116,
+    "defenderLoss": 5,
+    "tileCost": 1.63452,
+  },
+  "attackerTiles=50000": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "attackerTiles=500000": {
+    "attackerLoss": 23.0135,
+    "defenderLoss": 5,
+    "tileCost": 1.20304,
+  },
+  "defenderTiles=1000": {
+    "attackerLoss": 78.7041,
+    "defenderLoss": 100,
+    "tileCost": 3.18864,
+  },
+  "defenderTiles=10000": {
+    "attackerLoss": 41.1136,
+    "defenderLoss": 10,
+    "tileCost": 3.1757,
+  },
+  "defenderTiles=100000": {
+    "attackerLoss": 34.976,
+    "defenderLoss": 1,
+    "tileCost": 2.97,
+  },
+  "defenderTiles=1000000": {
+    "attackerLoss": 26.9217,
+    "defenderLoss": 0.1,
+    "tileCost": 2.31001,
+  },
+  "defenderTiles=100001": {
+    "attackerLoss": 34.976,
+    "defenderLoss": 0.99999,
+    "tileCost": 2.97,
+  },
+  "defenderTiles=150000": {
+    "attackerLoss": 32.9173,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.805,
+  },
+  "defenderTiles=200000": {
+    "attackerLoss": 30.928,
+    "defenderLoss": 0.5,
+    "tileCost": 2.64,
+  },
+  "defenderTiles=300000": {
+    "attackerLoss": 28.2987,
+    "defenderLoss": 0.333333,
+    "tileCost": 2.42,
+  },
+  "defenderTiles=50000": {
+    "attackerLoss": 36.928,
+    "defenderLoss": 2,
+    "tileCost": 3.102,
+  },
+  "defenderTiles=500000": {
+    "attackerLoss": 27.0525,
+    "defenderLoss": 0.2,
+    "tileCost": 2.31767,
+  },
+}
+`;
+
+exports[`attackLogic golden values > player vs player: situational modifiers 1`] = `
+{
+  "baseline": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "bot attacks bot": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "bot attacks human": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "defender has defense post": {
+    "attackerLoss": 194.245,
+    "defenderLoss": 5,
+    "tileCost": 9.47949,
+  },
+  "defender is traitor": {
+    "attackerLoss": 19.4245,
+    "defenderLoss": 5,
+    "tileCost": 2.52786,
+  },
+  "defense post + fallout + traitor (stacking)": {
+    "attackerLoss": 582.734,
+    "defenderLoss": 5,
+    "tileCost": 45.9612,
+  },
+  "disconnected teammate": {
+    "attackerLoss": 0,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "fallout 10%": {
+    "attackerLoss": 186.475,
+    "defenderLoss": 5,
+    "tileCost": 15.1672,
+  },
+  "fallout 100%": {
+    "attackerLoss": 116.547,
+    "defenderLoss": 5,
+    "tileCost": 9.47949,
+  },
+  "human attacks bot": {
+    "attackerLoss": 27.1943,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "nation attacks bot": {
+    "attackerLoss": 27.1943,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "no fallout": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+}
+`;
+
+exports[`attackLogic golden values > player vs player: terrain × territory × troops grid 1`] = `
+{
+  "Highland aTiles=1000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 51.5802,
+    "defenderLoss": 10,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 33.0281,
+    "defenderLoss": 10,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 33.0281,
+    "defenderLoss": 10,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 144.76,
+    "defenderLoss": 100,
+    "tileCost": 28.9876,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 98.3802,
+    "defenderLoss": 100,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 79.8281,
+    "defenderLoss": 100,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 612.76,
+    "defenderLoss": 1000,
+    "tileCost": 28.9876,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 612.76,
+    "defenderLoss": 1000,
+    "tileCost": 28.9876,
+  },
+  "Highland aTiles=1000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 566.38,
+    "defenderLoss": 1000,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 40.8347,
+    "defenderLoss": 0.0666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 24.5147,
+    "defenderLoss": 0.0666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 24.5147,
+    "defenderLoss": 0.0666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 81.9467,
+    "defenderLoss": 0.666667,
+    "tileCost": 25.5,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 41.1467,
+    "defenderLoss": 0.666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 24.8267,
+    "defenderLoss": 0.666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 85.0667,
+    "defenderLoss": 6.66667,
+    "tileCost": 25.5,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 85.0667,
+    "defenderLoss": 6.66667,
+    "tileCost": 25.5,
+  },
+  "Highland aTiles=1000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 44.2667,
+    "defenderLoss": 6.66667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 34.0494,
+    "defenderLoss": 0.025,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 20.4348,
+    "defenderLoss": 0.025,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 20.4348,
+    "defenderLoss": 0.025,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 68.2027,
+    "defenderLoss": 0.25,
+    "tileCost": 21.2727,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 34.1664,
+    "defenderLoss": 0.25,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 20.5518,
+    "defenderLoss": 0.25,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 69.3727,
+    "defenderLoss": 2.5,
+    "tileCost": 21.2727,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 69.3727,
+    "defenderLoss": 2.5,
+    "tileCost": 21.2727,
+  },
+  "Highland aTiles=1000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 35.3364,
+    "defenderLoss": 2.5,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 45.224,
+    "defenderLoss": 0.2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 27.176,
+    "defenderLoss": 0.2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 27.176,
+    "defenderLoss": 0.2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 91.28,
+    "defenderLoss": 2,
+    "tileCost": 28.2,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 46.16,
+    "defenderLoss": 2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 28.112,
+    "defenderLoss": 2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 100.64,
+    "defenderLoss": 20,
+    "tileCost": 28.2,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 100.64,
+    "defenderLoss": 20,
+    "tileCost": 28.2,
+  },
+  "Highland aTiles=1000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 55.52,
+    "defenderLoss": 20,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 41.5891,
+    "defenderLoss": 10,
+    "tileCost": 2.54996,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 27.0335,
+    "defenderLoss": 10,
+    "tileCost": 2.54996,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 27.0335,
+    "defenderLoss": 10,
+    "tileCost": 2.54996,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 124.778,
+    "defenderLoss": 100,
+    "tileCost": 19.1247,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 88.3891,
+    "defenderLoss": 100,
+    "tileCost": 2.54996,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 73.8335,
+    "defenderLoss": 100,
+    "tileCost": 2.54996,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 592.778,
+    "defenderLoss": 1000,
+    "tileCost": 19.1247,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 592.778,
+    "defenderLoss": 1000,
+    "tileCost": 19.1247,
+  },
+  "Highland aTiles=200000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 556.389,
+    "defenderLoss": 1000,
+    "tileCost": 2.54996,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 32.0457,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.24316,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 19.2413,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.24316,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 19.2413,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.24316,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 64.3687,
+    "defenderLoss": 0.666667,
+    "tileCost": 16.8237,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 32.3577,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.24316,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 19.5533,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.24316,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 67.4887,
+    "defenderLoss": 6.66667,
+    "tileCost": 16.8237,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 67.4887,
+    "defenderLoss": 6.66667,
+    "tileCost": 16.8237,
+  },
+  "Highland aTiles=200000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 35.4777,
+    "defenderLoss": 6.66667,
+    "tileCost": 2.24316,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 26.7174,
+    "defenderLoss": 0.025,
+    "tileCost": 1.8713,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 16.0356,
+    "defenderLoss": 0.025,
+    "tileCost": 1.8713,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 16.0356,
+    "defenderLoss": 0.025,
+    "tileCost": 1.8713,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 53.5388,
+    "defenderLoss": 0.25,
+    "tileCost": 14.0348,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 26.8344,
+    "defenderLoss": 0.25,
+    "tileCost": 1.8713,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 16.1526,
+    "defenderLoss": 0.25,
+    "tileCost": 1.8713,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 54.7088,
+    "defenderLoss": 2.5,
+    "tileCost": 14.0348,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 54.7088,
+    "defenderLoss": 2.5,
+    "tileCost": 14.0348,
+  },
+  "Highland aTiles=200000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 28.0044,
+    "defenderLoss": 2.5,
+    "tileCost": 1.8713,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 35.5044,
+    "defenderLoss": 0.2,
+    "tileCost": 2.48067,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 21.3443,
+    "defenderLoss": 0.2,
+    "tileCost": 2.48067,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 21.3443,
+    "defenderLoss": 0.2,
+    "tileCost": 2.48067,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 71.8409,
+    "defenderLoss": 2,
+    "tileCost": 18.6051,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 36.4404,
+    "defenderLoss": 2,
+    "tileCost": 2.48067,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 22.2803,
+    "defenderLoss": 2,
+    "tileCost": 2.48067,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 81.2009,
+    "defenderLoss": 20,
+    "tileCost": 18.6051,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 81.2009,
+    "defenderLoss": 20,
+    "tileCost": 18.6051,
+  },
+  "Highland aTiles=200000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 45.8004,
+    "defenderLoss": 20,
+    "tileCost": 2.48067,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 51.5802,
+    "defenderLoss": 10,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 33.0281,
+    "defenderLoss": 10,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 33.0281,
+    "defenderLoss": 10,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 144.76,
+    "defenderLoss": 100,
+    "tileCost": 28.9876,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 98.3802,
+    "defenderLoss": 100,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 79.8281,
+    "defenderLoss": 100,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 612.76,
+    "defenderLoss": 1000,
+    "tileCost": 28.9876,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 612.76,
+    "defenderLoss": 1000,
+    "tileCost": 28.9876,
+  },
+  "Highland aTiles=50000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 566.38,
+    "defenderLoss": 1000,
+    "tileCost": 3.86501,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 40.8347,
+    "defenderLoss": 0.0666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 24.5147,
+    "defenderLoss": 0.0666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 24.5147,
+    "defenderLoss": 0.0666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 81.9467,
+    "defenderLoss": 0.666667,
+    "tileCost": 25.5,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 41.1467,
+    "defenderLoss": 0.666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 24.8267,
+    "defenderLoss": 0.666667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 85.0667,
+    "defenderLoss": 6.66667,
+    "tileCost": 25.5,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 85.0667,
+    "defenderLoss": 6.66667,
+    "tileCost": 25.5,
+  },
+  "Highland aTiles=50000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 44.2667,
+    "defenderLoss": 6.66667,
+    "tileCost": 3.4,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 34.0494,
+    "defenderLoss": 0.025,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 20.4348,
+    "defenderLoss": 0.025,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 20.4348,
+    "defenderLoss": 0.025,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 68.2027,
+    "defenderLoss": 0.25,
+    "tileCost": 21.2727,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 34.1664,
+    "defenderLoss": 0.25,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 20.5518,
+    "defenderLoss": 0.25,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 69.3727,
+    "defenderLoss": 2.5,
+    "tileCost": 21.2727,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 69.3727,
+    "defenderLoss": 2.5,
+    "tileCost": 21.2727,
+  },
+  "Highland aTiles=50000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 35.3364,
+    "defenderLoss": 2.5,
+    "tileCost": 2.83636,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 45.224,
+    "defenderLoss": 0.2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 27.176,
+    "defenderLoss": 0.2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 27.176,
+    "defenderLoss": 0.2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 91.28,
+    "defenderLoss": 2,
+    "tileCost": 28.2,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 46.16,
+    "defenderLoss": 2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 28.112,
+    "defenderLoss": 2,
+    "tileCost": 3.76,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 100.64,
+    "defenderLoss": 20,
+    "tileCost": 28.2,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 100.64,
+    "defenderLoss": 20,
+    "tileCost": 28.2,
+  },
+  "Highland aTiles=50000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 55.52,
+    "defenderLoss": 20,
+    "tileCost": 3.76,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 61.8962,
+    "defenderLoss": 10,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 39.6337,
+    "defenderLoss": 10,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 39.6337,
+    "defenderLoss": 10,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 173.712,
+    "defenderLoss": 100,
+    "tileCost": 36.2345,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 118.056,
+    "defenderLoss": 100,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 95.7937,
+    "defenderLoss": 100,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 735.312,
+    "defenderLoss": 1000,
+    "tileCost": 36.2345,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 735.312,
+    "defenderLoss": 1000,
+    "tileCost": 36.2345,
+  },
+  "Mountain aTiles=1000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 679.656,
+    "defenderLoss": 1000,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 49.0016,
+    "defenderLoss": 0.0666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 29.4176,
+    "defenderLoss": 0.0666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 29.4176,
+    "defenderLoss": 0.0666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 98.336,
+    "defenderLoss": 0.666667,
+    "tileCost": 31.875,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 49.376,
+    "defenderLoss": 0.666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 29.792,
+    "defenderLoss": 0.666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 102.08,
+    "defenderLoss": 6.66667,
+    "tileCost": 31.875,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 102.08,
+    "defenderLoss": 6.66667,
+    "tileCost": 31.875,
+  },
+  "Mountain aTiles=1000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 53.12,
+    "defenderLoss": 6.66667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 40.8592,
+    "defenderLoss": 0.025,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 24.5218,
+    "defenderLoss": 0.025,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 24.5218,
+    "defenderLoss": 0.025,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 81.8433,
+    "defenderLoss": 0.25,
+    "tileCost": 26.5909,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 40.9996,
+    "defenderLoss": 0.25,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 24.6622,
+    "defenderLoss": 0.25,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 83.2473,
+    "defenderLoss": 2.5,
+    "tileCost": 26.5909,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 83.2473,
+    "defenderLoss": 2.5,
+    "tileCost": 26.5909,
+  },
+  "Mountain aTiles=1000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 42.4036,
+    "defenderLoss": 2.5,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 54.2688,
+    "defenderLoss": 0.2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 32.6112,
+    "defenderLoss": 0.2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 32.6112,
+    "defenderLoss": 0.2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 109.536,
+    "defenderLoss": 2,
+    "tileCost": 35.25,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 55.392,
+    "defenderLoss": 2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 33.7344,
+    "defenderLoss": 2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 120.768,
+    "defenderLoss": 20,
+    "tileCost": 35.25,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 120.768,
+    "defenderLoss": 20,
+    "tileCost": 35.25,
+  },
+  "Mountain aTiles=1000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 66.624,
+    "defenderLoss": 20,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 49.907,
+    "defenderLoss": 10,
+    "tileCost": 3.18745,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 32.4402,
+    "defenderLoss": 10,
+    "tileCost": 3.18745,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 32.4402,
+    "defenderLoss": 10,
+    "tileCost": 3.18745,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 149.734,
+    "defenderLoss": 100,
+    "tileCost": 23.9059,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 106.067,
+    "defenderLoss": 100,
+    "tileCost": 3.18745,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 88.6002,
+    "defenderLoss": 100,
+    "tileCost": 3.18745,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 711.334,
+    "defenderLoss": 1000,
+    "tileCost": 23.9059,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 711.334,
+    "defenderLoss": 1000,
+    "tileCost": 23.9059,
+  },
+  "Mountain aTiles=200000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 667.667,
+    "defenderLoss": 1000,
+    "tileCost": 3.18745,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 38.4548,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.80395,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 23.0895,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.80395,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 23.0895,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.80395,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 77.2425,
+    "defenderLoss": 0.666667,
+    "tileCost": 21.0297,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 38.8292,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.80395,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 23.4639,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.80395,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 80.9865,
+    "defenderLoss": 6.66667,
+    "tileCost": 21.0297,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 80.9865,
+    "defenderLoss": 6.66667,
+    "tileCost": 21.0297,
+  },
+  "Mountain aTiles=200000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 42.5732,
+    "defenderLoss": 6.66667,
+    "tileCost": 2.80395,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 32.0609,
+    "defenderLoss": 0.025,
+    "tileCost": 2.33913,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 19.2428,
+    "defenderLoss": 0.025,
+    "tileCost": 2.33913,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 19.2428,
+    "defenderLoss": 0.025,
+    "tileCost": 2.33913,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 64.2465,
+    "defenderLoss": 0.25,
+    "tileCost": 17.5435,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 32.2013,
+    "defenderLoss": 0.25,
+    "tileCost": 2.33913,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 19.3832,
+    "defenderLoss": 0.25,
+    "tileCost": 2.33913,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 65.6505,
+    "defenderLoss": 2.5,
+    "tileCost": 17.5435,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 65.6505,
+    "defenderLoss": 2.5,
+    "tileCost": 17.5435,
+  },
+  "Mountain aTiles=200000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 33.6053,
+    "defenderLoss": 2.5,
+    "tileCost": 2.33913,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 42.6053,
+    "defenderLoss": 0.2,
+    "tileCost": 3.10084,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 25.6131,
+    "defenderLoss": 0.2,
+    "tileCost": 3.10084,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 25.6131,
+    "defenderLoss": 0.2,
+    "tileCost": 3.10084,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 86.209,
+    "defenderLoss": 2,
+    "tileCost": 23.2563,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 43.7285,
+    "defenderLoss": 2,
+    "tileCost": 3.10084,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 26.7363,
+    "defenderLoss": 2,
+    "tileCost": 3.10084,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 97.441,
+    "defenderLoss": 20,
+    "tileCost": 23.2563,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 97.441,
+    "defenderLoss": 20,
+    "tileCost": 23.2563,
+  },
+  "Mountain aTiles=200000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 54.9605,
+    "defenderLoss": 20,
+    "tileCost": 3.10084,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 61.8962,
+    "defenderLoss": 10,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 39.6337,
+    "defenderLoss": 10,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 39.6337,
+    "defenderLoss": 10,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 173.712,
+    "defenderLoss": 100,
+    "tileCost": 36.2345,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 118.056,
+    "defenderLoss": 100,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 95.7937,
+    "defenderLoss": 100,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 735.312,
+    "defenderLoss": 1000,
+    "tileCost": 36.2345,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 735.312,
+    "defenderLoss": 1000,
+    "tileCost": 36.2345,
+  },
+  "Mountain aTiles=50000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 679.656,
+    "defenderLoss": 1000,
+    "tileCost": 4.83127,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 49.0016,
+    "defenderLoss": 0.0666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 29.4176,
+    "defenderLoss": 0.0666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 29.4176,
+    "defenderLoss": 0.0666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 98.336,
+    "defenderLoss": 0.666667,
+    "tileCost": 31.875,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 49.376,
+    "defenderLoss": 0.666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 29.792,
+    "defenderLoss": 0.666667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 102.08,
+    "defenderLoss": 6.66667,
+    "tileCost": 31.875,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 102.08,
+    "defenderLoss": 6.66667,
+    "tileCost": 31.875,
+  },
+  "Mountain aTiles=50000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 53.12,
+    "defenderLoss": 6.66667,
+    "tileCost": 4.25,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 40.8592,
+    "defenderLoss": 0.025,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 24.5218,
+    "defenderLoss": 0.025,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 24.5218,
+    "defenderLoss": 0.025,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 81.8433,
+    "defenderLoss": 0.25,
+    "tileCost": 26.5909,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 40.9996,
+    "defenderLoss": 0.25,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 24.6622,
+    "defenderLoss": 0.25,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 83.2473,
+    "defenderLoss": 2.5,
+    "tileCost": 26.5909,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 83.2473,
+    "defenderLoss": 2.5,
+    "tileCost": 26.5909,
+  },
+  "Mountain aTiles=50000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 42.4036,
+    "defenderLoss": 2.5,
+    "tileCost": 3.54545,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 54.2688,
+    "defenderLoss": 0.2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 32.6112,
+    "defenderLoss": 0.2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 32.6112,
+    "defenderLoss": 0.2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 109.536,
+    "defenderLoss": 2,
+    "tileCost": 35.25,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 55.392,
+    "defenderLoss": 2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 33.7344,
+    "defenderLoss": 2,
+    "tileCost": 4.7,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 120.768,
+    "defenderLoss": 20,
+    "tileCost": 35.25,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 120.768,
+    "defenderLoss": 20,
+    "tileCost": 35.25,
+  },
+  "Mountain aTiles=50000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 66.624,
+    "defenderLoss": 20,
+    "tileCost": 4.7,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 41.2641,
+    "defenderLoss": 10,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 26.4225,
+    "defenderLoss": 10,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 26.4225,
+    "defenderLoss": 10,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 115.808,
+    "defenderLoss": 100,
+    "tileCost": 23.9148,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 78.7041,
+    "defenderLoss": 100,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 63.8625,
+    "defenderLoss": 100,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 490.208,
+    "defenderLoss": 1000,
+    "tileCost": 23.9148,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 490.208,
+    "defenderLoss": 1000,
+    "tileCost": 23.9148,
+  },
+  "Plains aTiles=1000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 453.104,
+    "defenderLoss": 1000,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 32.6677,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 19.6117,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 19.6117,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 65.5573,
+    "defenderLoss": 0.666667,
+    "tileCost": 21.0375,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 32.9173,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 19.8613,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 68.0533,
+    "defenderLoss": 6.66667,
+    "tileCost": 21.0375,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 68.0533,
+    "defenderLoss": 6.66667,
+    "tileCost": 21.0375,
+  },
+  "Plains aTiles=1000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 35.4133,
+    "defenderLoss": 6.66667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 27.2395,
+    "defenderLoss": 0.025,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 16.3479,
+    "defenderLoss": 0.025,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 16.3479,
+    "defenderLoss": 0.025,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 54.5622,
+    "defenderLoss": 0.25,
+    "tileCost": 17.55,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 27.3331,
+    "defenderLoss": 0.25,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 16.4415,
+    "defenderLoss": 0.25,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 55.4982,
+    "defenderLoss": 2.5,
+    "tileCost": 17.55,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 55.4982,
+    "defenderLoss": 2.5,
+    "tileCost": 17.55,
+  },
+  "Plains aTiles=1000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 28.2691,
+    "defenderLoss": 2.5,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 36.1792,
+    "defenderLoss": 0.2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 21.7408,
+    "defenderLoss": 0.2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 21.7408,
+    "defenderLoss": 0.2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 73.024,
+    "defenderLoss": 2,
+    "tileCost": 23.265,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 36.928,
+    "defenderLoss": 2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 22.4896,
+    "defenderLoss": 2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 80.512,
+    "defenderLoss": 20,
+    "tileCost": 23.265,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 80.512,
+    "defenderLoss": 20,
+    "tileCost": 23.265,
+  },
+  "Plains aTiles=1000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 44.416,
+    "defenderLoss": 20,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 33.2713,
+    "defenderLoss": 10,
+    "tileCost": 2.10372,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 21.6268,
+    "defenderLoss": 10,
+    "tileCost": 2.10372,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 21.6268,
+    "defenderLoss": 10,
+    "tileCost": 2.10372,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 99.8226,
+    "defenderLoss": 100,
+    "tileCost": 15.7779,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 70.7113,
+    "defenderLoss": 100,
+    "tileCost": 2.10372,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 59.0668,
+    "defenderLoss": 100,
+    "tileCost": 2.10372,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 474.223,
+    "defenderLoss": 1000,
+    "tileCost": 15.7779,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 474.223,
+    "defenderLoss": 1000,
+    "tileCost": 15.7779,
+  },
+  "Plains aTiles=200000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 445.111,
+    "defenderLoss": 1000,
+    "tileCost": 2.10372,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 25.6366,
+    "defenderLoss": 0.0666667,
+    "tileCost": 1.85061,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 15.393,
+    "defenderLoss": 0.0666667,
+    "tileCost": 1.85061,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 15.393,
+    "defenderLoss": 0.0666667,
+    "tileCost": 1.85061,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 51.495,
+    "defenderLoss": 0.666667,
+    "tileCost": 13.8796,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 25.8862,
+    "defenderLoss": 0.666667,
+    "tileCost": 1.85061,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 15.6426,
+    "defenderLoss": 0.666667,
+    "tileCost": 1.85061,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 53.991,
+    "defenderLoss": 6.66667,
+    "tileCost": 13.8796,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 53.991,
+    "defenderLoss": 6.66667,
+    "tileCost": 13.8796,
+  },
+  "Plains aTiles=200000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 28.3822,
+    "defenderLoss": 6.66667,
+    "tileCost": 1.85061,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 21.3739,
+    "defenderLoss": 0.025,
+    "tileCost": 1.54382,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 12.8285,
+    "defenderLoss": 0.025,
+    "tileCost": 1.54382,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 12.8285,
+    "defenderLoss": 0.025,
+    "tileCost": 1.54382,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 42.831,
+    "defenderLoss": 0.25,
+    "tileCost": 11.5787,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 21.4675,
+    "defenderLoss": 0.25,
+    "tileCost": 1.54382,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 12.9221,
+    "defenderLoss": 0.25,
+    "tileCost": 1.54382,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 43.767,
+    "defenderLoss": 2.5,
+    "tileCost": 11.5787,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 43.767,
+    "defenderLoss": 2.5,
+    "tileCost": 11.5787,
+  },
+  "Plains aTiles=200000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 22.4035,
+    "defenderLoss": 2.5,
+    "tileCost": 1.54382,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 28.4035,
+    "defenderLoss": 0.2,
+    "tileCost": 2.04656,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 17.0754,
+    "defenderLoss": 0.2,
+    "tileCost": 2.04656,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 17.0754,
+    "defenderLoss": 0.2,
+    "tileCost": 2.04656,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 57.4727,
+    "defenderLoss": 2,
+    "tileCost": 15.3492,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 29.1523,
+    "defenderLoss": 2,
+    "tileCost": 2.04656,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 17.8242,
+    "defenderLoss": 2,
+    "tileCost": 2.04656,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 64.9607,
+    "defenderLoss": 20,
+    "tileCost": 15.3492,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 64.9607,
+    "defenderLoss": 20,
+    "tileCost": 15.3492,
+  },
+  "Plains aTiles=200000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 36.6403,
+    "defenderLoss": 20,
+    "tileCost": 2.04656,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=10000 attack=10000": {
+    "attackerLoss": 41.2641,
+    "defenderLoss": 10,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=10000 attack=100000": {
+    "attackerLoss": 26.4225,
+    "defenderLoss": 10,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 26.4225,
+    "defenderLoss": 10,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=100000 attack=10000": {
+    "attackerLoss": 115.808,
+    "defenderLoss": 100,
+    "tileCost": 23.9148,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=100000 attack=100000": {
+    "attackerLoss": 78.7041,
+    "defenderLoss": 100,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 63.8625,
+    "defenderLoss": 100,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 490.208,
+    "defenderLoss": 1000,
+    "tileCost": 23.9148,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 490.208,
+    "defenderLoss": 1000,
+    "tileCost": 23.9148,
+  },
+  "Plains aTiles=50000 dTiles=1000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 453.104,
+    "defenderLoss": 1000,
+    "tileCost": 3.18864,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=10000 attack=10000": {
+    "attackerLoss": 32.6677,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=10000 attack=100000": {
+    "attackerLoss": 19.6117,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 19.6117,
+    "defenderLoss": 0.0666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=100000 attack=10000": {
+    "attackerLoss": 65.5573,
+    "defenderLoss": 0.666667,
+    "tileCost": 21.0375,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=100000 attack=100000": {
+    "attackerLoss": 32.9173,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 19.8613,
+    "defenderLoss": 0.666667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 68.0533,
+    "defenderLoss": 6.66667,
+    "tileCost": 21.0375,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 68.0533,
+    "defenderLoss": 6.66667,
+    "tileCost": 21.0375,
+  },
+  "Plains aTiles=50000 dTiles=150000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 35.4133,
+    "defenderLoss": 6.66667,
+    "tileCost": 2.805,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=10000 attack=10000": {
+    "attackerLoss": 27.2395,
+    "defenderLoss": 0.025,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=10000 attack=100000": {
+    "attackerLoss": 16.3479,
+    "defenderLoss": 0.025,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 16.3479,
+    "defenderLoss": 0.025,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=100000 attack=10000": {
+    "attackerLoss": 54.5622,
+    "defenderLoss": 0.25,
+    "tileCost": 17.55,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=100000 attack=100000": {
+    "attackerLoss": 27.3331,
+    "defenderLoss": 0.25,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 16.4415,
+    "defenderLoss": 0.25,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 55.4982,
+    "defenderLoss": 2.5,
+    "tileCost": 17.55,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 55.4982,
+    "defenderLoss": 2.5,
+    "tileCost": 17.55,
+  },
+  "Plains aTiles=50000 dTiles=400000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 28.2691,
+    "defenderLoss": 2.5,
+    "tileCost": 2.34,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=10000 attack=10000": {
+    "attackerLoss": 36.1792,
+    "defenderLoss": 0.2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=10000 attack=100000": {
+    "attackerLoss": 21.7408,
+    "defenderLoss": 0.2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=10000 attack=1000000": {
+    "attackerLoss": 21.7408,
+    "defenderLoss": 0.2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=100000 attack=10000": {
+    "attackerLoss": 73.024,
+    "defenderLoss": 2,
+    "tileCost": 23.265,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=100000 attack=100000": {
+    "attackerLoss": 36.928,
+    "defenderLoss": 2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=100000 attack=1000000": {
+    "attackerLoss": 22.4896,
+    "defenderLoss": 2,
+    "tileCost": 3.102,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=1000000 attack=10000": {
+    "attackerLoss": 80.512,
+    "defenderLoss": 20,
+    "tileCost": 23.265,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=1000000 attack=100000": {
+    "attackerLoss": 80.512,
+    "defenderLoss": 20,
+    "tileCost": 23.265,
+  },
+  "Plains aTiles=50000 dTiles=50000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 44.416,
+    "defenderLoss": 20,
+    "tileCost": 3.102,
+  },
+}
+`;
+
+exports[`attackLogic golden values > player vs player: troop ratio clamps 1`] = `
+{
+  "defenderTroops/attackTroops=0.01": {
+    "attackerLoss": 24.1414,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "defenderTroops/attackTroops=0.1": {
+    "attackerLoss": 24.1414,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "defenderTroops/attackTroops=0.5": {
+    "attackerLoss": 24.1414,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "defenderTroops/attackTroops=0.6": {
+    "attackerLoss": 24.1414,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "defenderTroops/attackTroops=1": {
+    "attackerLoss": 38.8489,
+    "defenderLoss": 5,
+    "tileCost": 3.15983,
+  },
+  "defenderTroops/attackTroops=10": {
+    "attackerLoss": 75.6179,
+    "defenderLoss": 5,
+    "tileCost": 23.6987,
+  },
+  "defenderTroops/attackTroops=100": {
+    "attackerLoss": 75.6179,
+    "defenderLoss": 5,
+    "tileCost": 23.6987,
+  },
+  "defenderTroops/attackTroops=2": {
+    "attackerLoss": 75.6179,
+    "defenderLoss": 5,
+    "tileCost": 6.31966,
+  },
+  "defenderTroops/attackTroops=5": {
+    "attackerLoss": 75.6179,
+    "defenderLoss": 5,
+    "tileCost": 15.7992,
+  },
+  "defenderTroops/attackTroops=7.5": {
+    "attackerLoss": 75.6179,
+    "defenderLoss": 5,
+    "tileCost": 23.6987,
+  },
+}
+`;
+
+exports[`attackLogic golden values > player vs terra nullius 1`] = `
+{
+  "Highland BOT attack=100 fallout=0": {
+    "attackerLoss": 10,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Highland BOT attack=100 fallout=0.5": {
+    "attackerLoss": 40,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Highland BOT attack=1000 fallout=0": {
+    "attackerLoss": 10,
+    "defenderLoss": 0,
+    "tileCost": 40,
+  },
+  "Highland BOT attack=1000 fallout=0.5": {
+    "attackerLoss": 40,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Highland BOT attack=10000 fallout=0": {
+    "attackerLoss": 10,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland BOT attack=10000 fallout=0.5": {
+    "attackerLoss": 40,
+    "defenderLoss": 0,
+    "tileCost": 16,
+  },
+  "Highland BOT attack=100000 fallout=0": {
+    "attackerLoss": 10,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland BOT attack=100000 fallout=0.5": {
+    "attackerLoss": 40,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland BOT attack=1000000 fallout=0": {
+    "attackerLoss": 10,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland BOT attack=1000000 fallout=0.5": {
+    "attackerLoss": 40,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland HUMAN attack=100 fallout=0": {
+    "attackerLoss": 20,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Highland HUMAN attack=100 fallout=0.5": {
+    "attackerLoss": 80,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Highland HUMAN attack=1000 fallout=0": {
+    "attackerLoss": 20,
+    "defenderLoss": 0,
+    "tileCost": 40,
+  },
+  "Highland HUMAN attack=1000 fallout=0.5": {
+    "attackerLoss": 80,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Highland HUMAN attack=10000 fallout=0": {
+    "attackerLoss": 20,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland HUMAN attack=10000 fallout=0.5": {
+    "attackerLoss": 80,
+    "defenderLoss": 0,
+    "tileCost": 16,
+  },
+  "Highland HUMAN attack=100000 fallout=0": {
+    "attackerLoss": 20,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland HUMAN attack=100000 fallout=0.5": {
+    "attackerLoss": 80,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland HUMAN attack=1000000 fallout=0": {
+    "attackerLoss": 20,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Highland HUMAN attack=1000000 fallout=0.5": {
+    "attackerLoss": 80,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain BOT attack=100 fallout=0": {
+    "attackerLoss": 12,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Mountain BOT attack=100 fallout=0.5": {
+    "attackerLoss": 48,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Mountain BOT attack=1000 fallout=0": {
+    "attackerLoss": 12,
+    "defenderLoss": 0,
+    "tileCost": 50,
+  },
+  "Mountain BOT attack=1000 fallout=0.5": {
+    "attackerLoss": 48,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Mountain BOT attack=10000 fallout=0": {
+    "attackerLoss": 12,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain BOT attack=10000 fallout=0.5": {
+    "attackerLoss": 48,
+    "defenderLoss": 0,
+    "tileCost": 20,
+  },
+  "Mountain BOT attack=100000 fallout=0": {
+    "attackerLoss": 12,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain BOT attack=100000 fallout=0.5": {
+    "attackerLoss": 48,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain BOT attack=1000000 fallout=0": {
+    "attackerLoss": 12,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain BOT attack=1000000 fallout=0.5": {
+    "attackerLoss": 48,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain HUMAN attack=100 fallout=0": {
+    "attackerLoss": 24,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Mountain HUMAN attack=100 fallout=0.5": {
+    "attackerLoss": 96,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Mountain HUMAN attack=1000 fallout=0": {
+    "attackerLoss": 24,
+    "defenderLoss": 0,
+    "tileCost": 50,
+  },
+  "Mountain HUMAN attack=1000 fallout=0.5": {
+    "attackerLoss": 96,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Mountain HUMAN attack=10000 fallout=0": {
+    "attackerLoss": 24,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain HUMAN attack=10000 fallout=0.5": {
+    "attackerLoss": 96,
+    "defenderLoss": 0,
+    "tileCost": 20,
+  },
+  "Mountain HUMAN attack=100000 fallout=0": {
+    "attackerLoss": 24,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain HUMAN attack=100000 fallout=0.5": {
+    "attackerLoss": 96,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain HUMAN attack=1000000 fallout=0": {
+    "attackerLoss": 24,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Mountain HUMAN attack=1000000 fallout=0.5": {
+    "attackerLoss": 96,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains BOT attack=100 fallout=0": {
+    "attackerLoss": 8,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Plains BOT attack=100 fallout=0.5": {
+    "attackerLoss": 32,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Plains BOT attack=1000 fallout=0": {
+    "attackerLoss": 8,
+    "defenderLoss": 0,
+    "tileCost": 33,
+  },
+  "Plains BOT attack=1000 fallout=0.5": {
+    "attackerLoss": 32,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Plains BOT attack=10000 fallout=0": {
+    "attackerLoss": 8,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains BOT attack=10000 fallout=0.5": {
+    "attackerLoss": 32,
+    "defenderLoss": 0,
+    "tileCost": 13.2,
+  },
+  "Plains BOT attack=100000 fallout=0": {
+    "attackerLoss": 8,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains BOT attack=100000 fallout=0.5": {
+    "attackerLoss": 32,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains BOT attack=1000000 fallout=0": {
+    "attackerLoss": 8,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains BOT attack=1000000 fallout=0.5": {
+    "attackerLoss": 32,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains HUMAN attack=100 fallout=0": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Plains HUMAN attack=100 fallout=0.5": {
+    "attackerLoss": 64,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Plains HUMAN attack=1000 fallout=0": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 33,
+  },
+  "Plains HUMAN attack=1000 fallout=0.5": {
+    "attackerLoss": 64,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "Plains HUMAN attack=10000 fallout=0": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains HUMAN attack=10000 fallout=0.5": {
+    "attackerLoss": 64,
+    "defenderLoss": 0,
+    "tileCost": 13.2,
+  },
+  "Plains HUMAN attack=100000 fallout=0": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains HUMAN attack=100000 fallout=0.5": {
+    "attackerLoss": 64,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains HUMAN attack=1000000 fallout=0": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "Plains HUMAN attack=1000000 fallout=0.5": {
+    "attackerLoss": 64,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+}
+`;

--- a/tests/__snapshots__/AttackScenarios.test.ts.snap
+++ b/tests/__snapshots__/AttackScenarios.test.ts.snap
@@ -1,0 +1,433 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`attack scenarios > big_plains equal 20k tiles each, 1M vs 1M, attack 200k 1`] = `
+{
+  "attackerLossPerSecond": 8511,
+  "attackerLossPerTile": 94.34,
+  "attackerTiles": 20000,
+  "attackerTroopsLost": 200000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 4511,
+  "defenderLossPerTile": 50,
+  "defenderTiles": 20000,
+  "defenderTroopsLost": 106000,
+  "finished": true,
+  "ticks": 235,
+  "tilesConquered": 2120,
+  "tilesPerSecond": 90.21,
+}
+`;
+
+exports[`attack scenarios > big_plains equal 20k tiles each, 200k vs 200k, attack 40k 1`] = `
+{
+  "attackerLossPerSecond": 6780,
+  "attackerLossPerTile": 77.67,
+  "attackerTiles": 20000,
+  "attackerTroopsLost": 40000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 872.9,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 20000,
+  "defenderTroopsLost": 5150,
+  "finished": true,
+  "ticks": 59,
+  "tilesConquered": 515,
+  "tilesPerSecond": 87.29,
+}
+`;
+
+exports[`attack scenarios > plains big attacker (9500 tiles) vs small defender (500 tiles) 1`] = `
+{
+  "attackerLossPerSecond": 5882,
+  "attackerLossPerTile": 114.9,
+  "attackerTiles": 9500,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 5118,
+  "defenderLossPerTile": 100,
+  "defenderTiles": 500,
+  "defenderTroopsLost": 8700,
+  "finished": true,
+  "ticks": 17,
+  "tilesConquered": 87,
+  "tilesPerSecond": 51.18,
+}
+`;
+
+exports[`attack scenarios > plains bot vs human defender 1`] = `
+{
+  "attackerLossPerSecond": 3846,
+  "attackerLossPerTile": 78.13,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 492.3,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 1280,
+  "finished": true,
+  "ticks": 26,
+  "tilesConquered": 128,
+  "tilesPerSecond": 49.23,
+}
+`;
+
+exports[`attack scenarios > plains bot vs terra nullius, attack 2k 1`] = `
+{
+  "attackerLossPerSecond": 400,
+  "attackerLossPerTile": 8,
+  "attackerTiles": 1000,
+  "attackerTroopsLost": 2000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 0,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 50,
+  "tilesConquered": 250,
+  "tilesPerSecond": 50,
+}
+`;
+
+exports[`attack scenarios > plains defender with defense posts covering the whole border 1`] = `
+{
+  "attackerLossPerSecond": 8333,
+  "attackerLossPerTile": 384.6,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 216.7,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 260,
+  "finished": true,
+  "ticks": 12,
+  "tilesConquered": 26,
+  "tilesPerSecond": 21.67,
+}
+`;
+
+exports[`attack scenarios > plains defender with one defense post at the border 1`] = `
+{
+  "attackerLossPerSecond": 7143,
+  "attackerLossPerTile": 250,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 285.7,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 400,
+  "finished": true,
+  "ticks": 14,
+  "tilesConquered": 40,
+  "tilesPerSecond": 28.57,
+}
+`;
+
+exports[`attack scenarios > plains equal 50k vs 50k, attack 10k 1`] = `
+{
+  "attackerLossPerSecond": 3846,
+  "attackerLossPerTile": 78.13,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 492.3,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 1280,
+  "finished": true,
+  "ticks": 26,
+  "tilesConquered": 128,
+  "tilesPerSecond": 49.23,
+}
+`;
+
+exports[`attack scenarios > plains equal 50k vs 50k, attack 25k 1`] = `
+{
+  "attackerLossPerSecond": 6757,
+  "attackerLossPerTile": 78.13,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 25000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 864.9,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 3200,
+  "finished": true,
+  "ticks": 37,
+  "tilesConquered": 320,
+  "tilesPerSecond": 86.49,
+}
+`;
+
+exports[`attack scenarios > plains equal 50k vs 50k, attack 50k (all-in) 1`] = `
+{
+  "attackerLossPerSecond": 10420,
+  "attackerLossPerTile": 61.73,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 50000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 1688,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 8100,
+  "finished": true,
+  "ticks": 48,
+  "tilesConquered": 810,
+  "tilesPerSecond": 168.8,
+}
+`;
+
+exports[`attack scenarios > plains human vs bot defender 1`] = `
+{
+  "attackerLossPerSecond": 2703,
+  "attackerLossPerTile": 54.64,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 494.6,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 1830,
+  "finished": true,
+  "ticks": 37,
+  "tilesConquered": 183,
+  "tilesPerSecond": 49.46,
+}
+`;
+
+exports[`attack scenarios > plains human vs terra nullius, attack 2k 1`] = `
+{
+  "attackerLossPerSecond": 800,
+  "attackerLossPerTile": 16,
+  "attackerTiles": 1000,
+  "attackerTroopsLost": 2000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 0,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 25,
+  "tilesConquered": 125,
+  "tilesPerSecond": 50,
+}
+`;
+
+exports[`attack scenarios > plains human vs terra nullius, attack 20k 1`] = `
+{
+  "attackerLossPerSecond": 3571,
+  "attackerLossPerTile": 16,
+  "attackerTiles": 1000,
+  "attackerTroopsLost": 20000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 0,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 56,
+  "tilesConquered": 1250,
+  "tilesPerSecond": 223.2,
+}
+`;
+
+exports[`attack scenarios > plains nation vs bot defender 1`] = `
+{
+  "attackerLossPerSecond": 2703,
+  "attackerLossPerTile": 54.64,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 494.6,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 1830,
+  "finished": true,
+  "ticks": 37,
+  "tilesConquered": 183,
+  "tilesPerSecond": 49.46,
+}
+`;
+
+exports[`attack scenarios > plains outmatched 20k vs 200k, attack 4k 1`] = `
+{
+  "attackerLossPerSecond": 1290,
+  "attackerLossPerTile": 88.89,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 4000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 580.6,
+  "defenderLossPerTile": 40,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 1800,
+  "finished": true,
+  "ticks": 31,
+  "tilesConquered": 45,
+  "tilesPerSecond": 14.52,
+}
+`;
+
+exports[`attack scenarios > plains outmatched 20k vs 200k, attack 20k (all-in) 1`] = `
+{
+  "attackerLossPerSecond": 3390,
+  "attackerLossPerTile": 90.5,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 20000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 1498,
+  "defenderLossPerTile": 40,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 8840,
+  "finished": true,
+  "ticks": 59,
+  "tilesConquered": 221,
+  "tilesPerSecond": 37.46,
+}
+`;
+
+exports[`attack scenarios > plains overwhelming 200k vs 20k, attack 40k 1`] = `
+{
+  "attackerLossPerSecond": 11110,
+  "attackerLossPerTile": 34.72,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 40000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 1280,
+  "defenderLossPerTile": 4,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 4608,
+  "finished": true,
+  "ticks": 36,
+  "tilesConquered": 1152,
+  "tilesPerSecond": 320,
+}
+`;
+
+exports[`attack scenarios > plains small attacker (500 tiles) vs big defender (9500 tiles) 1`] = `
+{
+  "attackerLossPerSecond": 3704,
+  "attackerLossPerTile": 75.76,
+  "attackerTiles": 500,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 244.4,
+  "defenderLossPerTile": 5,
+  "defenderTiles": 9500,
+  "defenderTroopsLost": 660,
+  "finished": true,
+  "ticks": 27,
+  "tilesConquered": 132,
+  "tilesPerSecond": 48.89,
+}
+`;
+
+exports[`attack scenarios > plains traitor defender 1`] = `
+{
+  "attackerLossPerSecond": 2381,
+  "attackerLossPerTile": 39.06,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 10000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 609.5,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 2560,
+  "finished": true,
+  "ticks": 42,
+  "tilesConquered": 256,
+  "tilesPerSecond": 60.95,
+}
+`;
+
+exports[`attack scenarios > world highland/mountain region, 100k vs 100k, attack 20k 1`] = `
+{
+  "attackerLossPerSecond": 4545,
+  "attackerLossPerTile": 111.1,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 20000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 818.2,
+  "defenderLossPerTile": 20,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 3600,
+  "finished": true,
+  "ticks": 44,
+  "tilesConquered": 180,
+  "tilesPerSecond": 40.91,
+}
+`;
+
+exports[`attack scenarios > world huge empires (~150k tiles each), 2M vs 2M, attack 400k 1`] = `
+{
+  "attackerLossPerSecond": 10230,
+  "attackerLossPerTile": 80.31,
+  "attackerTiles": 108968,
+  "attackerTroopsLost": 400000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 2038,
+  "defenderLossPerTile": 16,
+  "defenderTiles": 121741,
+  "defenderTroopsLost": 79696,
+  "finished": true,
+  "ticks": 391,
+  "tilesConquered": 4981,
+  "tilesPerSecond": 127.4,
+}
+`;
+
+exports[`attack scenarios > world mountain region, 100k vs 100k, attack 20k 1`] = `
+{
+  "attackerLossPerSecond": 4348,
+  "attackerLossPerTile": 114.9,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 20000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 756.5,
+  "defenderLossPerTile": 20,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 3480,
+  "finished": true,
+  "ticks": 46,
+  "tilesConquered": 174,
+  "tilesPerSecond": 37.83,
+}
+`;
+
+exports[`attack scenarios > world mountain region, human vs terra nullius, attack 20k 1`] = `
+{
+  "attackerLossPerSecond": 11760,
+  "attackerLossPerTile": 22,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 20000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 0,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 17,
+  "tilesConquered": 909,
+  "tilesPerSecond": 534.7,
+}
+`;
+
+exports[`attack scenarios > world plains-ish region, 100k vs 100k, attack 20k 1`] = `
+{
+  "attackerLossPerSecond": 4255,
+  "attackerLossPerTile": 89.29,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 20000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 953.2,
+  "defenderLossPerTile": 20,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 4480,
+  "finished": true,
+  "ticks": 47,
+  "tilesConquered": 224,
+  "tilesPerSecond": 47.66,
+}
+`;

--- a/tests/util/TestConfig.ts
+++ b/tests/util/TestConfig.ts
@@ -1,12 +1,10 @@
-import { Config, NukeMagnitude } from "../../src/core/configuration/Config";
 import {
-  Game,
-  Player,
-  TerraNullius,
-  Tick,
-  UnitType,
-} from "../../src/core/game/Game";
-import { TileRef } from "../../src/core/game/GameMap";
+  AttackLogicInput,
+  AttackLogicResult,
+  Config,
+  NukeMagnitude,
+} from "../../src/core/configuration/Config";
+import { Player, TerraNullius, Tick, UnitType } from "../../src/core/game/Game";
 
 export class TestConfig extends Config {
   private _proximityBonusPortsNb: number = 0;
@@ -76,17 +74,7 @@ export class TestConfig extends Config {
     return this._nationSpawnImmunityDuration;
   }
 
-  attackLogic(
-    gm: Game,
-    attackTroops: number,
-    attacker: Player,
-    defender: Player | TerraNullius,
-    tileToConquer: TileRef,
-  ): {
-    attackerTroopLoss: number;
-    defenderTroopLoss: number;
-    tilesPerTickUsed: number;
-  } {
+  attackLogic(_input: AttackLogicInput): AttackLogicResult {
     return { attackerTroopLoss: 1, defenderTroopLoss: 1, tilesPerTickUsed: 1 };
   }
 
@@ -100,24 +88,7 @@ export class TestConfig extends Config {
   }
 }
 export class UseRealAttackLogic extends TestConfig {
-  attackLogic(
-    gm: Game,
-    attackTroops: number,
-    attacker: Player,
-    defender: Player | TerraNullius,
-    tileToConquer: TileRef,
-  ): {
-    attackerTroopLoss: number;
-    defenderTroopLoss: number;
-    tilesPerTickUsed: number;
-  } {
-    return Config.prototype.attackLogic.call(
-      this,
-      gm,
-      attackTroops,
-      attacker,
-      defender,
-      tileToConquer,
-    );
+  attackLogic(input: AttackLogicInput): AttackLogicResult {
+    return Config.prototype.attackLogic.call(this, input);
   }
 }


### PR DESCRIPTION
## Summary
- `Config.attackLogic` now takes a plain `AttackLogicInput` (terrain, troop counts, territory sizes, defense-post / fallout / traitor / disconnected-teammate flags) instead of a `Game` + `Player`s. `AttackExecution.attackLogicInput()` does the extraction (terrain lookup, `nearbyUnits` defense-post scan, fallout ratio, team check).
- Cleanup inside the now-pure function: terrain lookup extracted to `terrainAttackBase`, tunables named (`LARGE_ATTACKER_TILES`, `BOT_DEFENDER_LOSS_MULT`, `TERRA_NULLIUS_*`), the two identical `largeDefender*Debuff` expressions collapsed, `speed` renamed to `tileCost` (it is a cost, higher = slower), dead `Math.max(10, …)` removed. Operand order in every product is unchanged so results are bit-identical.
- **No balance change.** This is groundwork so the attack meta can later be simplified with measurable impact.
- New `tests/AttackLogicGolden.test.ts`: snapshot of the formula across terrain × territory × troop grids and every situational modifier.
- New `tests/AttackScenarios.test.ts`: 24 real `AttackExecution` runs on real maps (`plains`, `big_plains`, three terrain regions of `world`, including ~150k-tile empires) recording ticks, tiles conquered, troop loss per side and per-second / per-tile rates. Any future formula change shows up as a per-scenario numeric diff.
- `TestConfig` / `UseRealAttackLogic` updated to the new signature. Note: `UseRealAttackLogic` still leaves `attackTilesPerTick` stubbed to 1; the scenario test restores both locally.

## Test plan
- `npx vitest tests/AttackLogicGolden.test.ts tests/AttackScenarios.test.ts tests/Disconnected --run` — scenario snapshot is byte-identical before and after the refactor.
- Full `npm test`: 338 files / 3996 tests pass.
- `tsc --noEmit`, eslint, prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)