### PR TITLE
Add "Evan's Pick" built-in graphics preset

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -812,6 +812,8 @@
     "preset_default": "Default",
     "preset_default_desc": "The standard OpenFront look",
     "preset_delete_confirm": "Delete preset \"{name}\"?",
+    "preset_evans_pick": "Evan's Pick",
+    "preset_evans_pick_desc": "The settings Evan actually plays with",
     "preset_migrated_name": "My settings",
     "preset_name_placeholder": "Preset name",
     "preset_night": "Night",

--- a/src/client/render/gl/graphics-presets.json
+++ b/src/client/render/gl/graphics-presets.json
@@ -10,6 +10,38 @@
     "overrides": { "lighting": { "ambient": 0.36 } }
   },
   {
+    "nameKey": "graphics_setting.preset_evans_pick",
+    "descKey": "graphics_setting.preset_evans_pick_desc",
+    "overrides": {
+      "name": {
+        "hoverFadeAlpha": 0.4,
+        "hoverGlowWidth": 8
+      },
+      "structure": {
+        "classicIcons": false
+      },
+      "mapOverlay": {
+        "navalHighlight": true,
+        "highlightFillBrighten": 0.68,
+        "highlightBrighten": 0.17,
+        "highlightThicken": 3,
+        "territorySaturation": 1,
+        "territoryAlpha": 0.54
+      },
+      "terrain": {
+        "backgroundColor": "#131b25",
+        "oceanColor": "#274963",
+        "plainsColor": "#b3d080",
+        "highlandColor": "#d6c69a",
+        "mountainColor": "#fff5f5"
+      },
+      "lighting": {
+        "ambient": 0.76,
+        "falloffPower": 1
+      }
+    }
+  },
+  {
     "nameKey": "graphics_setting.preset_colorblind",
     "descKey": "graphics_setting.preset_colorblind_desc",
     "overrides": {

--- a/tests/TranslationSystem.test.ts
+++ b/tests/TranslationSystem.test.ts
@@ -29,7 +29,7 @@ const DYNAMIC_KEY_PATTERNS: RegExp[] = [
   /^news_box\.(tournament|tutorial|news|warning|firefox_warning)$/,
   // Built-in graphics preset names/descriptions are referenced from
   // src/client/render/gl/graphics-presets.json, not translateText literals.
-  /^graphics_setting\.preset_(default|night|colorblind)(_desc)?$/,
+  /^graphics_setting\.preset_(default|night|evans_pick|colorblind)(_desc)?$/,
 ];
 
 /**


### PR DESCRIPTION
## Summary
- Adds a new built-in graphics preset, "Evan's Pick", to `graphics-presets.json` — Evan's personal overrides: dark navy map background, muted ocean/soft plains/snowy mountain terrain colors, naval highlight on with brighter highlight fill, softened name-hover fade/glow, and ambient lighting at 0.76.
- Placed between Night and Colorblind in the preset dropdown; available from both the main-menu selector and the in-game graphics modal.
- Adds the `preset_evans_pick` name/description strings to `en.json`, and extends the TranslationSystem test's dynamic-key allow-list (preset keys are referenced from the JSON manifest, not `translateText` literals).

## Test plan
- `npx vitest tests/GraphicsPresets.test.ts tests/TranslationSystem.test.ts --run` — 13 tests pass; the existing built-in-preset schema-validation test covers the new entry.
- Prettier clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)