### PR TITLE
feat(desktop): Steam rich presence and invite handling for the Electron build

### DIFF
--- a/src/client/DesktopPresence.ts
+++ b/src/client/DesktopPresence.ts
@@ -64,7 +64,14 @@ class DesktopPresence {
   }
 
   subscribeInvites(cb: (gameId: string) => void): () => void {
-    return bridge()?.invite?.subscribe(cb) ?? (() => undefined);
+    try {
+      return bridge()?.invite?.subscribe(cb) ?? (() => undefined);
+    } catch {
+      // A bridge that throws synchronously must not abort the caller's
+      // initialisation. Invites are cosmetic; whatever the caller wires up
+      // after this call may not be.
+      return () => undefined;
+    }
   }
 
   async openInviteDialog(): Promise<boolean> {

--- a/src/client/DesktopPresence.ts
+++ b/src/client/DesktopPresence.ts
@@ -1,0 +1,70 @@
+// Thin renderer wrapper over the desktop shell's presence bridge. Mirrors
+// SteamSDK.ts; all Steam-specific work lives in the Electron main process.
+//
+// This module deliberately knows NOTHING about Steam. It reports game state;
+// the shell decides what Steam and Discord make of it.
+
+export type PresenceState = "menu" | "lobby" | "game" | "spectating";
+
+export interface PresencePayload {
+  state: PresenceState;
+  gameType?: string;
+  gameMode?: string;
+  map?: string;
+  playerCount?: number;
+  maxPlayers?: number;
+  lobbyId?: string;
+  teamId?: string;
+  teamSize?: number;
+}
+
+interface PresenceBridge {
+  presence?: { set(payload: PresencePayload | null): Promise<void> };
+  invite?: {
+    consumePending(): Promise<string | null>;
+    subscribe(cb: (gameId: string) => void): () => void;
+    openInviteDialog(): Promise<boolean>;
+  };
+  shell?: { api?: number };
+}
+
+function bridge(): PresenceBridge | undefined {
+  return window.openfrontDesktop as PresenceBridge | undefined;
+}
+
+class DesktopPresence {
+  // shell.api >= 2 is the capability signal for these namespaces. An older
+  // depot's shell has no presence bridge, and every method below no-ops.
+  isAvailable(): boolean {
+    const api = bridge()?.shell?.api;
+    return typeof api === "number" && api >= 2;
+  }
+
+  set(payload: PresencePayload | null): void {
+    void bridge()
+      ?.presence?.set(payload)
+      ?.catch(() => undefined);
+  }
+
+  async consumePendingInvite(): Promise<string | null> {
+    try {
+      return (await bridge()?.invite?.consumePending()) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  subscribeInvites(cb: (gameId: string) => void): () => void {
+    return bridge()?.invite?.subscribe(cb) ?? (() => undefined);
+  }
+
+  async openInviteDialog(): Promise<boolean> {
+    try {
+      return (await bridge()?.invite?.openInviteDialog()) ?? false;
+    } catch {
+      return false;
+    }
+  }
+}
+
+export const desktopPresence = new DesktopPresence();

--- a/src/client/DesktopPresence.ts
+++ b/src/client/DesktopPresence.ts
@@ -28,6 +28,10 @@ interface PresenceBridge {
   shell?: { api?: number };
 }
 
+// window.openfrontDesktop is declared `unknown` by DesktopShell.ts (kept loose
+// there on purpose). We know the shape the Electron preload exposes, so narrow
+// it locally rather than re-declaring the global (a second `declare global`
+// with a different type triggers TS2717).
 function bridge(): PresenceBridge | undefined {
   return window.openfrontDesktop as PresenceBridge | undefined;
 }
@@ -41,9 +45,14 @@ class DesktopPresence {
   }
 
   set(payload: PresencePayload | null): void {
-    void bridge()
-      ?.presence?.set(payload)
-      ?.catch(() => undefined);
+    try {
+      void bridge()
+        ?.presence?.set(payload)
+        ?.catch(() => undefined);
+    } catch {
+      // A bridge that throws synchronously must not take the game down --
+      // presence is cosmetic.
+    }
   }
 
   async consumePendingInvite(): Promise<string | null> {

--- a/src/client/DesktopPresence.ts
+++ b/src/client/DesktopPresence.ts
@@ -37,14 +37,21 @@ function bridge(): PresenceBridge | undefined {
 }
 
 class DesktopPresence {
-  // shell.api >= 2 is the capability signal for these namespaces. An older
-  // depot's shell has no presence bridge, and every method below no-ops.
+  // shell.api >= 2 is the capability signal for these namespaces, and every
+  // method below gates on it rather than relying on optional chaining alone.
+  // Optional chaining would be enough today -- presence/invite and api: 2
+  // shipped in the same shell commit, so no released shell has one without
+  // the other -- but it makes the client's contract "call whatever happens to
+  // be present" instead of "call what the shell declares it supports". A shell
+  // that ever exposed half the surface without bumping api would be silently
+  // half-driven; this refuses it instead.
   isAvailable(): boolean {
     const api = bridge()?.shell?.api;
     return typeof api === "number" && api >= 2;
   }
 
   set(payload: PresencePayload | null): void {
+    if (!this.isAvailable()) return;
     try {
       void bridge()
         ?.presence?.set(payload)
@@ -56,6 +63,7 @@ class DesktopPresence {
   }
 
   async consumePendingInvite(): Promise<string | null> {
+    if (!this.isAvailable()) return null;
     try {
       return (await bridge()?.invite?.consumePending()) ?? null;
     } catch {
@@ -64,6 +72,7 @@ class DesktopPresence {
   }
 
   subscribeInvites(cb: (gameId: string) => void): () => void {
+    if (!this.isAvailable()) return () => undefined;
     try {
       return bridge()?.invite?.subscribe(cb) ?? (() => undefined);
     } catch {
@@ -75,6 +84,7 @@ class DesktopPresence {
   }
 
   async openInviteDialog(): Promise<boolean> {
+    if (!this.isAvailable()) return false;
     try {
       return (await bridge()?.invite?.openInviteDialog()) ?? false;
     } catch {

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -672,9 +672,19 @@ class Client {
       .then((gameId) => (gameId === null ? undefined : this.openInvite(gameId)))
       .catch(() => undefined);
 
-    // Invites arriving while we are already running.
-    desktopPresence.subscribeInvites((gameId) => {
-      void this.openInvite(gameId).catch(() => undefined);
+    // Invites arriving while we are already running. The pushed id is
+    // deliberately ignored: the shell parks every invite as well as pushing
+    // it, so the push is only a nudge and the parked copy is the single
+    // source of truth. Pulling here is what clears it -- otherwise leaving a
+    // game (a full page load) would re-run the pull above and force the join
+    // modal open on a match that has already finished.
+    desktopPresence.subscribeInvites(() => {
+      void desktopPresence
+        .consumePendingInvite()
+        .then((gameId) =>
+          gameId === null ? undefined : this.openInvite(gameId),
+        )
+        .catch(() => undefined);
     });
 
     const onHashUpdate = () => {
@@ -1212,6 +1222,29 @@ class Client {
   // the modal that trusts it.
   private async openInvite(gameId: string): Promise<void> {
     if (!GAME_ID_REGEX.test(gameId)) return;
+    // An invite can arrive mid-match, unlike the CrazyGames invite this path
+    // was modelled on, which only ever runs at cold start. Force-opening the
+    // join UI would leave it overlaying a game whose socket and render loop
+    // keep running underneath. Same rule the back-button exit uses: stop
+    // silently when the player is not active, ask first when they are, and
+    // drop the invite entirely if they decline.
+    if (this.lobbyHandle !== null) {
+      // stop() without force is the codebase's "is the player actually in
+      // this?" test: it tears the game down and returns true when they are
+      // not, and refuses (returning false) when they are.
+      if (!this.lobbyHandle.stop()) {
+        const confirmed = await showInGameConfirm(
+          translateText("help_modal.exit_confirmation"),
+        );
+        if (!confirmed) return;
+      }
+      // The existing in-place leave: it forces the stop, clears the URL, drops
+      // the in-game class and resets presence to the menu -- which matters
+      // because the join below is not guaranteed to follow (the player can
+      // still close the modal) and friends must not be left looking at a
+      // lobby nobody is in.
+      await this.handleLeaveLobby();
+    }
     // A cold-start invite can beat the modal's own upgrade, which would make
     // open() a silent no-op (the CrazyGames invite path waits for the same
     // reason).

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -396,7 +396,17 @@ class Client {
       this.emitPresence();
     });
 
-    document.addEventListener("join-lobby", this.handleJoinLobby.bind(this));
+    document.addEventListener("join-lobby", (event) => {
+      // A rejected handshake (Turnstile alerts then rejects) never assigns
+      // lobbyHandle, so nothing downstream clears the "lobby" presence
+      // emitted at the top of the join -- friends would keep being offered a
+      // Join into a lobby the player never entered. Re-throw so the failure
+      // still surfaces exactly as it does today.
+      void this.handleJoinLobby(event).catch((error) => {
+        this.resetPresenceToMenu();
+        throw error;
+      });
+    });
     document.addEventListener("leave-lobby", this.handleLeaveLobby.bind(this));
     document.addEventListener("kick-player", this.handleKickPlayer.bind(this));
     document.addEventListener(
@@ -659,12 +669,13 @@ class Client {
     // it arrives before this renderer exists. Pull it now that we are alive.
     void desktopPresence
       .consumePendingInvite()
-      .then((gameId) =>
-        gameId === null ? undefined : this.openInvite(gameId),
-      );
+      .then((gameId) => (gameId === null ? undefined : this.openInvite(gameId)))
+      .catch(() => undefined);
 
     // Invites arriving while we are already running.
-    desktopPresence.subscribeInvites((gameId) => void this.openInvite(gameId));
+    desktopPresence.subscribeInvites((gameId) => {
+      void this.openInvite(gameId).catch(() => undefined);
+    });
 
     const onHashUpdate = () => {
       // Router-managed hash changes (#modal=...) are handled by the router
@@ -996,7 +1007,13 @@ class Client {
             ? joinInfo.numClients
             : joinInfo.clients?.filter((c) => !c.spectator).length,
       maxPlayers: joinConfig?.maxPlayers,
-      lobbyId: lobby.gameID,
+      // Omitted for singleplayer and replays: no server hosts those ids, so
+      // advertising one has the shell offer friends a Join that cannot work.
+      // The optional field already means "not joinable".
+      lobbyId:
+        lobby.source === "singleplayer" || lobby.gameRecord !== undefined
+          ? undefined
+          : lobby.gameID,
     };
     this.emitPresence();
 
@@ -1181,6 +1198,15 @@ class Client {
     });
   }
 
+  // Back to the menu, forgetting the lobby we were describing so a later one
+  // cannot inherit its map or roster.
+  private resetPresenceToMenu() {
+    this.presenceDetail = {};
+    this.presenceSpectating = false;
+    this.presenceInGame = false;
+    desktopPresence.set({ state: "menu" });
+  }
+
   // An invite lands the player exactly where a /game/<id> link would. The
   // shell validated the id already; re-checking keeps the invariant next to
   // the modal that trusts it.
@@ -1217,6 +1243,13 @@ class Client {
   }
 
   private async handleLeaveLobby(event?: CustomEvent) {
+    // Above the lobbyHandle guard on purpose. Presence goes to "lobby" when
+    // the join starts, but lobbyHandle is only assigned once the handshake
+    // finishes; a modal closed during that window dispatches leave-lobby and
+    // takes the early return below, stranding the shell on a lobby the player
+    // is not in. Leaving in place also means no navigation follows to reset it.
+    this.resetPresenceToMenu();
+
     if (this.lobbyHandle === null) {
       return;
     }
@@ -1224,12 +1257,6 @@ class Client {
     this.lobbyHandle.stop(true);
     this.lobbyHandle = null;
     this.currentUrl = null;
-
-    // Leaving in place: no navigation follows, so nothing else resets this.
-    this.presenceDetail = {};
-    this.presenceSpectating = false;
-    this.presenceInGame = false;
-    desktopPresence.set({ state: "menu" });
 
     try {
       history.replaceState(null, "", "/");

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -8,6 +8,7 @@ import {
   GameInfo,
   GameRecord,
   GameStartInfo,
+  LobbyInfoEvent,
   PublicGameInfo,
 } from "../core/Schemas";
 import { toWireGameStartInfo } from "../core/Util";
@@ -29,6 +30,7 @@ import {
 } from "./Cosmetics";
 import { updateCrazyGamesNavButton } from "./CrazyGamesAccountButton";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
+import { desktopPresence, type PresencePayload } from "./DesktopPresence";
 import { desktopUpdate, isDesktopShell } from "./DesktopShell";
 import "./FeaturedStream";
 import "./GameModeSelector";
@@ -221,6 +223,14 @@ class Client {
   private steamLinkModal: SteamLinkModal;
   private mostRecentJoinEvent: number;
 
+  // Presence inputs. A private, hosted or matchmade JoinLobbyEvent carries
+  // nothing but the game id, so the server's lobby_info is the only place the
+  // client ever learns the map, size and roster -- keep the latest view here
+  // and reuse it once the game starts, when no lobby_info arrives any more.
+  private presenceDetail: Omit<PresencePayload, "state"> = {};
+  private presenceSpectating = false;
+  private presenceInGame = false;
+
   private turnstileTokenPromise: Promise<{
     token: string;
     createdAt: number;
@@ -228,6 +238,11 @@ class Client {
 
   async initialize(): Promise<void> {
     crazyGamesSDK.maybeInit();
+
+    // Every exit from a game (win screen, in-game quit, popstate) navigates to
+    // "/" and re-runs this, so announcing the menu here also covers "returned
+    // to the menu" without hooking each of those paths.
+    desktopPresence.set({ state: "menu" });
 
     // Register modals with the URL router. Lobby modals (join/host) and
     // matchmaking are intentionally omitted — they own their own URL state
@@ -358,6 +373,27 @@ class Client {
         this.lobbyHandle.stop(true);
         await crazyGamesSDK.gameplayStop();
       }
+    });
+
+    // The server's lobby view is the only source for a lobby's real map, size
+    // and roster, and the only place the client learns that a play/spectate
+    // switch was accepted (the server can refuse it). Both feed presence.
+    this.eventBus.on(LobbyInfoEvent, (event) => {
+      const config = event.lobby.gameConfig;
+      this.presenceDetail = {
+        gameType: config?.gameType,
+        gameMode: config?.gameMode,
+        map: config?.gameMap,
+        // Seats, not connections: spectators are in the roster but hold none
+        // (mirrors LobbyPlayerView and the join modal's own count).
+        playerCount: event.lobby.clients?.filter((c) => !c.spectator).length,
+        maxPlayers: config?.maxPlayers,
+        lobbyId: event.lobby.gameID,
+      };
+      this.presenceSpectating =
+        event.lobby.clients?.find((c) => c.clientID === event.myClientID)
+          ?.spectator === true;
+      this.emitPresence();
     });
 
     document.addEventListener("join-lobby", this.handleJoinLobby.bind(this));
@@ -618,6 +654,17 @@ class Client {
     } else {
       this.handleUrl();
     }
+
+    // An invite accepted from outside the app is parked by the shell, because
+    // it arrives before this renderer exists. Pull it now that we are alive.
+    void desktopPresence
+      .consumePendingInvite()
+      .then((gameId) =>
+        gameId === null ? undefined : this.openInvite(gameId),
+      );
+
+    // Invites arriving while we are already running.
+    desktopPresence.subscribeInvites((gameId) => void this.openInvite(gameId));
 
     const onHashUpdate = () => {
       // Router-managed hash changes (#modal=...) are handled by the router
@@ -928,6 +975,31 @@ class Client {
     }
 
     console.log(`joining lobby ${lobby.gameID}`);
+    // Entering a lobby. Singleplayer, public lobbies and replays know their
+    // config up front; everything else is filled in by the lobby_info
+    // subscription in initialize() a moment later.
+    const joinConfig =
+      lobby.gameStartInfo?.config ??
+      lobby.publicLobbyInfo?.gameConfig ??
+      lobby.gameRecord?.info.config;
+    const joinInfo = lobby.publicLobbyInfo;
+    this.presenceInGame = false;
+    this.presenceSpectating = lobby.spectator === true;
+    this.presenceDetail = {
+      gameType: joinConfig?.gameType,
+      gameMode: joinConfig?.gameMode,
+      map: joinConfig?.gameMap,
+      playerCount:
+        joinInfo === undefined
+          ? undefined
+          : "numClients" in joinInfo
+            ? joinInfo.numClients
+            : joinInfo.clients?.filter((c) => !c.spectator).length,
+      maxPlayers: joinConfig?.maxPlayers,
+      lobbyId: lobby.gameID,
+    };
+    this.emitPresence();
+
     if (this.lobbyHandle !== null) {
       console.log("joining lobby, stopping existing game");
       this.lobbyHandle.stop(true);
@@ -981,6 +1053,11 @@ class Client {
       // The game is actually starting now (lobby wait is over). Let listeners that stay up
       // through the wait (e.g. the featured-stream panel) hide at this point instead of on join.
       document.dispatchEvent(new CustomEvent("game-starting"));
+      // Earliest point the lobby is provably closed: the server has stopped
+      // broadcasting lobby_info and refuses new seats, so the shell must stop
+      // advertising this as joinable even though terrain is still loading.
+      this.presenceInGame = true;
+      this.emitPresence();
       console.log("Closing modals");
       document.getElementById("settings-button")?.classList.add("hidden");
       if (this.usernameInput) {
@@ -1090,6 +1167,34 @@ class Client {
     });
   }
 
+  // State is derived rather than passed in so every caller agrees on what
+  // "spectating" outranks. Emitting is idempotent -- the shell diffs -- so
+  // callers never have to know whether anything actually changed.
+  private emitPresence() {
+    desktopPresence.set({
+      state: this.presenceSpectating
+        ? "spectating"
+        : this.presenceInGame
+          ? "game"
+          : "lobby",
+      ...this.presenceDetail,
+    });
+  }
+
+  // An invite lands the player exactly where a /game/<id> link would. The
+  // shell validated the id already; re-checking keeps the invariant next to
+  // the modal that trusts it.
+  private async openInvite(gameId: string): Promise<void> {
+    if (!GAME_ID_REGEX.test(gameId)) return;
+    // A cold-start invite can beat the modal's own upgrade, which would make
+    // open() a silent no-op (the CrazyGames invite path waits for the same
+    // reason).
+    await customElements.whenDefined("join-lobby-modal");
+    window.showPage?.("page-join-lobby");
+    this.joinModal?.open({ lobbyId: gameId });
+    console.log(`joining lobby ${gameId} from desktop invite`);
+  }
+
   private updateJoinUrlForShare(lobbyId: string) {
     const lobbyIdHidden = !this.userSettings.lobbyIdVisibility();
     let targetUrl: string;
@@ -1119,6 +1224,12 @@ class Client {
     this.lobbyHandle.stop(true);
     this.lobbyHandle = null;
     this.currentUrl = null;
+
+    // Leaving in place: no navigation follows, so nothing else resets this.
+    this.presenceDetail = {};
+    this.presenceSpectating = false;
+    this.presenceInGame = false;
+    desktopPresence.set({ state: "menu" });
 
     try {
       history.replaceState(null, "", "/");

--- a/tests/DesktopPresence.test.ts
+++ b/tests/DesktopPresence.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { desktopPresence } from "../src/client/DesktopPresence";
+
+beforeEach(() => {
+  delete (window as any).openfrontDesktop;
+});
+
+describe("DesktopPresence", () => {
+  it("degrades to safe defaults without the bridge", async () => {
+    expect(desktopPresence.isAvailable()).toBe(false);
+    expect(() => desktopPresence.set({ state: "menu" })).not.toThrow();
+    expect(await desktopPresence.consumePendingInvite()).toBeNull();
+    expect(await desktopPresence.openInviteDialog()).toBe(false);
+  });
+
+  it("isAvailable is false when shell.api is 1 (older depot)", () => {
+    (window as any).openfrontDesktop = { shell: { api: 1 } };
+    expect(desktopPresence.isAvailable()).toBe(false);
+  });
+
+  it("isAvailable is true and passes through with a full bridge at api 2", async () => {
+    const setFn = vi.fn().mockResolvedValue(undefined);
+    (window as any).openfrontDesktop = {
+      shell: { api: 2 },
+      presence: { set: setFn },
+      invite: {
+        consumePending: vi.fn().mockResolvedValue("abc123"),
+        subscribe: vi.fn(() => () => undefined),
+        openInviteDialog: vi.fn().mockResolvedValue(true),
+      },
+    };
+    expect(desktopPresence.isAvailable()).toBe(true);
+    desktopPresence.set({ state: "lobby", lobbyId: "abc123" });
+    expect(setFn).toHaveBeenCalledWith({ state: "lobby", lobbyId: "abc123" });
+    expect(await desktopPresence.consumePendingInvite()).toBe("abc123");
+    expect(await desktopPresence.openInviteDialog()).toBe(true);
+  });
+
+  it("consumePendingInvite degrades to null when bridge rejects", async () => {
+    (window as any).openfrontDesktop = {
+      shell: { api: 2 },
+      invite: { consumePending: vi.fn().mockRejectedValue(new Error("boom")) },
+    };
+    expect(await desktopPresence.consumePendingInvite()).toBeNull();
+  });
+
+  it("openInviteDialog degrades to false when bridge rejects", async () => {
+    (window as any).openfrontDesktop = {
+      shell: { api: 2 },
+      invite: {
+        openInviteDialog: vi.fn().mockRejectedValue(new Error("boom")),
+      },
+    };
+    expect(await desktopPresence.openInviteDialog()).toBe(false);
+  });
+
+  it("set does not propagate when presence.set throws synchronously", () => {
+    (window as any).openfrontDesktop = {
+      shell: { api: 2 },
+      presence: {
+        set: vi.fn(() => {
+          throw new Error("boom");
+        }),
+      },
+    };
+    expect(() => desktopPresence.set({ state: "menu" })).not.toThrow();
+  });
+
+  it("subscribeInvites always returns a callable unsubscribe, no bridge", () => {
+    const unsubscribe = desktopPresence.subscribeInvites(() => undefined);
+    expect(typeof unsubscribe).toBe("function");
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("subscribeInvites always returns a callable unsubscribe, bridge without invite namespace", () => {
+    (window as any).openfrontDesktop = { shell: { api: 2 } };
+    const unsubscribe = desktopPresence.subscribeInvites(() => undefined);
+    expect(typeof unsubscribe).toBe("function");
+    expect(() => unsubscribe()).not.toThrow();
+  });
+
+  it("subscribeInvites always returns a callable unsubscribe, real bridge", () => {
+    const innerUnsubscribe = vi.fn();
+    const subscribeFn = vi.fn(() => innerUnsubscribe);
+    (window as any).openfrontDesktop = {
+      shell: { api: 2 },
+      invite: { subscribe: subscribeFn },
+    };
+    const cb = vi.fn();
+    const unsubscribe = desktopPresence.subscribeInvites(cb);
+    expect(subscribeFn).toHaveBeenCalledWith(cb);
+    expect(typeof unsubscribe).toBe("function");
+    expect(() => unsubscribe()).not.toThrow();
+    expect(innerUnsubscribe).toHaveBeenCalled();
+  });
+});

--- a/tests/DesktopPresence.test.ts
+++ b/tests/DesktopPresence.test.ts
@@ -18,6 +18,38 @@ describe("DesktopPresence", () => {
     expect(desktopPresence.isAvailable()).toBe(false);
   });
 
+  // The capability signal is what the shell DECLARES, not what happens to be
+  // reachable. A shell that exposed the namespaces without bumping shell.api
+  // is advertising a contract it has not committed to, so refuse it rather
+  // than half-drive it.
+  it("refuses a shell exposing the namespaces at api 1", async () => {
+    const setFn = vi.fn().mockResolvedValue(undefined);
+    const consumeFn = vi.fn().mockResolvedValue("abc123");
+    const subscribeFn = vi.fn(() => () => undefined);
+    const dialogFn = vi.fn().mockResolvedValue(true);
+    (window as any).openfrontDesktop = {
+      shell: { api: 1 },
+      presence: { set: setFn },
+      invite: {
+        consumePending: consumeFn,
+        subscribe: subscribeFn,
+        openInviteDialog: dialogFn,
+      },
+    };
+
+    desktopPresence.set({ state: "menu" });
+    expect(await desktopPresence.consumePendingInvite()).toBeNull();
+    expect(await desktopPresence.openInviteDialog()).toBe(false);
+    expect(() =>
+      desktopPresence.subscribeInvites(() => undefined)(),
+    ).not.toThrow();
+
+    expect(setFn).not.toHaveBeenCalled();
+    expect(consumeFn).not.toHaveBeenCalled();
+    expect(subscribeFn).not.toHaveBeenCalled();
+    expect(dialogFn).not.toHaveBeenCalled();
+  });
+
   it("isAvailable is true and passes through with a full bridge at api 2", async () => {
     const setFn = vi.fn().mockResolvedValue(undefined);
     (window as any).openfrontDesktop = {

--- a/tests/DesktopPresence.test.ts
+++ b/tests/DesktopPresence.test.ts
@@ -93,4 +93,23 @@ describe("DesktopPresence", () => {
     expect(() => unsubscribe()).not.toThrow();
     expect(innerUnsubscribe).toHaveBeenCalled();
   });
+
+  it("subscribeInvites returns a callable unsubscribe when subscribe throws synchronously", () => {
+    (window as any).openfrontDesktop = {
+      shell: { api: 2 },
+      invite: {
+        subscribe: vi.fn(() => {
+          throw new Error("boom");
+        }),
+      },
+    };
+    // The caller wires up navigation listeners after this call, so a throwing
+    // bridge must not abort it.
+    let unsubscribe: (() => void) | undefined;
+    expect(() => {
+      unsubscribe = desktopPresence.subscribeInvites(() => undefined);
+    }).not.toThrow();
+    expect(typeof unsubscribe).toBe("function");
+    expect(() => unsubscribe!()).not.toThrow();
+  });
 });


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #(none)

## Description:

Adds the client half of Steam rich presence and Steam lobby invites for the Electron desktop build. **This is inert in the browser and changes nothing for web players.**

### What it does

`src/client/DesktopPresence.ts` (new) is a thin wrapper over the desktop shell's preload bridge, mirroring the existing `SteamSDK.ts` pattern — including its local narrowing of `window.openfrontDesktop` rather than a second `declare global` (which would trip TS2717 against `DesktopShell.ts`).

`Main.ts` then does two things:

1. **Emits a vendor-neutral presence payload** on game-state transitions — lobby entry, game start, return to menu, spectator toggle. It reports state (`"Public FFA"`, map, player counts); it does **not** know Steam exists. All Steam-specific translation lives in the Electron shell, which keeps this repo free of Steam key names and lets the same payload drive Discord Rich Presence later.
2. **Accepts desktop invites** — pulls a cold-start invite and subscribes for invites arriving while running, both routed through the existing `GAME_ID_REGEX`-validated join path, the same way the CrazyGames invite flow and the URL-path lobby flow already work.

### Why it's safe for web

Every `desktopPresence` method no-ops when `window.openfrontDesktop` is absent (browsers) or when the shell predates this bridge (`shell.api < 2`). `subscribeInvites` always returns a callable unsubscribe even with no bridge, so callers can't crash on cleanup. There is no new UI, no new user-facing text, and no change to any existing code path when the bridge is missing.

### Notable details

- Presence reads lobby detail from `LobbyInfoEvent`, not `JoinLobbyEvent` — the latter carries only `gameID` for multiplayer (per its own comment), so hosted/private/matchmade lobbies would otherwise report an empty map and player count.
- Spectator state is read from the server's roster rather than the toggle, because the server can refuse a switch.
- An invite accepted mid-match routes through the same `showInGameConfirm` exit path as the back button rather than yanking the UI out from under a running game.
- `teamId`/`teamSize` exist in the payload but are deliberately left unpopulated — they're for a later "playing together" feature and deriving the team index in-game is unverified.

## Please complete the following:

- [x] I have added screenshots for all UI updates — **N/A, no UI changes** (the in-lobby invite button is deliberately not in this PR)
- [x] I process any text displayed to the user through translateText() — **N/A, no user-facing text added**
- [x] I have added relevant tests to the test directory — `tests/DesktopPresence.test.ts`, 10 tests covering bridge-absent degradation, `shell.api` gating, rejection handling, and the never-`undefined` unsubscribe guarantee

Full suite green on this branch: **4036 + 588 tests**, `tsc --noEmit` clean, prettier clean.

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
