### PR TITLE
refactor(client): extract name resolution into a pure resolvePlayerName()

### DIFF
--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -32,7 +32,6 @@ import {
   purchaseWithCurrency,
 } from "./Api";
 import { showInGameAlert, showInGameConfirm } from "./InGameModal";
-import { isPlayingVerified } from "./UsernameInput";
 import { translateText } from "./Utils";
 
 export const TEMP_FLARE_OFFSET = 1 * 60 * 1000; // 1 minute
@@ -848,7 +847,13 @@ export function resolvedToPlayerPattern(
   };
 }
 
-export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
+// `verified` is passed in rather than looked up: the caller has already
+// resolved what name the player is joining under (see resolvePlayerName), and
+// the badge has to agree with that exact decision. Reading it back out of the
+// DOM here was the same missing seam.
+export async function getPlayerCosmeticsRefs(
+  opts: { verified?: boolean } = {},
+): Promise<PlayerCosmeticRefs> {
   const userSettings = new UserSettings();
   // Resolve the profile first: getUserMe activates the per-player cosmetics
   // scope (UserSettings.setPlayerId), which must happen before selections are
@@ -978,12 +983,14 @@ export async function getPlayerCosmeticsRefs(): Promise<PlayerCosmeticRefs> {
     skinName,
     crownName,
     effects: Object.keys(effects).length > 0 ? effects : undefined,
-    verified: isPlayingVerified() ? true : undefined,
+    verified: opts.verified ? true : undefined,
   };
 }
 
