### PR TITLE
Add per-layer alpha slider with manifest defaults 🎨

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -771,6 +771,7 @@
     "import_json_desc": "Paste settings JSON from a friend and apply it",
     "import_json_invalid": "That doesn't look like valid settings JSON",
     "import_json_label": "Import settings JSON",
+    "layer_alpha_label": "Opacity",
     "layer_nukeable": "Nukeable",
     "layer_placement_land": "Land layer",
     "layer_placement_water": "Water layer",

--- a/src/client/controllers/MapLayerController.ts
+++ b/src/client/controllers/MapLayerController.ts
@@ -34,6 +34,7 @@ export class MapLayerController implements Controller {
       // Images already loaded (e.g. from cache) — set up immediately.
       this.view.setMapLayers(this.gameMap.layers, this.gameMap.layerImages);
       this.applyVisibility();
+      this.applyAlpha();
     } else {
       // Layer images loaded off the critical path. Start fetching now;
       // the renderer tolerates missing layers (warn + skip) until they
@@ -48,6 +49,7 @@ export class MapLayerController implements Controller {
           if (!this.abortSignal.aborted) {
             this.view.setMapLayers(this.gameMap.layers!, images);
             this.applyVisibility();
+            this.applyAlpha();
           }
         })
         .catch((e) =>
@@ -63,6 +65,20 @@ export class MapLayerController implements Controller {
       const vis = overrides.mapLayerVisibility[layer.id];
       if (vis !== undefined) {
         this.view.setLayerVisible(layer.id, vis);
+      }
+    }
+  }
+
+  private applyAlpha() {
+    const overrides = this.userSettings.graphicsOverrides();
+    if (!this.gameMap.layers) return;
+    for (const layer of this.gameMap.layers) {
+      const alpha = overrides.mapLayerAlpha?.[layer.id];
+      if (alpha !== undefined) {
+        this.view.setLayerAlpha(layer.id, alpha);
+      } else if (layer.alpha !== undefined) {
+        // Apply manifest default when no user override exists.
+        this.view.setLayerAlpha(layer.id, layer.alpha);
       }
     }
   }

