### PR TITLE
fix(desktop): navigate on a mid-match Steam invite instead of leaving the lobby in place

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1343,9 +1343,24 @@ class Client {
       // the invite survives the reload without needing to be stashed: the
       // path parser in handleUrl() opens the join modal on the way back up,
       // which is the same route a shared lobby link takes.
-      this.resetPresenceToMenu();
-      window.location.href = `/${ClientEnv.workerPath(gameId)}/game/${gameId}`;
-      return;
+      // The /w<n>/game/<id> shape only exists on the game-server origin, so
+      // this root-relative navigation must not run on the replay shell host --
+      // it would resolve against replay.<domain>, 404, and lose the invite,
+      // which consumePendingInvite() has already taken. Same guard, for the
+      // same reason, as handleJoinLobby and updateJoinUrlForShare above.
+      //
+      // Not reachable from the desktop shell today: it classifies every
+      // https:// URL as open-externally, so redirectToVersionedShell() hands
+      // the replay host to the OS browser and this window stays on
+      // app://openfront/. That is a policy in a different repo though, and
+      // nothing here would notice if it changed -- so guard rather than depend
+      // on it. On the replay host, fall back to the in-place leave.
+      if (!isReplayShellHost(window.location.hostname)) {
+        this.resetPresenceToMenu();
+        window.location.href = `/${ClientEnv.workerPath(gameId)}/game/${gameId}`;
+        return;
+      }
+      await this.handleLeaveLobby();
     }
     // A cold-start invite can beat the modal's own upgrade, which would make
     // open() a silent no-op (the CrazyGames invite path waits for the same

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1327,12 +1327,25 @@ class Client {
         );
         if (!confirmed) return;
       }
-      // The existing in-place leave: it forces the stop, clears the URL, drops
-      // the in-game class and resets presence to the menu -- which matters
-      // because the join below is not guaranteed to follow (the player can
-      // still close the modal) and friends must not be left looking at a
-      // lobby nobody is in.
-      await this.handleLeaveLobby();
+      // Navigate rather than leaving in place. handleLeaveLobby() was only
+      // ever called during the pre-start lobby wait; every exit from a
+      // STARTED game goes through a full location.href navigation, and it is
+      // that reload -- not handleLeaveLobby -- which restores the started-game
+      // teardown. Two pieces of it have no in-place restore path:
+      // gameModeSelector.stop() (line ~1139/1157) kills the public lobby
+      // socket, whose start() is only ever called from connectedCallback();
+      // and the same block hides every .ad element, which nothing ever
+      // un-hides. Leaving in place therefore stranded the player on a
+      // homepage with a frozen lobby list and no ad rails whenever the join
+      // did not complete -- modal closed, or lobby full/already started.
+      //
+      // Navigating to the lobby's own /game/<id> URL rather than "/" means
+      // the invite survives the reload without needing to be stashed: the
+      // path parser in handleUrl() opens the join modal on the way back up,
+      // which is the same route a shared lobby link takes.
+      this.resetPresenceToMenu();
+      window.location.href = `/${ClientEnv.workerPath(gameId)}/game/${gameId}`;
+      return;
     }
     // A cold-start invite can beat the modal's own upgrade, which would make
     // open() a silent no-op (the CrazyGames invite path waits for the same


### PR DESCRIPTION
Follow-up to #5194, which merged before this was addressed. Raised there by the Claude Code review bot (medium severity) and verified against the merged code.

**Add approved & assigned issue number here:**

Resolves #(follow-up to #5194)

## Description:

`openInvite()` was the only caller to invoke `handleLeaveLobby()` **in place after a game had actually started**. Every other exit from a started game — win screen, back button/popstate, in-game quit — does a full `location.href` navigation, and it's that reload, not `handleLeaveLobby()`, which undoes the started-game teardown.

Two pieces of that teardown have no in-place restore path:

- **The public lobby browser.** `gameModeSelector.stop()` (`Main.ts:1139`/`1157`) stops `lobbySocket`, and `lobbySocket.start()` is only ever called from `connectedCallback()` (`GameModeSelector.ts:81`) — there's no restart anywhere in the codebase.
- **The ad rails.** The same block sets `display: none` on every `.ad` element (`Main.ts:1140`/`1160`). Grepping the client for any restore turns up nothing — those two hides are the only writes.

So a player who accepted a Steam invite mid-match and then didn't complete the join — closed the modal, or the target lobby was full/already started — landed back on the homepage with a frozen, non-updating lobby list and no ad rails, until they happened to navigate again.

### The fix

Navigate instead of leaving in place, matching every other post-start exit.

Navigating to the lobby's own `/game/<id>` URL rather than `/` means **the invite survives the reload with nothing stashed**: `handleUrl()`'s path parser (`Main.ts:918`) opens the join modal on the way back up — the same route a shared lobby link already takes. `ClientEnv.workerPath()` always returns `w<n>`, so the path is always `/wN/game/<id>`, which that parser's regex handles.

Only when a game is actually running. With no `lobbyHandle` there's nothing to tear down, so the modal still opens in place with no reload — the common case (invite accepted from the menu) is unchanged.

## Please complete the following:

- [x] I have added screenshots for all UI updates — **N/A, no UI changes**
- [x] I process any text displayed to the user through translateText() — **N/A, no new user-facing text**
- [x] I have added relevant tests to the test directory — **none added; see below**

On tests: the changed branch is a `location.href` assignment inside a private method of the `Client` class, reached only when a real `lobbyHandle` exists. There's no existing harness that drives that path, and asserting on a stubbed `window.location` would test the stub rather than the behaviour. Happy to add coverage if you'd like a particular shape.

`tsc --noEmit` and prettier clean. Full suite run locally — note it has some pre-existing flakiness under parallel load on my machine: three full runs produced three *different* failure sets (`NationName`/`InventoryModal`, then `MapConsistency`/`TranslationSystem`, then `InventoryModal` alone), and a run on clean `main` with no patch failed too. All pass in isolation. Unrelated to this change, but worth flagging.

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
