### PR TITLE
fix(desktop): make the Steam session gate apply to every join path

### DIFF
--- a/src/client/Auth.ts
+++ b/src/client/Auth.ts
@@ -265,6 +265,30 @@ export async function userAuth(
   }
 }
 
+/**
+ * Never rest on a state that gates without offering a way out.
+ *
+ * Both "unknown" (nothing has resolved yet) and "retrying" are transient: some
+ * branch downstream is expected to publish a terminal state. But refreshJwt's
+ * finally has no catch, so an unexpected throw inside doRefreshJwt reaches
+ * userAuth's top-level catch, which logs and returns false without touching
+ * session state -- leaving the transient status published forever. "retrying"
+ * gates multiplayer and renders no button; "unknown" does not gate, so it
+ * fails the other way, silently allowing a join the server will refuse.
+ *
+ * Called from every path that can leave one of those pending, so the guarantee
+ * does not depend on each branch remembering to publish.
+ */
+function settlePendingSession(): void {
+  if (!steamSDK.isOnSteam()) return;
+  if (
+    __sessionState.status === "unknown" ||
+    __sessionState.status === "retrying"
+  ) {
+    setSessionState({ status: "signed-out", reason: "steam-error" });
+  }
+}
+
 async function refreshJwt(): Promise<void> {
   if (__refreshPromise) {
     return __refreshPromise;
@@ -274,6 +298,7 @@ async function refreshJwt(): Promise<void> {
     await __refreshPromise;
   } finally {
     __refreshPromise = null;
+    settlePendingSession();
   }
 }
 
@@ -483,9 +508,7 @@ export async function retrySteamSignIn(): Promise<UserAuth> {
       // including "retrying", and DesktopStatusBar.sessionAction renders no
       // button for it. If nothing moved us off "retrying" by the time this
       // settles, force a terminal, actionable state instead.
-      if (__sessionState.status === "retrying") {
-        setSessionState({ status: "signed-out", reason: "steam-error" });
-      }
+      settlePendingSession();
       __steamRetryPromise = null;
     }
   })();

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -6,6 +6,7 @@ import {
   Duos,
   GameMapType,
   GameMode,
+  GameType,
   HumansVsNations,
   Quads,
   Trios,
@@ -57,6 +58,20 @@ export function shouldBlockMultiplayerAction(
   if (update !== null && !multiplayerAllowed(update)) return true;
   if (session !== null && !multiplayerAllowedForSession(session)) return true;
   return false;
+}
+
+/**
+ * Whether the desktop gate applies to a given join at all. Single-player runs
+ * entirely in-client and a replay simulates from an archived record, so
+ * neither needs a session or an up-to-date build -- the same carve-out
+ * Main.ts's getTurnstileToken makes. Exported for tests and kept free of
+ * component state, like shouldBlockMultiplayerAction above.
+ */
+export function joinIsGateable(lobby: JoinLobbyEvent): boolean {
+  return (
+    lobby.gameStartInfo?.config.gameType !== GameType.Singleplayer &&
+    lobby.gameRecord === undefined
+  );
 }
 
 @customElement("game-mode-selector")

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -63,8 +63,9 @@ export function shouldBlockMultiplayerAction(
 /**
  * Whether the desktop gate applies to a given join at all. Single-player runs
  * entirely in-client and a replay simulates from an archived record, so
- * neither needs a session or an up-to-date build -- the same carve-out
- * Main.ts's getTurnstileToken makes. Exported for tests and kept free of
+ * neither needs a session or an up-to-date build. getTurnstileToken in
+ * Main.ts exempts the same pair (alongside two conditions irrelevant here),
+ * and calls this so the two cannot drift. Exported for tests and kept free of
  * component state, like shouldBlockMultiplayerAction above.
  */
 export function joinIsGateable(lobby: JoinLobbyEvent): boolean {
@@ -72,6 +73,20 @@ export function joinIsGateable(lobby: JoinLobbyEvent): boolean {
     lobby.gameStartInfo?.config.gameType !== GameType.Singleplayer &&
     lobby.gameRecord === undefined
   );
+}
+
+/**
+ * The whole gate decision for one join, as a pure function so it is testable
+ * without mounting Main's client. Main adds only the shell check and the
+ * status-bar wiggle around it.
+ */
+export function shouldBlockDesktopJoin(
+  lobby: JoinLobbyEvent,
+  update: DesktopUpdateState | null,
+  session: DesktopSessionState | null,
+): boolean {
+  if (!joinIsGateable(lobby)) return false;
+  return shouldBlockMultiplayerAction(update, session);
 }
 
 @customElement("game-mode-selector")

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -13,7 +13,6 @@ import {
 } from "../core/Schemas";
 import { toWireGameStartInfo } from "../core/Util";
 import { GameEnv } from "../core/configuration/Config";
-import { GameType } from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import "./AccountModal";
 import "./AccountSettingsModal";
@@ -46,7 +45,7 @@ import "./GameModeSelector";
 import {
   GameModeSelector,
   joinIsGateable,
-  shouldBlockMultiplayerAction,
+  shouldBlockDesktopJoin,
 } from "./GameModeSelector";
 import { GameStartingModal } from "./GameStartingModal";
 import "./GameStatsModal";
@@ -644,11 +643,17 @@ class Client {
     // account button and the cached profile -- the same reason the
     // CrazyGames listener above lives here. The authGeneration guard means a
     // response that arrives after another auth change cannot be applied.
-    // The status bar re-broadcasts the shell's update state as a document
-    // event; mirror it here so blockedDesktopJoin can gate on it too. No
-    // second bridge subscription -- the bar owns that one.
-    document.addEventListener("desktop-update-state", (e: Event) => {
-      this.desktopUpdateState = (e as CustomEvent<DesktopUpdateState>).detail;
+    // Subscribe to the bridge directly rather than to the status bar's
+    // re-broadcast. The bar subscribes when its element upgrades and the
+    // bridge replays the current state immediately, so that event fires long
+    // before this code runs (it sits after `await userAuth()`), and a listener
+    // added here would miss it. That matters most for a `staged` update, which
+    // is persisted across restarts and then never re-emitted -- the gate would
+    // sit on a null update state forever. subscribe() replays on subscribe and
+    // the updater supports multiple subscribers, so this is safe alongside the
+    // bar's own subscription.
+    desktopUpdate()?.subscribe((state) => {
+      this.desktopUpdateState = state;
     });
 
     document.addEventListener("desktop-session-retry", () => {
@@ -1034,24 +1039,30 @@ class Client {
    * without this a signed-out player queues, matches, and is closed by the
    * server with the Turnstile error this whole feature exists to replace.
    *
-   * Single-player runs entirely in-client and a replay simulates from an
-   * archived record, so neither needs a session or a current build -- the same
-   * carve-out getTurnstileToken makes.
+   * The decision itself lives in shouldBlockDesktopJoin, which is pure and
+   * unit-tested; this adds the shell check, the modal cleanup and the wiggle.
    *
    * Draws attention to the status bar rather than failing silently, matching
    * what the dimmed buttons do.
    */
   private blockedDesktopJoin(lobby: JoinLobbyEvent): boolean {
     if (!isDesktopShell()) return false;
-    if (!joinIsGateable(lobby)) return false;
     if (
-      !shouldBlockMultiplayerAction(
+      !shouldBlockDesktopJoin(
+        lobby,
         this.desktopUpdateState,
         getDesktopSessionState(),
       )
     ) {
       return false;
     }
+    // The dispatcher may already have told the player they are in a lobby:
+    // JoinLobbyModal dispatches only after it has joined and rendered
+    // "joined, waiting", and HostLobbyModal after the server lobby exists.
+    // Refusing without closing those would leave the UI claiming a lobby the
+    // client never entered, with the game starting without them.
+    this.joinModal?.close();
+    this.hostModal?.close();
     (
       document.querySelector("desktop-status-bar") as
         | (HTMLElement & { wiggle?: () => void })
@@ -1062,13 +1073,16 @@ class Client {
 
   private async handleJoinLobby(event: CustomEvent<JoinLobbyEvent>) {
     const lobby = event.detail;
-    this.mostRecentJoinEvent = event.timeStamp;
     if (this.usernameInput && !this.usernameInput.canPlay()) {
       return;
     }
     if (this.blockedDesktopJoin(lobby)) {
       return;
     }
+    // Only once the join is actually going ahead: a refused dispatch that
+    // bumped this would supersede a legitimate join still awaiting userAuth
+    // and cosmetics, stopping it as stale and leaving the player nowhere.
+    this.mostRecentJoinEvent = event.timeStamp;
 
     console.log(`joining lobby ${lobby.gameID}`);
     // Entering a lobby. Singleplayer, public lobbies and replays know their
@@ -1451,11 +1465,10 @@ class Client {
     if (
       ClientEnv.env() === GameEnv.Dev ||
       ClientEnv.instanceId() === "desktop" ||
-      lobby.gameStartInfo?.config.gameType === GameType.Singleplayer ||
-      // Replays simulate locally from the archived record; there is no
-      // server to verify a token (and on the CDN replay shells Turnstile
-      // cannot load at all).
-      lobby.gameRecord !== undefined
+      // Single-player and replays: no server to verify a token against (and
+      // on the CDN replay shells Turnstile cannot load at all). Shared with
+      // the desktop gate so the exemption has one definition.
+      !joinIsGateable(lobby)
     ) {
       return null;
     }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -21,6 +21,7 @@ import { adGatekeeper } from "./AdGatekeeper";
 import { loadAdmiral, onAdmiralMeasured } from "./Admiral";
 import { getUserMe, invalidateUserMe } from "./Api";
 import {
+  getDesktopSessionState,
   reauthAfterCrazyGamesChange,
   retrySteamSignIn,
   userAuth,
@@ -35,10 +36,18 @@ import {
 import { updateCrazyGamesNavButton } from "./CrazyGamesAccountButton";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { desktopPresence, type PresencePayload } from "./DesktopPresence";
-import { desktopUpdate, isDesktopShell } from "./DesktopShell";
+import {
+  desktopUpdate,
+  isDesktopShell,
+  type DesktopUpdateState,
+} from "./DesktopShell";
 import "./FeaturedStream";
 import "./GameModeSelector";
-import { GameModeSelector } from "./GameModeSelector";
+import {
+  GameModeSelector,
+  joinIsGateable,
+  shouldBlockMultiplayerAction,
+} from "./GameModeSelector";
 import { GameStartingModal } from "./GameStartingModal";
 import "./GameStatsModal";
 import { HelpModal } from "./HelpModal";
@@ -635,6 +644,13 @@ class Client {
     // account button and the cached profile -- the same reason the
     // CrazyGames listener above lives here. The authGeneration guard means a
     // response that arrives after another auth change cannot be applied.
+    // The status bar re-broadcasts the shell's update state as a document
+    // event; mirror it here so blockedDesktopJoin can gate on it too. No
+    // second bridge subscription -- the bar owns that one.
+    document.addEventListener("desktop-update-state", (e: Event) => {
+      this.desktopUpdateState = (e as CustomEvent<DesktopUpdateState>).detail;
+    });
+
     document.addEventListener("desktop-session-retry", () => {
       invalidateUserMe();
       const generation = authGeneration;
@@ -1007,10 +1023,50 @@ class Client {
     return mode;
   }
 
+  private desktopUpdateState: DesktopUpdateState | null = null;
+
+  /**
+   * The real multiplayer gate. The entry-point components dim their own
+   * buttons, but EVERY join -- theirs, matchmaking's, a deep link, the
+   * host/join modals -- funnels through handleJoinLobby, and most of those
+   * never pass a button. Matchmaking is the sharpest case: it dispatches
+   * join-lobby itself when a match is found, with no click to intercept, so
+   * without this a signed-out player queues, matches, and is closed by the
+   * server with the Turnstile error this whole feature exists to replace.
+   *
+   * Single-player runs entirely in-client and a replay simulates from an
+   * archived record, so neither needs a session or a current build -- the same
+   * carve-out getTurnstileToken makes.
+   *
+   * Draws attention to the status bar rather than failing silently, matching
+   * what the dimmed buttons do.
+   */
+  private blockedDesktopJoin(lobby: JoinLobbyEvent): boolean {
+    if (!isDesktopShell()) return false;
+    if (!joinIsGateable(lobby)) return false;
+    if (
+      !shouldBlockMultiplayerAction(
+        this.desktopUpdateState,
+        getDesktopSessionState(),
+      )
+    ) {
+      return false;
+    }
+    (
+      document.querySelector("desktop-status-bar") as
+        | (HTMLElement & { wiggle?: () => void })
+        | null
+    )?.wiggle?.();
+    return true;
+  }
+
   private async handleJoinLobby(event: CustomEvent<JoinLobbyEvent>) {
     const lobby = event.detail;
     this.mostRecentJoinEvent = event.timeStamp;
     if (this.usernameInput && !this.usernameInput.canPlay()) {
+      return;
+    }
+    if (this.blockedDesktopJoin(lobby)) {
       return;
     }
 

--- a/tests/GameModeSelectorGating.test.ts
+++ b/tests/GameModeSelectorGating.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   joinIsGateable,
+  shouldBlockDesktopJoin,
   shouldBlockMultiplayerAction,
 } from "../src/client/GameModeSelector";
 import { GameType } from "../src/core/game/Game";
@@ -137,5 +138,55 @@ describe("joinIsGateable", () => {
         gameRecord: {},
       } as any),
     ).toBe(false);
+  });
+});
+
+describe("shouldBlockDesktopJoin", () => {
+  const mp = { gameID: "g", source: "matchmaking" } as any;
+  const solo = {
+    gameID: "g",
+    source: "private",
+    gameStartInfo: { config: { gameType: GameType.Singleplayer } },
+  } as any;
+  const healthy = { status: "current", bytes: 0, total: 0 } as const;
+
+  it("allows a multiplayer join when both states are healthy", () => {
+    expect(shouldBlockDesktopJoin(mp, healthy, { status: "signed-in" })).toBe(
+      false,
+    );
+  });
+
+  it("blocks a multiplayer join when signed out", () => {
+    expect(
+      shouldBlockDesktopJoin(mp, healthy, {
+        status: "signed-out",
+        reason: "steam-wedged",
+      }),
+    ).toBe(true);
+  });
+
+  // The claim that update-gating inherits the funnel fix, actually pinned.
+  it("blocks a multiplayer join on a pending update even when signed in", () => {
+    expect(
+      shouldBlockDesktopJoin(
+        mp,
+        { status: "staged", bytes: 0, total: 0 },
+        { status: "signed-in" },
+      ),
+    ).toBe(true);
+  });
+
+  it("never blocks single-player, whatever the states say", () => {
+    expect(
+      shouldBlockDesktopJoin(
+        solo,
+        { status: "staged", bytes: 0, total: 0 },
+        { status: "signed-out", reason: "steam-wedged" },
+      ),
+    ).toBe(false);
+  });
+
+  it("does not block on the web, where neither state exists", () => {
+    expect(shouldBlockDesktopJoin(mp, null, null)).toBe(false);
   });
 });

--- a/tests/GameModeSelectorGating.test.ts
+++ b/tests/GameModeSelectorGating.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { shouldBlockMultiplayerAction } from "../src/client/GameModeSelector";
+import {
+  joinIsGateable,
+  shouldBlockMultiplayerAction,
+} from "../src/client/GameModeSelector";
+import { GameType } from "../src/core/game/Game";
 
 describe("shouldBlockMultiplayerAction", () => {
   it("allows everything when no desktop update state has arrived", () => {
@@ -94,5 +98,44 @@ describe("shouldBlockMultiplayerAction with a session", () => {
 
   it("does not block on the web, where neither state exists", () => {
     expect(shouldBlockMultiplayerAction(null, null)).toBe(false);
+  });
+});
+
+describe("joinIsGateable", () => {
+  // Matchmaking, deep links and the host/join modals all dispatch join-lobby
+  // without passing a dimmed button, so the funnel gate is the only thing
+  // standing between a signed-out player and the server's Turnstile close.
+  it("gates an ordinary multiplayer join", () => {
+    expect(joinIsGateable({ gameID: "g1", source: "public" } as any)).toBe(
+      true,
+    );
+  });
+
+  it("gates a matchmaking join", () => {
+    expect(joinIsGateable({ gameID: "g2", source: "matchmaking" } as any)).toBe(
+      true,
+    );
+  });
+
+  // Runs entirely in-client -- no session, no server, nothing to gate.
+  it("does not gate single-player", () => {
+    expect(
+      joinIsGateable({
+        gameID: "g3",
+        source: "private",
+        gameStartInfo: { config: { gameType: GameType.Singleplayer } },
+      } as any),
+    ).toBe(false);
+  });
+
+  // Simulates from the archived record; there is no server to refuse it.
+  it("does not gate a replay", () => {
+    expect(
+      joinIsGateable({
+        gameID: "g4",
+        source: "private",
+        gameRecord: {},
+      } as any),
+    ).toBe(false);
   });
 });

--- a/tests/client/Auth.steam.test.ts
+++ b/tests/client/Auth.steam.test.ts
@@ -121,6 +121,48 @@ describe("Steam login", () => {
   // available". The Electron profile has no refresh cookie, so that
   // fallthrough was a guaranteed 401 that then ran logOut() and dropped the
   // player's persistent ID. The Steam branch is now terminal.
+  // The initial sign-in had no equivalent of the retry path's guarantee: an
+  // unexpected throw inside doRefreshJwt reaches userAuth's catch, which
+  // returns false without publishing, leaving "unknown" -- which does NOT
+  // gate, so multiplayer stays open and the join is refused by the server.
+  it("settles a thrown initial sign-in instead of resting on unknown", async () => {
+    // Drive the module to a genuine "unknown" first: __sessionState is
+    // module-level and leaks between tests, and only a logOut from signed-in
+    // produces "unknown". Asserting from a leaked state would prove nothing.
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    const getTicket = vi
+      .spyOn(steamSDK, "getTicket")
+      .mockResolvedValue({ ok: true, ticket: "t" });
+    const jwt = new UnsecuredJWT({
+      jti: "some-id",
+      sub: "AAAAAAAAAAAAAAAAAAAAAA",
+      iat: Math.floor(Date.now() / 1000),
+      iss: "https://api.openfront.dev",
+      aud: "openfront.dev",
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    }).encode();
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response(JSON.stringify({ jwt, expiresIn: 900 }), { status: 200 }),
+    );
+    await getAuthHeader();
+    await logOut();
+    expect(getDesktopSessionState()).toEqual({ status: "unknown" });
+
+    // Now an unexpected throw inside doRefreshJwt. userAuth's catch swallows
+    // it and returns false without publishing, so without the guarantee the
+    // state would rest at "unknown" -- which does NOT gate, leaving multiplayer
+    // open for a join the server will refuse.
+    getTicket.mockImplementation(() => {
+      throw new Error("boom");
+    });
+
+    await getAuthHeader();
+
+    const state = getDesktopSessionState();
+    expect(state).toEqual({ status: "signed-out", reason: "steam-error" });
+    expect(multiplayerAllowedForSession(state)).toBe(false);
+  });
+
   // A diagnosed failure must survive an UNRELATED logOut. getAuthHeader
   // returns "" when signed out, so any authenticated call still goes out and
   // still comes back 401, and Api.ts calls logOut() on 401 from 13 places.


### PR DESCRIPTION
Follow-up to #5185, which merged before these two fixes were ready. Both close gaps in the feature that PR added; neither changes its design.

## The gate was decorative

#5185 gated multiplayer on the Steam session state, but only in `GameModeSelector` and `DetailedGameViewModal`. **Nine** call sites dispatch `join-lobby`, and the other seven walked straight past it:

| Dispatcher | Gated before |
|---|---|
| `GameModeSelector`, `DetailedGameViewModal` | ✅ |
| `Matchmaking.ts` | ❌ |
| `JoinLobbyModal.ts` (×2, incl. deep links) | ❌ |
| `HostLobbyModal.ts` (×2) | ❌ |

Matchmaking is the sharpest case: it dispatches `join-lobby` itself when a match is found, with no click to intercept. A signed-out player queued, waited, matched, and was closed by the server with the exact Turnstile error #5185 exists to replace.

`handleJoinLobby` is the single funnel all nine pass through, so the check belongs there. It reuses `shouldBlockMultiplayerAction` rather than restating the rule, which means **update-gating inherits the same fix** — it had the identical hole.

Single-player and replays are carved out through a new exported `joinIsGateable`: both run without a server, the same exemption `getTurnstileToken` already makes. Exported and unit-tested rather than inlined.

`Main.ts` mirrors the update state from the document event the status bar already broadcasts, rather than opening a second bridge subscription.

## Never rest on a transient session state

`retrySteamSignIn` already forced a terminal state if nothing moved it off `retrying`. The initial sign-in had no equivalent, and fails the *other* way: `refreshJwt`'s `finally` has no `catch`, so an unexpected throw inside `doRefreshJwt` reaches `userAuth`'s top-level catch, which logs and returns `false` without publishing — leaving `unknown`, which does **not** gate, so the player is allowed into a join the server will refuse.

Both are now one helper, `settlePendingSession`, called from `refreshJwt`'s `finally` as well as the retry's. `retrying` gates with no button; `unknown` fails open — neither is a state to rest on, and the guarantee no longer depends on each branch remembering to publish.

Unreachable today by inspection, which is rather the point: the retry path was hardened on the same argument, and this closes the asymmetry.

## Testing

Full suite green on current `main` (4091 tests), `tsc --noEmit` clean.

Both fixes are mutation-verified: removing `settlePendingSession` fails the two guarantee tests, and the `joinIsGateable` cases cover matchmaking, ordinary joins, single-player and replays.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
