### PR TITLE
Simplify attackLogic algebra without changing balance

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -821,10 +821,9 @@ export class Config {
 
     // Attacker loss blends a ratio-driven term (how outnumbered the attack
     // is, clamped) with a density-driven term (defender troops per tile).
+    const troopRatio = defender.troops / attackTroops;
     const ratioTerm =
-      within(defender.troops / attackTroops, 0.6, 2) *
-      largeDefenderDebuff *
-      largeAttackerLossBonus;
+      within(troopRatio, 0.6, 2) * largeDefenderDebuff * largeAttackerLossBonus;
     const attackerTroopLoss =
       mag *
       traitorLossMod *
@@ -835,7 +834,7 @@ export class Config {
       attackerTroopLoss,
       defenderTroopLoss,
       tilesPerTickUsed:
-        within(defender.troops / (5 * attackTroops), 0.2, 1.5) *
+        (within(troopRatio, 1, 7.5) / 5) *
         tileCost *
         largeDefenderDebuff *
         largeAttackerCostBonus *

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -98,6 +98,13 @@ const BOT_DEFENDER_LOSS_MULT = 0.7;
 const TERRA_NULLIUS_COST_SCALE = 2000;
 const TERRA_NULLIUS_MIN_COST = 5;
 const TERRA_NULLIUS_MAX_COST = 100;
+// Was sqrt(ratio) ** 0.7 and ratio ** 0.6.
+const LARGE_ATTACKER_LOSS_EXPONENT = 0.35;
+const LARGE_ATTACKER_COST_EXPONENT = 0.6;
+// Attacker loss = mag * (RATIO_WEIGHT * clampedRatio + DENSITY_WEIGHT * troopsPerTile).
+// Was 0.6 * (ratio * mag * 0.8) + 0.4 * (1.3 * density * mag / 100).
+const ATTACKER_LOSS_RATIO_WEIGHT = 0.48;
+const ATTACKER_LOSS_DENSITY_WEIGHT = 0.0052;
 
 function terrainAttackBase(terrain: TerrainType): {
   mag: number;
@@ -786,25 +793,24 @@ export class Config {
       mag *= BOT_DEFENDER_LOSS_MULT;
     }
 
-    // Big defenders are easier to bite into: both loss and cost scale down
-    // towards 0.7 as the defender's territory grows past the midpoint.
+    // Big defenders are easier to bite into: loss and cost scale from ~1
+    // down to 0.7 as the defender's territory grows past the midpoint.
     const largeDefenderDebuff =
-      0.7 +
+      1 -
       0.3 *
-        (1 -
-          sigmoid(
-            defender.numTiles,
-            DEFENSE_DEBUFF_DECAY_RATE,
-            DEFENSE_DEBUFF_MIDPOINT,
-          ));
+        sigmoid(
+          defender.numTiles,
+          DEFENSE_DEBUFF_DECAY_RATE,
+          DEFENSE_DEBUFF_MIDPOINT,
+        );
 
     // Big attackers get cheaper, faster tiles past LARGE_ATTACKER_TILES.
     let largeAttackerLossBonus = 1;
     let largeAttackerCostBonus = 1;
     if (attacker.numTiles > LARGE_ATTACKER_TILES) {
       const ratio = LARGE_ATTACKER_TILES / attacker.numTiles;
-      largeAttackerLossBonus = Math.sqrt(ratio) ** 0.7;
-      largeAttackerCostBonus = ratio ** 0.6;
+      largeAttackerLossBonus = ratio ** LARGE_ATTACKER_LOSS_EXPONENT;
+      largeAttackerCostBonus = ratio ** LARGE_ATTACKER_COST_EXPONENT;
     }
 
     const traitorLossMod = defender.isTraitor ? this.traitorDefenseDebuff() : 1;
@@ -815,15 +821,15 @@ export class Config {
 
     // Attacker loss blends a ratio-driven term (how outnumbered the attack
     // is, clamped) with a density-driven term (defender troops per tile).
-    const ratioLoss =
+    const ratioTerm =
       within(defender.troops / attackTroops, 0.6, 2) *
-      mag *
-      0.8 *
       largeDefenderDebuff *
-      largeAttackerLossBonus *
-      traitorLossMod;
-    const densityLoss = 1.3 * defenderTroopLoss * (mag / 100) * traitorLossMod;
-    const attackerTroopLoss = 0.6 * ratioLoss + 0.4 * densityLoss;
+      largeAttackerLossBonus;
+    const attackerTroopLoss =
+      mag *
+      traitorLossMod *
+      (ATTACKER_LOSS_RATIO_WEIGHT * ratioTerm +
+        ATTACKER_LOSS_DENSITY_WEIGHT * defenderTroopLoss);
 
     return {
       attackerTroopLoss,


### PR DESCRIPTION
## Summary
- Collapse the attacker-loss blend `0.6*(ratio*mag*0.8*…) + 0.4*(1.3*density*mag/100*…)` into `mag * traitor * (0.48 * ratioTerm + 0.0052 * troopsPerTile)` with the two weights named; `mag` and the traitor mod are applied once instead of inside each term.
- Rewrite the large-defender debuff `0.7 + 0.3*(1 - sigmoid)` as `1 - 0.3*sigmoid`.
- Replace `Math.sqrt(ratio) ** 0.7` with `ratio ** 0.35` and name both large-attacker exponents.
- Pure algebra: no balance change. Both `AttackLogicGolden` and `AttackScenarios` snapshots pass unmodified.

## Test plan
- `npx vitest tests/AttackLogicGolden.test.ts tests/AttackScenarios.test.ts --run` — 31 passed, snapshots untouched
- `npm test` — 338 files / 3996 tests pass
- `tsc --noEmit`, eslint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)