### PR TITLE
small-fix: train despawn on track splitting

### DIFF
--- a/src/core/execution/TrainExecution.ts
+++ b/src/core/execution/TrainExecution.ts
@@ -224,10 +224,20 @@ export class TrainExecution implements Execution {
     }
   }
 
-  private nextStation() {
+  private nextStation(): boolean {
     if (this.stations.length > 2) {
       this.stations.shift();
-      const railRoad = getOrientedRailroad(this.stations[0], this.stations[1]);
+      let railRoad = getOrientedRailroad(this.stations[0], this.stations[1]);
+      if (!railRoad) {
+        const subPath = this.railNetwork.findStationsPath(
+          this.stations[0],
+          this.stations[1],
+        );
+        if (subPath && subPath.length > 2) {
+          this.stations.splice(1, 0, ...subPath.slice(1, -1));
+          railRoad = getOrientedRailroad(this.stations[0], this.stations[1]);
+        }
+      }
       if (railRoad) {
         this.currentRailroad = railRoad;
         return true;

--- a/src/core/execution/TrainExecution.ts
+++ b/src/core/execution/TrainExecution.ts
@@ -25,6 +25,8 @@ export class TrainExecution implements Execution {
   private currentRailroad: OrientedRailroad | null = null;
   private speed: number = 2;
   private _tradeStopsVisited: number = 0;
+  private pathTiles: TileRef[] = [];
+  private pathIndex: number = 0;
 
   constructor(
     private railNetwork: RailNetwork,
@@ -86,7 +88,9 @@ export class TrainExecution implements Execution {
     const startTile = this.train.tile();
     if (pathTiles.length === 0 || pathTiles[0] !== startTile) {
       pathTiles.unshift(startTile);
+      this.pathIndex = 1;
     }
+    this.pathTiles = pathTiles;
 
     const plan: MotionPlanRecord = {
       kind: "train",
@@ -226,24 +230,38 @@ export class TrainExecution implements Execution {
 
   private nextStation(): boolean {
     if (this.stations.length > 2) {
+      this.pathIndex += this.currentRailroad?.getTiles().length ?? 0;
       this.stations.shift();
-      let railRoad = getOrientedRailroad(this.stations[0], this.stations[1]);
-      if (!railRoad) {
-        const subPath = this.railNetwork.findStationsPath(
-          this.stations[0],
-          this.stations[1],
-        );
-        if (subPath && subPath.length > 2) {
-          this.stations.splice(1, 0, ...subPath.slice(1, -1));
-          railRoad = getOrientedRailroad(this.stations[0], this.stations[1]);
-        }
-      }
+      const railRoad =
+        getOrientedRailroad(this.stations[0], this.stations[1]) ??
+        this.resolveSplitRailroad();
       if (railRoad) {
         this.currentRailroad = railRoad;
         return true;
       }
     }
     return false;
+  }
+
+  private resolveSplitRailroad(): OrientedRailroad | null {
+    const [station0, station1] = this.stations;
+    const path = this.railNetwork.findStationsPath(station0, station1);
+    if (!path || path.length <= 2) return null;
+    let cursor = this.pathIndex;
+    for (let i = 0; i < path.length - 1; i++) {
+      const segment = getOrientedRailroad(path[i], path[i + 1]);
+      if (!segment) return null;
+      cursor += segment.getTiles().length;
+      if (
+        i < path.length - 2 &&
+        this.pathTiles[cursor] !== segment.getEnd().tile() &&
+        this.pathTiles[cursor - 1] !== segment.getEnd().tile()
+      ) {
+        return null;
+      }
+    }
+    this.stations.splice(0, 2, ...path);
+    return getOrientedRailroad(this.stations[0], this.stations[1]);
   }
 
   private canTradeWithDestination() {

--- a/src/core/execution/TrainExecution.ts
+++ b/src/core/execution/TrainExecution.ts
@@ -251,13 +251,10 @@ export class TrainExecution implements Execution {
     for (let i = 0; i < path.length - 1; i++) {
       const segment = getOrientedRailroad(path[i], path[i + 1]);
       if (!segment) return null;
-      cursor += segment.getTiles().length;
-      if (
-        i < path.length - 2 &&
-        this.pathTiles[cursor] !== segment.getEnd().tile() &&
-        this.pathTiles[cursor - 1] !== segment.getEnd().tile()
-      ) {
-        return null;
+      for (const tile of segment.getTiles()) {
+        if (this.pathTiles[cursor++] !== tile) {
+          return null;
+        }
       }
     }
     this.stations.splice(0, 2, ...path);

--- a/tests/core/executions/TrainExecution.test.ts
+++ b/tests/core/executions/TrainExecution.test.ts
@@ -105,4 +105,98 @@ describe("TrainExecution", () => {
     // At station B, the train attempts nextStation() but rejects the detour through tile 4
     expect(exec.isActive()).toBe(false);
   });
+
+  it("re-resolves when intermediate station is placed off-track (adjacent building tile)", async () => {
+    const game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("p1", PlayerType.Human, null, "p1"),
+    ]);
+    const player = game.player("p1")!;
+
+    [0, 1, 2, 3, 4, 10].forEach((t) => player.conquer(t));
+    // Station D is at tile 10 (adjacent off-track building tile, not in the railroad tile array)
+    const [stationA, stationB, stationC, stationD] = [0, 1, 3, 10].map(
+      (t) => new TrainStation(game, player.buildUnit(UnitType.City, t, {})),
+    );
+
+    const net = game.railNetwork();
+    const stationManager = net.stationManager();
+    [stationA, stationB, stationC].forEach((s) => stationManager.addStation(s));
+
+    const link = (
+      a: TrainStation,
+      b: TrainStation,
+      tiles: TileRef[],
+      id: number,
+    ) => {
+      const r = new Railroad(a, b, tiles, id);
+      a.addRailroad(r);
+      b.addRailroad(r);
+      return r;
+    };
+
+    link(stationA, stationB, [0, 1], 1);
+    const railBC = link(stationB, stationC, [1, 2, 2, 3], 2);
+
+    const exec = new TrainExecution(net, player, stationA, stationC, 1);
+    exec.init(game, 0);
+
+    // Split edge B->C into B->D [1, 2] and D->C [2, 3], where stationD.tile() = 10
+    stationB.removeRailroad(railBC);
+    stationC.removeRailroad(railBC);
+    stationManager.addStation(stationD);
+    link(stationB, stationD, [1, 2], 3);
+    link(stationD, stationC, [2, 3], 4);
+
+    exec.tick(1);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(2);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(3);
+    expect(exec.isActive()).toBe(false);
+  });
+
+  it("rejects detour when only the final segment detours off motion plan", async () => {
+    const game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("p1", PlayerType.Human, null, "p1"),
+    ]);
+    const player = game.player("p1")!;
+
+    [0, 1, 2, 3, 9].forEach((t) => player.conquer(t));
+    const [stationA, stationB, stationC, stationD] = [0, 1, 3, 2].map(
+      (t) => new TrainStation(game, player.buildUnit(UnitType.City, t, {})),
+    );
+
+    const net = game.railNetwork();
+    const stationManager = net.stationManager();
+    [stationA, stationB, stationC].forEach((s) => stationManager.addStation(s));
+
+    const link = (
+      a: TrainStation,
+      b: TrainStation,
+      tiles: TileRef[],
+      id: number,
+    ) => {
+      const r = new Railroad(a, b, tiles, id);
+      a.addRailroad(r);
+      b.addRailroad(r);
+      return r;
+    };
+
+    link(stationA, stationB, [0, 1], 1);
+    const railBC = link(stationB, stationC, [1, 2, 2, 3], 2);
+
+    const exec = new TrainExecution(net, player, stationA, stationC, 1);
+    exec.init(game, 0);
+
+    // B->D uses planned tiles [1, 2], but D->C detours through tile 9 [2, 9, 3]
+    stationB.removeRailroad(railBC);
+    stationC.removeRailroad(railBC);
+    stationManager.addStation(stationD);
+    link(stationB, stationD, [1, 2], 3);
+    link(stationD, stationC, [2, 9, 3], 4);
+
+    exec.tick(1);
+    // Rejects because final segment D->C uses unrecorded tile 9
+    expect(exec.isActive()).toBe(false);
+  });
 });

--- a/tests/core/executions/TrainExecution.test.ts
+++ b/tests/core/executions/TrainExecution.test.ts
@@ -13,8 +13,62 @@ describe("TrainExecution", () => {
     ]);
     const player = game.player("p1")!;
 
-    [0, 1, 2, 3].forEach((t) => player.conquer(t));
-    const [stationA, stationB, stationC, stationD] = [0, 1, 2, 3].map(
+    [0, 1, 2, 3, 4].forEach((t) => player.conquer(t));
+    const [stationA, stationB, stationC, stationD1, stationD2] = [
+      0, 1, 4, 2, 3,
+    ].map(
+      (t) => new TrainStation(game, player.buildUnit(UnitType.City, t, {})),
+    );
+
+    const net = game.railNetwork();
+    const stationManager = net.stationManager();
+    [stationA, stationB, stationC].forEach((s) => stationManager.addStation(s));
+
+    const link = (
+      a: TrainStation,
+      b: TrainStation,
+      tiles: TileRef[],
+      id: number,
+    ) => {
+      const r = new Railroad(a, b, tiles, id);
+      a.addRailroad(r);
+      b.addRailroad(r);
+      return r;
+    };
+
+    link(stationA, stationB, [0, 1], 1);
+    const railBC = link(stationB, stationC, [1, 2, 2, 3, 3, 4], 2);
+
+    const exec = new TrainExecution(net, player, stationA, stationC, 1);
+    exec.init(game, 0);
+
+    // Split edge B->C into B->D1, D1->D2, and D2->C while train is in transit
+    stationB.removeRailroad(railBC);
+    stationC.removeRailroad(railBC);
+    stationManager.addStation(stationD1);
+    stationManager.addStation(stationD2);
+    link(stationB, stationD1, [1, 2], 3);
+    link(stationD1, stationD2, [2, 3], 4);
+    link(stationD2, stationC, [3, 4], 5);
+
+    exec.tick(1);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(2);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(3);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(4);
+    expect(exec.isActive()).toBe(false);
+  });
+
+  it("rejects detour when railroad is rerouted off original motion plan", async () => {
+    const game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("p1", PlayerType.Human, null, "p1"),
+    ]);
+    const player = game.player("p1")!;
+
+    [0, 1, 2, 3, 4].forEach((t) => player.conquer(t));
+    const [stationA, stationB, stationC, stationD] = [0, 1, 2, 4].map(
       (t) => new TrainStation(game, player.buildUnit(UnitType.City, t, {})),
     );
 
@@ -40,18 +94,15 @@ describe("TrainExecution", () => {
     const exec = new TrainExecution(net, player, stationA, stationC, 1);
     exec.init(game, 0);
 
-    // Split edge B->C into B->D and D->C while train is in transit
+    // Replace B->C with a detour through station D (tile 4, not on original path [0, 1, 1, 3, 2])
     stationB.removeRailroad(railBC);
     stationC.removeRailroad(railBC);
     stationManager.addStation(stationD);
-    link(stationB, stationD, [1, 3], 3);
-    link(stationD, stationC, [3, 2], 4);
+    link(stationB, stationD, [1, 4], 3);
+    link(stationD, stationC, [4, 2], 4);
 
     exec.tick(1);
-    expect(exec.isActive()).toBe(true);
-    exec.tick(2);
-    expect(exec.isActive()).toBe(true);
-    exec.tick(3);
+    // At station B, the train attempts nextStation() but rejects the detour through tile 4
     expect(exec.isActive()).toBe(false);
   });
 });

--- a/tests/core/executions/TrainExecution.test.ts
+++ b/tests/core/executions/TrainExecution.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { TrainExecution } from "../../../src/core/execution/TrainExecution";
+import { PlayerInfo, PlayerType, UnitType } from "../../../src/core/game/Game";
+import { TileRef } from "../../../src/core/game/GameMap";
+import { Railroad } from "../../../src/core/game/Railroad";
+import { TrainStation } from "../../../src/core/game/TrainStation";
+import { setup } from "../../util/Setup";
+
+describe("TrainExecution", () => {
+  it("re-resolves intermediate stations when railroad is split in transit", async () => {
+    const game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("p1", PlayerType.Human, null, "p1"),
+    ]);
+    const player = game.player("p1")!;
+
+    [0, 1, 2, 3].forEach((t) => player.conquer(t));
+    const [stationA, stationB, stationC, stationD] = [0, 1, 2, 3].map(
+      (t) => new TrainStation(game, player.buildUnit(UnitType.City, t, {})),
+    );
+
+    const net = game.railNetwork();
+    const stationManager = net.stationManager();
+    [stationA, stationB, stationC].forEach((s) => stationManager.addStation(s));
+
+    const link = (
+      a: TrainStation,
+      b: TrainStation,
+      tiles: TileRef[],
+      id: number,
+    ) => {
+      const r = new Railroad(a, b, tiles, id);
+      a.addRailroad(r);
+      b.addRailroad(r);
+      return r;
+    };
+
+    link(stationA, stationB, [0, 1], 1);
+    const railBC = link(stationB, stationC, [1, 3, 2], 2);
+
+    const exec = new TrainExecution(net, player, stationA, stationC, 1);
+    exec.init(game, 0);
+
+    // Split edge B->C into B->D and D->C while train is in transit
+    stationB.removeRailroad(railBC);
+    stationC.removeRailroad(railBC);
+    stationManager.addStation(stationD);
+    link(stationB, stationD, [1, 3], 3);
+    link(stationD, stationC, [3, 2], 4);
+
+    exec.tick(1);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(2);
+    expect(exec.isActive()).toBe(true);
+    exec.tick(3);
+    expect(exec.isActive()).toBe(false);
+  });
+});


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

None - small fix

## Description:

There are no train execution tests so I had to add one - but this solve an issue introduced in #3003. Instead of overlapping many trails, it splits them when a structure is built on them. However all trains carry a static array of their stops on the way. A new structure on a track makes it unable to find the next stop and causes it to despawn when it gets to the relevant track.

Below a recording (Thanks to legan)
https://github.com/user-attachments/assets/9dffe860-5726-4279-bb30-d2dbd89f8996


The fix: When no path is found from A to B, find a sub


## Please complete the following:

- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:
JB940
