### PR TITLE
small-fix: Fix keybind already bound display issue due to wrong split

### DIFF
--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -139,15 +139,16 @@ export class UserSettingModal extends BaseModal {
               </svg>
               <span class="font-medium">
                 ${(() => {
+                  const placeholder = "__KEY__";
                   const message = translateText(
                     "user_setting.keybind_conflict_error",
-                    { key: displayKey },
+                    { key: placeholder },
                   );
-                  const parts = message.split(displayKey);
-                  return html`${parts[0]}<span
+                  const [prefix, suffix] = message.split(placeholder);
+                  return html`${prefix}<span
                       class="font-mono font-bold bg-white/10 px-1.5 py-0.5 rounded text-red-200 mx-1 border border-white/10"
                       >${displayKey}</span
-                    >${parts[1] || ""}`;
+                    >${suffix || ""}`;
                 })()}
               </span>
             `,


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

None - small fix

## Description:

Fix keybind already bound display issue due to wrong split. Main splits the "KEY ALREADY BOUND" error on the key that was pressed. If the pressed key is present as a letter in the string before {key} in the translation - it instead splits the actual string on that letter and not the pressed key

Old

<img width="274" height="101" alt="image" src="https://github.com/user-attachments/assets/f3534e12-ca6f-4919-8305-1383ebfd95b9" />
<img width="534" height="96" alt="image" src="https://github.com/user-attachments/assets/20068660-383a-436e-84df-22267aeb3c4a" />

New

<img width="540" height="83" alt="image" src="https://github.com/user-attachments/assets/f7acb6a7-7032-4ede-b8ef-1eca181c2a05" />

## Please complete the following:

- [x] I have added screenshots for all UI updates

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
