### PR TITLE
feat(desktop): add an Invite Friends button to the lobby

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1562,6 +1562,7 @@
   },
   "public_lobby": {
     "connecting": "Connecting to lobby...",
+    "invite_friends": "Invite Friends",
     "join_timeout": "You didn't enter the game in time.",
     "players_per_team": "of {num}",
     "started": "Started",

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -29,6 +29,7 @@ import {
 } from "../core/game/Game";
 import { getApiBase } from "./Api";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
+import { desktopPresence } from "./DesktopPresence";
 import { PublicLobbySocket } from "./LobbySocket";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
@@ -102,6 +103,36 @@ export class JoinLobbyModal extends BaseModal {
     });
   };
 
+  // Steam's invite dialog is reachable only through the in-game overlay, so
+  // this is desktop-shell-only: isAvailable() checks shell.api >= 2, which is
+  // false in a browser and on an older depot's shell. The click is
+  // best-effort — the bridge resolves false when Steam is absent or the
+  // overlay refuses, and a lobby must not break on that.
+  private renderInviteFriends() {
+    if (!desktopPresence.isAvailable()) return undefined;
+    const label = translateText("public_lobby.invite_friends");
+    return html`<button
+      data-test-invite-friends
+      type="button"
+      @click=${() => void desktopPresence.openInviteDialog()}
+      class="flex items-center gap-1.5 bg-white/5 hover:bg-white/10 rounded-lg px-2 py-1 border border-white/10 text-white/60 hover:text-white text-xs font-bold uppercase tracking-widest transition-colors"
+      title=${label}
+      aria-label=${label}
+    >
+      <svg
+        class="w-4 h-4"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM16 7a1 1 0 00-2 0v2h-2a1 1 0 000 2h2v2a1 1 0 002 0v-2h2a1 1 0 000-2h-2V7z"
+        ></path>
+      </svg>
+      ${label}
+    </button>`;
+  }
+
   protected renderHeaderSlot() {
     if (!this.currentLobbyId) {
       return modalHeader({
@@ -110,14 +141,26 @@ export class JoinLobbyModal extends BaseModal {
         ariaLabel: translateText("common.close"),
       });
     }
+    // Both affordances answer "get my friends into this lobby", so they sit
+    // together. Copy stays private-only (the ID is how a private lobby is
+    // shared); the Steam invite works for either, because the shell keeps a
+    // shadow lobby for any joined game.
+    const copy =
+      this.currentLobbyId && this.isPrivateLobby()
+        ? html`<copy-button .lobbyId=${this.currentLobbyId}></copy-button>`
+        : undefined;
+    const invite = this.renderInviteFriends();
     return modalHeader({
       title: translateText("public_lobby.title"),
       onBack: () => this.closeAndLeave(),
       ariaLabel: translateText("common.close"),
+      // Only pair them behind a wrapper when both are present, so a browser --
+      // which never gets the invite button -- renders exactly the markup it
+      // rendered before this change.
       rightContent:
-        this.currentLobbyId && this.isPrivateLobby()
-          ? html`<copy-button .lobbyId=${this.currentLobbyId}></copy-button>`
-          : undefined,
+        copy && invite
+          ? html`<div class="flex items-center gap-2">${copy}${invite}</div>`
+          : (copy ?? invite),
     });
   }
 

--- a/tests/client/JoinLobbyModal.test.ts
+++ b/tests/client/JoinLobbyModal.test.ts
@@ -1,4 +1,24 @@
+import { render } from "lit";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const presenceMocks = vi.hoisted(() => ({
+  isAvailable: vi.fn(() => false),
+  openInviteDialog: vi.fn(async () => true),
+}));
+
+// The desktop bridge is absent in a browser and in jsdom. Mocking the module
+// lets each test state which shell it is running in, which is the only thing
+// the invite button is gated on.
+vi.mock("../../src/client/DesktopPresence", () => ({
+  desktopPresence: {
+    isAvailable: presenceMocks.isAvailable,
+    openInviteDialog: presenceMocks.openInviteDialog,
+    set: vi.fn(),
+    consumePendingInvite: vi.fn(async () => null),
+    subscribeInvites: vi.fn(() => () => undefined),
+  },
+}));
+
 import { JoinLobbyModal } from "../../src/client/JoinLobbyModal";
 
 describe("JoinLobbyModal server time offset", () => {
@@ -111,5 +131,98 @@ describe("JoinLobbyModal spectate link", () => {
     await (modal as any).handleUrlJoin("AbCd1234", true);
     expect((modal as any).checkArchivedGame).toHaveBeenCalledWith("AbCd1234");
     expect((modal as any).showMessage).not.toHaveBeenCalled();
+  });
+});
+
+// OPE-205. Steam's invite dialog is reachable only through the in-game
+// overlay, so this button is desktop-shell-only: desktopPresence.isAvailable()
+// checks shell.api >= 2, which is false in a browser and on an older depot's
+// shell. These tests pin the gating and the wiring; whether the dialog
+// actually renders is OPE-200's acceptance criterion and needs a packaged
+// Steam build to verify.
+describe("JoinLobbyModal Steam invite button", () => {
+  const INVITE = "[data-test-invite-friends]";
+
+  function renderHeader(modal: JoinLobbyModal): HTMLElement {
+    const container = document.createElement("div");
+    render(
+      (
+        modal as unknown as { renderHeaderSlot(): unknown }
+      ).renderHeaderSlot() as never,
+      container,
+    );
+    return container;
+  }
+
+  function lobbyModal(): JoinLobbyModal {
+    const modal = new JoinLobbyModal();
+    (modal as unknown as { currentLobbyId: string }).currentLobbyId =
+      "ABCD1234";
+    return modal;
+  }
+
+  beforeEach(() => {
+    presenceMocks.isAvailable.mockReset().mockReturnValue(false);
+    presenceMocks.openInviteDialog.mockReset().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is absent in a browser", () => {
+    presenceMocks.isAvailable.mockReturnValue(false);
+
+    expect(renderHeader(lobbyModal()).querySelector(INVITE)).toBeNull();
+  });
+
+  it("is absent before joining a lobby, even on the desktop shell", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    const modal = new JoinLobbyModal();
+
+    // There is nothing to invite anyone into until a lobby is joined.
+    expect(renderHeader(modal).querySelector(INVITE)).toBeNull();
+  });
+
+  it("appears in a joined lobby on the desktop shell", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+
+    expect(renderHeader(lobbyModal()).querySelector(INVITE)).not.toBeNull();
+  });
+
+  it("opens the Steam invite dialog when clicked", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    const button =
+      renderHeader(lobbyModal()).querySelector<HTMLButtonElement>(INVITE);
+
+    button?.click();
+
+    expect(presenceMocks.openInviteDialog).toHaveBeenCalledOnce();
+  });
+
+  // The bridge resolves false when Steam is absent or the overlay refuses.
+  // Nothing in the lobby should break on that -- the click is best-effort.
+  it("survives the bridge reporting failure", async () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    presenceMocks.openInviteDialog.mockResolvedValue(false);
+    const button =
+      renderHeader(lobbyModal()).querySelector<HTMLButtonElement>(INVITE);
+
+    expect(() => button?.click()).not.toThrow();
+    await Promise.resolve();
+  });
+
+  it("does not suppress the private-lobby copy button", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    const modal = lobbyModal();
+    vi.spyOn(
+      modal as unknown as { isPrivateLobby(): boolean },
+      "isPrivateLobby",
+    ).mockReturnValue(true);
+
+    const header = renderHeader(modal);
+
+    expect(header.querySelector("copy-button")).not.toBeNull();
+    expect(header.querySelector(INVITE)).not.toBeNull();
   });
 });