-export async function getPlayerCosmetics(): Promise<PlayerCosmetics> {
-  const refs = await getPlayerCosmeticsRefs();
+export async function getPlayerCosmetics(
+  opts: { verified?: boolean } = {},
+): Promise<PlayerCosmetics> {
+  const refs = await getPlayerCosmeticsRefs(opts);
   const cosmetics = await fetchCosmetics();
 
   const result: PlayerCosmetics = {};

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -65,6 +65,7 @@ import { modalRouter } from "./ModalRouter";
 import { updateAccountNavButton } from "./NavAccountButton";
 import { initNavigation } from "./Navigation";
 import "./NewsModal";
+import { fallbackPlayerName } from "./PlayerName";
 import "./PlayerProfileModal";
 import { RewardsModal } from "./RewardsModal";
 import "./SinglePlayerModal";
@@ -85,7 +86,7 @@ import {
 } from "./Transport";
 import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
-import { genAnonUsername, UsernameInput } from "./UsernameInput";
+import { UsernameInput } from "./UsernameInput";
 import { incrementGamesPlayed, translateText } from "./Utils";
 import { isReplayShellHost } from "./VersionedReplay";
 import "./components/BannedModal";
@@ -1138,11 +1139,18 @@ class Client {
     // handshake. whenSeeded() always resolves (falling back to the generated
     // anon name on failure/timeout), so this can only delay, never block.
     await this.usernameInput?.whenSeeded();
+    // One resolution for the whole join: the name and the verified badge have
+    // to describe the same decision, so they are read together rather than
+    // asked for separately.
+    const resolvedName =
+      this.usernameInput?.resolvedName() ?? fallbackPlayerName();
     const newLobbyHandle = joinLobby(this.eventBus, {
       gameID: lobby.gameID,
-      cosmetics: await getPlayerCosmeticsRefs(),
+      cosmetics: await getPlayerCosmeticsRefs({
+        verified: resolvedName.verified,
+      }),
       turnstileToken: await this.getTurnstileToken(lobby),
-      playerName: this.usernameInput?.getUsername() ?? genAnonUsername(),
+      playerName: resolvedName.name,
       playerClanTag: this.usernameInput?.getClanTag() ?? null,
       clanTagCheck: this.usernameInput?.getClanCheck(),
       playerRole,

--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -1,0 +1,160 @@
+import { ANON_WORDS, anonWordName } from "../core/AnonNames";
+import { isTemporaryUsername, type UserMeResponse } from "../core/ApiSchemas";
+import {
+  MAX_USERNAME_LENGTH,
+  validateUsername,
+} from "../core/validations/username";
+
+// What name a player plays under, resolved in one place.
+//
+// This used to live inside <username-input>, which meant the join path had to
+// reach back into the DOM to ask (`document.querySelector("username-input")`)
+// and the verified branch could skip validation with nothing downstream
+// re-checking it. Both are the same missing seam. Everything here is pure:
+// callers pass values in, so the whole precedence is unit-testable without a
+// component, and every caller gets the same answer.
+
+/** Which branch of the precedence produced the name. */
+export type PlayerNameSource = "verified" | "stored" | "persona" | "generated";
+
+export interface PlayerNameInputs {
+  /**
+   * The account's bare name when the player is eligible to play verified, else
+   * null. See accountVerifiedName.
+   */
+  verifiedName: string | null;
+  /** Whether the player has opted in to playing under that name. */
+  verifiedOptIn: boolean;
+  /**
+   * The free-form name the player typed or has stored. Reported as-is (trimmed
+   * and clamped) even when it fails validation — it is the player's own text,
+   * so the caller shows an error rather than resolution silently swapping in
+   * another name.
+   */
+  storedName: string | null;
+  /** The raw platform persona (Steam), before sanitising. */
+  persona: string | null;
+  /** The generated Anon… name to fall back to. Minted once per session. */
+  generatedName: string;
+}
+
+export interface ResolvedPlayerName {
+  name: string;
+  source: PlayerNameSource;
+  /** Playing under the verified account name — drives the blue check. */
+  verified: boolean;
+}
+
+// Trim rather than reject: a name stored before the cap would otherwise fail
+// validation and block play.
+export function clampUsername(name: string): string {
+  return name.length > MAX_USERNAME_LENGTH
+    ? name.slice(0, MAX_USERNAME_LENGTH).trim()
+    : name;
+}
+
+// The server-resolved bare name this player may play verified under, or null
+// when ineligible. Sub-only by design: `claimed` (lapsed) holders and
+// TEMPORARY####-renamed players don't qualify.
+export function accountVerifiedName(
+  userMe: UserMeResponse | false | null,
+): string | null {
+  if (userMe === null || userMe === false) return null;
+  const player = userMe.player;
+  const status = player.usernameStatus;
+  if (status !== "premium" && status !== "indefinite") return null;
+  if (!player.username || isTemporaryUsername(player.usernameBase)) return null;
+  return player.username;
+}
+
+// A platform persona reduced to something playable, or null when nothing
+// usable survives.
+//
+// Steam personas can contain characters our usernames disallow (e.g. brackets)
+// or exceed the length limit; strip brackets, trim, and only accept the persona
+// if it validates. Not clamped, unlike stored names: a wildly long persona is
+// rejected rather than truncated to a stub.
+//
+// OPE-221 replaces this reject-wholesale rule with strip-and-keep, which is
+// what actually fixes Steam buyers landing on a generated guest name — any
+// emoji, hyphen, accent or non-Latin script currently falls through here.
+export function sanitizePersona(
+  persona: string | null | undefined,
+): string | null {
+  const candidate = persona?.replace(/[[\]]/g, "").trim();
+  if (!candidate) return null;
+  return validateUsername(candidate).isValid ? candidate : null;
+}
+
+/**
+ * The one ordered rule for what name a player plays under:
+ *
+ * 1. eligible for the verified name **and** opted in → the account bare name
+ * 2. else the free-form name the player typed or stored
+ * 3. else the sanitised platform persona
+ * 4. else a generated Anon… name
+ *
+ * Branches 1, 3 and 4 are guaranteed representable on the wire
+ * (`UsernameSchema`), which is what keeps the verified path — the one that
+ * skips free-form validation — from closing the join socket. Branch 2 is the
+ * player's own live text and is validated by the caller instead.
+ */
+export function resolvePlayerName(
+  inputs: PlayerNameInputs,
+): ResolvedPlayerName {
+  const { verifiedName, verifiedOptIn, storedName, persona, generatedName } =
+    inputs;
+
+  if (verifiedOptIn && verifiedName !== null) {
+    return { name: verifiedName, source: "verified", verified: true };
+  }
+
+  // An empty field is the player having cleared it, not a name — fall through
+  // rather than handing the join an empty string.
+  const stored = storedName?.trim();
+  if (stored) {
+    return { name: clampUsername(stored), source: "stored", verified: false };
+  }
+
+  const sanitized = sanitizePersona(persona);
+  if (sanitized !== null) {
+    return { name: sanitized, source: "persona", verified: false };
+  }
+
+  return { name: generatedName, source: "generated", verified: false };
+}
+
+/**
+ * Resolution with nothing to go on — for join paths that can't reach the
+ * identity bar at all. Nothing is stored or claimed from here, so this is
+ * always branch 4.
+ */
+export function fallbackPlayerName(): ResolvedPlayerName {
+  return { name: genAnonUsername(), source: "generated", verified: false };
+}
+
+// A memorable anonymous username: "Anon" + animal (+ digit). Draws from the same
+// word bank as the server-side anonymisation overlay, but keeps the "Anon" prefix
+// that the overlay drops — here it tells the player their name is a placeholder.
+// Client-side fallback for players who never set a name — no roster here, so it
+// draws a random slot (best-effort-unique); the overlay is what guarantees
+// uniqueness in-game.
+//
+// Rejection-sample a uniform slot in [0, bound) from the CSPRNG: drawing a raw
+// uint32 and taking `% bound` would be very slightly biased (the top partial
+// bucket), so we discard the unrepresentable tail first. The bias is cosmetically
+// irrelevant here, but this keeps the draw provably uniform.
+export function genAnonUsername(): string {
+  const bound = ANON_WORDS.length * 10;
+  const limit = Math.floor(0x1_0000_0000 / bound) * bound;
+  const buf = new Uint32Array(1);
+  let rand: number;
+  do {
+    crypto.getRandomValues(buf);
+    rand = buf[0] ?? 0;
+  } while (rand >= limit);
+  // The "Anon" prefix lives HERE, not in anonWordName: a signed-out player's
+  // handle should say it is a placeholder, whereas the in-game anonymisation
+  // setting makes everyone anonymous and gains nothing from repeating the word.
+  return `Anon${anonWordName(rand % bound)}`;
+}

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -26,6 +26,7 @@ import { modalHeader } from "./components/ui/ModalHeader";
 import { getPlayerCosmetics } from "./Cosmetics";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { JoinLobbyEvent } from "./Main";
+import { fallbackPlayerName } from "./PlayerName";
 import { UsernameInput } from "./UsernameInput";
 import {
   getBotsForCompactMap,
@@ -878,6 +879,8 @@ export class SinglePlayerModal extends BaseModal {
     // getUsername(), so a fast single-player start uses the Steam persona
     // rather than the interim generated anon name. Always resolves.
     await usernameInput?.whenSeeded();
+    // Name and badge from one resolution, as on the multiplayer join path.
+    const resolvedName = usernameInput?.resolvedName() ?? fallbackPlayerName();
 
     await crazyGamesSDK.requestMidgameAd();
 
@@ -890,9 +893,11 @@ export class SinglePlayerModal extends BaseModal {
             players: [
               {
                 clientID,
-                username: usernameInput.getUsername(),
-                clanTag: usernameInput.getClanTag() ?? null,
-                cosmetics: await getPlayerCosmetics(),
+                username: resolvedName.name,
+                clanTag: usernameInput?.getClanTag() ?? null,
+                cosmetics: await getPlayerCosmetics({
+                  verified: resolvedName.verified,
+                }),
               },
             ],
             config: {

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -1,8 +1,7 @@
 import { html, LitElement } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { translateText } from "../client/Utils";
-import { ANON_WORDS, anonWordName } from "../core/AnonNames";
-import { isTemporaryUsername, UserMeResponse } from "../core/ApiSchemas";
+import { UserMeResponse } from "../core/ApiSchemas";
 import { sanitizeClanTag } from "../core/Util";
 import {
   MAX_CLAN_TAG_LENGTH,
@@ -17,6 +16,13 @@ import { checkClanTagOwnership } from "./ClanApi";
 import { verifiedBadge } from "./components/ui/VerifiedBadge";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { showInGameConfirm } from "./InGameModal";
+import {
+  accountVerifiedName,
+  clampUsername,
+  genAnonUsername,
+  resolvePlayerName,
+  type ResolvedPlayerName,
+} from "./PlayerName";
 import { steamSDK } from "./SteamSDK";
 
 interface LangSelectorLike {
@@ -33,14 +39,6 @@ const useVerifiedNameKey: string = "useVerifiedName";
 // fresh userMeResponse.
 const CLAN_REMOVED_EVENTS = ["clan-left", "clan-disbanded"];
 const CLAN_MEMBERSHIP_EVENTS = ["clan-joined", ...CLAN_REMOVED_EVENTS];
-
-// Trim rather than reject: a name stored before the cap would otherwise fail
-// validation and block play.
-function clampUsername(name: string): string {
-  return name.length > MAX_USERNAME_LENGTH
-    ? name.slice(0, MAX_USERNAME_LENGTH).trim()
-    : name;
-}
 
 // Shared by the input and the verified chip, which swap places: any drift in
 // box or text metrics shows up as the name jumping on toggle.
@@ -61,6 +59,12 @@ export class UsernameInput extends LitElement {
   // name stays in baseUsername/localStorage so unchecking restores it.
   @state() private verifiedActive: boolean = false;
   private userMe: UserMeResponse | false | null = null;
+  // The raw Steam persona, once it lands. Kept alongside the free-form name so
+  // resolution sees the same inputs the seed did (see resolvedName).
+  private persona: string | null = null;
+  // Minted once so re-resolving is stable: the player must never watch their
+  // placeholder name change under them.
+  private readonly generatedName: string = genAnonUsername();
 
   // Clans aren't supported on CrazyGames — hide the tag input and never submit one.
   private readonly onCrazyGames = crazyGamesSDK.isOnCrazyGames();
@@ -220,18 +224,11 @@ export class UsernameInput extends LitElement {
     });
   };
 
-  // The server-resolved bare name this player may play verified under, or null
-  // when ineligible. Sub-only by design: `claimed` (lapsed) holders and
-  // TEMPORARY####-renamed players don't qualify.
+  // The bare name this player may play verified under, or null when
+  // ineligible. The rule itself lives in PlayerName so the join path and the
+  // resolver can't disagree with the toggle about who qualifies.
   private verifiedName(): string | null {
-    if (this.userMe === null || this.userMe === false) return null;
-    const player = this.userMe.player;
-    const status = player.usernameStatus;
-    if (status !== "premium" && status !== "indefinite") return null;
-    if (!player.username || isTemporaryUsername(player.usernameBase)) {
-      return null;
-    }
-    return player.username;
+    return accountVerifiedName(this.userMe);
   }
 
   // Turn the toggle on iff the player opted in previously AND is still
@@ -278,17 +275,31 @@ export class UsernameInput extends LitElement {
     }
   }
 
+  /**
+   * The name this player will play under, and where it came from. The single
+   * seam join paths read — they take the whole result rather than asking the
+   * component two separate questions and risking them disagreeing.
+   *
+   * `verifiedActive` already folds in eligibility and the CrazyGames exclusion
+   * (see applyVerifiedPreference), so it is the opt-in the resolver wants.
+   */
+  public resolvedName(): ResolvedPlayerName {
+    return resolvePlayerName({
+      verifiedName: this.verifiedName(),
+      verifiedOptIn: this.verifiedActive,
+      storedName: this.baseUsername,
+      persona: this.persona,
+      generatedName: this.generatedName,
+    });
+  }
+
   public getUsername(): string {
-    if (this.verifiedActive) {
-      const verified = this.verifiedName();
-      if (verified !== null) return verified;
-    }
-    return this.baseUsername.trim();
+    return this.resolvedName().name;
   }
 
   /** True when the player is playing under their verified account name. */
   public isVerified(): boolean {
-    return this.verifiedActive && this.verifiedName() !== null;
+    return this.resolvedName().verified;
   }
 
   public getClanTag(): string | null {
@@ -414,17 +425,18 @@ export class UsernameInput extends LitElement {
         .getUser()
         .then((user) => {
           if (this.baseUsername !== generated) return;
-          // Steam personas can contain characters our usernames disallow (e.g.
-          // brackets) or exceed the length limit; strip brackets, trim, and only
-          // accept the persona if it validates — otherwise keep the generated
-          // name so the player can always start a game.
-          // Not clamped, unlike stored and CrazyGames names: a wildly long
-          // persona is rejected rather than truncated to a stub.
-          const candidate = user?.name?.replace(/[[\]]/g, "").trim();
-          if (candidate && validateUsername(candidate).isValid) {
-            this.baseUsername = candidate;
-            this.validateAndStore();
-          }
+          this.persona = user?.name ?? null;
+          // Nothing is stored (that is what got us here), so this is branch 3
+          // then 4: the sanitised persona, or the same generated name back
+          // when none of it survives. Either way the player can start a game.
+          this.baseUsername = resolvePlayerName({
+            verifiedName: null,
+            verifiedOptIn: false,
+            storedName: null,
+            persona: this.persona,
+            generatedName: generated,
+          }).name;
+          this.validateAndStore();
         })
         .catch(() => {
           // Swallow: keep the generated name so the player can always play.
@@ -473,13 +485,18 @@ export class UsernameInput extends LitElement {
       : localStorage.getItem(usernameKey);
     if (storedUsername) {
       this.clanTag = localStorage.getItem(clanTagKey) ?? "";
-      this.baseUsername = clampUsername(storedUsername);
-      this.validateAndStore();
-      this.startClanCheck();
-    } else {
-      this.baseUsername = genAnonUsername();
-      this.validateAndStore();
     }
+    // No persona yet — it arrives asynchronously and reseeds in
+    // connectedCallback, so this settles on the stored or generated name.
+    this.baseUsername = resolvePlayerName({
+      verifiedName: null,
+      verifiedOptIn: false,
+      storedName: storedUsername,
+      persona: null,
+      generatedName: this.generatedName,
+    }).name;
+    this.validateAndStore();
+    if (storedUsername) this.startClanCheck();
   }
 
   render() {
@@ -853,7 +870,10 @@ export class UsernameInput extends LitElement {
   }
 
   private validateAndStore() {
-    const trimmedBase = this.getUsername();
+    // The free-form field's own contents, not resolvedName(): resolution falls
+    // through an emptied field to the persona or a generated name, and play
+    // must stay blocked until the player puts a name back.
+    const trimmedBase = this.baseUsername.trim();
 
     const clanTagResult = validateClanTag(this.clanTag);
     if (!clanTagResult.isValid) {
@@ -907,37 +927,4 @@ export class UsernameInput extends LitElement {
       this._isValid && this.clanTagOwnershipError !== "username.tag_not_member"
     );
   }
-}
-
-// Whether the player is currently playing under their verified account name.
-// For join paths that can't reach the component instance (Cosmetics refs).
-export function isPlayingVerified(): boolean {
-  const el = document.querySelector<UsernameInput>("username-input");
-  return el?.isVerified() ?? false;
-}
-
-// A memorable anonymous username: "Anon" + animal (+ digit). Draws from the same
-// word bank as the server-side anonymisation overlay, but keeps the "Anon" prefix
-// that the overlay drops — here it tells the player their name is a placeholder.
-// Client-side fallback for players who never set a name — no roster here, so it
-// draws a random slot (best-effort-unique); the overlay is what guarantees
-// uniqueness in-game.
-//
-// Rejection-sample a uniform slot in [0, bound) from the CSPRNG: drawing a raw
-// uint32 and taking `% bound` would be very slightly biased (the top partial
-// bucket), so we discard the unrepresentable tail first. The bias is cosmetically
-// irrelevant here, but this keeps the draw provably uniform.
-export function genAnonUsername(): string {
-  const bound = ANON_WORDS.length * 10;
-  const limit = Math.floor(0x1_0000_0000 / bound) * bound;
-  const buf = new Uint32Array(1);
-  let rand: number;
-  do {
-    crypto.getRandomValues(buf);
-    rand = buf[0] ?? 0;
-  } while (rand >= limit);
-  // The "Anon" prefix lives HERE, not in anonWordName: a signed-out player's
-  // handle should say it is a placeholder, whereas the in-game anonymisation
-  // setting makes everyone anonymous and gains nothing from repeating the word.
-  return `Anon${anonWordName(rand % bound)}`;
 }

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from "vitest";
+import {
+  accountVerifiedName,
+  clampUsername,
+  fallbackPlayerName,
+  genAnonUsername,
+  resolvePlayerName,
+  sanitizePersona,
+  type PlayerNameInputs,
+} from "../../src/client/PlayerName";
+import type { UserMeResponse } from "../../src/core/ApiSchemas";
+import { UsernameSchema } from "../../src/core/Schemas";
+import { MAX_USERNAME_LENGTH } from "../../src/core/validations/username";
+
+// The resolver takes plain values, so every case below is expressed as a full
+// set of inputs rather than by mounting the component.
+function inputs(overrides: Partial<PlayerNameInputs> = {}): PlayerNameInputs {
+  return {
+    verifiedName: null,
+    verifiedOptIn: false,
+    storedName: null,
+    persona: null,
+    generatedName: "AnonBadger",
+    ...overrides,
+  };
+}
+
+function player(
+  overrides: Partial<{
+    username: string | null;
+    usernameBase: string | null;
+    usernameStatus: string;
+  }> = {},
+): UserMeResponse {
+  return {
+    player: {
+      username: "RyanTheGreat",
+      usernameBase: "RyanTheGreat",
+      usernameStatus: "premium",
+      ...overrides,
+    },
+  } as unknown as UserMeResponse;
+}
+
+describe("resolvePlayerName precedence", () => {
+  // Eligible x opted-in x what else is available. The verified name wins over
+  // everything, and nothing else can displace it.
+  it("returns the verified name over a stored name", () => {
+    expect(
+      resolvePlayerName(
+        inputs({
+          verifiedName: "RyanTheGreat",
+          verifiedOptIn: true,
+          storedName: "MyCoolName",
+          persona: "Ada",
+        }),
+      ),
+    ).toEqual({ name: "RyanTheGreat", source: "verified", verified: true });
+  });
+
+  it("returns the verified name when nothing else is available", () => {
+    expect(
+      resolvePlayerName(
+        inputs({ verifiedName: "RyanTheGreat", verifiedOptIn: true }),
+      ),
+    ).toEqual({ name: "RyanTheGreat", source: "verified", verified: true });
+  });
+
+  // Opted out: eligibility alone must never put a player under their account
+  // name. Deliberate — an eligible player may want to play anonymously.
+  it("falls to the stored name when eligible but opted out", () => {
+    expect(
+      resolvePlayerName(
+        inputs({
+          verifiedName: "RyanTheGreat",
+          verifiedOptIn: false,
+          storedName: "MyCoolName",
+        }),
+      ),
+    ).toEqual({ name: "MyCoolName", source: "stored", verified: false });
+  });
+
+  // Opted in but ineligible (signed out, lapsed sub, TEMPORARY#### rename).
+  it("falls to the stored name when opted in but ineligible", () => {
+    expect(
+      resolvePlayerName(
+        inputs({
+          verifiedName: null,
+          verifiedOptIn: true,
+          storedName: "MyCoolName",
+        }),
+      ),
+    ).toEqual({ name: "MyCoolName", source: "stored", verified: false });
+  });
+
+  it("prefers the stored name over the persona", () => {
+    expect(
+      resolvePlayerName(inputs({ storedName: "MyCoolName", persona: "Ada" })),
+    ).toEqual({ name: "MyCoolName", source: "stored", verified: false });
+  });
+
+  it("uses the persona when nothing is stored", () => {
+    expect(resolvePlayerName(inputs({ persona: "Ada" }))).toEqual({
+      name: "Ada",
+      source: "persona",
+      verified: false,
+    });
+  });
+
+  it("uses the generated name when nothing is stored and there is no persona", () => {
+    expect(resolvePlayerName(inputs())).toEqual({
+      name: "AnonBadger",
+      source: "generated",
+      verified: false,
+    });
+  });
+
+  it("uses the generated name when the persona is unusable", () => {
+    expect(resolvePlayerName(inputs({ persona: "x".repeat(100) }))).toEqual({
+      name: "AnonBadger",
+      source: "generated",
+      verified: false,
+    });
+  });
+
+  // A blank or whitespace-only stored name is not a name — it is the player
+  // having cleared the field, which the component reports as invalid. The
+  // resolver must not hand the join an empty string.
+  it("treats a blank stored name as absent", () => {
+    expect(resolvePlayerName(inputs({ storedName: "   " })).source).toBe(
+      "generated",
+    );
+    expect(resolvePlayerName(inputs({ storedName: "" })).source).toBe(
+      "generated",
+    );
+  });
+
+  it("trims and clamps a stored name rather than rejecting it", () => {
+    const long = "a".repeat(MAX_USERNAME_LENGTH + 7);
+    expect(resolvePlayerName(inputs({ storedName: long })).name).toBe(
+      "a".repeat(MAX_USERNAME_LENGTH),
+    );
+    expect(resolvePlayerName(inputs({ storedName: "  Spaced  " })).name).toBe(
+      "Spaced",
+    );
+  });
+
+  // The player typed it; resolution reports it as-is so the component can show
+  // its own validation error, rather than silently swapping in another name.
+  it("keeps an invalid stored name instead of falling through", () => {
+    expect(
+      resolvePlayerName(inputs({ storedName: "ab", persona: "Ada" })),
+    ).toEqual({ name: "ab", source: "stored", verified: false });
+  });
+});
+
+describe("resolvePlayerName wire-schema invariant", () => {
+  // Every branch the resolver picks for itself must be representable on the
+  // wire, or the join socket closes with 1002 and the Play button stays lit.
+  // Branch 2 is excluded: that is the player's own live edit buffer, which the
+  // component validates and blocks play on.
+  it("returns a wire-valid name for the verified, persona and generated branches", () => {
+    const cases: PlayerNameInputs[] = [
+      inputs({ verifiedName: "Ryan-The-Great", verifiedOptIn: true }),
+      inputs({ verifiedName: "Ryan The Great", verifiedOptIn: true }),
+      inputs({ verifiedName: "a".repeat(20), verifiedOptIn: true }),
+      inputs({ persona: "[Ada]" }),
+      inputs({ persona: "Ada Lovelace" }),
+      inputs({ persona: "x".repeat(100) }),
+      inputs(),
+    ];
+    for (const c of cases) {
+      const resolved = resolvePlayerName(c);
+      expect(
+        UsernameSchema.safeParse(resolved.name).success,
+        `${resolved.source}: ${resolved.name}`,
+      ).toBe(true);
+    }
+  });
+
+  it("keeps a wire-valid stored name unchanged", () => {
+    expect(
+      UsernameSchema.safeParse(
+        resolvePlayerName(inputs({ storedName: "MyCoolName" })).name,
+      ).success,
+    ).toBe(true);
+  });
+});
+
+describe("sanitizePersona", () => {
+  it("strips the bracket decoration Steam personas carry", () => {
+    expect(sanitizePersona("[Ada]")).toBe("Ada");
+    expect(sanitizePersona("  Ada  ")).toBe("Ada");
+  });
+
+  it("returns null for nothing to sanitise", () => {
+    expect(sanitizePersona(null)).toBeNull();
+    expect(sanitizePersona(undefined)).toBeNull();
+    expect(sanitizePersona("")).toBeNull();
+    expect(sanitizePersona("   ")).toBeNull();
+    expect(sanitizePersona("[]")).toBeNull();
+  });
+
+  // Today's rule is reject-wholesale: anything the free-form charset does not
+  // already allow falls through to a generated name. These fixtures pin that
+  // behaviour so OPE-221 — which replaces it with strip-and-keep and widens
+  // the charset to the MSDF atlas range — has to change them deliberately.
+  it("rejects personas outside the free-form charset (OPE-221 will keep them)", () => {
+    expect(sanitizePersona("José")).toBeNull();
+    expect(sanitizePersona("Müller-42")).toBeNull();
+    expect(sanitizePersona("🔥Ada🔥")).toBeNull();
+    expect(sanitizePersona("日本語")).toBeNull();
+    expect(sanitizePersona("Пётр")).toBeNull();
+  });
+
+  it("rejects an over-length persona rather than truncating it to a stub", () => {
+    expect(sanitizePersona("x".repeat(100))).toBeNull();
+  });
+
+  it("rejects residue shorter than the minimum", () => {
+    expect(sanitizePersona("[ab]")).toBeNull();
+  });
+});
+
+describe("accountVerifiedName", () => {
+  it("returns the bare name for a subscriber who has claimed one", () => {
+    expect(accountVerifiedName(player())).toBe("RyanTheGreat");
+    expect(accountVerifiedName(player({ usernameStatus: "indefinite" }))).toBe(
+      "RyanTheGreat",
+    );
+  });
+
+  it("returns null when there is no profile", () => {
+    expect(accountVerifiedName(null)).toBeNull();
+    expect(accountVerifiedName(false)).toBeNull();
+  });
+
+  it("returns null for a lapsed or absent subscription", () => {
+    expect(
+      accountVerifiedName(player({ usernameStatus: "claimed" })),
+    ).toBeNull();
+    expect(accountVerifiedName(player({ usernameStatus: "none" }))).toBeNull();
+  });
+
+  it("returns null when no name has been claimed", () => {
+    expect(
+      accountVerifiedName(player({ username: null, usernameBase: null })),
+    ).toBeNull();
+  });
+
+  it("returns null for a TEMPORARY#### server rename", () => {
+    expect(
+      accountVerifiedName(
+        player({ username: "TEMPORARY7823", usernameBase: "TEMPORARY7823" }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("clampUsername", () => {
+  it("trims a name that predates the cap rather than rejecting it", () => {
+    expect(clampUsername("a".repeat(MAX_USERNAME_LENGTH + 7))).toBe(
+      "a".repeat(MAX_USERNAME_LENGTH),
+    );
+  });
+
+  it("leaves a name within the cap alone", () => {
+    expect(clampUsername("MyCoolName")).toBe("MyCoolName");
+  });
+});
+
+describe("fallbackPlayerName", () => {
+  // The join path's last resort when the component is missing entirely.
+  it("is a wire-valid generated name", () => {
+    const resolved = fallbackPlayerName();
+    expect(resolved.source).toBe("generated");
+    expect(resolved.verified).toBe(false);
+    expect(UsernameSchema.safeParse(resolved.name).success).toBe(true);
+  });
+});
+
+describe("genAnonUsername", () => {
+  it("produces wire-valid names", () => {
+    for (let i = 0; i < 200; i++) {
+      const name = genAnonUsername();
+      expect(name.startsWith("Anon")).toBe(true);
+      expect(UsernameSchema.safeParse(name).success, name).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
Closes #5087.

Enabler for the rest of the Steam username work (OPE-220). Design doc: `docs/superpowers/specs/2026-08-23-steam-username-resolution-design.md` in the `openfront-desktop` repo, decision 6.

## The problem

Which name a player plays under is decided inside `<username-input>`, so every caller has to reach into the component to find out — and one of them reaches into the DOM to do it:

```ts
export function isPlayingVerified(): boolean {
  const el = document.querySelector<UsernameInput>("username-input");
  return el?.isVerified() ?? false;
}
```

`Cosmetics.ts` calls that to decide whether to send `verified: true` with the join, while `Main.ts` separately calls `usernameInput.getUsername()` for the name. Two questions about one decision, answered from two places, one of them by a global DOM lookup.

That entanglement is the bug class rather than just a tidiness problem. The verified branch deliberately skips free-form validation because the name is server-issued, and nothing between the account name and the join re-checks it — which is how a hyphenated account name used to close the join socket with `1002` while the Play button stayed lit (fixed in #4983 by widening the wire schema, but the missing seam is still there).

## What this does

Moves the decision into a new `src/client/PlayerName.ts` as one ordered, DOM-free function:

1. eligible for the verified name **and** opted in → the account bare name
2. else the free-form name the player typed or stored
3. else the sanitised platform persona
4. else a generated `Anon…` name

Branches 1, 3 and 4 are guaranteed representable on the wire (`UsernameSchema`), asserted directly in the tests. Branch 2 is excluded on purpose: it is the player's own live edit buffer, which the component validates and blocks play on — resolution reports it as-is rather than silently swapping in a different name.

Callers now take the whole result instead of asking two questions that could disagree:

- `getPlayerCosmeticsRefs()` / `getPlayerCosmetics()` take `verified` as a parameter; the DOM lookup is gone and `isPlayingVerified()` is deleted.
- `Main.ts` and `SinglePlayerModal.ts` each read the name and the badge from one `resolvedName()` call.
- `genAnonUsername()` and `clampUsername()` move to `PlayerName.ts` with them — they are branch 4 and part of branch 2, and `Main.ts` no longer has to import a helper out of a Lit component.

## Deliberately not in scope

This is a pure refactor. `sanitizePersona()` keeps today's reject-wholesale rule, so an emoji / hyphen / CJK / accented Steam persona still falls through to a generated guest name. That is the actual "Steam buyers appear as random guests" bug and it is OPE-221's job — the fixtures pinning the current behaviour are commented so that change has to flip them deliberately rather than by accident.

## Testing

- New `tests/client/PlayerName.test.ts`: 27 cases over the full eligible × opted-in × stored/persona/generated matrix, the sanitiser fixtures (bracket decoration, emoji, CJK, Cyrillic, accented Latin, over-length, sub-minimum residue), `accountVerifiedName` eligibility including the `TEMPORARY####` rename, and the wire-schema invariant. No DOM.
- `tests/UsernameInput.test.ts`, `tests/client/UsernameInput.steam.test.ts`, `tests/client/UsernameVerifiedRoute.test.ts` unchanged and green.
- Full suite: 346 files, 4165 tests passing. `tsc --noEmit`, `prettier --check .` and `npm run lint` clean.
