### PR TITLE
small bug / Flag fix on playerPanel

### DIFF
--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -568,7 +568,8 @@ export class PlayerPanel extends LitElement implements Controller {
   }
 
   private renderIdentityRow(other: PlayerView, my: PlayerView) {
-    const flagCode = other.cosmetics.flag;
+    const flagPath = other.cosmetics.flag;
+    const flagCode = flagPath?.match(/\/flags\/([A-Za-z0-9_-]+)\.svg/)?.[1];
     const country =
       typeof flagCode === "string"
         ? Countries.find((c) => c.code === flagCode)
@@ -581,10 +582,11 @@ export class PlayerPanel extends LitElement implements Controller {
 
     return html`
       <div class="flex items-center gap-2.5 flex-wrap">
-        ${country && typeof flagCode === "string"
+        ${flagPath
           ? html`<img
-              src=${assetUrl(`flags/${encodeURIComponent(flagCode)}.svg`)}
+              src=${assetUrl(flagPath)}
               alt=${country?.name ?? "Flag"}
+              title=${country?.name ?? "Flag"}
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -569,7 +569,7 @@ export class PlayerPanel extends LitElement implements Controller {
 
   private renderIdentityRow(other: PlayerView, my: PlayerView) {
     const flagPath = other.cosmetics.flag;
-    const flagCode = flagPath?.match(/\/flags\/([A-Za-z0-9_-]+)\.svg/)?.[1];
+    const flagCode = flagPath?.match(/\/flags\/(.+)\.svg$/)?.[1];
     const country =
       typeof flagCode === "string"
         ? Countries.find((c) => c.code === flagCode)

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -585,8 +585,8 @@ export class PlayerPanel extends LitElement implements Controller {
         ${flagPath
           ? html`<img
               src=${assetUrl(flagPath)}
-              alt=${country?.name ?? "Flag"}
-              title=${country?.name ?? "Flag"}
+              alt=${country?.name ?? translateText("cosmetics.type_flag")}
+              title=${country?.name ?? translateText("cosmetics.type_flag")}
               class="h-10 w-10 rounded-full object-cover"
               @error=${(e: Event) => {
                 (e.target as HTMLImageElement).style.display = "none";


### PR DESCRIPTION

**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

PlayerPanel always had the players flag beside their name. There was a small bug in how this is implemented.

## Before:
<img width="350" height="400" alt="beforeFix" src="https://github.com/user-attachments/assets/40e155f3-f74d-4040-a9cf-0d49e4b71f16" />

## After:
<img width="350" height="400" alt="Screenshot 2026-09-01 122414" src="https://github.com/user-attachments/assets/55b7edb6-d577-4553-bde5-f4dcc80248bd" />






Describe the PR.

## Please complete the following:

- [ x] I have added screenshots for all UI updates
- [x ] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [ x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

DISCORD_USERNAME
Boostry
