### PR TITLE
Add hover highlight delay and fade-in

### DIFF
--- a/src/client/controllers/HoverHighlightController.ts
+++ b/src/client/controllers/HoverHighlightController.ts
@@ -6,6 +6,15 @@
  * was bound to the WebGL canvas; that canvas has pointer-events: none in the
  * current input architecture so its listeners never fired). All input flows
  * through InputHandler → MouseMoveEvent on the EventBus, so we just listen.
+ *
+ * The highlight is deliberately not instant: an owner is only pushed to the
+ * view after the cursor has hovered it continuously for
+ * `mapOverlay.highlightDelayMs` (see issue #4310). Quickly sweeping the mouse
+ * across many territories then never triggers a highlight at all — the
+ * previously applied highlight simply holds until a new owner qualifies —
+ * which removes the disturbing strobing flicker. Once the delay elapses the
+ * renderer fades the highlight in gradually (see Renderer's highlight
+ * intensity ramp), so the appearance is progressive rather than a pop.
  */
 
 import { EventBus } from "../../core/EventBus";
@@ -17,8 +26,18 @@ import { OWNER_MASK } from "../render/gl/utils/TileCodec";
 import { TransformHandler } from "../TransformHandler";
 import { GameView, UnitView } from "../view";
 
+/** Fallback for the settings-driven delay, matching render-settings.json. */
+const DEFAULT_HIGHLIGHT_DELAY_MS = 500;
+
 export class HoverHighlightController implements Controller {
+  /** Owner currently pushed to the view (0 = no highlight). */
   private lastOwnerID = 0;
+  /** Owner the cursor is hovering right now; becomes lastOwnerID once it qualifies. */
+  private pendingOwnerID = 0;
+  /** performance.now() at which the cursor entered `pendingOwnerID`'s tiles. */
+  private pendingSinceMs = 0;
+  /** True while `pendingOwnerID` differs from `lastOwnerID` and is waiting out the delay. */
+  private hasPending = false;
 
   constructor(
     private game: GameView,
@@ -31,6 +50,22 @@ export class HoverHighlightController implements Controller {
     this.eventBus.on(MouseMoveEvent, (e) => this.onMouseMove(e));
   }
 
+  /**
+   * Applies the pending highlight once its delay has elapsed. Runs on the
+   * controller tick so the highlight still appears when the mouse stops
+   * moving (no further MouseMoveEvents arrive while parked).
+   */
+  tick(): void {
+    this.applyPendingIfDue();
+  }
+
+  private highlightDelayMs(): number {
+    return (
+      this.view.getSettings()?.mapOverlay?.highlightDelayMs ??
+      DEFAULT_HIGHLIGHT_DELAY_MS
+    );
+  }
+
   private navalHighlightEnabled(): boolean {
     return this.view.getSettings().mapOverlay.navalHighlight;
   }
@@ -41,10 +76,8 @@ export class HoverHighlightController implements Controller {
 
     const cell = this.transformHandler.screenToWorldCoordinates(e.x, e.y);
     if (!this.game.isValidCoord(cell.x, cell.y)) {
-      if (this.lastOwnerID !== 0) {
-        this.lastOwnerID = 0;
-        this.view.setHighlightOwner(0);
-      }
+      this.setPendingOwner(0);
+      this.applyPendingIfDue();
       return;
     }
     let ownerID = 0;
@@ -72,8 +105,38 @@ export class HoverHighlightController implements Controller {
       }
     }
 
-    if (ownerID === this.lastOwnerID) return;
-    this.lastOwnerID = ownerID;
-    this.view.setHighlightOwner(ownerID);
+    this.setPendingOwner(ownerID);
+    this.applyPendingIfDue();
+  }
+
+  /**
+   * Records the hovered owner. Entering a different owner (re)starts the
+   * delay timer; moving within the already-pending owner keeps it running.
+   * Hovering the owner that is already highlighted cancels the pending
+   * transition instead of resetting its timer, so brief excursions off an
+   * applied highlight don't flash it off and back on.
+   */
+  private setPendingOwner(ownerID: number): void {
+    if (ownerID === this.lastOwnerID) {
+      this.hasPending = false;
+      this.pendingOwnerID = ownerID;
+      return;
+    }
+    if (!this.hasPending || ownerID !== this.pendingOwnerID) {
+      this.pendingOwnerID = ownerID;
+      this.pendingSinceMs = performance.now();
+      this.hasPending = true;
+    }
+  }
+
+  /** Pushes the pending owner to the view once it has hovered long enough. */
+  private applyPendingIfDue(): void {
+    if (!this.hasPending) return;
+    if (performance.now() - this.pendingSinceMs < this.highlightDelayMs()) {
+      return;
+    }
+    this.lastOwnerID = this.pendingOwnerID;
+    this.hasPending = false;
+    this.view.setHighlightOwner(this.lastOwnerID);
   }
 }

--- a/src/client/render/gl/RenderSettings.ts
+++ b/src/client/render/gl/RenderSettings.ts
@@ -148,6 +148,16 @@ export interface RenderSettings {
     highlightBrighten: number;
     highlightFillBrighten: number;
     highlightThicken: number;
+    /**
+     * Hover highlight delay (issue #4310): the cursor must hover the same
+     * owner this long before the highlight is applied. 0 = immediate.
+     */
+    highlightDelayMs: number;
+    /**
+     * Hover highlight fade-in duration in ms, counted from when the delay
+     * elapses. 0 = pop in at full strength once the delay has passed.
+     */
+    highlightFadeMs: number;
     defensePostRange: number;
     embargoTintRatio: number;
     friendlyTintRatio: number;

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -205,6 +205,12 @@ export class GPURenderer {
   private samGhostVisible = false;
   private samHighlightVisible = false;
 
+  // Hover highlight: the controller only forwards an owner after the hover
+  // delay has elapsed; the fade-in is animated here per frame (issue #4310).
+  private highlightOwner = 0;
+  private highlightIntensity = 0;
+  private highlightSetAtMs = 0;
+
   // Warship selection — supports any number of selections.
   private selectedUnitIds: number[] = [];
   /** Reusable scratch buffer of {x,y,r,g,b} for the selection-box pass. */
@@ -1090,12 +1096,36 @@ export class GPURenderer {
   // ---------------------------------------------------------------------------
 
   setHighlightOwner(ownerID: number): void {
+    if (ownerID === this.highlightOwner) return;
+    this.highlightOwner = ownerID;
+    this.highlightSetAtMs = performance.now();
+    this.highlightIntensity = 0;
     this.borderPass.setHighlightOwner(ownerID);
     this.territoryPass.setHighlightOwner(ownerID);
     this.namePass.setHighlightOwner(ownerID);
     this.structurePass.setHighlightOwner(ownerID);
     this.railroadPass.setHighlightOwner(ownerID);
     this.affiliationPalette.setHoveredOwner(ownerID);
+  }
+
+  /**
+   * Fade the hover highlight in. HoverHighlightController only forwards an
+   * owner once the cursor has hovered it for `mapOverlay.highlightDelayMs`,
+   * so from this moment the highlight strength ramps 0→1 over
+   * `mapOverlay.highlightFadeMs` — the highlight increasingly appears
+   * instead of popping (issue #4310).
+   */
+  private updateHighlightFade(): void {
+    const fadeMs = this.settings.mapOverlay.highlightFadeMs;
+    const t =
+      fadeMs <= 0
+        ? 1
+        : Math.min(1, (performance.now() - this.highlightSetAtMs) / fadeMs);
+    // Smoothstep easing for a gentle start/end of the ramp.
+    this.highlightIntensity = t * t * (3 - 2 * t);
+    this.territoryPass.setHighlightIntensity(this.highlightIntensity);
+    this.borderStampPass.setHighlightIntensity(this.highlightIntensity);
+    this.namePass.setHighlightIntensity(this.highlightIntensity);
   }
   setMouseWorldPos(x: number, y: number): void {
     this.namePass.setMouseWorldPos(x, y);
@@ -1234,6 +1264,7 @@ export class GPURenderer {
   // ---------------------------------------------------------------------------
 
   draw(): void {
+    this.updateHighlightFade();
     this.uploadTextures();
     this.computeTextures();
     this.renderFrame();

--- a/src/client/render/gl/passes/BorderStampPass.ts
+++ b/src/client/render/gl/passes/BorderStampPass.ts
@@ -24,6 +24,7 @@ export class BorderStampPass {
   private uCam: WebGLUniformLocation;
   private uMapSize: WebGLUniformLocation;
   private uHighlightBrighten: WebGLUniformLocation;
+  private uHighlightIntensity: WebGLUniformLocation;
   private uDefenseCheckerDarken: WebGLUniformLocation;
   private uEmbargoTintRatio: WebGLUniformLocation;
   private uFriendlyTintRatio: WebGLUniformLocation;
@@ -38,6 +39,8 @@ export class BorderStampPass {
   private defenseCoverageTex: WebGLTexture | null = null;
   private affiliationTex: WebGLTexture | null = null;
   private altView = false;
+  /** 0–1 fade-in factor for the hover highlight (animated by the renderer). */
+  private highlightIntensity = 0;
 
   constructor(
     gl: WebGL2RenderingContext,
@@ -70,6 +73,10 @@ export class BorderStampPass {
       this.program,
       "uHighlightBrighten",
     )!;
+    this.uHighlightIntensity = gl.getUniformLocation(
+      this.program,
+      "uHighlightIntensity",
+    )!;
     this.uDefenseCheckerDarken = gl.getUniformLocation(
       this.program,
       "uDefenseCheckerDarken",
@@ -99,6 +106,11 @@ export class BorderStampPass {
   setAltView(active: boolean): void {
     this.altView = active;
   }
+
+  /** Fade-in factor for the hover highlight; 0 = invisible, 1 = full strength. */
+  setHighlightIntensity(intensity: number): void {
+    this.highlightIntensity = intensity;
+  }
   setAffiliationTex(tex: WebGLTexture): void {
     this.affiliationTex = tex;
   }
@@ -115,6 +127,7 @@ export class BorderStampPass {
     gl.uniformMatrix3fv(this.uCam, false, cameraMatrix);
     gl.uniform2f(this.uMapSize, this.mapW, this.mapH);
     gl.uniform1f(this.uHighlightBrighten, mo.highlightBrighten);
+    gl.uniform1f(this.uHighlightIntensity, this.highlightIntensity);
     gl.uniform1f(this.uDefenseCheckerDarken, mo.defenseCheckerDarken);
     gl.uniform1f(this.uEmbargoTintRatio, mo.embargoTintRatio);
     gl.uniform1f(this.uFriendlyTintRatio, mo.friendlyTintRatio);

--- a/src/client/render/gl/passes/TerritoryPass.ts
+++ b/src/client/render/gl/passes/TerritoryPass.ts
@@ -37,6 +37,7 @@ export class TerritoryPass {
   private uStaleNukeColor: WebGLUniformLocation;
   private uHighlightOwner: WebGLUniformLocation;
   private uHighlightBrighten: WebGLUniformLocation;
+  private uHighlightIntensity: WebGLUniformLocation;
   private uShowPatterns: WebGLUniformLocation;
   private uIsTeamMode: WebGLUniformLocation;
   private uDefenseDarken: WebGLUniformLocation;
@@ -44,6 +45,8 @@ export class TerritoryPass {
   private uTerritoryAlpha: WebGLUniformLocation;
   private uAltFillAlpha: WebGLUniformLocation;
   private highlightOwner = 0;
+  /** 0–1 fade-in factor for the hover highlight (animated by the renderer). */
+  private highlightIntensity = 0;
   private isTeamMode = false;
 
   private vao: WebGLVertexArrayObject;
@@ -170,6 +173,10 @@ export class TerritoryPass {
     this.uHighlightBrighten = gl.getUniformLocation(
       this.program,
       "uHighlightBrighten",
+    )!;
+    this.uHighlightIntensity = gl.getUniformLocation(
+      this.program,
+      "uHighlightIntensity",
     )!;
     this.uShowPatterns = gl.getUniformLocation(this.program, "uShowPatterns")!;
     this.uIsTeamMode = gl.getUniformLocation(this.program, "uIsTeamMode")!;
@@ -406,6 +413,11 @@ export class TerritoryPass {
     this.highlightOwner = ownerID;
   }
 
+  /** Fade-in factor for the hover highlight; 0 = invisible, 1 = full strength. */
+  setHighlightIntensity(intensity: number): void {
+    this.highlightIntensity = intensity;
+  }
+
   /** Defense-coverage texture (R8) — darkens the fill on defended tiles. */
   setDefenseCoverageTex(tex: WebGLTexture): void {
     this.defenseCoverageTex = tex;
@@ -443,6 +455,7 @@ export class TerritoryPass {
     );
     gl.uniform1ui(this.uHighlightOwner, this.highlightOwner);
     gl.uniform1f(this.uHighlightBrighten, mo.highlightFillBrighten);
+    gl.uniform1f(this.uHighlightIntensity, this.highlightIntensity);
     gl.uniform1i(
       this.uShowPatterns,
       this.settings.passEnabled.territoryPatterns && this.showPatterns ? 1 : 0,

--- a/src/client/render/gl/passes/name-pass/TextProgram.ts
+++ b/src/client/render/gl/passes/name-pass/TextProgram.ts
@@ -42,6 +42,7 @@ export class TextProgram {
   private uNameScaleCap: WebGLUniformLocation;
   private uTroopSizeMultiplier: WebGLUniformLocation;
   private uHighlightOwnerID: WebGLUniformLocation;
+  private uHighlightIntensity: WebGLUniformLocation;
   private uFadeOwnerID: WebGLUniformLocation;
   private uHoverFadeAlpha: WebGLUniformLocation;
   private uOutlineWidth: WebGLUniformLocation;
@@ -114,6 +115,10 @@ export class TextProgram {
       this.program,
       "uHighlightOwnerID",
     )!;
+    this.uHighlightIntensity = gl.getUniformLocation(
+      this.program,
+      "uHighlightIntensity",
+    )!;
     this.uFadeOwnerID = gl.getUniformLocation(this.program, "uFadeOwnerID")!;
     this.uHoverFadeAlpha = gl.getUniformLocation(
       this.program,
@@ -171,6 +176,7 @@ export class TextProgram {
     maxPlayers: number,
     ambient: number,
     highlightOwnerID: number,
+    highlightIntensity: number,
     fadeOwnerID: number,
   ): void {
     if (!this.atlasReady) return;
@@ -188,6 +194,7 @@ export class TextProgram {
     gl.uniform1f(this.uNameScaleCap, ns.nameScaleCap);
     gl.uniform1f(this.uTroopSizeMultiplier, ns.troopSizeMultiplier);
     gl.uniform1f(this.uHighlightOwnerID, highlightOwnerID);
+    gl.uniform1f(this.uHighlightIntensity, highlightIntensity);
     gl.uniform1f(this.uFadeOwnerID, fadeOwnerID);
     gl.uniform1f(this.uHoverFadeAlpha, ns.hoverFadeAlpha);
     gl.uniform1f(this.uOutlineWidth, ns.outlineWidth);

--- a/src/client/render/gl/passes/name-pass/index.ts
+++ b/src/client/render/gl/passes/name-pass/index.ts
@@ -119,6 +119,8 @@ export class NamePass {
 
   // Hovered player's small ID (0 = no highlight, matches TerritoryPass).
   private highlightOwnerID = 0;
+  /** 0–1 fade-in factor for the name glow (animated by the renderer). */
+  private highlightIntensity = 0;
   // Cursor in world coords — fades names under it (far off-map = no fade).
   private mouseWorldX = -1e9;
   private mouseWorldY = -1e9;
@@ -702,6 +704,11 @@ export class NamePass {
     this.highlightOwnerID = ownerID;
   }
 
+  /** Fade-in factor for the hover name glow; 0 = off, 1 = full glow. */
+  setHighlightIntensity(intensity: number): void {
+    this.highlightIntensity = intensity;
+  }
+
   setMouseWorldPos(x: number, y: number): void {
     this.mouseWorldX = x;
     this.mouseWorldY = y;
@@ -822,6 +829,7 @@ export class NamePass {
       this.maxPlayers,
       ambient,
       this.highlightOwnerID,
+      this.highlightIntensity,
       fadeOwnerID,
     );
     this.statusIconProgram.draw(

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -90,6 +90,8 @@
     "highlightBrighten": 0.25,
     "highlightFillBrighten": 0.15,
     "highlightThicken": 1,
+    "highlightDelayMs": 500,
+    "highlightFadeMs": 250,
     "defensePostRange": 30,
     "embargoTintRatio": 0.35,
     "friendlyTintRatio": 0.35,

--- a/src/client/render/gl/shaders/day-night/border-stamp.frag.glsl
+++ b/src/client/render/gl/shaders/day-night/border-stamp.frag.glsl
@@ -10,6 +10,7 @@ uniform sampler2D uAffiliation;   // 256×2 RGBA8 — affiliation colors (row 0 
 uniform vec2 uMapSize;
 uniform int uAltView;
 uniform float uHighlightBrighten;
+uniform float uHighlightIntensity; // 0–1 fade-in factor of the hover highlight
 uniform float uDefenseCheckerDarken;
 uniform float uEmbargoTintRatio;
 uniform float uFriendlyTintRatio;
@@ -45,7 +46,9 @@ void main() {
       float u = (float(owner) + 0.5) / float(PALETTE_SIZE);
       bc = texture(uPalette, vec2(u, 0.75)).rgb;
       if (isHighlightBorder) {
-        bc = mix(bc, vec3(1.0), uHighlightBrighten);
+        // Fade the brightening with uHighlightIntensity so the highlight band
+        // increasingly appears after the hover delay (issue #4310).
+        bc = mix(bc, vec3(1.0), uHighlightBrighten * uHighlightIntensity);
       }
       // Relationship tint (applied BEFORE defense checkerboard, matching game)
       if (relation > 0.75) {

--- a/src/client/render/gl/shaders/map-overlay/territory.frag.glsl
+++ b/src/client/render/gl/shaders/map-overlay/territory.frag.glsl
@@ -22,6 +22,7 @@ uniform float uStaleNukeAlpha;
 uniform vec3 uStaleNukeColor;
 uniform uint uHighlightOwner;      // 0 = no highlight; otherwise smallID of hovered owner
 uniform float uHighlightBrighten;  // hover contrast boost strength; 0 = disabled
+uniform float uHighlightIntensity; // 0–1 fade-in factor of the hover highlight
 uniform sampler2D uDefenseCoverageTex; // R8 — 1.0 = tile defended by same-owner post
 uniform float uDefenseDarken;      // multiplier applied to fill on defended tiles
 uniform sampler2D uBorderTex;      // RGBA8 — border flags; R > 0.25 = border tile
@@ -115,8 +116,10 @@ void main() {
 
   // Hover highlight: boost contrast on the hovered player's tiles, pushing
   // channels away from mid-gray. uHighlightBrighten is the strength; 0 disables.
+  // uHighlightIntensity ramps 0→1 after the hover delay so the highlight
+  // increasingly appears instead of popping (issue #4310).
   if (uHighlightOwner != 0u && owner == uHighlightOwner && uHighlightBrighten > 0.0) {
-    float contrast = 1.0 + uHighlightBrighten;
+    float contrast = 1.0 + uHighlightBrighten * uHighlightIntensity;
     color.rgb = clamp((color.rgb - 0.5) * contrast + 0.5, 0.0, 1.0);
   }
 

--- a/src/client/render/gl/shaders/name/name.frag.glsl
+++ b/src/client/render/gl/shaders/name/name.frag.glsl
@@ -14,7 +14,7 @@ uniform float uHoverGlowAlpha; // peak opacity of the hover glow
 in vec2 vUV;
 in vec4 vPlayerColor;   // player territory color (rgb) + alpha
 in float vNameShade;      // name fill grayscale shade (0.0 = black)
-flat in float vHighlight; // 1.0 when this player is hovered (white glow)
+flat in float vHighlight; // hover glow strength (0 = none, ramps to 1 after hover delay)
 out vec4 fragColor;
 
 float median(float r, float g, float b) {
@@ -67,11 +67,13 @@ void main() {
 
   // Soft white glow behind the hovered player's name. Width is clamped to
   // the SDF margin past the outline so it never hard-clips at the quad edge.
-  if (vHighlight > 0.5 && uHoverGlowAlpha > 0.0) {
+  // vHighlight carries the renderer's fade-in so the glow increasingly
+  // appears after the hover delay (issue #4310).
+  if (vHighlight > 0.0 && uHoverGlowAlpha > 0.0) {
     float glowWidth = min(uHoverGlowWidth, max(maxOutline - effectiveOutline, 0.0));
     if (glowWidth > 0.0) {
       float g = clamp(1.0 + (screenPxDist + effectiveOutline) / glowWidth, 0.0, 1.0);
-      float glowAlpha = g * g * uHoverGlowAlpha;
+      float glowAlpha = g * g * uHoverGlowAlpha * vHighlight;
       float total = coverage + glowAlpha * (1.0 - coverage);
       if (total > 0.0) {
         color = mix(vec3(1.0), color, coverage / total);

--- a/src/client/render/gl/shaders/name/name.vert.glsl
+++ b/src/client/render/gl/shaders/name/name.vert.glsl
@@ -28,13 +28,14 @@ uniform float uNameScaleFactor;
 uniform float uNameScaleCap;
 uniform float uTroopSizeMultiplier;
 uniform float uHighlightOwnerID;
+uniform float uHighlightIntensity; // 0–1 fade-in of the hover glow
 uniform float uFadeOwnerID;    // smallID of player whose name plate the cursor is over (0 = none)
 uniform float uHoverFadeAlpha; // alpha multiplier applied to that player's name plate
 
 out vec2 vUV;
 out vec4 vPlayerColor;  // player territory color (rgb) + alpha
 out float vNameShade;     // name fill grayscale shade (0.0 = black)
-flat out float vHighlight; // 1.0 when this player is hovered (white glow)
+flat out float vHighlight; // hover glow strength: 0 = none, else uHighlightIntensity
 
 void main() {
   // 1. Decode instance ID → playerIdx, lineIdx, charPos
@@ -172,5 +173,5 @@ void main() {
   vUV = vec2(mix(u0, u1, aPos.x), mix(v0, v1, aPos.y));
   vPlayerColor = vec4(pd2.rgb, pd2.a * hoverAlpha); // player territory color + alpha
   vNameShade = pd3.z;         // name fill grayscale shade (0.0 = black)
-  vHighlight = isHighlighted ? 1.0 : 0.0;
+  vHighlight = isHighlighted ? uHighlightIntensity : 0.0;
 }

--- a/tests/client/controllers/HoverHighlightController.test.ts
+++ b/tests/client/controllers/HoverHighlightController.test.ts
@@ -1,5 +1,5 @@
 import { PlayerInfo, PlayerType, UnitType } from "src/core/game/Game";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HoverHighlightController } from "../../../src/client/controllers/HoverHighlightController";
 import { MouseMoveEvent } from "../../../src/client/InputHandler";
 import { setup } from "../../util/Setup";
@@ -9,13 +9,22 @@ describe("HoverHighlightController", () => {
   let eventBus: any;
   let transformHandler: any;
   let view: any;
+  // Controlled performance.now() — the controller delays the highlight by
+  // wall-clock time, so tests drive the clock explicitly.
+  let nowMs: number;
 
   beforeEach(async () => {
     game = await setup(
       "giantworldmap",
       { infiniteGold: true, instantBuild: true },
-      [new PlayerInfo("player1", PlayerType.Human, null, "player1_id")],
+      [
+        new PlayerInfo("player1", PlayerType.Human, null, "player1_id"),
+        new PlayerInfo("player2", PlayerType.Human, null, "player2_id"),
+      ],
     );
+
+    nowMs = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => nowMs);
 
     eventBus = { on: vi.fn() };
     transformHandler = {
@@ -29,7 +38,15 @@ describe("HoverHighlightController", () => {
     view = {
       setMouseWorldPos: vi.fn(),
       setHighlightOwner: vi.fn(),
+      // Default to no delay so the immediate-behavior tests stay focused on
+      // routing; the delay itself is covered by the dedicated tests below.
+      getSettings: () =>
+        ({ mapOverlay: { navalHighlight: false, highlightDelayMs: 0 } }) as any,
     };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
   });
 
   it("sets highlight owner for land tiles and updates mouse world pos", () => {
@@ -106,5 +123,151 @@ describe("HoverHighlightController", () => {
     const handler = (eventBus.on as any).mock.calls[0][1];
     handler(new MouseMoveEvent(200, 100)); // >50 tiles from unit
     expect(view.setHighlightOwner).toHaveBeenCalledWith(0);
+  });
+
+  describe("hover delay", () => {
+    let player1: any;
+    let player2: any;
+    let handler: (e: MouseMoveEvent) => void;
+    let ui: HoverHighlightController;
+
+    beforeEach(() => {
+      // Use the settings-driven delay so these tests cover the gating logic.
+      view.getSettings = () =>
+        ({
+          mapOverlay: { navalHighlight: false, highlightDelayMs: 500 },
+        }) as any;
+
+      player1 = game.player("player1_id");
+      player2 = game.player("player2_id");
+      ui = new HoverHighlightController(game, eventBus, transformHandler, view);
+      ui.init();
+      handler = (eventBus.on as any).mock.calls[0][1];
+    });
+
+    it("does not highlight a newly hovered owner before the delay elapses", () => {
+      const tile = game.ref(200, 200);
+      expect(game.isLand(tile)).toBe(true);
+      player1.conquer(tile);
+
+      nowMs = 1_000;
+      handler(new MouseMoveEvent(200, 200)); // enter the territory
+      expect(view.setHighlightOwner).not.toHaveBeenCalled();
+
+      // The highlight must still apply via tick() even though the mouse
+      // stopped moving and no further MouseMoveEvents arrive.
+      nowMs = 1_400;
+      ui.tick();
+      expect(view.setHighlightOwner).not.toHaveBeenCalled();
+
+      nowMs = 1_500;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenCalledTimes(1);
+      expect(view.setHighlightOwner).toHaveBeenCalledWith(player1.smallID());
+    });
+
+    it("keeps the delay timer running while the cursor moves within the same territory", () => {
+      // Conquer a block so adjacent moves stay on the same owner.
+      for (let x = 196; x <= 204; x++) {
+        for (let y = 196; y <= 204; y++) {
+          const t = game.ref(x, y);
+          if (game.isLand(t)) player1.conquer(t);
+        }
+      }
+
+      nowMs = 1_000;
+      handler(new MouseMoveEvent(200, 200)); // enter the territory
+      // Wander within the same territory — every event must land on the same
+      // owner, so the entry timestamp must not reset.
+      for (let i = 1; i <= 4; i++) {
+        nowMs = 1_000 + i * 100;
+        handler(new MouseMoveEvent(200 + i, 200 + i));
+      }
+      expect(view.setHighlightOwner).not.toHaveBeenCalled();
+
+      nowMs = 1_500;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenCalledWith(player1.smallID());
+    });
+
+    it("does not reset the delay when sweeping to a new owner and back to the highlighted one", () => {
+      const tileA = game.ref(200, 200);
+      const tileB = game.ref(300, 200);
+      expect(game.isLand(tileA)).toBe(true);
+      expect(game.isLand(tileB)).toBe(true);
+      player1.conquer(tileA);
+      player2.conquer(tileB);
+
+      nowMs = 1_000;
+      handler(new MouseMoveEvent(200, 200)); // hover A
+      nowMs = 1_500;
+      ui.tick(); // A qualifies
+      expect(view.setHighlightOwner).toHaveBeenCalledTimes(1);
+      expect(view.setHighlightOwner).toHaveBeenCalledWith(player1.smallID());
+
+      // Quick excursion to B and back before B's delay elapses.
+      nowMs = 1_600;
+      handler(new MouseMoveEvent(300, 200)); // hover B — pending
+      nowMs = 1_700;
+      handler(new MouseMoveEvent(200, 200)); // back on A (already applied)
+      nowMs = 2_500;
+      ui.tick();
+      // A stays highlighted the whole time; nothing flashes off and back on.
+      expect(view.setHighlightOwner).toHaveBeenCalledTimes(1);
+    });
+
+    it("highlights a new owner only after it has been hovered for the full delay", () => {
+      const tileA = game.ref(200, 200);
+      const tileB = game.ref(300, 200);
+      expect(game.isLand(tileA)).toBe(true);
+      expect(game.isLand(tileB)).toBe(true);
+      player1.conquer(tileA);
+      player2.conquer(tileB);
+
+      nowMs = 1_000;
+      handler(new MouseMoveEvent(200, 200)); // hover A
+      nowMs = 1_500;
+      ui.tick(); // A qualifies
+      expect(view.setHighlightOwner).toHaveBeenCalledWith(player1.smallID());
+
+      nowMs = 2_000;
+      handler(new MouseMoveEvent(300, 200)); // move to B — timer restarts
+      nowMs = 2_400;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenCalledTimes(1); // B not yet due
+
+      nowMs = 2_500;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenCalledTimes(2);
+      expect(view.setHighlightOwner).toHaveBeenLastCalledWith(
+        player2.smallID(),
+      );
+    });
+
+    it("delays clearing the highlight when the cursor leaves the map", () => {
+      const tile = game.ref(200, 200);
+      expect(game.isLand(tile)).toBe(true);
+      player1.conquer(tile);
+
+      nowMs = 1_000;
+      handler(new MouseMoveEvent(200, 200)); // hover the territory
+      nowMs = 1_500;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenCalledWith(player1.smallID());
+
+      transformHandler.screenToWorldCoordinates.mockReturnValue({
+        x: -50,
+        y: -50,
+      });
+      nowMs = 1_600;
+      handler(new MouseMoveEvent(0, 0)); // off-map — clear becomes pending
+      nowMs = 2_000;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenCalledTimes(1); // still held
+
+      nowMs = 2_100;
+      ui.tick();
+      expect(view.setHighlightOwner).toHaveBeenLastCalledWith(0);
+    });
   });
 });


### PR DESCRIPTION
Gate the hover highlight behind mapOverlay.highlightDelayMs (500ms) in HoverHighlightController so sweeping the cursor across many territories no longer strobes the map, and fade the highlight in over mapOverlay.highlightFadeMs (250ms) once the delay elapses.

- HoverHighlightController: only push setHighlightOwner after the cursor has hovered one owner for the full delay; tick() applies it when the mouse stops moving, returning to the already-highlighted owner cancels the pending transition, and clearing (owner 0) is delayed the same way
- Renderer: animate a smoothstep intensity ramp per frame and push it to the territory, border stamp and name passes
- TerritoryPass/border-stamp/name shaders: scale the highlight brighten and name glow by the intensity uniform
- render-settings.json/RenderSettings: add highlightDelayMs and highlightFadeMs tuning knobs
- Tests: cover the delay, timer persistence while moving within one territory, sweep-and-return cancellation, delayed transition between owners and delayed clear

> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

Describe the PR.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ ] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

NOBODYiran
