### PR TITLE
feat(desktop): tell Steam players why they cannot sign in, instead of a Turnstile error

### DIFF
--- a/index.html
+++ b/index.html
@@ -441,11 +441,11 @@
          component is position:fixed and self-manages visibility (pauses in-game). -->
     <featured-stream></featured-stream>
 
-    <!-- Steam shell runtime-update bar. A direct <body> child, like
+    <!-- Steam shell status bar. A direct <body> child, like
          featured-stream above, so it is not inside the home container -- but
          unlike it, deliberately hidden in-game (see the component's comment).
          Renders nothing outside the desktop shell. -->
-    <desktop-update-bar></desktop-update-bar>
+    <desktop-status-bar></desktop-status-bar>
 
     <!-- Scripts -->
     <script>

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -484,6 +484,16 @@
     "verified_name": "Verified username",
     "verified_name_info": "Your username is reserved for your account and shows a verified badge in-game."
   },
+  "desktop_session": {
+    "generic": "Couldn't sign in to your OpenFront account",
+    "network": "Can't reach OpenFront. Check your connection.",
+    "retry": "Retry",
+    "retrying": "Signing in…",
+    "steam_backend": "Steam is having trouble signing you in. Try again shortly.",
+    "steam_rejected": "Steam couldn't confirm your account. Restarting Steam usually fixes this.",
+    "steam_unavailable": "Steam isn't running. Start Steam to play online.",
+    "steam_wedged": "Steam couldn't verify your session. Restarting Steam usually fixes this."
+  },
   "desktop_update": {
     "blocked": "A Steam update is required for the latest version",
     "downloading": "Downloading update… {percent}%",

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -159,14 +159,17 @@ export function clearLocalSession(): void {
   // to desync. Skipped while a retry is legitimately in flight (status
   // "retrying"): retrySteamSignIn already owns that transition end-to-end via
   // its own userAuth() call, and this must not race ahead of it with a stale
-  // "signed-out" that the retry is about to overwrite anyway.
+  // state that the retry is about to overwrite anyway.
   //
-  // "steam-error" is the closest of the six SessionFailureKinds: unlike the
-  // others it names no specific cause (ticket rejection, backend 5xx, no
-  // client, etc.), which matches clearLocalSession not knowing why the
-  // session went away -- it just renders the bar's generic message.
+  // Publish "unknown" rather than a failure reason: logOut() runs on ANY 401
+  // from /users/@me, on key rotation, and on an iss/aud claim mismatch --
+  // none of which mean Steam sign-in failed. Asserting "signed-out" with a
+  // Steam reason here would gate multiplayer and show a Steam-specific error
+  // for an unrelated auth event that used to self-heal invisibly. "unknown"
+  // does not gate (see multiplayerAllowedForSession), and the next
+  // userAuth() call re-establishes the real state.
   if (steamSDK.isOnSteam() && __sessionState.status !== "retrying") {
-    setSessionState({ status: "signed-out", reason: "steam-error" });
+    setSessionState({ status: "unknown" });
   }
   if (hadSession) announceLoggedOut();
 }
@@ -318,6 +321,12 @@ async function doRefreshJwt(): Promise<void> {
 
 // Total mapping from the shell's three ticket failures. Kept exhaustive by
 // the parameter type: adding a SteamTicketFailure value fails the build here.
+// The `default` is not reachable through that exhaustive type, but the shell
+// lives in a separate repo and the bridge shape reaches us as `unknown` at
+// the boundary (see SteamSDK.getTicket's normalisation) -- a malformed
+// `reason` from an old or misbehaving shell must still map to something
+// rather than return `undefined` at runtime despite the non-optional return
+// type.
 function ticketReason(
   result: Extract<SteamTicketResult, { ok: false }>,
 ): SessionFailureKind {
@@ -327,6 +336,8 @@ function ticketReason(
     case "timeout":
       return "steam-wedged";
     case "error":
+      return "steam-error";
+    default:
       return "steam-error";
   }
 }
@@ -381,7 +392,11 @@ async function doSteamLogin(ticket: string): Promise<void> {
       __jwt = null;
       // 401 is infra's unauthorized("Invalid Steam ticket"); 5xx is its
       // internalServerError for "steam unreachable" / "steam auth error",
-      // which is Steam's backend rather than anything the player did.
+      // which is Steam's backend rather than anything the player did. Any
+      // other status (a Cloudflare WAF 403, a 429) still reached the server
+      // -- it is not a transport failure, so it must not render "Can't reach
+      // OpenFront. Check your connection." Fold it into "steam-error", the
+      // generic bucket, rather than "network".
       setSessionState({
         status: "signed-out",
         reason:
@@ -389,7 +404,7 @@ async function doSteamLogin(ticket: string): Promise<void> {
             ? "steam-ticket-rejected"
             : response.status >= 500
               ? "steam-backend"
-              : "network",
+              : "steam-error",
       });
       return;
     }
@@ -449,6 +464,21 @@ export async function retrySteamSignIn(): Promise<UserAuth> {
       setSessionState({ status: "retrying" });
       return await userAuth();
     } finally {
+      // Guarantee, not a duplicate of the happy path: userAuth() is expected
+      // to publish a terminal state itself via doSteamLogin/doRefreshJwt's
+      // Steam branch. But refreshJwt()'s finally has no catch, so an
+      // exception inside doRefreshJwt() (e.g. steamSDK.getTicket() throwing
+      // synchronously, or doSteamLogin throwing before it can call
+      // setSessionState) propagates straight to userAuth()'s top-level catch,
+      // which logs and returns false without touching session state --
+      // leaving "retrying" published forever. That is a lockout:
+      // multiplayerAllowedForSession gates on every non-signed-in status
+      // including "retrying", and DesktopStatusBar.sessionAction renders no
+      // button for it. If nothing moved us off "retrying" by the time this
+      // settles, force a terminal, actionable state instead.
+      if (__sessionState.status === "retrying") {
+        setSessionState({ status: "signed-out", reason: "steam-error" });
+      }
       __steamRetryPromise = null;
     }
   })();

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -161,14 +161,21 @@ export function clearLocalSession(): void {
   // its own userAuth() call, and this must not race ahead of it with a stale
   // state that the retry is about to overwrite anyway.
   //
-  // Publish "unknown" rather than a failure reason: logOut() runs on ANY 401
-  // from /users/@me, on key rotation, and on an iss/aud claim mismatch --
-  // none of which mean Steam sign-in failed. Asserting "signed-out" with a
-  // Steam reason here would gate multiplayer and show a Steam-specific error
-  // for an unrelated auth event that used to self-heal invisibly. "unknown"
-  // does not gate (see multiplayerAllowedForSession), and the next
-  // userAuth() call re-establishes the real state.
-  if (steamSDK.isOnSteam() && __sessionState.status !== "retrying") {
+  // Scoped to "signed-in" ONLY. The job here is narrow: a session was just
+  // dropped, so a state still claiming "signed-in" is now a lie and must be
+  // downgraded. "unknown" is the right downgrade rather than a failure reason
+  // -- logOut() runs on ANY 401, on key rotation, and on an iss/aud claim
+  // mismatch, none of which mean Steam sign-in failed, and asserting a Steam
+  // error for those would gate multiplayer over an unrelated auth event.
+  //
+  // Every other status must survive untouched. A diagnosed
+  // {signed-out, steam-*} is the whole point of this feature, and getAuthHeader
+  // returns "" once signed out, so an authenticated call still fires and still
+  // 401s -- which reaches logOut() from any of Api.ts's call sites. Resetting
+  // there would un-gate multiplayer and hide the bar, handing the player back
+  // the raw Turnstile error. "retrying" must survive for the same reason:
+  // retrySteamSignIn owns that transition end to end.
+  if (steamSDK.isOnSteam() && __sessionState.status === "signed-in") {
     setSessionState({ status: "unknown" });
   }
   if (hadSession) announceLoggedOut();

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -151,6 +151,23 @@ export function clearLocalSession(): void {
   // selections stay stored under their publicId and are restored on the
   // next login (#4955).
   UserSettings.setPlayerId(null);
+  // Keep the desktop bar's session state in sync: without this, a 401-driven
+  // logOut() (or any other clearLocalSession caller) leaves __sessionState at
+  // "signed-in" with no JWT behind it, so the bar hides and multiplayer
+  // unlocks with nothing backing it until the next join self-heals it.
+  // Guarded to Steam only -- web/CrazyGames have no bar and no session-gating
+  // to desync. Skipped while a retry is legitimately in flight (status
+  // "retrying"): retrySteamSignIn already owns that transition end-to-end via
+  // its own userAuth() call, and this must not race ahead of it with a stale
+  // "signed-out" that the retry is about to overwrite anyway.
+  //
+  // "steam-error" is the closest of the six SessionFailureKinds: unlike the
+  // others it names no specific cause (ticket rejection, backend 5xx, no
+  // client, etc.), which matches clearLocalSession not knowing why the
+  // session went away -- it just renders the bar's generic message.
+  if (steamSDK.isOnSteam() && __sessionState.status !== "retrying") {
+    setSessionState({ status: "signed-out", reason: "steam-error" });
+  }
   if (hadSession) announceLoggedOut();
 }
 
@@ -347,10 +364,17 @@ async function doCrazyGamesLogin(token: string): Promise<void> {
 async function doSteamLogin(ticket: string): Promise<void> {
   try {
     console.log("Logging in with Steam");
+    // Bounded so a response that never settles can't leave the session
+    // pinned at "retrying" forever (it gates multiplayer and the status bar
+    // renders no button for that state -- see DesktopStatusBar.sessionAction).
+    // An abort throws, which the catch below already maps to "network", so
+    // this also means the initial sign-in can no longer hang at "unknown".
+    // 10s is generous headroom over a healthy web-api round trip (~1.3s).
     const response = await fetch(getApiBase() + "/auth/steam", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ ticket }),
+      signal: AbortSignal.timeout(10_000),
     });
     if (response.status !== 200) {
       console.error("Steam login failed", response);

--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -5,6 +5,8 @@ import { TokenPayload, TokenPayloadSchema } from "../core/ApiSchemas";
 import { base64urlToUuid } from "../core/Base64";
 import { getApiBase, getAudience } from "./Api";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
+import type { DesktopSessionState, SessionFailureKind } from "./DesktopShell";
+import type { SteamTicketResult } from "./SteamSDK";
 import { steamSDK } from "./SteamSDK";
 import { generateCryptoRandomUUID } from "./Utils";
 
@@ -15,6 +17,25 @@ const PERSISTENT_ID_KEY = "player_persistent_id";
 let __jwt: string | null = null;
 let __refreshPromise: Promise<void> | null = null;
 let __expiresAt: number = 0;
+
+let __sessionState: DesktopSessionState = { status: "unknown" };
+
+/**
+ * The shell's current session state. Exported for components that mount after
+ * the first transition has already been published, so they are not left blank
+ * waiting for the next change -- the same reason the update bridge delivers
+ * its current state on subscribe.
+ */
+export function getDesktopSessionState(): DesktopSessionState {
+  return __sessionState;
+}
+
+function setSessionState(state: DesktopSessionState): void {
+  __sessionState = state;
+  document.dispatchEvent(
+    new CustomEvent("desktop-session-state", { detail: state }),
+  );
+}
 
 export function discordLogin() {
   const redirectUri = encodeURIComponent(window.location.href);
@@ -231,12 +252,19 @@ async function refreshJwt(): Promise<void> {
 
 async function doRefreshJwt(): Promise<void> {
   if (steamSDK.isOnSteam()) {
-    const ticket = await steamSDK.getTicket();
-    if (ticket) {
-      // On Steam, we exchange a Steam Web-API ticket for our session. No
-      // ticket (Steam unavailable) falls through to the guest flow below.
-      return doSteamLogin(ticket);
+    const result = await steamSDK.getTicket();
+    if (result.ok) {
+      // On Steam we exchange a Steam Web-API ticket for our session.
+      return doSteamLogin(result.ticket);
     }
+    // TERMINAL, deliberately: this used to fall through to /auth/refresh,
+    // which cannot succeed in the shell (the Electron profile has no refresh
+    // cookie). That was a guaranteed 401 followed by logOut(), costing two
+    // pointless round trips and the player's stored persistent ID every time
+    // Steam hiccuped. Record why and stop.
+    __jwt = null;
+    setSessionState({ status: "signed-out", reason: ticketReason(result) });
+    return;
   }
   if (crazyGamesSDK.isOnCrazyGames()) {
     const token = await crazyGamesSDK.getUserToken();
@@ -268,6 +296,21 @@ async function doRefreshJwt(): Promise<void> {
     // if server unreachable, just clear jwt
     __jwt = null;
     return;
+  }
+}
+
+// Total mapping from the shell's three ticket failures. Kept exhaustive by
+// the parameter type: adding a SteamTicketFailure value fails the build here.
+function ticketReason(
+  result: Extract<SteamTicketResult, { ok: false }>,
+): SessionFailureKind {
+  switch (result.reason) {
+    case "unavailable":
+      return "steam-unavailable";
+    case "timeout":
+      return "steam-wedged";
+    case "error":
+      return "steam-error";
   }
 }
 
@@ -312,6 +355,18 @@ async function doSteamLogin(ticket: string): Promise<void> {
     if (response.status !== 200) {
       console.error("Steam login failed", response);
       __jwt = null;
+      // 401 is infra's unauthorized("Invalid Steam ticket"); 5xx is its
+      // internalServerError for "steam unreachable" / "steam auth error",
+      // which is Steam's backend rather than anything the player did.
+      setSessionState({
+        status: "signed-out",
+        reason:
+          response.status === 401
+            ? "steam-ticket-rejected"
+            : response.status >= 500
+              ? "steam-backend"
+              : "network",
+      });
       return;
     }
     const json = await response.json();
@@ -319,9 +374,11 @@ async function doSteamLogin(ticket: string): Promise<void> {
     __expiresAt = Date.now() + expiresIn * 1000;
     console.log("Steam login succeeded");
     __jwt = jwt;
+    setSessionState({ status: "signed-in" });
   } catch (e) {
     console.error("Steam login failed", e);
     __jwt = null;
+    setSessionState({ status: "signed-out", reason: "network" });
   }
 }
 
@@ -346,6 +403,32 @@ export async function reauthAfterCrazyGamesChange(): Promise<UserAuth> {
     }
   })();
   return __reauthPromise;
+}
+
+// The Retry action on the desktop status bar. Single-flight for the same
+// reason reauthAfterCrazyGamesChange is: the bar and any other caller must
+// share one exchange rather than race on __jwt. A refresh already in flight
+// is allowed to settle first so its stale result cannot satisfy the retry.
+//
+// There is no automatic retry anywhere: a wedged Steam session does not
+// self-heal (only a Steam restart cleared it in both observed cases), so a
+// silent retry would buy nothing and delay the message.
+let __steamRetryPromise: Promise<UserAuth> | null = null;
+export async function retrySteamSignIn(): Promise<UserAuth> {
+  __steamRetryPromise ??= (async () => {
+    try {
+      if (__refreshPromise) {
+        await __refreshPromise.catch(() => {});
+      }
+      __jwt = null;
+      __expiresAt = 0;
+      setSessionState({ status: "retrying" });
+      return await userAuth();
+    } finally {
+      __steamRetryPromise = null;
+    }
+  })();
+  return __steamRetryPromise;
 }
 
 export async function sendMagicLink(email: string): Promise<boolean> {

--- a/src/client/DesktopShell.ts
+++ b/src/client/DesktopShell.ts
@@ -142,3 +142,53 @@ export function multiplayerAllowed(state: DesktopUpdateState): boolean {
   // downloading (wait) and staged (reload) both have a real remedy.
   return false;
 }
+
+export type DesktopSessionStatus =
+  | "unknown" // the first sign-in attempt is still in flight
+  | "signed-in"
+  | "retrying" // the player pressed Retry and it has not settled
+  | "signed-out";
+
+/**
+ * Why the shell has no session. Each maps to its own player-facing message,
+ * because they are not equally actionable -- `steam-wedged` is the one with a
+ * one-step fix (restart Steam), and it is the one we used to say nothing about.
+ */
+export type SessionFailureKind =
+  | "steam-unavailable" // no Steam client running, or no native addon
+  | "steam-wedged" // the web-api ticket timed out -- restart Steam
+  | "steam-error" // the native ticket call threw for some other reason
+  | "steam-ticket-rejected" // /auth/steam 401: Steam refused the ticket
+  | "steam-backend" // /auth/steam 5xx: Steam's backend, not the player
+  | "network"; // the request never completed
+
+export interface DesktopSessionState {
+  status: DesktopSessionStatus;
+  reason?: SessionFailureKind;
+}
+
+/**
+ * Whether multiplayer should be available in a given session state.
+ *
+ * This DELIBERATELY diverges from multiplayerAllowed's governing rule above
+ * ("gate when there is a remedy, not merely when there is a problem"), and the
+ * divergence is the point:
+ *
+ * With updates, declining to gate still lets the player play -- gating is a
+ * cost we impose to keep them in sync. With a missing session, declining to
+ * gate does NOT let them play. Worker.ts closes the socket on any first join
+ * without a Steam-provider JWT, and Transport.ts renders that as a Turnstile
+ * error the player never encountered. Gating is the only way that refusal
+ * happens somewhere we can name a cause and offer Retry.
+ *
+ * So every signed-out reason gates, including the ones the player cannot fix.
+ *
+ * A null state means no desktop shell -- the web build -- where a logged-out
+ * player passes Turnstile normally and must not be gated.
+ */
+export function multiplayerAllowedForSession(
+  state: DesktopSessionState | null,
+): boolean {
+  if (state === null) return true;
+  return state.status === "unknown" || state.status === "signed-in";
+}

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -327,7 +327,7 @@ export class GameModeSelector extends LitElement {
     // degrades to a silent no-op in that case instead of firing an event with
     // no listener.
     (
-      document.querySelector("desktop-update-bar") as
+      document.querySelector("desktop-status-bar") as
         | (HTMLElement & { wiggle?: () => void })
         | null
     )?.wiggle?.();

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -11,6 +11,7 @@ import {
   Trios,
 } from "../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../core/Schemas";
+import { getDesktopSessionState } from "./Auth";
 import "./components/IOSAddToHomeScreenBanner";
 import {
   canJoinTrustedLobby,
@@ -21,7 +22,13 @@ import {
   viewerIsTrusted,
 } from "./components/LobbyCard";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
-import { multiplayerAllowed, type DesktopUpdateState } from "./DesktopShell";
+import {
+  isDesktopShell,
+  multiplayerAllowed,
+  multiplayerAllowedForSession,
+  type DesktopSessionState,
+  type DesktopUpdateState,
+} from "./DesktopShell";
 import { HostLobbyModal } from "./HostLobbyModal";
 import { JoinLobbyModal } from "./JoinLobbyModal";
 import { PublicLobbySocket } from "./LobbySocket";
@@ -40,13 +47,16 @@ const CARD_BG = "bg-surface";
 /**
  * Whether a multiplayer entry point should refuse to act. Exported for tests
  * and kept free of component state so the rule is checkable in isolation.
- * A null state means no desktop shell (the web build), so nothing is gated.
+ * A null state means that bridge is absent (the web build), so it gates
+ * nothing; either state alone is enough to block.
  */
 export function shouldBlockMultiplayerAction(
-  state: DesktopUpdateState | null,
+  update: DesktopUpdateState | null,
+  session: DesktopSessionState | null,
 ): boolean {
-  if (state === null) return false;
-  return !multiplayerAllowed(state);
+  if (update !== null && !multiplayerAllowed(update)) return true;
+  if (session !== null && !multiplayerAllowedForSession(session)) return true;
+  return false;
 }
 
 @customElement("game-mode-selector")
@@ -57,6 +67,7 @@ export class GameModeSelector extends LitElement {
   @state() private viewerTrusted: boolean = false;
   @state() private viewerSignedIn: boolean = false;
   @state() private showTrustRequired: boolean = false;
+  @state() private desktopSessionState: DesktopSessionState | null = null;
   private serverTimeOffset: number = 0;
   private defaultLobbyTime: number = 0;
 
@@ -89,6 +100,13 @@ export class GameModeSelector extends LitElement {
       this.onDesktopUpdateState,
     );
     document.addEventListener("userMeResponse", this.onUserMe);
+    if (isDesktopShell()) {
+      this.desktopSessionState = getDesktopSessionState();
+    }
+    document.addEventListener(
+      "desktop-session-state",
+      this.onDesktopSessionState,
+    );
     // Pick up the current value in case username-input validated before us.
     const usernameInput = document.querySelector(
       "username-input",
@@ -109,6 +127,10 @@ export class GameModeSelector extends LitElement {
       this.onDesktopUpdateState,
     );
     document.removeEventListener("userMeResponse", this.onUserMe);
+    document.removeEventListener(
+      "desktop-session-state",
+      this.onDesktopSessionState,
+    );
     super.disconnectedCallback();
   }
 
@@ -131,6 +153,10 @@ export class GameModeSelector extends LitElement {
         if (user !== null) this.viewerSignedIn = true;
       });
     }
+  };
+
+  private onDesktopSessionState = (e: Event) => {
+    this.desktopSessionState = (e as CustomEvent<DesktopSessionState>).detail;
   };
 
   public stop() {
@@ -321,7 +347,13 @@ export class GameModeSelector extends LitElement {
    * actionable.
    */
   private blockedByUpdate(): boolean {
-    if (!shouldBlockMultiplayerAction(this.desktopUpdateState)) return false;
+    if (
+      !shouldBlockMultiplayerAction(
+        this.desktopUpdateState,
+        this.desktopSessionState,
+      )
+    )
+      return false;
     // Optional-call the method rather than dispatching an event: the bar is a
     // sibling custom element that may not have upgraded yet, and `?.wiggle?.()`
     // degrades to a silent no-op in that case instead of firing an event with
@@ -381,7 +413,11 @@ export class GameModeSelector extends LitElement {
     gated: boolean = false,
   ) {
     const blocked =
-      gated && shouldBlockMultiplayerAction(this.desktopUpdateState);
+      gated &&
+      shouldBlockMultiplayerAction(
+        this.desktopUpdateState,
+        this.desktopSessionState,
+      );
     return html`
       <button
         @click=${onClick}
@@ -434,7 +470,10 @@ export class GameModeSelector extends LitElement {
       timeDisplay,
       timeDisplayUppercase,
       disabled: !this.inputValid,
-      blocked: shouldBlockMultiplayerAction(this.desktopUpdateState),
+      blocked: shouldBlockMultiplayerAction(
+        this.desktopUpdateState,
+        this.desktopSessionState,
+      ),
       viewerTrusted: this.viewerTrusted,
       onClick: () => this.validateAndJoin(lobby),
     });

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -19,7 +19,11 @@ import "./AccountSettingsModal";
 import { adGatekeeper } from "./AdGatekeeper";
 import { loadAdmiral, onAdmiralMeasured } from "./Admiral";
 import { getUserMe, invalidateUserMe } from "./Api";
-import { reauthAfterCrazyGamesChange, userAuth } from "./Auth";
+import {
+  reauthAfterCrazyGamesChange,
+  retrySteamSignIn,
+  userAuth,
+} from "./Auth";
 import "./ChangeUsernameModal";
 import "./ClanModal";
 import { joinLobby, type JoinLobbyResult } from "./ClientGameRunner";
@@ -574,6 +578,21 @@ class Client {
       invalidateUserMe();
       const generation = authGeneration;
       reauthAfterCrazyGamesChange().then((result) =>
+        result === false
+          ? applyUserMe(generation)(false)
+          : getUserMe().then(applyUserMe(generation)),
+      );
+    });
+
+    // The desktop status bar's Retry. Orchestrated here rather than in the
+    // bar because a successful sign-in also has to refresh userMe, the nav
+    // account button and the cached profile -- the same reason the
+    // CrazyGames listener above lives here. The authGeneration guard means a
+    // response that arrives after another auth change cannot be applied.
+    document.addEventListener("desktop-session-retry", () => {
+      invalidateUserMe();
+      const generation = authGeneration;
+      retrySteamSignIn().then((result) =>
         result === false
           ? applyUserMe(generation)(false)
           : getUserMe().then(applyUserMe(generation)),

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -75,7 +75,7 @@ import { genAnonUsername, UsernameInput } from "./UsernameInput";
 import { incrementGamesPlayed, translateText } from "./Utils";
 import { isReplayShellHost } from "./VersionedReplay";
 import "./components/BannedModal";
-import "./components/DesktopUpdateBar";
+import "./components/DesktopStatusBar";
 import "./components/MarketingConsentToast";
 import "./components/PurchaseNudgeModal";
 import {

--- a/src/client/SteamSDK.ts
+++ b/src/client/SteamSDK.ts
@@ -1,5 +1,14 @@
+// Mirrors SteamTicketResult in openfront-desktop's src/main/steam.ts. The two
+// repositories cannot import from each other, so this is a hand-kept copy; if
+// you change one, change the other.
+export type SteamTicketFailure = "unavailable" | "timeout" | "error";
+
+export type SteamTicketResult =
+  | { ok: true; ticket: string }
+  | { ok: false; reason: SteamTicketFailure };
+
 interface SteamBridge {
-  getAuthTicket(): Promise<string | null>;
+  getAuthTicket(): Promise<SteamTicketResult>;
   getUser(): Promise<{ steamId: string; name: string } | null>;
 }
 
@@ -21,13 +30,14 @@ class SteamSDK {
     return steamBridge() !== undefined;
   }
 
-  async getTicket(): Promise<string | null> {
+  async getTicket(): Promise<SteamTicketResult> {
     const bridge = steamBridge();
-    if (!bridge) return null;
+    if (!bridge) return { ok: false, reason: "unavailable" };
     try {
       return await bridge.getAuthTicket();
     } catch {
-      return null;
+      // The IPC call itself failed, which tells us nothing about Steam.
+      return { ok: false, reason: "error" };
     }
   }
 

--- a/src/client/SteamSDK.ts
+++ b/src/client/SteamSDK.ts
@@ -23,6 +23,34 @@ function steamBridge(): SteamBridge | undefined {
   return desktop?.steam;
 }
 
+// The shell runs its own 5s watchdog on the native Steam ticket call and
+// reports an accurate "timeout" reason when that fires. This outer bound
+// must sit above that so the shell's own timeout wins the race in the normal
+// case; it only fires when the IPC call itself is dead (e.g. the shell
+// process wedged), where it maps to the same "timeout" reason the shell
+// would have reported.
+const GET_TICKET_TIMEOUT_MS = 8000;
+
+// A shell older than this client may still return the legacy string | null
+// shape getAuthTicket() had before SteamTicketResult existed. Normalise it
+// rather than trust the shape, the same convention DesktopShell.ts follows
+// for desktopVersion()/desktopUpdate(): a client newer than its shell must
+// degrade rather than break.
+function normaliseTicketResult(value: unknown): SteamTicketResult {
+  if (typeof value === "string") {
+    return value.length > 0
+      ? { ok: true, ticket: value }
+      : { ok: false, reason: "unavailable" };
+  }
+  if (value === null || value === undefined) {
+    return { ok: false, reason: "unavailable" };
+  }
+  if (typeof value === "object" && "ok" in value) {
+    return value as SteamTicketResult;
+  }
+  return { ok: false, reason: "error" };
+}
+
 // Thin renderer wrapper over the desktop shell's Steam bridge. Mirrors
 // CrazyGamesSDK; the native work lives in the Electron main process.
 class SteamSDK {
@@ -33,11 +61,24 @@ class SteamSDK {
   async getTicket(): Promise<SteamTicketResult> {
     const bridge = steamBridge();
     if (!bridge) return { ok: false, reason: "unavailable" };
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<SteamTicketResult>((resolve) => {
+      timer = setTimeout(
+        () => resolve({ ok: false, reason: "timeout" }),
+        GET_TICKET_TIMEOUT_MS,
+      );
+    });
     try {
-      return await bridge.getAuthTicket();
+      const result = await Promise.race([
+        bridge.getAuthTicket().then(normaliseTicketResult),
+        timeout,
+      ]);
+      return result;
     } catch {
       // The IPC call itself failed, which tells us nothing about Steam.
       return { ok: false, reason: "error" };
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/src/client/SteamSDK.ts
+++ b/src/client/SteamSDK.ts
@@ -46,7 +46,19 @@ function normaliseTicketResult(value: unknown): SteamTicketResult {
     return { ok: false, reason: "unavailable" };
   }
   if (typeof value === "object" && "ok" in value) {
-    return value as SteamTicketResult;
+    const candidate = value as { ok: unknown; ticket?: unknown };
+    // Validate the success case rather than casting it: a malformed
+    // { ok: true } without a usable ticket would otherwise be POSTed to
+    // /auth/steam as-is. A malformed FAILURE needs no check here -- an
+    // unrecognised reason is already handled by ticketReason's default.
+    if (candidate.ok === true) {
+      return typeof candidate.ticket === "string" && candidate.ticket.length > 0
+        ? { ok: true, ticket: candidate.ticket }
+        : { ok: false, reason: "error" };
+    }
+    if (candidate.ok === false) {
+      return value as SteamTicketResult;
+    }
   }
   return { ok: false, reason: "error" };
 }

--- a/src/client/components/DesktopStatusBar.ts
+++ b/src/client/components/DesktopStatusBar.ts
@@ -1,15 +1,42 @@
 import { html, LitElement, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { createRef, ref, type Ref } from "lit/directives/ref.js";
-import { desktopUpdate, type DesktopUpdateState } from "../DesktopShell";
+import { getDesktopSessionState } from "../Auth";
+import {
+  desktopUpdate,
+  isDesktopShell,
+  multiplayerAllowedForSession,
+  type DesktopSessionState,
+  type DesktopUpdateState,
+} from "../DesktopShell";
 import { translateText } from "../Utils";
 
 const WIGGLE_CLASS = "animate-bounce";
 
 /**
- * Bottom-of-screen progress/action bar for the Steam shell's runtime updates:
- * download progress while an update is fetching, and a reload action once one
- * is ready to apply.
+ * Which state the single bottom slot shows. Session takes precedence over
+ * every update state -- the update's remedy is a reload, which leads straight
+ * back to the same wall, and a reload re-runs the update flow anyway. One
+ * rule, deliberately, rather than a precedence matrix.
+ */
+export function barSource(
+  update: DesktopUpdateState | null,
+  session: DesktopSessionState | null,
+): "session" | "update" | "none" {
+  if (session !== null && !multiplayerAllowedForSession(session)) {
+    return "session";
+  }
+  if (update === null) return "none";
+  if (update.status === "current" || update.status === "checking") {
+    return "none";
+  }
+  return "update";
+}
+
+/**
+ * Bottom-of-screen status bar for the Steam shell: runtime-update
+ * progress/action, or a missing session and its remedy, whichever applies.
+ * One bottom slot, two kinds of status, so the two can never stack.
  *
  * Mounted in index.html as a direct <body> child with `in-[.in-game]:hidden`,
  * so "we do not update mid-game" is a property of the markup rather than of
@@ -19,8 +46,8 @@ const WIGGLE_CLASS = "animate-bounce";
  * Renders nothing on the web, and nothing on a desktop shell too old to expose
  * the update bridge.
  */
-@customElement("desktop-update-bar")
-export class DesktopUpdateBar extends LitElement {
+@customElement("desktop-status-bar")
+export class DesktopStatusBar extends LitElement {
   // Light DOM so the app's Tailwind classes apply, matching the other
   // components in this directory.
   createRenderRoot() {
@@ -28,8 +55,13 @@ export class DesktopUpdateBar extends LitElement {
   }
 
   @state() private updateState: DesktopUpdateState | null = null;
+  @state() private sessionState: DesktopSessionState | null = null;
 
   private unsubscribe: (() => void) | null = null;
+
+  private onSessionState = (e: Event) => {
+    this.sessionState = (e as CustomEvent<DesktopSessionState>).detail;
+  };
 
   // The bar's own element, so wiggle() can restart the animation with a real
   // synchronous class removal + reflow + re-add. Routing that through a Lit
@@ -43,21 +75,28 @@ export class DesktopUpdateBar extends LitElement {
   connectedCallback(): void {
     super.connectedCallback();
     const bridge = desktopUpdate();
-    if (bridge === null) return;
-    this.unsubscribe = bridge.subscribe((state) => {
-      this.updateState = state;
-      // Broadcast so entry-point components can gate without each opening its
-      // own subscription to the bridge.
-      document.dispatchEvent(
-        new CustomEvent("desktop-update-state", { detail: state }),
-      );
-    });
+    if (bridge !== null) {
+      this.unsubscribe = bridge.subscribe((state) => {
+        this.updateState = state;
+        // Broadcast so entry-point components can gate without each opening
+        // its own subscription to the bridge.
+        document.dispatchEvent(
+          new CustomEvent("desktop-update-state", { detail: state }),
+        );
+      });
+    }
+
+    // Seed from the current value: Auth publishes its first transition during
+    // startup, quite possibly before this element upgrades.
+    if (isDesktopShell()) this.sessionState = getDesktopSessionState();
+    document.addEventListener("desktop-session-state", this.onSessionState);
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribe?.();
     this.unsubscribe = null;
+    document.removeEventListener("desktop-session-state", this.onSessionState);
     window.clearTimeout(this.wiggleTimer);
   }
 
@@ -82,9 +121,10 @@ export class DesktopUpdateBar extends LitElement {
   }
 
   render() {
-    const s = this.updateState;
-    if (s === null) return nothing;
-    if (s.status === "current" || s.status === "checking") return nothing;
+    const source = barSource(this.updateState, this.sessionState);
+    if (source === "none") return nothing;
+    const update = this.updateState;
+    const session = this.sessionState;
 
     return html`
       <div
@@ -96,8 +136,14 @@ export class DesktopUpdateBar extends LitElement {
         aria-live="polite"
       >
         <div class="flex-1 min-w-0">
-          <div class="text-sm font-medium truncate">${this.label(s)}</div>
-          ${s.status === "downloading"
+          <div class="text-sm font-medium truncate">
+            ${source === "session" && session !== null
+              ? this.sessionLabel(session)
+              : update !== null
+                ? this.label(update)
+                : ""}
+          </div>
+          ${source === "update" && update?.status === "downloading"
             ? html`<div
                 class="mt-1 h-1.5 w-full rounded-full bg-white/15 overflow-hidden"
               >
@@ -108,7 +154,11 @@ export class DesktopUpdateBar extends LitElement {
               </div>`
             : nothing}
         </div>
-        ${this.action(s)}
+        ${source === "session" && session !== null
+          ? this.sessionAction(session)
+          : update !== null
+            ? this.action(update)
+            : nothing}
       </div>
     `;
   }
@@ -139,7 +189,7 @@ export class DesktopUpdateBar extends LitElement {
                text-sm font-medium uppercase tracking-wider"
         @click=${() => {
           bridge.apply().catch((err: unknown) => {
-            console.error("desktop-update-bar: apply failed", err);
+            console.error("desktop-status-bar: apply failed", err);
           });
         }}
       >
@@ -152,7 +202,7 @@ export class DesktopUpdateBar extends LitElement {
                text-sm font-medium uppercase tracking-wider"
         @click=${() => {
           bridge.retry().catch((err: unknown) => {
-            console.error("desktop-update-bar: retry failed", err);
+            console.error("desktop-status-bar: retry failed", err);
           });
         }}
       >
@@ -160,5 +210,41 @@ export class DesktopUpdateBar extends LitElement {
       </button>`;
     }
     return nothing;
+  }
+
+  private sessionLabel(s: DesktopSessionState): string {
+    switch (s.reason) {
+      case "steam-wedged":
+        return translateText("desktop_session.steam_wedged");
+      case "steam-unavailable":
+        return translateText("desktop_session.steam_unavailable");
+      case "steam-ticket-rejected":
+        return translateText("desktop_session.steam_rejected");
+      case "steam-backend":
+        return translateText("desktop_session.steam_backend");
+      case "network":
+        return translateText("desktop_session.network");
+      default:
+        // `retrying`, and `steam-error` -- nothing specific to say.
+        return s.status === "retrying"
+          ? translateText("desktop_session.retrying")
+          : translateText("desktop_session.generic");
+    }
+  }
+
+  private sessionAction(s: DesktopSessionState) {
+    if (s.status === "retrying") return nothing;
+    return html`<button
+      class="shrink-0 px-4 py-2 rounded-md bg-malibu-blue hover:bg-aquarius
+             text-sm font-medium uppercase tracking-wider"
+      @click=${() => {
+        // Main.ts owns the retry, because a successful sign-in also has to
+        // refresh userMe, the nav account button and the cached profile --
+        // all of which already live there. See its crazyGamesSDK listener.
+        document.dispatchEvent(new CustomEvent("desktop-session-retry"));
+      }}
+    >
+      ${translateText("desktop_session.retry")}
+    </button>`;
   }
 }

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -4,8 +4,13 @@ import { repeat } from "lit/directives/repeat.js";
 import { UserMeResponse } from "../../core/ApiSchemas";
 import { GameMapType } from "../../core/game/Game";
 import { PublicGameInfo, PublicGames } from "../../core/Schemas";
+import { getDesktopSessionState } from "../Auth";
 import { crazyGamesSDK } from "../CrazyGamesSDK";
-import { type DesktopUpdateState } from "../DesktopShell";
+import {
+  isDesktopShell,
+  type DesktopSessionState,
+  type DesktopUpdateState,
+} from "../DesktopShell";
 import { shouldBlockMultiplayerAction } from "../GameModeSelector";
 import { JoinLobbyModal } from "../JoinLobbyModal";
 import { PublicLobbySocket } from "../LobbySocket";
@@ -112,6 +117,7 @@ export class DetailedGameViewModal extends BaseModal {
   @state() private viewerTrusted: boolean = false;
   @state() private viewerSignedIn: boolean = false;
   @state() private showTrustRequired: boolean = false;
+  @state() private desktopSessionState: DesktopSessionState | null = null;
 
   private serverTimeOffset = 0;
   private countdownTimer: number | null = null;
@@ -172,6 +178,13 @@ export class DetailedGameViewModal extends BaseModal {
       this.onDesktopUpdateState,
     );
     document.addEventListener("userMeResponse", this.onUserMe);
+    if (isDesktopShell()) {
+      this.desktopSessionState = getDesktopSessionState();
+    }
+    document.addEventListener(
+      "desktop-session-state",
+      this.onDesktopSessionState,
+    );
   }
 
   disconnectedCallback() {
@@ -180,6 +193,10 @@ export class DetailedGameViewModal extends BaseModal {
       this.onDesktopUpdateState,
     );
     document.removeEventListener("userMeResponse", this.onUserMe);
+    document.removeEventListener(
+      "desktop-session-state",
+      this.onDesktopSessionState,
+    );
     this.onClose();
     super.disconnectedCallback();
   }
@@ -199,6 +216,10 @@ export class DetailedGameViewModal extends BaseModal {
         if (user !== null) this.viewerSignedIn = true;
       });
     }
+  };
+
+  private onDesktopSessionState = (e: Event) => {
+    this.desktopSessionState = (e as CustomEvent<DesktopSessionState>).detail;
   };
 
   // ---- Slot animation ----
@@ -427,7 +448,10 @@ export class DetailedGameViewModal extends BaseModal {
       // Gated, not disabled: `disabled` also sets pointer-events-none and would
       // swallow the click that's supposed to make the update bar wiggle. join()
       // does the actual refusing.
-      blocked: shouldBlockMultiplayerAction(this.desktopUpdateState),
+      blocked: shouldBlockMultiplayerAction(
+        this.desktopUpdateState,
+        this.desktopSessionState,
+      ),
       viewerTrusted: this.viewerTrusted,
       onClick: () => this.join(lobby),
     });
@@ -750,7 +774,13 @@ export class DetailedGameViewModal extends BaseModal {
    * click.
    */
   private blockedByUpdate(): boolean {
-    if (!shouldBlockMultiplayerAction(this.desktopUpdateState)) return false;
+    if (
+      !shouldBlockMultiplayerAction(
+        this.desktopUpdateState,
+        this.desktopSessionState,
+      )
+    )
+      return false;
     (
       document.querySelector("desktop-status-bar") as
         | (HTMLElement & { wiggle?: () => void })

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -752,7 +752,7 @@ export class DetailedGameViewModal extends BaseModal {
   private blockedByUpdate(): boolean {
     if (!shouldBlockMultiplayerAction(this.desktopUpdateState)) return false;
     (
-      document.querySelector("desktop-update-bar") as
+      document.querySelector("desktop-status-bar") as
         | (HTMLElement & { wiggle?: () => void })
         | null
     )?.wiggle?.();

--- a/tests/AuthLogoutAnnounce.test.ts
+++ b/tests/AuthLogoutAnnounce.test.ts
@@ -4,7 +4,10 @@ vi.mock("../src/core/game/UserSettings", () => ({
   UserSettings: { setPlayerId: vi.fn() },
 }));
 vi.mock("../src/client/SteamSDK", () => ({
-  steamSDK: { isOnSteam: () => false, getTicket: async () => null },
+  steamSDK: {
+    isOnSteam: () => false,
+    getTicket: async () => ({ ok: false, reason: "unavailable" }),
+  },
 }));
 vi.mock("../src/client/CrazyGamesSDK", () => ({
   crazyGamesSDK: {

--- a/tests/DesktopShellSession.test.ts
+++ b/tests/DesktopShellSession.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  multiplayerAllowedForSession,
+  type SessionFailureKind,
+} from "../src/client/DesktopShell";
+
+const ALL_REASONS: SessionFailureKind[] = [
+  "steam-unavailable",
+  "steam-wedged",
+  "steam-error",
+  "steam-ticket-rejected",
+  "steam-backend",
+  "network",
+];
+
+describe("multiplayerAllowedForSession", () => {
+  it("allows multiplayer on the web, where there is no session state", () => {
+    expect(multiplayerAllowedForSession(null)).toBe(true);
+  });
+
+  it("allows multiplayer while the first attempt is still in flight", () => {
+    // Mirrors `checking` in the update state machine: no evidence of a
+    // problem yet, and blocking every launch to prove a negative is the
+    // blocking-splash design OPE-185 rejected.
+    expect(multiplayerAllowedForSession({ status: "unknown" })).toBe(true);
+  });
+
+  it("allows multiplayer once signed in", () => {
+    expect(multiplayerAllowedForSession({ status: "signed-in" })).toBe(true);
+  });
+
+  it("gates multiplayer while a retry is in flight", () => {
+    expect(multiplayerAllowedForSession({ status: "retrying" })).toBe(false);
+  });
+
+  // Deliberately unlike multiplayerAllowed, which spares the states the
+  // player cannot act on. Here, not gating does not let them play -- the
+  // game server refuses the join regardless -- so every reason gates.
+  it.each(ALL_REASONS)("gates multiplayer when signed out (%s)", (reason) => {
+    expect(multiplayerAllowedForSession({ status: "signed-out", reason })).toBe(
+      false,
+    );
+  });
+});

--- a/tests/DesktopStatusBar.test.ts
+++ b/tests/DesktopStatusBar.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import { barSource } from "../src/client/components/DesktopStatusBar";
+
+describe("barSource", () => {
+  it("shows nothing when both states are healthy", () => {
+    expect(
+      barSource(
+        { status: "current", bytes: 0, total: 0 },
+        { status: "signed-in" },
+      ),
+    ).toBe("none");
+  });
+
+  it("shows the update when the session is fine", () => {
+    expect(
+      barSource(
+        { status: "downloading", bytes: 1, total: 2 },
+        { status: "signed-in" },
+      ),
+    ).toBe("update");
+  });
+
+  // Session wins over EVERY update state, downloading and staged included:
+  // the update's remedy is a reload, which leads straight back to the same
+  // wall -- and a reload re-runs the update flow anyway, so nothing is lost.
+  it.each([
+    "checking",
+    "current",
+    "downloading",
+    "staged",
+    "blocked",
+    "failed",
+  ] as const)("shows the session over update state %s", (status) => {
+    expect(
+      barSource(
+        { status, bytes: 0, total: 0 },
+        {
+          status: "signed-out",
+          reason: "steam-wedged",
+        },
+      ),
+    ).toBe("session");
+  });
+
+  it("shows nothing on the web, where neither bridge exists", () => {
+    expect(barSource(null, null)).toBe("none");
+  });
+});

--- a/tests/DetailedGameViewModalGatingWiring.test.ts
+++ b/tests/DetailedGameViewModalGatingWiring.test.ts
@@ -95,7 +95,7 @@ beforeEach(async () => {
   wiggle = vi.fn();
   joinLobby = vi.fn();
   stub("join-lobby-modal", { open: joinModalOpen });
-  stub("desktop-update-bar", { wiggle });
+  stub("desktop-status-bar", { wiggle });
   // join() dispatches "join-lobby" as a bubbling/composed CustomEvent rather
   // than calling a modal's open() -- catch it at the document the same way
   // Main.ts's real listener would.

--- a/tests/GameModeSelectorGating.test.ts
+++ b/tests/GameModeSelectorGating.test.ts
@@ -3,31 +3,43 @@ import { shouldBlockMultiplayerAction } from "../src/client/GameModeSelector";
 
 describe("shouldBlockMultiplayerAction", () => {
   it("allows everything when no desktop update state has arrived", () => {
-    expect(shouldBlockMultiplayerAction(null)).toBe(false);
+    expect(shouldBlockMultiplayerAction(null, null)).toBe(false);
   });
 
   it("allows multiplayer when the client is current", () => {
     expect(
-      shouldBlockMultiplayerAction({ status: "current", bytes: 0, total: 0 }),
+      shouldBlockMultiplayerAction(
+        { status: "current", bytes: 0, total: 0 },
+        null,
+      ),
     ).toBe(false);
   });
 
   it("blocks while downloading and while staged", () => {
     expect(
-      shouldBlockMultiplayerAction({
-        status: "downloading",
-        bytes: 1,
-        total: 2,
-      }),
+      shouldBlockMultiplayerAction(
+        {
+          status: "downloading",
+          bytes: 1,
+          total: 2,
+        },
+        null,
+      ),
     ).toBe(true);
     expect(
-      shouldBlockMultiplayerAction({ status: "staged", bytes: 2, total: 2 }),
+      shouldBlockMultiplayerAction(
+        { status: "staged", bytes: 2, total: 2 },
+        null,
+      ),
     ).toBe(true);
   });
 
   it("does not block when the shell is too old to update", () => {
     expect(
-      shouldBlockMultiplayerAction({ status: "blocked", bytes: 0, total: 0 }),
+      shouldBlockMultiplayerAction(
+        { status: "blocked", bytes: 0, total: 0 },
+        null,
+      ),
     ).toBe(false);
   });
 
@@ -41,12 +53,46 @@ describe("shouldBlockMultiplayerAction", () => {
   });
 
   it("blocks a failed check when Retry is a real remedy", () => {
-    expect(shouldBlockMultiplayerAction(failed("network"))).toBe(true);
-    expect(shouldBlockMultiplayerAction(failed("verify"))).toBe(true);
+    expect(shouldBlockMultiplayerAction(failed("network"), null)).toBe(true);
+    expect(shouldBlockMultiplayerAction(failed("verify"), null)).toBe(true);
   });
 
   it("does not block failures no player-side action can change", () => {
-    expect(shouldBlockMultiplayerAction(failed("refused"))).toBe(false);
-    expect(shouldBlockMultiplayerAction(failed("parse"))).toBe(false);
+    expect(shouldBlockMultiplayerAction(failed("refused"), null)).toBe(false);
+    expect(shouldBlockMultiplayerAction(failed("parse"), null)).toBe(false);
+  });
+});
+
+describe("shouldBlockMultiplayerAction with a session", () => {
+  const healthyUpdate = { status: "current", bytes: 0, total: 0 } as const;
+
+  it("does not block when both are healthy", () => {
+    expect(
+      shouldBlockMultiplayerAction(healthyUpdate, { status: "signed-in" }),
+    ).toBe(false);
+  });
+
+  it("blocks on a signed-out session even when the update is current", () => {
+    expect(
+      shouldBlockMultiplayerAction(healthyUpdate, {
+        status: "signed-out",
+        reason: "steam-wedged",
+      }),
+    ).toBe(true);
+  });
+
+  it("blocks on a pending update even when signed in", () => {
+    expect(
+      shouldBlockMultiplayerAction(
+        { status: "staged", bytes: 0, total: 0 },
+        {
+          status: "signed-in",
+        },
+      ),
+    ).toBe(true);
+  });
+
+  it("does not block on the web, where neither state exists", () => {
+    expect(shouldBlockMultiplayerAction(null, null)).toBe(false);
   });
 });

--- a/tests/GameModeSelectorGatingWiring.test.ts
+++ b/tests/GameModeSelectorGatingWiring.test.ts
@@ -118,7 +118,7 @@ beforeEach(async () => {
   stub("join-lobby-modal", { open: joinOpen });
   stub("host-lobby-modal", { open: hostOpen });
   stub("single-player-modal", { open: vi.fn() });
-  stub("desktop-update-bar", { wiggle });
+  stub("desktop-status-bar", { wiggle });
   (window as { showPage?: (id: string) => void }).showPage = vi.fn();
   // validateAndJoin dispatches "join-lobby" as a bubbling/composed CustomEvent
   // rather than calling a modal's open() -- catch it at the document the same

--- a/tests/SteamSDK.test.ts
+++ b/tests/SteamSDK.test.ts
@@ -46,4 +46,58 @@ describe("SteamSDK", () => {
     };
     expect(await steamSDK.getUser()).toBeNull();
   });
+
+  // A shell older than this client's SteamTicketResult contract may still
+  // return the legacy `string | null` shape getAuthTicket() had before. A
+  // successful sign-in against that shell must not be read as a failure
+  // (result.ok undefined), and null must not throw.
+  it("normalises a legacy string ticket into a successful result", async () => {
+    (window as any).openfrontDesktop = {
+      steam: {
+        getAuthTicket: vi.fn().mockResolvedValue("deadbeef"),
+        getUser: vi.fn(),
+      },
+    };
+    expect(await steamSDK.getTicket()).toEqual({
+      ok: true,
+      ticket: "deadbeef",
+    });
+  });
+
+  it("normalises a legacy null ticket into steam-unavailable without throwing", async () => {
+    (window as any).openfrontDesktop = {
+      steam: {
+        getAuthTicket: vi.fn().mockResolvedValue(null),
+        getUser: vi.fn(),
+      },
+    };
+    await expect(steamSDK.getTicket()).resolves.toEqual({
+      ok: false,
+      reason: "unavailable",
+    });
+  });
+
+  // The IPC call itself has no bound otherwise: a hung shell would leave
+  // getTicket() (and everything downstream of it) waiting forever, which is
+  // the same "retrying" lockout the /auth/steam AbortSignal.timeout guards
+  // against. The bridge promise below never settles on its own.
+  it("times out rather than hanging when the bridge never settles", async () => {
+    vi.useFakeTimers();
+    try {
+      (window as any).openfrontDesktop = {
+        steam: {
+          getAuthTicket: vi.fn().mockReturnValue(new Promise(() => {})),
+          getUser: vi.fn(),
+        },
+      };
+      const ticketPromise = steamSDK.getTicket();
+      await vi.advanceTimersByTimeAsync(8000);
+      await expect(ticketPromise).resolves.toEqual({
+        ok: false,
+        reason: "timeout",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/tests/SteamSDK.test.ts
+++ b/tests/SteamSDK.test.ts
@@ -12,22 +12,30 @@ describe("SteamSDK", () => {
   it("isOnSteam true and passes through ticket/user with the bridge", async () => {
     (window as any).openfrontDesktop = {
       steam: {
-        getAuthTicket: vi.fn().mockResolvedValue("deadbeef"),
+        getAuthTicket: vi
+          .fn()
+          .mockResolvedValue({ ok: true, ticket: "deadbeef" }),
         getUser: vi.fn().mockResolvedValue({ steamId: "77", name: "Ada" }),
       },
     };
     expect(steamSDK.isOnSteam()).toBe(true);
-    expect(await steamSDK.getTicket()).toBe("deadbeef");
+    expect(await steamSDK.getTicket()).toEqual({
+      ok: true,
+      ticket: "deadbeef",
+    });
     expect(await steamSDK.getUser()).toEqual({ steamId: "77", name: "Ada" });
   });
-  it("getTicket degrades to null when bridge rejects", async () => {
+  it("getTicket degrades to a generic error when bridge rejects", async () => {
     (window as any).openfrontDesktop = {
       steam: {
         getAuthTicket: vi.fn().mockRejectedValue(new Error("boom")),
         getUser: vi.fn(),
       },
     };
-    expect(await steamSDK.getTicket()).toBeNull();
+    expect(await steamSDK.getTicket()).toEqual({
+      ok: false,
+      reason: "error",
+    });
   });
   it("getUser degrades to null when bridge rejects", async () => {
     (window as any).openfrontDesktop = {

--- a/tests/SteamSDK.test.ts
+++ b/tests/SteamSDK.test.ts
@@ -77,6 +77,22 @@ describe("SteamSDK", () => {
     });
   });
 
+  // A structured result is not trusted either: the shell is a separate repo,
+  // so a malformed success must not reach /auth/steam as a bogus ticket.
+  it.each([
+    ["a missing ticket", { ok: true }],
+    ["a non-string ticket", { ok: true, ticket: 1234 }],
+    ["an empty ticket", { ok: true, ticket: "" }],
+  ])("rejects a malformed success object with %s", async (_label, shape) => {
+    (window as any).openfrontDesktop = {
+      steam: {
+        getAuthTicket: vi.fn().mockResolvedValue(shape),
+        getUser: vi.fn(),
+      },
+    };
+    expect(await steamSDK.getTicket()).toEqual({ ok: false, reason: "error" });
+  });
+
   // The IPC call itself has no bound otherwise: a hung shell would leave
   // getTicket() (and everything downstream of it) waiting forever, which is
   // the same "retrying" lockout the /auth/steam AbortSignal.timeout guards

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -165,4 +165,27 @@ describe("Steam login", () => {
 
     expect(getTicket).toHaveBeenCalledTimes(1);
   });
+
+  // Guards against the /auth/steam fetch hanging forever: retrySteamSignIn
+  // sets "retrying" before the fetch settles, and with no AbortSignal a
+  // response that never arrives would leave the session pinned there --
+  // gated out of multiplayer with a status bar that renders no button for
+  // "retrying". The bound AbortSignal.timeout turns that into an aborted
+  // fetch, which the existing catch already maps to "network", so this
+  // proves the state always settles rather than sticking.
+  it("settles rather than sticking at retrying when the fetch rejects", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: true,
+      ticket: "t",
+    });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("aborted"));
+
+    await retrySteamSignIn();
+
+    expect(getDesktopSessionState()).toEqual({
+      status: "signed-out",
+      reason: "network",
+    });
+  });
 });

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -7,6 +7,7 @@ import {
   retrySteamSignIn,
 } from "../../src/client/Auth";
 import { ClientEnv } from "../../src/client/ClientEnv";
+import { multiplayerAllowedForSession } from "../../src/client/DesktopShell";
 import { steamSDK } from "../../src/client/SteamSDK";
 
 function setBootstrapConfig() {
@@ -57,6 +58,65 @@ describe("Steam login", () => {
     expect(getDesktopSessionState()).toEqual({ status: "signed-in" });
   });
 
+  // A shell older than this client's SteamTicketResult contract may still
+  // return the legacy `string | null` shape from getAuthTicket(). These two
+  // exercise SteamSDK's normalisation end-to-end through Auth.ts, so they
+  // mock the raw bridge rather than steamSDK.getTicket directly.
+  it("signs in via /auth/steam when the bridge returns a legacy string ticket", async () => {
+    (window as any).openfrontDesktop = {
+      steam: {
+        getAuthTicket: vi.fn().mockResolvedValue("legacyhexticket"),
+        getUser: vi.fn(),
+      },
+    };
+    try {
+      const jwt = new UnsecuredJWT({
+        jti: "some-id",
+        sub: "AAAAAAAAAAAAAAAAAAAAAA",
+        iat: Math.floor(Date.now() / 1000),
+        iss: "https://api.openfront.dev",
+        aud: "openfront.dev",
+        exp: Math.floor(Date.now() / 1000) + 3600,
+      }).encode();
+
+      const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(JSON.stringify({ jwt, expiresIn: 900 }), {
+          status: 200,
+        }),
+      );
+
+      const header = await getAuthHeader();
+
+      expect(String(fetchMock.mock.calls[0][0])).toContain("/auth/steam");
+      expect(header).toBe(`Bearer ${jwt}`);
+      expect(getDesktopSessionState()).toEqual({ status: "signed-in" });
+    } finally {
+      delete (window as any).openfrontDesktop;
+    }
+  });
+
+  it("yields signed-out/steam-unavailable without throwing when the bridge returns a legacy null", async () => {
+    (window as any).openfrontDesktop = {
+      steam: {
+        getAuthTicket: vi.fn().mockResolvedValue(null),
+        getUser: vi.fn(),
+      },
+    };
+    try {
+      const fetchMock = vi.spyOn(globalThis, "fetch");
+
+      await expect(getAuthHeader()).resolves.toBe("");
+
+      expect(fetchMock).not.toHaveBeenCalled();
+      expect(getDesktopSessionState()).toEqual({
+        status: "signed-out",
+        reason: "steam-unavailable",
+      });
+    } finally {
+      delete (window as any).openfrontDesktop;
+    }
+  });
+
   // Replaces "falls through to the guest/refresh flow when no Steam ticket is
   // available". The Electron profile has no refresh cookie, so that
   // fallthrough was a guaranteed 401 that then ran logOut() and dropped the
@@ -99,6 +159,10 @@ describe("Steam login", () => {
   it.each([
     [401, "steam-ticket-rejected"],
     [500, "steam-backend"],
+    // A Cloudflare WAF 403 (or a 429) still reached the server -- it is not a
+    // transport failure, so it must not fall into the "network" bucket
+    // ("Can't reach OpenFront. Check your connection.") the way it used to.
+    [403, "steam-error"],
   ] as const)(
     "maps /auth/steam %i to session reason %s",
     async (status, sessionReason) => {
@@ -164,6 +228,42 @@ describe("Steam login", () => {
     await Promise.all([retrySteamSignIn(), retrySteamSignIn()]);
 
     expect(getTicket).toHaveBeenCalledTimes(1);
+  });
+
+  // logOut() runs clearLocalSession() on ANY 401 from /users/@me, on key
+  // rotation, and on an iss/aud claim mismatch -- none of which mean Steam
+  // sign-in failed. It must not assert a Steam failure (which would gate
+  // multiplayer and show a Steam-specific error for an unrelated event); it
+  // must publish "unknown", which does not gate.
+  it("publishes unknown (not a Steam failure) and does not gate multiplayer after logOut on Steam", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 200 }),
+    );
+
+    await logOut();
+
+    const state = getDesktopSessionState();
+    expect(state).toEqual({ status: "unknown" });
+    expect(multiplayerAllowedForSession(state)).toBe(true);
+  });
+
+  // refreshJwt()'s finally has no catch, so an exception inside
+  // doRefreshJwt() (here, steamSDK.getTicket() rejecting) propagates to
+  // userAuth()'s top-level catch, which logs and returns false without
+  // touching session state. Without retrySteamSignIn's guarantee that would
+  // leave the session pinned at "retrying" forever -- gated out of
+  // multiplayer with a status bar that renders no button for that state.
+  it("settles to signed-out instead of sticking at retrying when doRefreshJwt throws", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getTicket").mockRejectedValue(new Error("boom"));
+
+    await retrySteamSignIn();
+
+    expect(getDesktopSessionState()).toEqual({
+      status: "signed-out",
+      reason: "steam-error",
+    });
   });
 
   // Guards against the /auth/steam fetch hanging forever: retrySteamSignIn

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -121,6 +121,34 @@ describe("Steam login", () => {
   // available". The Electron profile has no refresh cookie, so that
   // fallthrough was a guaranteed 401 that then ran logOut() and dropped the
   // player's persistent ID. The Steam branch is now terminal.
+  // A diagnosed failure must survive an UNRELATED logOut. getAuthHeader
+  // returns "" when signed out, so any authenticated call still goes out and
+  // still comes back 401, and Api.ts calls logOut() on 401 from 13 places.
+  // Resetting to "unknown" there would un-gate multiplayer and hide the bar,
+  // handing the player back the raw Turnstile error this work exists to remove.
+  it("keeps a diagnosed signed-out state through an unrelated logOut", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: false,
+      reason: "timeout",
+    });
+    await getAuthHeader();
+    expect(getDesktopSessionState()).toEqual({
+      status: "signed-out",
+      reason: "steam-wedged",
+    });
+
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(null, { status: 401 }),
+    );
+    await logOut();
+
+    expect(getDesktopSessionState()).toEqual({
+      status: "signed-out",
+      reason: "steam-wedged",
+    });
+  });
+
   // The boundary check in SteamSDK.getTicket exists so a malformed success
   // from a mismatched shell is never redeemed as a ticket. Asserted end to
   // end, not just at the SDK, because it is /auth/steam that would receive it.
@@ -259,11 +287,30 @@ describe("Steam login", () => {
   // sign-in failed. It must not assert a Steam failure (which would gate
   // multiplayer and show a Steam-specific error for an unrelated event); it
   // must publish "unknown", which does not gate.
-  it("publishes unknown (not a Steam failure) and does not gate multiplayer after logOut on Steam", async () => {
+  // The narrow job of clearLocalSession: a state still claiming "signed-in"
+  // after the session was dropped is a lie, so it is downgraded to "unknown".
+  // "unknown" rather than a Steam failure, because logOut() fires on any 401,
+  // key rotation, or claim mismatch -- none of which mean Steam failed.
+  it("downgrades a stale signed-in to unknown after logOut on Steam", async () => {
     vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: true,
+      ticket: "t",
+    });
+    const jwt = new UnsecuredJWT({
+      jti: "some-id",
+      sub: "AAAAAAAAAAAAAAAAAAAAAA",
+      iat: Math.floor(Date.now() / 1000),
+      iss: "https://api.openfront.dev",
+      aud: "openfront.dev",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }).encode();
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(null, { status: 200 }),
+      new Response(JSON.stringify({ jwt, expiresIn: 900 }), { status: 200 }),
     );
+
+    await getAuthHeader();
+    expect(getDesktopSessionState()).toEqual({ status: "signed-in" });
 
     await logOut();
 

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -1,6 +1,11 @@
 import { UnsecuredJWT } from "jose";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getAuthHeader, logOut } from "../../src/client/Auth";
+import {
+  getAuthHeader,
+  getDesktopSessionState,
+  logOut,
+  retrySteamSignIn,
+} from "../../src/client/Auth";
 import { ClientEnv } from "../../src/client/ClientEnv";
 import { steamSDK } from "../../src/client/SteamSDK";
 
@@ -25,7 +30,10 @@ beforeEach(async () => {
 describe("Steam login", () => {
   it("exchanges a Steam ticket for a session JWT via POST /auth/steam", async () => {
     vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
-    vi.spyOn(steamSDK, "getTicket").mockResolvedValue("ticket123");
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: true,
+      ticket: "ticket123",
+    });
 
     const jwt = new UnsecuredJWT({
       jti: "some-id",
@@ -36,36 +44,125 @@ describe("Steam login", () => {
       exp: Math.floor(Date.now() / 1000) + 3600,
     }).encode();
 
-    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(
-      new Response(JSON.stringify({ jwt, expiresIn: 900 }), {
-        status: 200,
-      }),
-    );
+    const fetchMock = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(
+        new Response(JSON.stringify({ jwt, expiresIn: 900 }), { status: 200 }),
+      );
 
     const header = await getAuthHeader();
 
-    expect(fetchMock).toHaveBeenCalledTimes(1);
-    const [url, init] = fetchMock.mock.calls[0];
-    expect(String(url)).toContain("/auth/steam");
-    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
-      ticket: "ticket123",
-    });
+    expect(String(fetchMock.mock.calls[0][0])).toContain("/auth/steam");
     expect(header).toBe(`Bearer ${jwt}`);
+    expect(getDesktopSessionState()).toEqual({ status: "signed-in" });
   });
 
-  it("falls through to the guest/refresh flow when no Steam ticket is available", async () => {
+  // Replaces "falls through to the guest/refresh flow when no Steam ticket is
+  // available". The Electron profile has no refresh cookie, so that
+  // fallthrough was a guaranteed 401 that then ran logOut() and dropped the
+  // player's persistent ID. The Steam branch is now terminal.
+  it("does not fall through to /auth/refresh when the ticket fails", async () => {
     vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
-    vi.spyOn(steamSDK, "getTicket").mockResolvedValue(null);
-
-    const fetchMock = vi
-      .spyOn(globalThis, "fetch")
-      .mockResolvedValue(new Response(null, { status: 401 }));
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: false,
+      reason: "timeout",
+    });
+    const fetchMock = vi.spyOn(globalThis, "fetch");
 
     await getAuthHeader();
 
-    expect(fetchMock).toHaveBeenCalled();
-    for (const call of fetchMock.mock.calls) {
-      expect(String(call[0])).not.toContain("/auth/steam");
-    }
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["unavailable", "steam-unavailable"],
+    ["timeout", "steam-wedged"],
+    ["error", "steam-error"],
+  ] as const)(
+    "maps ticket failure %s to session reason %s",
+    async (ticketReason, sessionReason) => {
+      vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+      vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+        ok: false,
+        reason: ticketReason,
+      });
+
+      await getAuthHeader();
+
+      expect(getDesktopSessionState()).toEqual({
+        status: "signed-out",
+        reason: sessionReason,
+      });
+    },
+  );
+
+  it.each([
+    [401, "steam-ticket-rejected"],
+    [500, "steam-backend"],
+  ] as const)(
+    "maps /auth/steam %i to session reason %s",
+    async (status, sessionReason) => {
+      vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+      vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+        ok: true,
+        ticket: "t",
+      });
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        new Response(null, { status }),
+      );
+
+      await getAuthHeader();
+
+      expect(getDesktopSessionState()).toEqual({
+        status: "signed-out",
+        reason: sessionReason,
+      });
+    },
+  );
+
+  it("maps a thrown fetch to the network reason", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: true,
+      ticket: "t",
+    });
+    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("offline"));
+
+    await getAuthHeader();
+
+    expect(getDesktopSessionState()).toEqual({
+      status: "signed-out",
+      reason: "network",
+    });
+  });
+
+  it("publishes each transition as a desktop-session-state event", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+      ok: false,
+      reason: "timeout",
+    });
+    const seen: unknown[] = [];
+    document.addEventListener("desktop-session-state", (e) =>
+      seen.push((e as CustomEvent).detail),
+    );
+
+    await getAuthHeader();
+
+    expect(seen).toContainEqual({
+      status: "signed-out",
+      reason: "steam-wedged",
+    });
+  });
+
+  it("runs one sign-in when retry is called twice concurrently", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    const getTicket = vi
+      .spyOn(steamSDK, "getTicket")
+      .mockResolvedValue({ ok: false, reason: "timeout" });
+
+    await Promise.all([retrySteamSignIn(), retrySteamSignIn()]);
+
+    expect(getTicket).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -170,22 +170,61 @@ describe("Steam login", () => {
   // sets "retrying" before the fetch settles, and with no AbortSignal a
   // response that never arrives would leave the session pinned there --
   // gated out of multiplayer with a status bar that renders no button for
-  // "retrying". The bound AbortSignal.timeout turns that into an aborted
-  // fetch, which the existing catch already maps to "network", so this
-  // proves the state always settles rather than sticking.
-  it("settles rather than sticking at retrying when the fetch rejects", async () => {
-    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
-    vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
-      ok: true,
-      ticket: "t",
-    });
-    vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("aborted"));
+  // "retrying". This mock fetch never settles on its own -- it only rejects
+  // when the AbortSignal it was handed actually fires, the way a real fetch
+  // does -- so the test can only pass if the code under test wires the
+  // AbortSignal.timeout(10_000) into the request and the existing catch maps
+  // the resulting abort to "network".
+  //
+  // AbortSignal.timeout schedules its abort on Node's internal timer, not
+  // the global setTimeout that vi.useFakeTimers() patches, so it doesn't
+  // advance with fake timers on its own. AbortSignal.timeout itself is
+  // stubbed here to route through a (now fake) setTimeout instead, purely so
+  // the 10s deadline can be crossed deterministically with
+  // advanceTimersByTimeAsync rather than waiting on the wall clock.
+  it("aborts and settles rather than sticking at retrying when the fetch hangs past the timeout", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+      vi.spyOn(steamSDK, "getTicket").mockResolvedValue({
+        ok: true,
+        ticket: "t",
+      });
+      vi.spyOn(AbortSignal, "timeout").mockImplementation((ms: number) => {
+        const controller = new AbortController();
+        setTimeout(
+          () =>
+            controller.abort(
+              new DOMException("The operation timed out.", "TimeoutError"),
+            ),
+          ms,
+        );
+        return controller.signal;
+      });
+      vi.spyOn(globalThis, "fetch").mockImplementation(
+        (_input, init) =>
+          new Promise<Response>((_resolve, reject) => {
+            const signal = init?.signal;
+            signal?.addEventListener("abort", () => {
+              reject(
+                signal.reason ?? new DOMException("Aborted", "AbortError"),
+              );
+            });
+          }),
+      );
 
-    await retrySteamSignIn();
+      const signInPromise = retrySteamSignIn();
+      expect(getDesktopSessionState()).toEqual({ status: "retrying" });
 
-    expect(getDesktopSessionState()).toEqual({
-      status: "signed-out",
-      reason: "network",
-    });
+      await vi.advanceTimersByTimeAsync(10_000);
+      await signInPromise;
+
+      expect(getDesktopSessionState()).toEqual({
+        status: "signed-out",
+        reason: "network",
+      });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -121,6 +121,30 @@ describe("Steam login", () => {
   // available". The Electron profile has no refresh cookie, so that
   // fallthrough was a guaranteed 401 that then ran logOut() and dropped the
   // player's persistent ID. The Steam branch is now terminal.
+  // The boundary check in SteamSDK.getTicket exists so a malformed success
+  // from a mismatched shell is never redeemed as a ticket. Asserted end to
+  // end, not just at the SDK, because it is /auth/steam that would receive it.
+  it("never POSTs /auth/steam for a malformed success from the bridge", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    (window as any).openfrontDesktop = {
+      steam: {
+        getAuthTicket: vi.fn().mockResolvedValue({ ok: true, ticket: 1234 }),
+        getUser: vi.fn(),
+      },
+    };
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    await getAuthHeader();
+
+    for (const call of fetchMock.mock.calls) {
+      expect(String(call[0])).not.toContain("/auth/steam");
+    }
+    expect(getDesktopSessionState()).toEqual({
+      status: "signed-out",
+      reason: "steam-error",
+    });
+  });
+
   it("does not fall through to /auth/refresh when the ticket fails", async () => {
     vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
     vi.spyOn(steamSDK, "getTicket").mockResolvedValue({


### PR DESCRIPTION
## Problem

A Steam desktop client that can't obtain a session is rejected from every multiplayer game, and the error names a Turnstile challenge the player never saw.

No ticket → no JWT. `Main.ts`'s `getTurnstileToken` returns null unconditionally on desktop, so `planJoinVerify` sees neither a Steam-provider JWT nor a Turnstile token, `Worker.ts` closes with `1002 "Unauthorized: Turnstile token rejected"`, and `Transport.ts` shows that string verbatim. The usual actual fix is restarting Steam.

The rejection itself is correct and stays: the desktop build injects Cloudflare's test site key (a real key is domain-locked and `app://openfront` can't satisfy one), and `isSteamAuthenticated` keys on a signed `provider="steam"` claim rather than the forgeable `instanceId`. This PR changes where the refusal surfaces and what it says, not whether it happens.

## Changes

- `DesktopShell.ts`: `DesktopSessionState` + `multiplayerAllowedForSession`.
- `Auth.ts`: derives a failure reason from the shell's ticket result and the `/auth/steam` response, published as a `desktop-session-state` document event (symmetric with the existing `desktop-update-state`).
- `DesktopUpdateBar` → `DesktopStatusBar`, rendering whichever status applies. Session takes precedence over every update state, so the two can't stack in the same slot.
- Multiplayer entry points gate on either state. Retry re-runs sign-in through the existing `authGeneration` path, so a success updates the account nav and unlocks the buttons together.

Six failure reasons, each with its own string. `steam-wedged` — "Steam couldn't verify your session. Restarting Steam usually fixes this." — is the case this exists for.

## Two behaviour changes worth review

**Every signed-out reason gates multiplayer, including ones the player can't fix.** This contradicts the "gate when there is a remedy, not merely when there is a problem" rule documented on `multiplayerAllowed` just above it. The reasoning: with a pending update, not gating still lets the player play. With no session it doesn't — the server refuses the join either way — so gating is what makes the refusal happen somewhere we can name a cause and offer Retry.

**The Steam branch of `doRefreshJwt` no longer falls through to `/auth/refresh`.** That request can't succeed in the Electron profile (no refresh cookie), so it was a guaranteed 401 that then ran `logOut()` and dropped the player's persistent ID on every transient Steam failure. It's now terminal.

## Depends on a shell change

Needs the matching `openfront-desktop` change that makes `steam:getAuthTicket` report why a ticket failed. The two are coupled: a shell built before that change returns a bare string, which this client reads as a failure — so the shell side must land alongside this.

## Testing

Rebased onto current `main`. Full suite green (340 files / 4044 tests) and `tsc --noEmit` clean after the rebase.

The rebase collided with the trusted-lobby work in `GameModeSelector` and `DetailedGameViewModal`. Both sides were kept; re-verified afterwards that all five `shouldBlockMultiplayerAction` call sites still pass both states and that the trusted-lobby additions survived intact.

The `/auth/steam` timeout regression test is mutation-verified — removing the `AbortSignal` makes it hang and fail.

The real wedged-Steam path can't be covered automatically: the join rejection is unreachable on a dev server (`ServerEnv.env() !== GameEnv.Dev`) and the state needs a live Steam client. Still to be checked by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