### PR DESCRIPTION
Implements **OPE-205** — the send half of Steam invites. The receive half (OPE-204) shipped in #5194.

## ⚠️ Unverified pending a packaged Steam run — please read before merging

**This has not been verified against a packaged Steam build launched from the Steam client, and it cannot be from here.** Per `CLAUDE.md`, real desktop verification needs an actual Windows machine with Steam running and the build installed through Steam. The tests below pin the *gating* and the *wiring* only — they do not and cannot prove the Steam overlay renders the invite dialog.

That matters more than usual here, because the whole point of this button is to open Steam's invite dialog, and that dialog is reachable **only** through the in-game overlay. `overlay.activateInviteDialog()` has no software fallback.

**Related: OPE-200 (the overlay not injecting) is still open — "In Progress" in Linear, not Done.** OPE-205's own spec says this button is droppable if OPE-200 does not land before the freeze, on the grounds that "shipping an unverifiable button that silently does nothing is worse than not shipping it". Flagging that explicitly so the merge decision is made with it in view rather than around it. If OPE-200 does not close, this should be cut, not shipped.

The verification checklist this needs, from the issue:
1. Button appears in a packaged Steam build; absent in a browser.
2. Clicking opens the Steam overlay on the invite dialog.
3. A second account receives the invite.
4. Accepting with the game **running** joins the lobby.
5. Accepting with the game **closed** launches and joins after the account-linking gate.