--- a/src/client/hud/GameRenderer.ts
+++ b/src/client/hud/GameRenderer.ts
@@ -203,6 +203,9 @@ export function createRenderer(
   graphicsSettingsModal.onLayerVisibilityChange = (layerId, visible) => {
     view.setLayerVisible(layerId, visible);
   };
+  graphicsSettingsModal.onLayerAlphaChange = (layerId, alpha) => {
+    view.setLayerAlpha(layerId, alpha);
+  };
 
   const unitDisplay = document.querySelector("unit-display") as UnitDisplay;
   if (!(unitDisplay instanceof UnitDisplay)) {

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -161,6 +161,9 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
   public onLayerVisibilityChange:
     | ((layerId: string, visible: boolean) => void)
     | null = null;
+  /** Callback to set layer alpha on the renderer. */
+  public onLayerAlphaChange: ((layerId: string, alpha: number) => void) | null =
+    null;
 
   @state()
   private isVisible: boolean = false;
@@ -372,6 +375,41 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
   private syncLayerVisibility() {
     for (const layer of this.mapLayers) {
       this.onLayerVisibilityChange?.(layer.id, this.isLayerVisible(layer.id));
+    }
+    this.syncLayerAlpha();
+  }
+
+  // ---- Map-layer alpha ----
+
+  private getLayerAlpha(layerId: string, manifestDefault?: number): number {
+    const overrides = this.userSettings.graphicsOverrides();
+    const alpha = overrides.mapLayerAlpha?.[layerId];
+    if (alpha !== undefined) return alpha;
+    return manifestDefault ?? 1;
+  }
+
+  private onLayerAlphaSliderChange(layerId: string, event: Event) {
+    const alpha = parseFloat((event.target as HTMLInputElement).value);
+    const current = this.userSettings.graphicsOverrides();
+    const currentAlpha = current.mapLayerAlpha ?? {};
+    this.userSettings.setGraphicsOverrides({
+      ...current,
+      mapLayerAlpha: { ...currentAlpha, [layerId]: alpha },
+    });
+    this.onLayerAlphaChange?.(layerId, alpha);
+    this.requestUpdate();
+  }
+
+  /**
+   * Re-apply layer alpha from current overrides to the renderer.
+   * Called after reset or preset import so the WebGL passes stay in sync.
+   */
+  private syncLayerAlpha() {
+    for (const layer of this.mapLayers) {
+      this.onLayerAlphaChange?.(
+        layer.id,
+        this.getLayerAlpha(layer.id, layer.alpha),
+      );
     }
   }
 
@@ -1509,29 +1547,66 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
             </div>
             ${this.mapLayers.map(
               (layer) => html`
-                <button
-                  class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
-                  @click=${() => this.onToggleLayer(layer.id)}
-                >
-                  <div class="flex-1">
-                    <div class="font-medium">${this.layerName(layer.id)}</div>
-                    <div class="text-sm text-slate-400">
-                      ${layer.placement === "land"
-                        ? translateText("graphics_setting.layer_placement_land")
-                        : translateText(
-                            "graphics_setting.layer_placement_water",
-                          )}
-                      ${layer.nukeable
-                        ? ` · ${translateText("graphics_setting.layer_nukeable")}`
-                        : ""}
+                <div>
+                  <button
+                    class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
+                    @click=${() => this.onToggleLayer(layer.id)}
+                  >
+                    <div class="flex-1">
+                      <div class="font-medium">${this.layerName(layer.id)}</div>
+                      <div class="text-sm text-slate-400">
+                        ${layer.placement === "land"
+                          ? translateText(
+                              "graphics_setting.layer_placement_land",
+                            )
+                          : translateText(
+                              "graphics_setting.layer_placement_water",
+                            )}
+                        ${layer.nukeable
+                          ? ` · ${translateText("graphics_setting.layer_nukeable")}`
+                          : ""}
+                      </div>
                     </div>
-                  </div>
-                  <div class="text-sm text-slate-400">
-                    ${this.isLayerVisible(layer.id)
-                      ? translateText("user_setting.on")
-                      : translateText("user_setting.off")}
-                  </div>
-                </button>
+                    <div class="text-sm text-slate-400">
+                      ${this.isLayerVisible(layer.id)
+                        ? translateText("user_setting.on")
+                        : translateText("user_setting.off")}
+                    </div>
+                  </button>
+                  ${this.isLayerVisible(layer.id)
+                    ? html`
+                        <div
+                          class="flex gap-3 items-center w-full text-left px-3 pb-2 text-white"
+                        >
+                          <div class="flex-1">
+                            <div class="text-sm text-slate-300">
+                              ${translateText(
+                                "graphics_setting.layer_alpha_label",
+                              )}
+                            </div>
+                            <input
+                              type="range"
+                              min="0"
+                              max="1"
+                              step="0.01"
+                              aria-label=${`${this.layerName(layer.id)} ${translateText("graphics_setting.layer_alpha_label")}`}
+                              .value=${String(
+                                this.getLayerAlpha(layer.id, layer.alpha),
+                              )}
+                              @input=${(e: Event) =>
+                                this.onLayerAlphaSliderChange(layer.id, e)}
+                              class="w-full border border-slate-500 rounded-lg"
+                            />
+                          </div>
+                          <div class="text-sm text-slate-400 w-12 text-right">
+                            ${this.getLayerAlpha(layer.id, layer.alpha).toFixed(
+                              2,
+                            )}
+                          </div>
+                        </div>
+                      `
+                    : ""}
+                </div>
               `,
             )}
           `

--- a/src/client/render/gl/GraphicsOverrides.ts
+++ b/src/client/render/gl/GraphicsOverrides.ts
@@ -105,6 +105,8 @@ export const GraphicsOverridesSchema = z
       .partial(),
     /** Per-layer visibility toggles keyed by layer id. */
     mapLayerVisibility: z.record(z.string(), z.boolean()),
+    /** Per-layer alpha (opacity 0–1) keyed by layer id. */
+    mapLayerAlpha: z.record(z.string(), z.number().min(0).max(1)),
   })
   .partial();
 

--- a/src/client/render/gl/MapRenderer.ts
+++ b/src/client/render/gl/MapRenderer.ts
@@ -43,6 +43,7 @@ export class MapRenderer {
   private storedLayerImages: Map<string, ImageBitmap> = new Map();
   // Layer state that survives context loss (GPU textures do not).
   private layerVisibility = new Map<string, boolean>();
+  private layerAlpha = new Map<string, number>();
   private layerDestroyedMasks = new Map<string, Uint8Array>();
 
   /**
@@ -118,6 +119,10 @@ export class MapRenderer {
       // Re-apply visibility overrides.
       for (const [id, vis] of this.layerVisibility) {
         this.renderer?.setLayerVisible(id, vis);
+      }
+      // Re-apply alpha overrides.
+      for (const [id, alpha] of this.layerAlpha) {
+        this.renderer?.setLayerAlpha(id, alpha);
       }
       // Re-apply destroyed masks.
       for (const [id, mask] of this.layerDestroyedMasks) {
@@ -288,6 +293,12 @@ export class MapRenderer {
   setLayerVisible(layerId: string, visible: boolean): void {
     this.layerVisibility.set(layerId, visible);
     this.renderer?.setLayerVisible(layerId, visible);
+  }
+
+  /** Set the alpha multiplier for a single map layer (0–1). */
+  setLayerAlpha(layerId: string, alpha: number): void {
+    this.layerAlpha.set(layerId, alpha);
+    this.renderer?.setLayerAlpha(layerId, alpha);
   }
 
   /** Batch-mark tiles as destroyed for a nukeable layer. */

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1425,6 +1425,11 @@ export class GPURenderer {
     this.mapLayerPasses.get(layerId)?.setVisible(visible);
   }
 
+  /** Set the alpha multiplier for a single layer (0–1). */
+  setLayerAlpha(layerId: string, alpha: number): void {
+    this.mapLayerPasses.get(layerId)?.setAlpha(alpha);
+  }
+
   /**
    * Mark tiles as destroyed for a nukeable layer.  Called when a nuke
    * detonates; batches all tile updates into a single GPU upload.

--- a/src/client/render/gl/passes/MapLayerPass.ts
+++ b/src/client/render/gl/passes/MapLayerPass.ts
@@ -25,6 +25,7 @@ export class MapLayerPass {
   private uPlacement: WebGLUniformLocation;
   private uNukeable: WebGLUniformLocation;
   private uVisible: WebGLUniformLocation;
+  private uAlpha: WebGLUniformLocation;
   private uLayerTex: WebGLUniformLocation;
   private uTerrainBytes: WebGLUniformLocation;
   private uDestroyedMask: WebGLUniformLocation;
@@ -32,6 +33,7 @@ export class MapLayerPass {
   /** CPU-side copy of the destroyed mask for context-restore re-uploads. */
   private destroyedData: Uint8Array;
   private _visible = true;
+  private _alpha = 1.0;
 
   constructor(
     private gl: WebGL2RenderingContext,
@@ -55,6 +57,7 @@ export class MapLayerPass {
     this.uPlacement = gl.getUniformLocation(this.program, "uPlacement")!;
     this.uNukeable = gl.getUniformLocation(this.program, "uNukeable")!;
     this.uVisible = gl.getUniformLocation(this.program, "uVisible")!;
+    this.uAlpha = gl.getUniformLocation(this.program, "uAlpha")!;
     this.uLayerTex = gl.getUniformLocation(this.program, "uLayerTex")!;
     this.uTerrainBytes = gl.getUniformLocation(this.program, "uTerrainBytes")!;
     this.uDestroyedMask = gl.getUniformLocation(
@@ -97,6 +100,11 @@ export class MapLayerPass {
   /** Show/hide this layer (driven by graphics settings). */
   setVisible(visible: boolean): void {
     this._visible = visible;
+  }
+
+  /** Set the alpha multiplier for this layer (0–1). */
+  setAlpha(alpha: number): void {
+    this._alpha = Math.max(0, Math.min(1, alpha));
   }
 
   /**
@@ -253,6 +261,7 @@ export class MapLayerPass {
     gl.uniform1i(this.uPlacement, this.placement);
     gl.uniform1i(this.uNukeable, this.nukeable ? 1 : 0);
     gl.uniform1f(this.uVisible, this._visible ? 1.0 : 0.0);
+    gl.uniform1f(this.uAlpha, this._alpha);
 
     gl.bindVertexArray(this.vao);
     gl.drawArrays(gl.TRIANGLES, 0, 6);

--- a/src/client/render/gl/shaders/map-layer/layer.frag.glsl
+++ b/src/client/render/gl/shaders/map-layer/layer.frag.glsl
@@ -21,6 +21,9 @@ uniform int uNukeable;
 // 0.0 = hidden (user toggle), 1.0 = visible.
 uniform float uVisible;
 
+// Per-layer alpha multiplier (0–1).  Manifest default × user slider.
+uniform float uAlpha;
+
 in vec2 vUV;
 out vec4 fragColor;
 
@@ -51,5 +54,5 @@ void main() {
   vec4 layer = texture(uLayerTex, vUV);
   if (layer.a < 0.01) discard;
 
-  fragColor = layer;
+  fragColor = vec4(layer.rgb, layer.a * uAlpha);
 }

--- a/src/core/game/TerrainMapLoader.ts
+++ b/src/core/game/TerrainMapLoader.ts
@@ -46,6 +46,11 @@ export interface MapLayer {
   placement: LayerPlacement;
   /** If true, the layer is permanently destroyed in nuke impact radii. */
   nukeable?: boolean;
+  /**
+   * Default opacity for this layer (0–1). Used as the initial value for the
+   * player's layer-alpha slider.  Omit to default to 1 (fully opaque).
+   */
+  alpha?: number;
 }
 
 export interface Nation {
@@ -123,12 +128,20 @@ export async function loadTerrainMap(
 
   const layers = manifest.layers;
 
-  // Validate layer placements at game start.
+  // Validate layer placements and alpha at game start.
   if (layers) {
     for (const layer of layers) {
       if (layer.placement !== "land" && layer.placement !== "water") {
         throw new Error(
           `Map ${map}: layer "${layer.id}" has invalid placement "${layer.placement}" (must be "land" or "water")`,
+        );
+      }
+      if (
+        layer.alpha !== undefined &&
+        (!Number.isFinite(layer.alpha) || layer.alpha < 0 || layer.alpha > 1)
+      ) {
+        throw new Error(
+          `Map ${map}: layer "${layer.id}" has invalid alpha ${layer.alpha} (must be a finite number between 0 and 1)`,
         );
       }
     }

--- a/tests/MapLayers.test.ts
+++ b/tests/MapLayers.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from "vitest";
 import { GraphicsOverridesSchema } from "../src/client/render/gl/GraphicsOverrides";
-import type { MapLayer } from "../src/core/game/TerrainMapLoader";
+import { GameMapSize, GameMapType } from "../src/core/game/Game";
+import type { GameMapLoader, MapData } from "../src/core/game/GameMapLoader";
+import {
+  loadTerrainMap,
+  type MapLayer,
+} from "../src/core/game/TerrainMapLoader";
 import { validateLayer } from "./util/layerValidation";
 
 describe("Map layer feature", () => {
@@ -29,6 +34,44 @@ describe("Map layer feature", () => {
         }).success,
       ).toBe(false);
     });
+
+    test("accepts mapLayerAlpha overrides", () => {
+      const cases = [
+        { mapLayerAlpha: {} },
+        { mapLayerAlpha: { forests: 0.7 } },
+        { mapLayerAlpha: { forests: 0, deserts: 1 } },
+        { mapLayerAlpha: { rivers: 0.5, coasts: 0.3 } },
+      ];
+      for (const c of cases) {
+        expect(GraphicsOverridesSchema.safeParse(c).success).toBe(true);
+      }
+    });
+
+    test("rejects out-of-range mapLayerAlpha values", () => {
+      expect(
+        GraphicsOverridesSchema.safeParse({
+          mapLayerAlpha: { forests: -0.1 },
+        }).success,
+      ).toBe(false);
+      expect(
+        GraphicsOverridesSchema.safeParse({
+          mapLayerAlpha: { forests: 1.1 },
+        }).success,
+      ).toBe(false);
+    });
+
+    test("rejects invalid mapLayerAlpha value types", () => {
+      expect(
+        GraphicsOverridesSchema.safeParse({
+          mapLayerAlpha: { forests: "0.7" },
+        }).success,
+      ).toBe(false);
+      expect(
+        GraphicsOverridesSchema.safeParse({
+          mapLayerAlpha: { forests: true },
+        }).success,
+      ).toBe(false);
+    });
   });
 
   describe("MapLayer type", () => {
@@ -49,6 +92,23 @@ describe("Map layer feature", () => {
         placement: "water",
       };
       expect(layer.nukeable).toBeUndefined();
+    });
+
+    test("layer with alpha stores the value", () => {
+      const layer: MapLayer = {
+        id: "rivers",
+        placement: "water",
+        alpha: 0.6,
+      };
+      expect(layer.alpha).toBe(0.6);
+    });
+
+    test("layer without alpha defaults to undefined", () => {
+      const layer: MapLayer = {
+        id: "deserts",
+        placement: "water",
+      };
+      expect(layer.alpha).toBeUndefined();
     });
 
     test("placement must be land or water", () => {
@@ -181,6 +241,175 @@ describe("Map layer feature", () => {
       expect(
         validateLayer({ id: "b", placement: "water" }, 0, "test", seen2),
       ).toHaveLength(0);
+    });
+
+    test("valid alpha value is accepted", () => {
+      const seen = new Set<string>();
+      expect(
+        validateLayer(
+          { id: "a", placement: "land", alpha: 0.5 },
+          0,
+          "test",
+          seen,
+        ),
+      ).toHaveLength(0);
+    });
+
+    test("alpha boundary values are accepted", () => {
+      const seen1 = new Set<string>();
+      expect(
+        validateLayer(
+          { id: "a", placement: "land", alpha: 0 },
+          0,
+          "test",
+          seen1,
+        ),
+      ).toHaveLength(0);
+      const seen2 = new Set<string>();
+      expect(
+        validateLayer(
+          { id: "b", placement: "land", alpha: 1 },
+          0,
+          "test",
+          seen2,
+        ),
+      ).toHaveLength(0);
+    });
+
+    test("negative alpha is rejected", () => {
+      const seen = new Set<string>();
+      const errors = validateLayer(
+        { id: "a", placement: "land", alpha: -0.1 },
+        0,
+        "test",
+        seen,
+      );
+      expect(errors.some((e) => e.includes("between 0 and 1"))).toBe(true);
+    });
+
+    test("alpha greater than 1 is rejected", () => {
+      const seen = new Set<string>();
+      const errors = validateLayer(
+        { id: "a", placement: "land", alpha: 1.5 },
+        0,
+        "test",
+        seen,
+      );
+      expect(errors.some((e) => e.includes("between 0 and 1"))).toBe(true);
+    });
+
+    test("non-numeric alpha is rejected", () => {
+      const seen = new Set<string>();
+      const errors = validateLayer(
+        { id: "a", placement: "land", alpha: "0.5" },
+        0,
+        "test",
+        seen,
+      );
+      expect(errors.some((e) => e.includes("must be a finite number"))).toBe(
+        true,
+      );
+    });
+
+    test("NaN alpha is rejected", () => {
+      const seen = new Set<string>();
+      const errors = validateLayer(
+        { id: "a", placement: "land", alpha: NaN },
+        0,
+        "test",
+        seen,
+      );
+      expect(errors.some((e) => e.includes("must be a finite number"))).toBe(
+        true,
+      );
+    });
+
+    test("undefined alpha is accepted", () => {
+      const seen = new Set<string>();
+      expect(
+        validateLayer({ id: "a", placement: "land" }, 0, "test", seen),
+      ).toHaveLength(0);
+    });
+  });
+
+  describe("loadTerrainMap alpha validation", () => {
+    function makeLoader(
+      layers: MapLayer[],
+      width = 2,
+      height = 2,
+    ): GameMapLoader {
+      const bin = new Uint8Array(width * height);
+      // Set one tile as land (bit 7 = 1).
+      bin[0] = 0x80;
+      const manifest = {
+        name: "test",
+        map: { width, height, num_land_tiles: 1 },
+        map4x: { width, height, num_land_tiles: 1 },
+        map16x: { width, height, num_land_tiles: 1 },
+        nations: [],
+        layers,
+      };
+      const mapData: MapData = {
+        mapBin: () => Promise.resolve(bin),
+        map4xBin: () => Promise.resolve(bin),
+        map16xBin: () => Promise.resolve(bin),
+        manifest: () => Promise.resolve(manifest as never),
+        webpPath: "",
+        layerPng: () =>
+          Promise.resolve(new ImageData(1, 1) as unknown as ImageBitmap),
+      };
+      return {
+        getMapData: () => mapData,
+      };
+    }
+
+    test("throws on alpha below 0", async () => {
+      const loader = makeLoader([
+        { id: "bad", placement: "land", alpha: -0.5 },
+      ]);
+      await expect(
+        loadTerrainMap(GameMapType.World, GameMapSize.Normal, loader, false),
+      ).rejects.toThrow("invalid alpha");
+    });
+
+    test("throws on alpha above 1", async () => {
+      const loader = makeLoader([{ id: "bad", placement: "land", alpha: 1.5 }]);
+      await expect(
+        loadTerrainMap(GameMapType.World, GameMapSize.Normal, loader, false),
+      ).rejects.toThrow("invalid alpha");
+    });
+
+    test("throws on NaN alpha", async () => {
+      const loader = makeLoader([{ id: "bad", placement: "land", alpha: NaN }]);
+      await expect(
+        loadTerrainMap(GameMapType.World, GameMapSize.Normal, loader, false),
+      ).rejects.toThrow("invalid alpha");
+    });
+
+    test("accepts valid alpha values", async () => {
+      const loader = makeLoader([
+        { id: "good", placement: "land", alpha: 0 },
+        { id: "good2", placement: "water", alpha: 0.7 },
+        { id: "good3", placement: "land", alpha: 1 },
+      ]);
+      const data = await loadTerrainMap(
+        GameMapType.World,
+        GameMapSize.Normal,
+        loader,
+        false,
+      );
+      expect(data.layers).toHaveLength(3);
+    });
+
+    test("accepts layers without alpha (undefined)", async () => {
+      const loader = makeLoader([{ id: "noalpha", placement: "land" }]);
+      const data = await loadTerrainMap(
+        GameMapType.Europe,
+        GameMapSize.Normal,
+        loader,
+        false,
+      );
+      expect(data.layers).toHaveLength(1);
     });
   });
 });

--- a/tests/util/layerValidation.ts
+++ b/tests/util/layerValidation.ts
@@ -9,6 +9,7 @@ export interface LayerDefinition {
   id: unknown;
   placement: unknown;
   nukeable?: unknown;
+  alpha?: unknown;
 }
 
 /**
@@ -53,6 +54,15 @@ export function validateLayer(
     errors.push(
       `${prefix} "nukeable" must be a boolean if present, got ${typeof layer.nukeable}`,
     );
+  }
+  if (layer.alpha !== undefined) {
+    if (typeof layer.alpha !== "number" || !Number.isFinite(layer.alpha)) {
+      errors.push(
+        `${prefix} "alpha" must be a finite number if present, got ${layer.alpha}`,
+      );
+    } else if (layer.alpha < 0 || layer.alpha > 1) {
+      errors.push(`${prefix} "alpha" (${layer.alpha}) must be between 0 and 1`);
+    }
   }
 
   return errors;


### PR DESCRIPTION
## Description:

<img width="408" height="170" alt="image" src="https://github.com/user-attachments/assets/551b26ff-1d0a-4d8f-9287-61df6d4dad81" />

Adds an opacity slider for each map layer in Graphics Settings, allowing players to adjust layer transparency independently. Map authors can set a default alpha value per layer in the manifest (e.g. `"alpha": 0.7`), which the slider initializes to. If no manifest default is set, layers default to fully opaque (1.0).

The alpha is applied as a uniform multiplier in the layer fragment shader (`uAlpha`), so the PNG's own alpha channel is preserved and the slider acts as a global opacity control on top. Player overrides are persisted in `GraphicsOverrides.mapLayerAlpha` (localStorage) and survive context loss/restoration.

Changes across the full stack:
- `MapLayer` interface: added optional `alpha` field
- `GraphicsOverrides` schema: added `mapLayerAlpha` record
- Layer fragment shader: added `uAlpha` uniform, multiplies output alpha
- `MapLayerPass`: added `setAlpha()` and uniform upload
- `Renderer` / `MapRenderer`: added `setLayerAlpha()` with context-restore support
- `MapLayerController`: applies saved alpha (user override or manifest default) on init
- `GraphicsSettingsModal`: opacity slider per layer (0-1, step 0.01), synced on reset/preset import
- `en.json`: added `layer_alpha_label` translation key

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin