### PR TITLE
feat(client): deep-link store cosmetics tab from inventory action

### DIFF
--- a/src/client/InventoryModal.ts
+++ b/src/client/InventoryModal.ts
@@ -474,9 +474,11 @@ export class InventoryModal extends BaseModal {
     );
 
     return html`
-      ${this.hasOwnedCatalogItem(["pattern", "skin"])
-        ? null
-        : this.renderEmptyState("skins")}
+      ${
+        this.hasOwnedCatalogItem(["pattern", "skin"])
+          ? null
+          : this.renderEmptyState("skins")
+      }
       <div
         data-inventory-grid="skins"
         class="grid grid-cols-2 gap-3 p-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
@@ -514,9 +516,11 @@ export class InventoryModal extends BaseModal {
 
     const equippedKey = this.equippedCrown()?.key;
     return html`
-      ${this.hasOwnedCatalogItem(["crown"])
-        ? null
-        : this.renderEmptyState("crowns")}
+      ${
+        this.hasOwnedCatalogItem(["crown"])
+          ? null
+          : this.renderEmptyState("crowns")
+      }
       <div
         data-inventory-grid="crowns"
         class="grid grid-cols-2 gap-3 p-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
@@ -613,13 +617,13 @@ export class InventoryModal extends BaseModal {
             class="no-crazygames"
             variant=${isLoggedIn ? "primary" : "danger"}
             size="sm"
-            .translationKey=${isLoggedIn
-              ? "main.store"
-              : "common.not_logged_in"}
+            .translationKey=${
+              isLoggedIn ? "main.store" : "common.not_logged_in"
+            }
             @click=${() => {
               if (isLoggedIn) {
                 this.close();
-                window.showPage?.("page-item-store");
+                window.location.hash = "modal=store&tab=cosmetics";
               } else {
                 window.showPage?.("page-account");
               }

--- a/src/client/InventoryModal.ts
+++ b/src/client/InventoryModal.ts
@@ -644,14 +644,16 @@ export class InventoryModal extends BaseModal {
           />
         </div>
       </div>
-      ${this.previewingCosmetic
-        ? html`<cosmetic-preview-modal
-            .resolved=${this.previewingCosmetic}
-            @close-preview=${() => {
+      ${
+        this.previewingCosmetic
+          ? html`<cosmetic-preview-modal
+              .resolved=${this.previewingCosmetic}
+              @close-preview=${() => {
               this.previewingCosmetic = null;
             }}
-          ></cosmetic-preview-modal>`
-        : nothing}
+            ></cosmetic-preview-modal>`
+          : nothing
+      }
     `;
   }
 

--- a/src/client/InventoryModal.ts
+++ b/src/client/InventoryModal.ts
@@ -474,11 +474,9 @@ export class InventoryModal extends BaseModal {
     );
 
     return html`
-      ${
-        this.hasOwnedCatalogItem(["pattern", "skin"])
-          ? null
-          : this.renderEmptyState("skins")
-      }
+      ${this.hasOwnedCatalogItem(["pattern", "skin"])
+        ? null
+        : this.renderEmptyState("skins")}
       <div
         data-inventory-grid="skins"
         class="grid grid-cols-2 gap-3 p-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
@@ -516,11 +514,9 @@ export class InventoryModal extends BaseModal {
 
     const equippedKey = this.equippedCrown()?.key;
     return html`
-      ${
-        this.hasOwnedCatalogItem(["crown"])
-          ? null
-          : this.renderEmptyState("crowns")
-      }
+      ${this.hasOwnedCatalogItem(["crown"])
+        ? null
+        : this.renderEmptyState("crowns")}
       <div
         data-inventory-grid="crowns"
         class="grid grid-cols-2 gap-3 p-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5"
@@ -617,9 +613,9 @@ export class InventoryModal extends BaseModal {
             class="no-crazygames"
             variant=${isLoggedIn ? "primary" : "danger"}
             size="sm"
-            .translationKey=${
-              isLoggedIn ? "main.store" : "common.not_logged_in"
-            }
+            .translationKey=${isLoggedIn
+              ? "main.store"
+              : "common.not_logged_in"}
             @click=${() => {
               if (isLoggedIn) {
                 this.close();
@@ -644,16 +640,14 @@ export class InventoryModal extends BaseModal {
           />
         </div>
       </div>
-      ${
-        this.previewingCosmetic
-          ? html`<cosmetic-preview-modal
-              .resolved=${this.previewingCosmetic}
-              @close-preview=${() => {
+      ${this.previewingCosmetic
+        ? html`<cosmetic-preview-modal
+            .resolved=${this.previewingCosmetic}
+            @close-preview=${() => {
               this.previewingCosmetic = null;
             }}
-            ></cosmetic-preview-modal>`
-          : nothing
-      }
+          ></cosmetic-preview-modal>`
+        : nothing}
     `;
   }
 

--- a/tests/client/InventoryModal.test.ts
+++ b/tests/client/InventoryModal.test.ts
@@ -419,13 +419,17 @@ describe("InventoryModal", () => {
   });
 
   it("deep-links to the store cosmetics tab from the header action", async () => {
-    const action = modal.querySelector<HTMLElement>(
-      "[data-inventory-header-action]",
-    )!;
-    await (action as LitElement).updateComplete;
-    action.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-    expect(window.location.hash).toBe("#modal=store&tab=cosmetics");
-    window.location.hash = "";
+    const originalHash = window.location.hash;
+    try {
+      const action = modal.querySelector<HTMLElement>(
+        "[data-inventory-header-action]",
+      )!;
+      await (action as LitElement).updateComplete;
+      action.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      expect(window.location.hash).toBe("#modal=store&tab=cosmetics");
+    } finally {
+      window.location.hash = originalHash;
+    }
   });
 
   it("keeps loadout, card, and swatch synchronized", async () => {

--- a/tests/client/InventoryModal.test.ts
+++ b/tests/client/InventoryModal.test.ts
@@ -418,6 +418,16 @@ describe("InventoryModal", () => {
     expect(action.textContent?.trim()).toBe("Not logged in");
   });
 
+  it("deep-links to the store cosmetics tab from the header action", async () => {
+    const action = modal.querySelector<HTMLElement>(
+      "[data-inventory-header-action]",
+    )!;
+    await (action as LitElement).updateComplete;
+    action.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(window.location.hash).toBe("#modal=store&tab=cosmetics");
+    window.location.hash = "";
+  });
+
   it("keeps loadout, card, and swatch synchronized", async () => {
     new UserSettings().setSelectedPatternName("pattern:stripes:red");
     await showTab(modal, "skins");


### PR DESCRIPTION
Resolves #5193

## Description:

Improves navigation from the inventory (cosmetics) interface. Currently the header **Store** action in the cosmetics locker only opens the store and drops the user on whatever tab was last active (the default `packs`), forcing an extra click to reach the cosmetics they were browsing.

This change makes the logged-in **Store** action open the shop directly on the **Cosmetics** tab, landing on `#modal=store&tab=cosmetics`.

### Changes
- `src/client/InventoryModal.ts` — the logged-in store action now navigates via `window.location.hash = "modal=store&tab=cosmetics"` (previously `window.showPage?.("page-item-store")`).
- `tests/client/InventoryModal.test.ts` — added a test asserting the header Store action sets the hash to `#modal=store&tab=cosmetics`.

This reuses the existing tab deep-linking pattern already used elsewhere (e.g. `modal=store&tab=subscriptions`), so tab selection, URL sync, and modal transitions are handled by the existing `ModalRouter` flow. No new user-facing strings were introduced, so there is no translation impact.

## Please complete the following:

- [ ] I have added screenshots for all UI updates
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

ItsTimeTooSleep