## Also worth knowing: rich presence is inert until OPE-203

OPE-202's rich presence **will not display anything meaningful until the Rich Presence localization file is uploaded to the Steamworks partner site (OPE-203)** — Steam renders a bare "OpenFront" on the friends list without it. That is a partner-site action, not a code change, and it is not part of this PR. Noting it here so a reviewer testing in this feature area does not see empty presence, conclude the merged code is broken, and go looking for a bug that is not there.

## What this does

The button renders in the joined-lobby header beside the copy-lobby-ID control, since both answer "get my friends into this lobby". Copy stays private-only (the lobby ID is how a private lobby is shared); the Steam invite applies to public and private alike, because the shell keeps a shadow Steam lobby for any joined game.

Gated on `desktopPresence.isAvailable()`, which checks `shell.api >= 2` — so it never appears in a browser or on an older depot's shell. The click is best-effort: the bridge resolves `false` when Steam is absent or the overlay refuses, and a lobby must not break on that.

The bridge call already existed; this is the UI that reaches it.

## Two deliberate departures from the plan's snippet

**1. The i18n key is namespaced `public_lobby.invite_friends`, not a bare top-level `invite_friends`.** `resources/lang/en.json` has **zero** top-level non-dict keys — every string in the file is namespaced — so a bare key would be the only unnamespaced entry in it. `public_lobby` is where the shared joined-lobby strings already live (`public_lobby.status`, `public_lobby.title`); that view is identical for public and private lobbies, as the `renderBody` comment states.

**2. The copy/invite pair is wrapped in a flex container only when both are present.** A browser never gets the invite button, so it renders exactly the markup it rendered before this change. This client is being frozen for release — the non-desktop path should be byte-identical, not merely equivalent.

## Tests

Six new tests in `tests/client/JoinLobbyModal.test.ts`, rendering the real header through Lit and querying the result rather than asserting on template internals: absent in a browser; absent before joining a lobby even on the desktop shell; present in a joined lobby on the shell; click reaches `openInviteDialog()`; survives the bridge resolving `false`; does not suppress the private-lobby copy button.

Mutation-checked the gate: removing the `isAvailable()` check fails exactly one test — `is absent in a browser` — and only that one.

Local: `tsc --noEmit` clean, `npm run lint` clean, `prettier --check .` clean, full suite **4144/4144 client and 588/588 server, zero failures**.

## Coordination

Touches `resources/lang/en.json`, which Lane B is also adding keys to. Expected mechanical conflict; whoever lands second rebases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFZGRXBMRSNyicA7V2MhtU
