### PR TITLE
Add extreme-case coverage to the attack golden and scenario tests

### DIFF
--- a/tests/AttackLogicGolden.test.ts
+++ b/tests/AttackLogicGolden.test.ts
@@ -199,6 +199,44 @@ describe("attackLogic golden values", () => {
     expect(table).toMatchSnapshot();
   });
 
+  // The extremes are where formulas break: giant vs tiny territories, 1-troop
+  // attacks, 10M-troop armies, empty defenders and turtles with thousands of
+  // troops per tile.
+  test("extremes: territory and troop counts", () => {
+    const attackerTiles = [100, 1_000_000, 5_000_000];
+    const defenderTiles = [100, 1_000_000];
+    const defenderTroops = [0, 1, 1_000, 1_000_000, 10_000_000];
+    const attackTroops = [1, 1_000, 1_000_000, 10_000_000];
+
+    const table: Record<string, ReturnType<typeof run>> = {};
+    for (const terrain of [TerrainType.Plains, TerrainType.Mountain])
+      for (const at of attackerTiles)
+        for (const dt of defenderTiles)
+          for (const dtr of defenderTroops)
+            for (const atr of attackTroops) {
+              const key = `${TerrainType[terrain]} aTiles=${at} dTiles=${dt} dTroops=${dtr} attack=${atr}`;
+              table[key] = run({
+                terrain,
+                attackTroops: atr,
+                attacker: { type: PlayerType.Human, numTiles: at },
+                defender: defender({ numTiles: dt, troops: dtr }),
+              });
+            }
+    expect(table).toMatchSnapshot();
+  });
+
+  test("extremes: terra nullius", () => {
+    const table: Record<string, ReturnType<typeof run>> = {};
+    for (const at of [100, 5_000_000])
+      for (const atr of [1, 10_000_000]) {
+        table[`aTiles=${at} attack=${atr}`] = run({
+          attackTroops: atr,
+          attacker: { type: PlayerType.Human, numTiles: at },
+        });
+      }
+    expect(table).toMatchSnapshot();
+  });
+
   test("impassable terrain throws", () => {
     expect(() =>
       run({ terrain: TerrainType.Impassable, attackTroops: 1 }),

--- a/tests/AttackScenarios.test.ts
+++ b/tests/AttackScenarios.test.ts
@@ -94,20 +94,17 @@ interface Metrics {
 
 const DEFAULT_MAX_TICKS = 3000; // 5 minutes of game time
 
-/** Conquer every passable land tile in the rect; returns tiles conquered. */
-function conquerRect(game: Game, player: Player, r: Rect): number {
+/** Conquer every passable land tile in the rect. */
+function conquerRect(game: Game, player: Player, r: Rect): void {
   const map = game.map();
-  let n = 0;
   for (let y = r.y; y < r.y + r.h; y++) {
     for (let x = r.x; x < r.x + r.w; x++) {
       const t = map.ref(x, y);
       if (map.isLand(t) && !map.isImpassable(t)) {
         player.conquer(t);
-        n++;
       }
     }
   }
-  return n;
 }
 
 function sig(x: number): number {
@@ -138,25 +135,32 @@ async function runScenario(s: Scenario): Promise<Metrics> {
   const attacker = game.player("attacker");
   const defender = game.player("defender");
 
-  const attackerTiles = conquerRect(game, attacker, s.attacker.rect);
-  attacker.setTroops(s.attacker.troops);
-  if (s.attacker.traitor) attacker.markTraitor();
-
-  let defenderTiles = 0;
+  // Conquer the larger rect first so a small territory can sit inside a big
+  // one (the later conquer overrides ownership).
+  const area = (r: Rect) => r.w * r.h;
+  const attackerFirst =
+    defenderSide === null || area(s.attacker.rect) >= area(defenderSide.rect);
+  if (attackerFirst) conquerRect(game, attacker, s.attacker.rect);
   if (defenderSide !== null) {
-    defenderTiles = conquerRect(game, defender, defenderSide.rect);
+    conquerRect(game, defender, defenderSide.rect);
     defender.setTroops(defenderSide.troops);
     if (defenderSide.traitor) defender.markTraitor();
     for (const [x, y] of defenderSide.defensePosts ?? []) {
       defender.buildUnit(UnitType.DefensePost, game.ref(x, y), {});
     }
   }
+  if (!attackerFirst) conquerRect(game, attacker, s.attacker.rect);
+  attacker.setTroops(s.attacker.troops);
+  if (s.attacker.traitor) attacker.markTraitor();
 
   const targetID =
     defenderSide === null ? game.terraNullius().id() : defender.id();
   const attackerTroopsBefore = attacker.troops();
   const defenderTroopsBefore = defender.troops();
   const attackerTilesBefore = attacker.numTilesOwned();
+  // Actual ownership: a nested rect overrides part of the other.
+  const attackerTiles = attackerTilesBefore;
+  const defenderTiles = defenderSide === null ? 0 : defender.numTilesOwned();
 
   game.addExecution(new AttackExecution(s.attackTroops, attacker, targetID));
 
@@ -218,6 +222,20 @@ function worldBlock(bx: number, by: number): [Rect, Rect] {
 const [WORLD_PLAINS_L, WORLD_PLAINS_R] = worldBlock(1200, 100);
 const [WORLD_HILLS_L, WORLD_HILLS_R] = worldBlock(1300, 200);
 const [WORLD_MTN_L, WORLD_MTN_R] = worldBlock(1400, 200);
+
+// 20x20 (400-tile) turtle in the middle of the plains map, surrounded by the
+// attacker. Note: players with < 100 tiles are conquered outright after
+// losing a single tile (AttackExecution.handleDeadDefender), so turtles must
+// be bigger than that to exercise the formula.
+const PLAINS_TURTLE: Rect = { x: 40, y: 40, w: 20, h: 20 };
+const PLAINS_TURTLE_TINY: Rect = { x: 45, y: 45, w: 10, h: 10 };
+
+// giantworldmap: 4108x1948, ~2.3M passable land tiles.
+// x 1600..3000 full height: ~1.01M land tiles; x 3000..4108: ~590k.
+const GIANT_WEST: Rect = { x: 1600, y: 0, w: 1400, h: 1948 };
+const GIANT_EAST: Rect = { x: 3000, y: 0, w: 1108, h: 1948 };
+// 20x20 turtle on solid land inside GIANT_WEST.
+const GIANT_TURTLE: Rect = { x: 2400, y: 300, w: 20, h: 20 };
 
 const scenarios: Record<string, Scenario> = {
   // --- plains, equal territories, vary attack size --------------------------
@@ -388,6 +406,101 @@ const scenarios: Record<string, Scenario> = {
     attacker: { rect: { x: 800, y: 100, w: 400, h: 400 }, troops: 2_000_000 },
     defender: { rect: { x: 1200, y: 100, w: 400, h: 400 }, troops: 2_000_000 },
     attackTroops: 400_000,
+  },
+  // --- extremes -------------------------------------------------------------
+  // The extremes are where formulas break.
+  "plains 1-troop attack vs 50k defender": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 50_000 },
+    attackTroops: 1,
+  },
+  "plains 100-troop attack vs 1M defender": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 1_000_000 },
+    attackTroops: 100,
+  },
+  "plains 10M-troop attack vs defender with 1 troop": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 10_000_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 1 },
+    attackTroops: 10_000_000,
+  },
+  "plains 50k attack vs defender with 0 troops": {
+    map: "plains",
+    attacker: { rect: PLAINS_LEFT, troops: 50_000 },
+    defender: { rect: PLAINS_RIGHT, troops: 0 },
+    attackTroops: 50_000,
+  },
+  "plains 400-tile turtle, 400k troops (1k/tile), attacked with 400k": {
+    map: "plains",
+    attacker: { rect: { x: 0, y: 0, w: 100, h: 100 }, troops: 2_000_000 },
+    defender: { rect: PLAINS_TURTLE, troops: 400_000 },
+    attackTroops: 400_000,
+  },
+  "plains 400-tile turtle, 4M troops (10k/tile) under a defense post, attacked with 1M":
+    {
+      map: "plains",
+      attacker: { rect: { x: 0, y: 0, w: 100, h: 100 }, troops: 2_000_000 },
+      defender: {
+        rect: PLAINS_TURTLE,
+        troops: 4_000_000,
+        defensePosts: [[50, 50]],
+      },
+      attackTroops: 1_000_000,
+    },
+  // Documents the <100-tile instant-conquest rule, not the formula.
+  "plains 100-tile turtle, 1M troops: conquered outright after one tile": {
+    map: "plains",
+    attacker: { rect: { x: 0, y: 0, w: 100, h: 100 }, troops: 2_000_000 },
+    defender: { rect: PLAINS_TURTLE_TINY, troops: 1_000_000 },
+    attackTroops: 100_000,
+  },
+  "giant 1M-tile attacker, 8M troops, attack 2M vs 400-tile turtle with 400k (1k/tile)":
+    {
+      map: "giantworldmap",
+      attacker: { rect: GIANT_WEST, troops: 8_000_000 },
+      defender: { rect: GIANT_TURTLE, troops: 400_000 },
+      attackTroops: 2_000_000,
+    },
+  "giant 1M-tile attacker, 8M troops, attack 2M vs 400-tile turtle with 4M (10k/tile)":
+    {
+      map: "giantworldmap",
+      attacker: { rect: GIANT_WEST, troops: 8_000_000 },
+      defender: { rect: GIANT_TURTLE, troops: 4_000_000 },
+      attackTroops: 2_000_000,
+    },
+  "giant 400-tile attacker, 100k troops, attack 50k vs 1M-tile sparse defender with 1M":
+    {
+      map: "giantworldmap",
+      attacker: { rect: GIANT_TURTLE, troops: 100_000 },
+      defender: { rect: GIANT_WEST, troops: 1_000_000 },
+      attackTroops: 50_000,
+    },
+  "giant 400-tile attacker, 1M troops all-in vs 1M-tile defender with 1M": {
+    map: "giantworldmap",
+    attacker: { rect: GIANT_TURTLE, troops: 1_000_000 },
+    defender: { rect: GIANT_WEST, troops: 1_000_000 },
+    attackTroops: 1_000_000,
+  },
+  "giant 1M vs 600k tiles, 8M vs 8M troops, attack 2M": {
+    map: "giantworldmap",
+    attacker: { rect: GIANT_WEST, troops: 8_000_000 },
+    defender: { rect: GIANT_EAST, troops: 8_000_000 },
+    attackTroops: 2_000_000,
+  },
+  "giant 1M vs 600k tiles, 8M troops all-in vs 1M defender": {
+    map: "giantworldmap",
+    attacker: { rect: GIANT_WEST, troops: 8_000_000 },
+    defender: { rect: GIANT_EAST, troops: 1_000_000 },
+    attackTroops: 8_000_000,
+  },
+  "giant 600k vs 1M tiles, 1M troops attack 500k vs 8M defender": {
+    map: "giantworldmap",
+    attacker: { rect: GIANT_EAST, troops: 1_000_000 },
+    defender: { rect: GIANT_WEST, troops: 8_000_000 },
+    attackTroops: 500_000,
   },
 };
 

--- a/tests/__snapshots__/AttackLogicGolden.test.ts.snap
+++ b/tests/__snapshots__/AttackLogicGolden.test.ts.snap
@@ -45,6 +45,1236 @@ exports[`attackLogic golden values > attackTilesPerTick 1`] = `
 }
 `;
 
+exports[`attackLogic golden values > extremes: terra nullius 1`] = `
+{
+  "aTiles=100 attack=1": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "aTiles=100 attack=10000000": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+  "aTiles=5000000 attack=1": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 100,
+  },
+  "aTiles=5000000 attack=10000000": {
+    "attackerLoss": 16,
+    "defenderLoss": 0,
+    "tileCost": 5,
+  },
+}
+`;
+
+exports[`attackLogic golden values > extremes: territory and troop counts 1`] = `
+{
+  "Mountain aTiles=100 dTiles=100 dTroops=0 attack=1": {
+    "attackerLoss": 33.4066,
+    "defenderLoss": 0,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=0 attack=1000": {
+    "attackerLoss": 33.4066,
+    "defenderLoss": 0,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=0 attack=1000000": {
+    "attackerLoss": 33.4066,
+    "defenderLoss": 0,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=0 attack=10000000": {
+    "attackerLoss": 33.4066,
+    "defenderLoss": 0,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1 attack=1": {
+    "attackerLoss": 55.6839,
+    "defenderLoss": 0.01,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1 attack=1000": {
+    "attackerLoss": 33.4128,
+    "defenderLoss": 0.01,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1 attack=1000000": {
+    "attackerLoss": 33.4128,
+    "defenderLoss": 0.01,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1 attack=10000000": {
+    "attackerLoss": 33.4128,
+    "defenderLoss": 0.01,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000 attack=1": {
+    "attackerLoss": 117.595,
+    "defenderLoss": 10,
+    "tileCost": 36.2485,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000 attack=1000": {
+    "attackerLoss": 61.9176,
+    "defenderLoss": 10,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000 attack=1000000": {
+    "attackerLoss": 39.6466,
+    "defenderLoss": 10,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000 attack=10000000": {
+    "attackerLoss": 39.6466,
+    "defenderLoss": 10,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000000 attack=1": {
+    "attackerLoss": 6351.36,
+    "defenderLoss": 10000,
+    "tileCost": 36.2485,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000000 attack=1000": {
+    "attackerLoss": 6351.36,
+    "defenderLoss": 10000,
+    "tileCost": 36.2485,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 6295.68,
+    "defenderLoss": 10000,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 6273.41,
+    "defenderLoss": 10000,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=10000000 attack=1": {
+    "attackerLoss": 62511.4,
+    "defenderLoss": 100000,
+    "tileCost": 36.2485,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=10000000 attack=1000": {
+    "attackerLoss": 62511.4,
+    "defenderLoss": 100000,
+    "tileCost": 36.2485,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 62511.4,
+    "defenderLoss": 100000,
+    "tileCost": 36.2485,
+  },
+  "Mountain aTiles=100 dTiles=100 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 62455.7,
+    "defenderLoss": 100000,
+    "tileCost": 4.83313,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=0 attack=1": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=0 attack=1000": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=0 attack=1000000": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=0 attack=10000000": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1 attack=1": {
+    "attackerLoss": 40.3201,
+    "defenderLoss": 0.000001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1 attack=1000": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0.000001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1 attack=1000000": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0.000001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1 attack=10000000": {
+    "attackerLoss": 24.1921,
+    "defenderLoss": 0.000001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000 attack=1": {
+    "attackerLoss": 80.6409,
+    "defenderLoss": 0.001,
+    "tileCost": 26.2501,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000 attack=1000": {
+    "attackerLoss": 40.3208,
+    "defenderLoss": 0.001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000 attack=1000000": {
+    "attackerLoss": 24.1927,
+    "defenderLoss": 0.001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000 attack=10000000": {
+    "attackerLoss": 24.1927,
+    "defenderLoss": 0.001,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000000 attack=1": {
+    "attackerLoss": 81.2643,
+    "defenderLoss": 1,
+    "tileCost": 26.2501,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000000 attack=1000": {
+    "attackerLoss": 81.2643,
+    "defenderLoss": 1,
+    "tileCost": 26.2501,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 40.9441,
+    "defenderLoss": 1,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 24.8161,
+    "defenderLoss": 1,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=10000000 attack=1": {
+    "attackerLoss": 86.8803,
+    "defenderLoss": 10,
+    "tileCost": 26.2501,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=10000000 attack=1000": {
+    "attackerLoss": 86.8803,
+    "defenderLoss": 10,
+    "tileCost": 26.2501,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 86.8803,
+    "defenderLoss": 10,
+    "tileCost": 26.2501,
+  },
+  "Mountain aTiles=100 dTiles=1000000 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 46.5601,
+    "defenderLoss": 10,
+    "tileCost": 3.50001,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=0 attack=1": {
+    "attackerLoss": 14.9222,
+    "defenderLoss": 0,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=0 attack=1000": {
+    "attackerLoss": 14.9222,
+    "defenderLoss": 0,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=0 attack=1000000": {
+    "attackerLoss": 14.9222,
+    "defenderLoss": 0,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=0 attack=10000000": {
+    "attackerLoss": 14.9222,
+    "defenderLoss": 0,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1 attack=1": {
+    "attackerLoss": 24.8765,
+    "defenderLoss": 0.01,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1 attack=1000": {
+    "attackerLoss": 14.9284,
+    "defenderLoss": 0.01,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1 attack=1000000": {
+    "attackerLoss": 14.9284,
+    "defenderLoss": 0.01,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1 attack=10000000": {
+    "attackerLoss": 14.9284,
+    "defenderLoss": 0.01,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000 attack=1": {
+    "attackerLoss": 55.9806,
+    "defenderLoss": 10,
+    "tileCost": 9.1052,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000 attack=1000": {
+    "attackerLoss": 31.1103,
+    "defenderLoss": 10,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000 attack=1000000": {
+    "attackerLoss": 21.1622,
+    "defenderLoss": 10,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000 attack=10000000": {
+    "attackerLoss": 21.1622,
+    "defenderLoss": 10,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000000 attack=1": {
+    "attackerLoss": 6289.74,
+    "defenderLoss": 10000,
+    "tileCost": 9.1052,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000000 attack=1000": {
+    "attackerLoss": 6289.74,
+    "defenderLoss": 10000,
+    "tileCost": 9.1052,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 6264.87,
+    "defenderLoss": 10000,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 6254.92,
+    "defenderLoss": 10000,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=10000000 attack=1": {
+    "attackerLoss": 62449.7,
+    "defenderLoss": 100000,
+    "tileCost": 9.1052,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=10000000 attack=1000": {
+    "attackerLoss": 62449.7,
+    "defenderLoss": 100000,
+    "tileCost": 9.1052,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 62449.7,
+    "defenderLoss": 100000,
+    "tileCost": 9.1052,
+  },
+  "Mountain aTiles=1000000 dTiles=100 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 62424.9,
+    "defenderLoss": 100000,
+    "tileCost": 1.21403,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=0 attack=1": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=0 attack=1000": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=0 attack=1000000": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=0 attack=10000000": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1 attack=1": {
+    "attackerLoss": 18.0103,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1 attack=1000": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1 attack=1000000": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1 attack=10000000": {
+    "attackerLoss": 10.8062,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000 attack=1": {
+    "attackerLoss": 36.0213,
+    "defenderLoss": 0.001,
+    "tileCost": 6.59372,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000 attack=1000": {
+    "attackerLoss": 18.011,
+    "defenderLoss": 0.001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000 attack=1000000": {
+    "attackerLoss": 10.8068,
+    "defenderLoss": 0.001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000 attack=10000000": {
+    "attackerLoss": 10.8068,
+    "defenderLoss": 0.001,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=1": {
+    "attackerLoss": 36.6447,
+    "defenderLoss": 1,
+    "tileCost": 6.59372,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=1000": {
+    "attackerLoss": 36.6447,
+    "defenderLoss": 1,
+    "tileCost": 6.59372,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 18.6343,
+    "defenderLoss": 1,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 11.4302,
+    "defenderLoss": 1,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=1": {
+    "attackerLoss": 42.2607,
+    "defenderLoss": 10,
+    "tileCost": 6.59372,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=1000": {
+    "attackerLoss": 42.2607,
+    "defenderLoss": 10,
+    "tileCost": 6.59372,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 42.2607,
+    "defenderLoss": 10,
+    "tileCost": 6.59372,
+  },
+  "Mountain aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 24.2503,
+    "defenderLoss": 10,
+    "tileCost": 0.879163,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=0 attack=1": {
+    "attackerLoss": 8.49557,
+    "defenderLoss": 0,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=0 attack=1000": {
+    "attackerLoss": 8.49557,
+    "defenderLoss": 0,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=0 attack=1000000": {
+    "attackerLoss": 8.49557,
+    "defenderLoss": 0,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=0 attack=10000000": {
+    "attackerLoss": 8.49557,
+    "defenderLoss": 0,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1 attack=1": {
+    "attackerLoss": 14.1655,
+    "defenderLoss": 0.01,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1 attack=1000": {
+    "attackerLoss": 8.50181,
+    "defenderLoss": 0.01,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1 attack=1000000": {
+    "attackerLoss": 8.50181,
+    "defenderLoss": 0.01,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1 attack=10000000": {
+    "attackerLoss": 8.50181,
+    "defenderLoss": 0.01,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000 attack=1": {
+    "attackerLoss": 34.5586,
+    "defenderLoss": 10,
+    "tileCost": 3.46663,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000 attack=1000": {
+    "attackerLoss": 20.3993,
+    "defenderLoss": 10,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000 attack=1000000": {
+    "attackerLoss": 14.7356,
+    "defenderLoss": 10,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000 attack=10000000": {
+    "attackerLoss": 14.7356,
+    "defenderLoss": 10,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000000 attack=1": {
+    "attackerLoss": 6268.32,
+    "defenderLoss": 10000,
+    "tileCost": 3.46663,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000000 attack=1000": {
+    "attackerLoss": 6268.32,
+    "defenderLoss": 10000,
+    "tileCost": 3.46663,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 6254.16,
+    "defenderLoss": 10000,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 6248.5,
+    "defenderLoss": 10000,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=10000000 attack=1": {
+    "attackerLoss": 62428.3,
+    "defenderLoss": 100000,
+    "tileCost": 3.46663,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=10000000 attack=1000": {
+    "attackerLoss": 62428.3,
+    "defenderLoss": 100000,
+    "tileCost": 3.46663,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 62428.3,
+    "defenderLoss": 100000,
+    "tileCost": 3.46663,
+  },
+  "Mountain aTiles=5000000 dTiles=100 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 62414.2,
+    "defenderLoss": 100000,
+    "tileCost": 0.462217,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=0 attack=1": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=0 attack=1000": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=0 attack=1000000": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=0 attack=10000000": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1 attack=1": {
+    "attackerLoss": 10.2537,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1 attack=1000": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1 attack=1000000": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1 attack=10000000": {
+    "attackerLoss": 6.15225,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000 attack=1": {
+    "attackerLoss": 20.5081,
+    "defenderLoss": 0.001,
+    "tileCost": 2.51043,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000 attack=1000": {
+    "attackerLoss": 10.2544,
+    "defenderLoss": 0.001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000 attack=1000000": {
+    "attackerLoss": 6.15287,
+    "defenderLoss": 0.001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000 attack=10000000": {
+    "attackerLoss": 6.15287,
+    "defenderLoss": 0.001,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=1": {
+    "attackerLoss": 21.1315,
+    "defenderLoss": 1,
+    "tileCost": 2.51043,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=1000": {
+    "attackerLoss": 21.1315,
+    "defenderLoss": 1,
+    "tileCost": 2.51043,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 10.8777,
+    "defenderLoss": 1,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 6.77625,
+    "defenderLoss": 1,
+    "tileCost": 0.334724,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=1": {
+    "attackerLoss": 26.7475,
+    "defenderLoss": 10,
+    "tileCost": 2.51043,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=1000": {
+    "attackerLoss": 26.7475,
+    "defenderLoss": 10,
+    "tileCost": 2.51043,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 26.7475,
+    "defenderLoss": 10,
+    "tileCost": 2.51043,
+  },
+  "Mountain aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 16.4937,
+    "defenderLoss": 10,
+    "tileCost": 0.334724,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=0 attack=1": {
+    "attackerLoss": 22.2711,
+    "defenderLoss": 0,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=0 attack=1000": {
+    "attackerLoss": 22.2711,
+    "defenderLoss": 0,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=0 attack=1000000": {
+    "attackerLoss": 22.2711,
+    "defenderLoss": 0,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=0 attack=10000000": {
+    "attackerLoss": 22.2711,
+    "defenderLoss": 0,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1 attack=1": {
+    "attackerLoss": 37.1226,
+    "defenderLoss": 0.01,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1 attack=1000": {
+    "attackerLoss": 22.2752,
+    "defenderLoss": 0.01,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1 attack=1000000": {
+    "attackerLoss": 22.2752,
+    "defenderLoss": 0.01,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1 attack=10000000": {
+    "attackerLoss": 22.2752,
+    "defenderLoss": 0.01,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000 attack=1": {
+    "attackerLoss": 78.3968,
+    "defenderLoss": 10,
+    "tileCost": 23.924,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000 attack=1000": {
+    "attackerLoss": 41.2784,
+    "defenderLoss": 10,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000 attack=1000000": {
+    "attackerLoss": 26.4311,
+    "defenderLoss": 10,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000 attack=10000000": {
+    "attackerLoss": 26.4311,
+    "defenderLoss": 10,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000000 attack=1": {
+    "attackerLoss": 4234.24,
+    "defenderLoss": 10000,
+    "tileCost": 23.924,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000000 attack=1000": {
+    "attackerLoss": 4234.24,
+    "defenderLoss": 10000,
+    "tileCost": 23.924,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 4197.12,
+    "defenderLoss": 10000,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 4182.27,
+    "defenderLoss": 10000,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=10000000 attack=1": {
+    "attackerLoss": 41674.2,
+    "defenderLoss": 100000,
+    "tileCost": 23.924,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=10000000 attack=1000": {
+    "attackerLoss": 41674.2,
+    "defenderLoss": 100000,
+    "tileCost": 23.924,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 41674.2,
+    "defenderLoss": 100000,
+    "tileCost": 23.924,
+  },
+  "Plains aTiles=100 dTiles=100 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 41637.1,
+    "defenderLoss": 100000,
+    "tileCost": 3.18986,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=0 attack=1": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=0 attack=1000": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=0 attack=1000000": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=0 attack=10000000": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1 attack=1": {
+    "attackerLoss": 26.8801,
+    "defenderLoss": 0.000001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1 attack=1000": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0.000001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1 attack=1000000": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0.000001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1 attack=10000000": {
+    "attackerLoss": 16.1281,
+    "defenderLoss": 0.000001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000 attack=1": {
+    "attackerLoss": 53.7606,
+    "defenderLoss": 0.001,
+    "tileCost": 17.3251,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000 attack=1000": {
+    "attackerLoss": 26.8805,
+    "defenderLoss": 0.001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000 attack=1000000": {
+    "attackerLoss": 16.1285,
+    "defenderLoss": 0.001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000 attack=10000000": {
+    "attackerLoss": 16.1285,
+    "defenderLoss": 0.001,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000000 attack=1": {
+    "attackerLoss": 54.1762,
+    "defenderLoss": 1,
+    "tileCost": 17.3251,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000000 attack=1000": {
+    "attackerLoss": 54.1762,
+    "defenderLoss": 1,
+    "tileCost": 17.3251,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 27.2961,
+    "defenderLoss": 1,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 16.5441,
+    "defenderLoss": 1,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=10000000 attack=1": {
+    "attackerLoss": 57.9202,
+    "defenderLoss": 10,
+    "tileCost": 17.3251,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=10000000 attack=1000": {
+    "attackerLoss": 57.9202,
+    "defenderLoss": 10,
+    "tileCost": 17.3251,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 57.9202,
+    "defenderLoss": 10,
+    "tileCost": 17.3251,
+  },
+  "Plains aTiles=100 dTiles=1000000 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 31.0401,
+    "defenderLoss": 10,
+    "tileCost": 2.31001,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=0 attack=1": {
+    "attackerLoss": 9.94811,
+    "defenderLoss": 0,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=0 attack=1000": {
+    "attackerLoss": 9.94811,
+    "defenderLoss": 0,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=0 attack=1000000": {
+    "attackerLoss": 9.94811,
+    "defenderLoss": 0,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=0 attack=10000000": {
+    "attackerLoss": 9.94811,
+    "defenderLoss": 0,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1 attack=1": {
+    "attackerLoss": 16.5844,
+    "defenderLoss": 0.01,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1 attack=1000": {
+    "attackerLoss": 9.95227,
+    "defenderLoss": 0.01,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1 attack=1000000": {
+    "attackerLoss": 9.95227,
+    "defenderLoss": 0.01,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1 attack=10000000": {
+    "attackerLoss": 9.95227,
+    "defenderLoss": 0.01,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000 attack=1": {
+    "attackerLoss": 37.3204,
+    "defenderLoss": 10,
+    "tileCost": 6.00943,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000 attack=1000": {
+    "attackerLoss": 20.7402,
+    "defenderLoss": 10,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000 attack=1000000": {
+    "attackerLoss": 14.1081,
+    "defenderLoss": 10,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000 attack=10000000": {
+    "attackerLoss": 14.1081,
+    "defenderLoss": 10,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000000 attack=1": {
+    "attackerLoss": 4193.16,
+    "defenderLoss": 10000,
+    "tileCost": 6.00943,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000000 attack=1000": {
+    "attackerLoss": 4193.16,
+    "defenderLoss": 10000,
+    "tileCost": 6.00943,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 4176.58,
+    "defenderLoss": 10000,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 4169.95,
+    "defenderLoss": 10000,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=10000000 attack=1": {
+    "attackerLoss": 41633.2,
+    "defenderLoss": 100000,
+    "tileCost": 6.00943,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=10000000 attack=1000": {
+    "attackerLoss": 41633.2,
+    "defenderLoss": 100000,
+    "tileCost": 6.00943,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 41633.2,
+    "defenderLoss": 100000,
+    "tileCost": 6.00943,
+  },
+  "Plains aTiles=1000000 dTiles=100 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 41616.6,
+    "defenderLoss": 100000,
+    "tileCost": 0.801258,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=0 attack=1": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=0 attack=1000": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=0 attack=1000000": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=0 attack=10000000": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1 attack=1": {
+    "attackerLoss": 12.0069,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1 attack=1000": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1 attack=1000000": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1 attack=10000000": {
+    "attackerLoss": 7.20414,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000 attack=1": {
+    "attackerLoss": 24.0142,
+    "defenderLoss": 0.001,
+    "tileCost": 4.35186,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000 attack=1000": {
+    "attackerLoss": 12.0073,
+    "defenderLoss": 0.001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000 attack=1000000": {
+    "attackerLoss": 7.20455,
+    "defenderLoss": 0.001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000 attack=10000000": {
+    "attackerLoss": 7.20455,
+    "defenderLoss": 0.001,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=1": {
+    "attackerLoss": 24.4298,
+    "defenderLoss": 1,
+    "tileCost": 4.35186,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=1000": {
+    "attackerLoss": 24.4298,
+    "defenderLoss": 1,
+    "tileCost": 4.35186,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 12.4229,
+    "defenderLoss": 1,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 7.62014,
+    "defenderLoss": 1,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=1": {
+    "attackerLoss": 28.1738,
+    "defenderLoss": 10,
+    "tileCost": 4.35186,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=1000": {
+    "attackerLoss": 28.1738,
+    "defenderLoss": 10,
+    "tileCost": 4.35186,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 28.1738,
+    "defenderLoss": 10,
+    "tileCost": 4.35186,
+  },
+  "Plains aTiles=1000000 dTiles=1000000 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 16.1669,
+    "defenderLoss": 10,
+    "tileCost": 0.580248,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=0 attack=1": {
+    "attackerLoss": 5.66371,
+    "defenderLoss": 0,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=0 attack=1000": {
+    "attackerLoss": 5.66371,
+    "defenderLoss": 0,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=0 attack=1000000": {
+    "attackerLoss": 5.66371,
+    "defenderLoss": 0,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=0 attack=10000000": {
+    "attackerLoss": 5.66371,
+    "defenderLoss": 0,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1 attack=1": {
+    "attackerLoss": 9.44368,
+    "defenderLoss": 0.01,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1 attack=1000": {
+    "attackerLoss": 5.66787,
+    "defenderLoss": 0.01,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1 attack=1000000": {
+    "attackerLoss": 5.66787,
+    "defenderLoss": 0.01,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1 attack=10000000": {
+    "attackerLoss": 5.66787,
+    "defenderLoss": 0.01,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000 attack=1": {
+    "attackerLoss": 23.039,
+    "defenderLoss": 10,
+    "tileCost": 2.28798,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000 attack=1000": {
+    "attackerLoss": 13.5995,
+    "defenderLoss": 10,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000 attack=1000000": {
+    "attackerLoss": 9.82371,
+    "defenderLoss": 10,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000 attack=10000000": {
+    "attackerLoss": 9.82371,
+    "defenderLoss": 10,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000000 attack=1": {
+    "attackerLoss": 4178.88,
+    "defenderLoss": 10000,
+    "tileCost": 2.28798,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000000 attack=1000": {
+    "attackerLoss": 4178.88,
+    "defenderLoss": 10000,
+    "tileCost": 2.28798,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 4169.44,
+    "defenderLoss": 10000,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 4165.66,
+    "defenderLoss": 10000,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=10000000 attack=1": {
+    "attackerLoss": 41618.9,
+    "defenderLoss": 100000,
+    "tileCost": 2.28798,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=10000000 attack=1000": {
+    "attackerLoss": 41618.9,
+    "defenderLoss": 100000,
+    "tileCost": 2.28798,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 41618.9,
+    "defenderLoss": 100000,
+    "tileCost": 2.28798,
+  },
+  "Plains aTiles=5000000 dTiles=100 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 41609.4,
+    "defenderLoss": 100000,
+    "tileCost": 0.305063,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=0 attack=1": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=0 attack=1000": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=0 attack=1000000": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=0 attack=10000000": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1 attack=1": {
+    "attackerLoss": 6.83583,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1 attack=1000": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1 attack=1000000": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1 attack=10000000": {
+    "attackerLoss": 4.1015,
+    "defenderLoss": 0.000001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000 attack=1": {
+    "attackerLoss": 13.6721,
+    "defenderLoss": 0.001,
+    "tileCost": 1.65689,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000 attack=1000": {
+    "attackerLoss": 6.83624,
+    "defenderLoss": 0.001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000 attack=1000000": {
+    "attackerLoss": 4.10191,
+    "defenderLoss": 0.001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000 attack=10000000": {
+    "attackerLoss": 4.10191,
+    "defenderLoss": 0.001,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=1": {
+    "attackerLoss": 14.0877,
+    "defenderLoss": 1,
+    "tileCost": 1.65689,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=1000": {
+    "attackerLoss": 14.0877,
+    "defenderLoss": 1,
+    "tileCost": 1.65689,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=1000000": {
+    "attackerLoss": 7.25183,
+    "defenderLoss": 1,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=1000000 attack=10000000": {
+    "attackerLoss": 4.5175,
+    "defenderLoss": 1,
+    "tileCost": 0.220918,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=1": {
+    "attackerLoss": 17.8317,
+    "defenderLoss": 10,
+    "tileCost": 1.65689,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=1000": {
+    "attackerLoss": 17.8317,
+    "defenderLoss": 10,
+    "tileCost": 1.65689,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=1000000": {
+    "attackerLoss": 17.8317,
+    "defenderLoss": 10,
+    "tileCost": 1.65689,
+  },
+  "Plains aTiles=5000000 dTiles=1000000 dTroops=10000000 attack=10000000": {
+    "attackerLoss": 10.9958,
+    "defenderLoss": 10,
+    "tileCost": 0.220918,
+  },
+}
+`;
+
 exports[`attackLogic golden values > player vs player: large-territory curves 1`] = `
 {
   "attackerTiles=1000": {

--- a/tests/__snapshots__/AttackScenarios.test.ts.snap
+++ b/tests/__snapshots__/AttackScenarios.test.ts.snap
@@ -36,6 +36,258 @@ exports[`attack scenarios > big_plains equal 20k tiles each, 200k vs 200k, attac
 }
 `;
 
+exports[`attack scenarios > giant 1M vs 600k tiles, 8M troops all-in vs 1M defender 1`] = `
+{
+  "attackerLossPerSecond": 130400,
+  "attackerLossPerTile": 10.14,
+  "attackerTiles": 1010406,
+  "attackerTroopsLost": 4680374,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 20600,
+  "defenderLossPerTile": 1.603,
+  "defenderTiles": 591663,
+  "defenderTroopsLost": 739638,
+  "finished": true,
+  "ticks": 359,
+  "tilesConquered": 461482,
+  "tilesPerSecond": 12850,
+}
+`;
+
+exports[`attack scenarios > giant 1M vs 600k tiles, 8M vs 8M troops, attack 2M 1`] = `
+{
+  "attackerLossPerSecond": 80320,
+  "attackerLossPerTile": 34.8,
+  "attackerTiles": 1010406,
+  "attackerTroopsLost": 2000000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 30010,
+  "defenderLossPerTile": 13,
+  "defenderTiles": 591663,
+  "defenderTroopsLost": 747214,
+  "finished": true,
+  "ticks": 249,
+  "tilesConquered": 57478,
+  "tilesPerSecond": 2308,
+}
+`;
+
+exports[`attack scenarios > giant 1M-tile attacker, 8M troops, attack 2M vs 400-tile turtle with 4M (10k/tile) 1`] = `
+{
+  "attackerLossPerSecond": 1783000,
+  "attackerLossPerTile": 3216,
+  "attackerTiles": 1010018,
+  "attackerTroopsLost": 1247957,
+  "defenderEliminated": true,
+  "defenderLossPerSecond": 4256000,
+  "defenderLossPerTile": 7679,
+  "defenderTiles": 388,
+  "defenderTroopsLost": 2979310,
+  "finished": true,
+  "ticks": 7,
+  "tilesConquered": 388,
+  "tilesPerSecond": 554.3,
+}
+`;
+
+exports[`attack scenarios > giant 1M-tile attacker, 8M troops, attack 2M vs 400-tile turtle with 400k (1k/tile) 1`] = `
+{
+  "attackerLossPerSecond": 317000,
+  "attackerLossPerTile": 326.8,
+  "attackerTiles": 1010018,
+  "attackerTroopsLost": 126816,
+  "defenderEliminated": true,
+  "defenderLossPerSecond": 744800,
+  "defenderLossPerTile": 767.9,
+  "defenderTiles": 388,
+  "defenderTroopsLost": 297931,
+  "finished": true,
+  "ticks": 4,
+  "tilesConquered": 388,
+  "tilesPerSecond": 970,
+}
+`;
+
+exports[`attack scenarios > giant 400-tile attacker, 1M troops all-in vs 1M-tile defender with 1M 1`] = `
+{
+  "attackerLossPerSecond": 18280,
+  "attackerLossPerTile": 43.57,
+  "attackerTiles": 388,
+  "attackerTroopsLost": 1000000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 236.5,
+  "defenderLossPerTile": 0.5635,
+  "defenderTiles": 1010018,
+  "defenderTroopsLost": 12935,
+  "finished": true,
+  "ticks": 547,
+  "tilesConquered": 22953,
+  "tilesPerSecond": 419.6,
+}
+`;
+
+exports[`attack scenarios > giant 400-tile attacker, 100k troops, attack 50k vs 1M-tile sparse defender with 1M 1`] = `
+{
+  "attackerLossPerSecond": 1408,
+  "attackerLossPerTile": 54.17,
+  "attackerTiles": 388,
+  "attackerTroopsLost": 50000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 1010018,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 355,
+  "tilesConquered": 923,
+  "tilesPerSecond": 26,
+}
+`;
+
+exports[`attack scenarios > giant 600k vs 1M tiles, 1M troops attack 500k vs 8M defender 1`] = `
+{
+  "attackerLossPerSecond": 16340,
+  "attackerLossPerTile": 40.93,
+  "attackerTiles": 591663,
+  "attackerTroopsLost": 500000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 2795,
+  "defenderLossPerTile": 7,
+  "defenderTiles": 1010406,
+  "defenderTroopsLost": 85519,
+  "finished": true,
+  "ticks": 306,
+  "tilesConquered": 12217,
+  "tilesPerSecond": 399.2,
+}
+`;
+
+exports[`attack scenarios > plains 1-troop attack vs 50k defender 1`] = `
+{
+  "attackerLossPerSecond": 3.333,
+  "attackerLossPerTile": 1,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 1,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 33.33,
+  "defenderLossPerTile": 10,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 10,
+  "finished": true,
+  "ticks": 3,
+  "tilesConquered": 1,
+  "tilesPerSecond": 3.333,
+}
+`;
+
+exports[`attack scenarios > plains 10M-troop attack vs defender with 1 troop 1`] = `
+{
+  "attackerLossPerSecond": 10900,
+  "attackerLossPerTile": 21.81,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 109037,
+  "defenderEliminated": true,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 100,
+  "tilesConquered": 5000,
+  "tilesPerSecond": 500,
+}
+`;
+
+exports[`attack scenarios > plains 50k attack vs defender with 0 troops 1`] = `
+{
+  "attackerLossPerSecond": 10640,
+  "attackerLossPerTile": 22.23,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 50000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 0,
+  "defenderLossPerTile": 0,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 0,
+  "finished": true,
+  "ticks": 47,
+  "tilesConquered": 2249,
+  "tilesPerSecond": 478.5,
+}
+`;
+
+exports[`attack scenarios > plains 100-tile turtle, 1M troops: conquered outright after one tile 1`] = `
+{
+  "attackerLossPerSecond": 21180,
+  "attackerLossPerTile": 42.35,
+  "attackerTiles": 9900,
+  "attackerTroopsLost": 4235,
+  "defenderEliminated": true,
+  "defenderLossPerSecond": 50000,
+  "defenderLossPerTile": 100,
+  "defenderTiles": 100,
+  "defenderTroopsLost": 10000,
+  "finished": true,
+  "ticks": 2,
+  "tilesConquered": 100,
+  "tilesPerSecond": 500,
+}
+`;
+
+exports[`attack scenarios > plains 100-troop attack vs 1M defender 1`] = `
+{
+  "attackerLossPerSecond": 333.3,
+  "attackerLossPerTile": 100,
+  "attackerTiles": 5000,
+  "attackerTroopsLost": 100,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 666.7,
+  "defenderLossPerTile": 200,
+  "defenderTiles": 5000,
+  "defenderTroopsLost": 200,
+  "finished": true,
+  "ticks": 3,
+  "tilesConquered": 1,
+  "tilesPerSecond": 3.333,
+}
+`;
+
+exports[`attack scenarios > plains 400-tile turtle, 4M troops (10k/tile) under a defense post, attacked with 1M 1`] = `
+{
+  "attackerLossPerSecond": 384600,
+  "attackerLossPerTile": 20830,
+  "attackerTiles": 9600,
+  "attackerTroopsLost": 1000000,
+  "defenderEliminated": false,
+  "defenderLossPerSecond": 184600,
+  "defenderLossPerTile": 10000,
+  "defenderTiles": 400,
+  "defenderTroopsLost": 480000,
+  "finished": true,
+  "ticks": 26,
+  "tilesConquered": 48,
+  "tilesPerSecond": 18.46,
+}
+`;
+
+exports[`attack scenarios > plains 400-tile turtle, 400k troops (1k/tile), attacked with 400k 1`] = `
+{
+  "attackerLossPerSecond": 111400,
+  "attackerLossPerTile": 334.3,
+  "attackerTiles": 9600,
+  "attackerTroopsLost": 133705,
+  "defenderEliminated": true,
+  "defenderLossPerSecond": 250800,
+  "defenderLossPerTile": 752.5,
+  "defenderTiles": 400,
+  "defenderTroopsLost": 301000,
+  "finished": true,
+  "ticks": 12,
+  "tilesConquered": 400,
+  "tilesPerSecond": 333.3,
+}
+`;
+
 exports[`attack scenarios > plains big attacker (9500 tiles) vs small defender (500 tiles) 1`] = `
 {
   "attackerLossPerSecond": 5882,


### PR DESCRIPTION
## Summary
- **Golden grid** (`tests/AttackLogicGolden.test.ts`, +240 rows): 100 / 1M / 5M-tile attackers × 100 / 1M-tile defenders × 0..10M defender troops × 1..10M attack troops on Plains and Mountain, plus terra nullius at the same extremes. No NaN/Infinity anywhere in the formula's output.
- **Scenarios** (`tests/AttackScenarios.test.ts`, +14): 1-troop and 10M-troop attacks, a 0-troop defender, 400-tile turtles at 1k and 10k troops/tile (one under a defense post), and real ~1M-tile / ~600k-tile players on `giantworldmap` attacking in both directions, including a 400-tile player inside a 1M-tile one.
- One 100-tile scenario documents that players under 100 tiles are conquered outright after losing a single tile (`AttackExecution.handleDeadDefender`) — a game rule, not the formula — so the turtle scenarios use 400 tiles to actually exercise `attackLogic`.
- Harness fix: conquer the larger rect first so a small territory can sit inside a big one (previously the later, bigger rect swallowed the smaller player), and report actual tile ownership rather than the rect count.
- Existing snapshot entries are unchanged; only new entries were added. Whole scenario file still runs in ~10s.

## Test plan
- `npx vitest tests/AttackLogicGolden.test.ts tests/AttackScenarios.test.ts --run` — 47 passed, re-run without `-u` confirms the new snapshots are deterministic
- `tsc --noEmit`, eslint, prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)