### PR TITLE
Replace Math.exp/log/pow/atan2 in src/core with deterministic DetMath

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -48,6 +48,51 @@ export default [
     },
   },
   {
+    // The simulation must be bit-identical on every client. Math.exp & co.
+    // are only "implementation approximated" by the spec; use DetMath.
+    files: ["src/core/**/*.ts"],
+    ignores: ["src/core/DetMath.ts"],
+    rules: {
+      "no-restricted-properties": [
+        "error",
+        ...[
+          "exp",
+          "expm1",
+          "log",
+          "log1p",
+          "log2",
+          "log10",
+          "pow",
+          "sin",
+          "cos",
+          "tan",
+          "asin",
+          "acos",
+          "atan",
+          "atan2",
+          "sinh",
+          "cosh",
+          "tanh",
+          "cbrt",
+          "hypot",
+        ].map((property) => ({
+          object: "Math",
+          property,
+          message: `Math.${property} differs between JS engines; use src/core/DetMath.ts to keep the simulation deterministic.`,
+        })),
+      ],
+      "no-restricted-syntax": [
+        "error",
+        {
+          selector:
+            "BinaryExpression[operator='**']:not([right.type='Literal'][right.value=2])",
+          message:
+            "`**` with a non-2 exponent differs between JS engines; use src/core/DetMath.ts to keep the simulation deterministic.",
+        },
+      ],
+    },
+  },
+  {
     rules: {
       // Enable rules
       "@typescript-eslint/prefer-nullish-coalescing": "error",

--- a/src/core/DetMath.ts
+++ b/src/core/DetMath.ts
@@ -27,8 +27,10 @@ const PI_2 = 1.5707963267948966;
 const PI_4 = 0.7853981633974483;
 const TAN_PI_8 = 0.41421356237309503;
 
-/** 2 ** n for integer n in [-1022, 1023]; exact. */
+/** 2 ** n for integer n; exact, saturating to Infinity / 0 like Math.pow. */
 export function pow2(n: number): number {
+  if (n > 1023) return Infinity;
+  if (n < -1022) return 0;
   u32[HI] = (n + 1023) << 20;
   u32[LO] = 0;
   return f64[0];

--- a/src/core/DetMath.ts
+++ b/src/core/DetMath.ts
@@ -1,0 +1,130 @@
+/**
+ * Deterministic replacements for the transcendental Math functions.
+ *
+ * The JS spec only requires Math.exp/log/pow/atan2 to be "implementation
+ * approximated", and engines differ in the last bit. The simulation runs on
+ * every client and compares hashes, so a one-bit difference that lands on a
+ * truncation boundary (toInt on troops, floor on gold, the nuke edge) is a
+ * desync. These versions use only + - * / and bit views, which IEEE 754
+ * requires to be correctly rounded, so every engine produces the same bits.
+ *
+ * Accuracy is about 1e-8 relative, which is plenty for game curves. Inputs
+ * are assumed finite; negative bases for pow are not supported.
+ */
+
+const f64 = new Float64Array(1);
+const u32 = new Uint32Array(f64.buffer);
+f64[0] = 1;
+/** Index of the high word (sign, exponent, top mantissa bits) in u32. */
+const HI = u32[1] === 0x3ff00000 ? 1 : 0;
+const LO = 1 - HI;
+
+const LN2 = 0.6931471805599453;
+const LOG2E = 1.4426950408889634;
+const SQRT2 = 1.4142135623730951;
+const PI = 3.141592653589793;
+const PI_2 = 1.5707963267948966;
+const PI_4 = 0.7853981633974483;
+const TAN_PI_8 = 0.41421356237309503;
+
+/** 2 ** n for integer n in [-1022, 1023]; exact. */
+export function pow2(n: number): number {
+  u32[HI] = (n + 1023) << 20;
+  u32[LO] = 0;
+  return f64[0];
+}
+
+/** e ** x. */
+export function exp(x: number): number {
+  if (x > 709) return Infinity;
+  if (x < -708) return 0;
+  // x = n ln2 + r, |r| <= ln2 / 2
+  const n = Math.floor(x * LOG2E + 0.5);
+  const r = x - n * LN2;
+  // Taylor to r^8; the next term is below 1e-9 relative at |r| <= 0.35.
+  const p =
+    1 +
+    r *
+      (1 +
+        r *
+          (1 / 2 +
+            r *
+              (1 / 6 +
+                r *
+                  (1 / 24 +
+                    r *
+                      (1 / 120 +
+                        r * (1 / 720 + r * (1 / 5040 + r * (1 / 40320))))))));
+  return p * pow2(n);
+}
+
+/** Natural log of x > 0. */
+export function log(x: number): number {
+  if (x <= 0) return x === 0 ? -Infinity : NaN;
+  let e = 0;
+  if (x < 2.2250738585072014e-308) {
+    // Subnormal: scale into the normal range first.
+    x *= 18014398509481984; // 2 ** 54
+    e = -54;
+  }
+  f64[0] = x;
+  e += ((u32[HI] >>> 20) & 0x7ff) - 1023;
+  u32[HI] = (u32[HI] & 0x000fffff) | 0x3ff00000;
+  let m = f64[0]; // [1, 2)
+  if (m > SQRT2) {
+    m *= 0.5;
+    e += 1;
+  }
+  // log(m) = 2 atanh(s), s = (m - 1) / (m + 1), |s| <= 0.172
+  const s = (m - 1) / (m + 1);
+  const z = s * s;
+  const series =
+    1 +
+    z *
+      (1 / 3 +
+        z * (1 / 5 + z * (1 / 7 + z * (1 / 9 + z * (1 / 11 + z * (1 / 13))))));
+  return e * LN2 + 2 * s * series;
+}
+
+/** x ** y for x >= 0. */
+export function pow(x: number, y: number): number {
+  if (y === 0 || x === 1) return 1;
+  if (x === 0) return y > 0 ? 0 : Infinity;
+  if (x < 0) return NaN;
+  return exp(y * log(x));
+}
+
+/** atan(z) for z in [0, 1]. */
+function atanUnit(z: number): number {
+  // Fold [tan(pi/8), 1] onto [-tan(pi/8), tan(pi/8)] around pi/4.
+  let base = 0;
+  if (z > TAN_PI_8) {
+    base = PI_4;
+    z = (z - 1) / (z + 1);
+  }
+  // Taylor to z^17; next term is below 2e-8 at |z| <= 0.4142.
+  const w = z * z;
+  const series =
+    1 -
+    w *
+      (1 / 3 -
+        w *
+          (1 / 5 -
+            w *
+              (1 / 7 -
+                w *
+                  (1 / 9 -
+                    w * (1 / 11 - w * (1 / 13 - w * (1 / 15 - w / 17)))))));
+  return base + z * series;
+}
+
+/** Angle of (x, y) in (-pi, pi], like Math.atan2 (ignoring signed zeros). */
+export function atan2(y: number, x: number): number {
+  if (y === 0) return x >= 0 ? 0 : PI;
+  if (x === 0) return y > 0 ? PI_2 : -PI_2;
+  const ax = x < 0 ? -x : x;
+  const ay = y < 0 ? -y : y;
+  let a = ay <= ax ? atanUnit(ay / ax) : PI_2 - atanUnit(ax / ay);
+  if (x < 0) a = PI - a;
+  return y < 0 ? -a : a;
+}

--- a/src/core/PseudoRandom.ts
+++ b/src/core/PseudoRandom.ts
@@ -6,7 +6,7 @@ export class PseudoRandom {
   private s2: number;
   private s3: number;
 
-  private static readonly POW36_8 = Math.pow(36, 8); // Pre-compute 36^8
+  private static readonly POW36_8 = 2_821_109_907_456; // 36 ** 8
 
   constructor(seed: number) {
     // The seed is truncated to 32 bits: seeds congruent mod 2^32 produce

--- a/src/core/Util.ts
+++ b/src/core/Util.ts
@@ -1,5 +1,6 @@
 import DOMPurify from "dompurify";
 import { customAlphabet } from "nanoid";
+import { exp } from "./DetMath";
 import { Cell, GameType, PlayerType, Unit } from "./game/Game";
 import { GameMap, TileRef } from "./game/GameMap";
 import { TileSet } from "./game/TileSet";
@@ -447,7 +448,7 @@ export function sigmoid(
   decayRate: number,
   midpoint: number,
 ): number {
-  return 1 / (1 + Math.exp(-decayRate * (value - midpoint)));
+  return 1 / (1 + exp(-decayRate * (value - midpoint)));
 }
 
 export function formatPlayerDisplayName(

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { PlayerView } from "../../client/view";
 import { AssetManifest } from "../AssetUrls";
+import { exp, log, pow, pow2 } from "../DetMath";
 import { DoomsdayClockSpeed } from "../game/DoomsdayClock";
 import {
   Difficulty,
@@ -126,9 +127,9 @@ function largeTerritoryBonus(numTiles: number, depth: number): number {
     1 -
     depth *
       sigmoid(
-        Math.log(numTiles),
+        log(numTiles),
         LARGE_TERRITORY_STEEPNESS,
-        Math.log(LARGE_TERRITORY_MIDPOINT),
+        log(LARGE_TERRITORY_MIDPOINT),
       )
   );
 }
@@ -443,8 +444,7 @@ export class Config {
   tradeShipGold(dist: number, player: Player | PlayerView): Gold {
     // Sigmoid: concave start, sharp S-curve middle, linear end - heavily punishes trades under range debuff.
     const debuff = this.tradeShipShortRangeDebuff();
-    const baseGold =
-      75_000 / (1 + Math.exp(-0.03 * (dist - debuff))) + 50 * dist;
+    const baseGold = 75_000 / (1 + exp(-0.03 * (dist - debuff))) + 50 * dist;
     return BigInt(Math.floor(baseGold * this.goldMultiplierFor(player)));
   }
 
@@ -500,8 +500,7 @@ export class Config {
       case UnitType.Port:
         info = {
           cost: this.costWrapper(
-            (numUnits: number) =>
-              Math.min(1_000_000, Math.pow(2, numUnits) * 125_000),
+            (numUnits: number) => Math.min(1_000_000, pow2(numUnits) * 125_000),
             UnitType.Port,
             UnitType.Factory,
           ),
@@ -574,8 +573,7 @@ export class Config {
       case UnitType.City:
         info = {
           cost: this.costWrapper(
-            (numUnits: number) =>
-              Math.min(1_000_000, Math.pow(2, numUnits) * 125_000),
+            (numUnits: number) => Math.min(1_000_000, pow2(numUnits) * 125_000),
             UnitType.City,
           ),
           constructionDuration: this.instantBuild() ? 0 : 2 * 10,
@@ -585,8 +583,7 @@ export class Config {
       case UnitType.Factory:
         info = {
           cost: this.costWrapper(
-            (numUnits: number) =>
-              Math.min(1_000_000, Math.pow(2, numUnits) * 125_000),
+            (numUnits: number) => Math.min(1_000_000, pow2(numUnits) * 125_000),
             UnitType.Factory,
             UnitType.Port,
           ),
@@ -926,7 +923,7 @@ export class Config {
     const maxTroops =
       player.type() === PlayerType.Human && this.hasInfiniteTroopsFor(player)
         ? 1_000_000_000
-        : 2 * (Math.pow(player.numTilesOwned(), 0.6) * 1000 + 50000) +
+        : 2 * (pow(player.numTilesOwned(), 0.6) * 1000 + 50000) +
           player
             .units(UnitType.City)
             .filter((u) => !u.isUnderConstruction())
@@ -959,7 +956,7 @@ export class Config {
   troopIncreaseRate(player: Player | PlayerView): number {
     const max = this.maxTroops(player);
 
-    let toAdd = 10 + Math.pow(player.troops(), 0.73) / 4;
+    let toAdd = 10 + pow(player.troops(), 0.73) / 4;
 
     const ratio = 1 - player.troops() / max;
     toAdd *= ratio;
@@ -1086,7 +1083,7 @@ export class Config {
 
     const steepness = 2;
     const normalizedExcess = excessTroops / maxTroops;
-    return scalingFactor * (1 - Math.exp(-steepness * normalizedExcess));
+    return scalingFactor * (1 - exp(-steepness * normalizedExcess));
   }
 
   structureMinDist(): number {

--- a/src/core/execution/NukeExecution.ts
+++ b/src/core/execution/NukeExecution.ts
@@ -1,3 +1,4 @@
+import { atan2 } from "../DetMath";
 import {
   Execution,
   Game,
@@ -99,7 +100,7 @@ export class NukeExecution implements Execution {
           const d2 = dx * dx + dy * dy;
           if (d2 > outer2) continue;
           if (d2 > inner2) {
-            const angle = Math.atan2(dy, dx) + Math.PI; // [0, 2π]
+            const angle = atan2(dy, dx) + Math.PI; // [0, 2π]
             const t = (angle / (2 * Math.PI)) * NUM_SAMPLES;
             const i0 = Math.floor(t) % NUM_SAMPLES;
             const i1 = (i0 + 1) % NUM_SAMPLES;

--- a/tests/core/DetMath.test.ts
+++ b/tests/core/DetMath.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from "vitest";
+import { atan2, exp, log, pow, pow2 } from "../../src/core/DetMath";
+
+function relErr(a: number, b: number): number {
+  return b === 0 ? Math.abs(a) : Math.abs(a - b) / Math.abs(b);
+}
+
+describe("DetMath", () => {
+  it("pow2 is exact for integer exponents", () => {
+    for (let n = -1022; n <= 1023; n++) {
+      expect(pow2(n)).toBe(2 ** n);
+    }
+  });
+
+  it("exp matches Math.exp to 1e-8 across the useful range", () => {
+    for (let x = -700; x <= 700; x += 0.37) {
+      expect(relErr(exp(x), Math.exp(x))).toBeLessThan(1e-8);
+    }
+    expect(exp(0)).toBe(1);
+    expect(exp(710)).toBe(Infinity);
+    expect(exp(-800)).toBe(0);
+  });
+
+  it("log matches Math.log to 1e-8 across the useful range", () => {
+    for (let p = -300; p <= 300; p += 0.61) {
+      const x = 10 ** p;
+      expect(relErr(log(x), Math.log(x))).toBeLessThan(1e-8);
+    }
+    for (let x = 0.5; x <= 4; x += 0.013) {
+      expect(Math.abs(log(x) - Math.log(x))).toBeLessThan(1e-9);
+    }
+    expect(log(1)).toBe(0);
+    expect(log(0)).toBe(-Infinity);
+    expect(log(-1)).toBeNaN();
+    expect(relErr(log(5e-324), Math.log(5e-324))).toBeLessThan(1e-8);
+  });
+
+  it("pow matches Math.pow to 1e-7 on game-sized inputs", () => {
+    const bases = [0.5, 1, 2, 7.3, 100, 5000, 123_456, 1e6, 4e6, 1e9];
+    const exps = [0, 0.15, 0.35, 0.5, 0.6, 0.73, 1, 2, 2.5];
+    for (const x of bases) {
+      for (const y of exps) {
+        expect(relErr(pow(x, y), Math.pow(x, y))).toBeLessThan(1e-7);
+      }
+    }
+    expect(pow(0, 0.6)).toBe(0);
+    expect(pow(0, 0)).toBe(1);
+    expect(pow(-2, 0.5)).toBeNaN();
+  });
+
+  it("atan2 matches Math.atan2 to 1e-7 radians in every quadrant", () => {
+    for (let y = -20; y <= 20; y++) {
+      for (let x = -20; x <= 20; x++) {
+        expect(Math.abs(atan2(y, x) - Math.atan2(y, x))).toBeLessThan(1e-7);
+      }
+    }
+    for (let t = -Math.PI + 1e-6; t < Math.PI; t += 0.0137) {
+      const y = 1000 * Math.sin(t);
+      const x = 1000 * Math.cos(t);
+      expect(Math.abs(atan2(y, x) - Math.atan2(y, x))).toBeLessThan(1e-7);
+    }
+    expect(atan2(0, 1)).toBe(0);
+    expect(atan2(0, -1)).toBe(Math.PI);
+    expect(atan2(1, 0)).toBe(Math.PI / 2);
+    expect(atan2(-1, 0)).toBe(-Math.PI / 2);
+  });
+
+  it("produces exactly these bits (guards against accidental changes)", () => {
+    expect([
+      exp(1),
+      exp(-12.5),
+      log(3),
+      log(150_000),
+      pow(50_000, 0.6),
+      pow(1_234_567, 0.73),
+      atan2(3, 4),
+      atan2(-7, -2),
+    ]).toMatchSnapshot();
+  });
+});

--- a/tests/core/DetMath.test.ts
+++ b/tests/core/DetMath.test.ts
@@ -10,6 +10,12 @@ describe("DetMath", () => {
     for (let n = -1022; n <= 1023; n++) {
       expect(pow2(n)).toBe(2 ** n);
     }
+    // Out of range saturates like Math.pow(2, n) rather than wrapping the shift.
+    expect(pow2(1024)).toBe(Infinity);
+    expect(pow2(1025)).toBe(Infinity);
+    expect(pow2(5000)).toBe(Infinity);
+    expect(pow2(-1023)).toBe(0);
+    expect(Math.min(1_000_000, pow2(1026) * 125_000)).toBe(1_000_000);
   });
 
   it("exp matches Math.exp to 1e-8 across the useful range", () => {

--- a/tests/core/__snapshots__/DetMath.test.ts.snap
+++ b/tests/core/__snapshots__/DetMath.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`DetMath > produces exactly these bits (guards against accidental changes) 1`] = `
+[
+  2.718281828321915,
+  0.00000372665317207867,
+  1.0986122886681382,
+  11.918390573078392,
+  659.7539553801837,
+  27977.293878826826,
+  0.6435011087932844,
+  -1.8490959858022622,
+]
+`;


### PR DESCRIPTION
## Summary

The simulation runs on every client and compares hashes, but `src/core` called `Math.exp`, `Math.log`, `Math.pow` and `Math.atan2`, which the JS spec only requires to be "implementation approximated". V8 and SpiderMonkey use fdlibm ports; JavaScriptCore routes some through the platform libm. A last-bit difference is harmless until it lands on a truncation boundary — `toInt` on troops, `floor` on trade gold, or the `Math.floor(t)` bucket in the nuke's irregular edge — at which point clients diverge.

- **`src/core/DetMath.ts`**: `exp`, `log`, `pow`, `atan2`, `pow2` built from `+ − × ÷` and `Float64Array` bit views only. IEEE 754 requires those to be correctly rounded and JS has no FMA contraction, so every engine produces identical bits. Range reduction + short Taylor series; ~1e-8 relative accuracy (pow via `exp(y·log x)`, ~1e-7).
- **Swapped every sim-path call** (8 sites): `Util.sigmoid`, `largeTerritoryBonus`, `tradeShipGold`, `maxTroops`, `troopIncreaseRate`, MIRV death scaling, the nuke blast edge angle, and `Math.pow(2, n)` structure costs (→ exact `pow2`). `PseudoRandom`'s `36 ** 8` becomes a literal.
- **ESLint guard** for `src/core/**`: `no-restricted-properties` on all `Math.<transcendental>` and `no-restricted-syntax` on `**` with a non-`2` exponent, so they can't creep back. `Math.sqrt` and `x ** 2` are left alone (correctly rounded / exact).
- **No snapshot changed**: the full suite (339 files, 4026 tests) passes against existing snapshots — the approximation error is below every truncation in the game.

## Test plan

- `tests/core/DetMath.test.ts`: vs `Math.*` to 1e-8 (exp/log), 1e-7 (pow on game-sized inputs, atan2 in every quadrant), edge cases (0, subnormals, ±∞, NaN), `pow2` exact for all 2046 exponents, and a bit-exact snapshot guarding accidental changes.
- Full suite green; `npm run lint` clean (the new rule fires on any remaining `Math.exp` etc. in `src/core`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)