### PR TITLE
Add crown:* wildcard coverage to cosmetic relationship tests

### DIFF
--- a/tests/CosmeticRelationship.test.ts
+++ b/tests/CosmeticRelationship.test.ts
@@ -1,5 +1,9 @@
-import { cosmeticRelationship } from "../src/client/Cosmetics";
+import {
+  cosmeticRelationship,
+  crownRelationship,
+} from "../src/client/Cosmetics";
 import { UserMeResponse } from "../src/core/ApiSchemas";
+import { Crown } from "../src/core/CosmeticSchemas";
 
 function makeUserMe(flares: string[]): UserMeResponse {
   return {
@@ -181,5 +185,43 @@ describe("cosmeticRelationship", () => {
         makeUserMe(["pattern:*"]),
       ),
     ).toBe("owned");
+  });
+
+  it("returns owned when user has wildcard flare for crowns", () => {
+    expect(
+      cosmeticRelationship(
+        {
+          wildcardFlare: "crown:*",
+          requiredFlare: "crown:gold",
+          priceSoft: undefined,
+          priceHard: undefined,
+          affiliateCode: null,
+          itemAffiliateCode: null,
+        },
+        makeUserMe(["crown:*"]),
+      ),
+    ).toBe("owned");
+  });
+});
+
+describe("crownRelationship", () => {
+  const crown = { name: "gold", url: "/crowns/gold.png" } as Crown;
+
+  it("returns owned when user has the crown:* wildcard flare", () => {
+    expect(crownRelationship(crown, makeUserMe(["crown:*"]), null)).toBe(
+      "owned",
+    );
+  });
+
+  it("returns owned when user has the specific crown flare", () => {
+    expect(crownRelationship(crown, makeUserMe(["crown:gold"]), null)).toBe(
+      "owned",
+    );
+  });
+
+  it("does not treat other type wildcards as owning a crown", () => {
+    expect(
+      crownRelationship(crown, makeUserMe(["pattern:*", "flag:*"]), null),
+    ).toBe("blocked");
   });
 });


### PR DESCRIPTION
## Summary
- `crownRelationship` already honours the `crown:*` wildcard flare exactly like `patternRelationship` / `flagRelationship` (and the server's `isCrownAllowed`), but `tests/CosmeticRelationship.test.ts` only covered the `flag:*` and `pattern:*` wildcards.
- Adds a `crown:*` case to the generic `cosmeticRelationship` suite.
- Adds a `crownRelationship` suite exercising the real entry point: `crown:*` → owned, specific `crown:<name>` → owned, and `pattern:*` / `flag:*` do **not** grant crowns.
- No source changes — test-only.

## Test plan
- `npx vitest tests/CosmeticRelationship.test.ts --run` — 15/15 pass
- `npx eslint tests/CosmeticRelationship.test.ts` — clean
- `npx prettier --write` on the test file

🤖 Generated with [Claude Code](https://claude.com/claude-code)