### PR TITLE
fix(client): keep Steam personas instead of discarding them

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1976,7 +1976,7 @@
     "clan_none_joined": "You haven't joined a clan yet.",
     "clan_your_clans": "Your clans",
     "enter_username": "Enter your username",
-    "invalid_chars": "Username can only contain letters, numbers, spaces, and underscores.",
+    "invalid_chars": "Username can only contain letters, numbers, spaces, underscores, hyphens, and periods.",
     "not_string": "Username must be a string.",
     "tag": "TAG",
     "tag_invalid_chars": "Clan tag can only contain letters and numbers.",

--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -81,10 +81,17 @@ export function accountVerifiedName(
 function truncateToCap(name: string): string {
   if (name.length <= MAX_USERNAME_LENGTH) return name;
   const hard = name.slice(0, MAX_USERNAME_LENGTH).trim();
-  const lastSpace = hard.lastIndexOf(" ");
-  if (lastSpace < MIN_USERNAME_LENGTH) return hard;
-  // Already ended on a boundary — the next character is where the cut fell.
+  // Already a clean cut — don't go looking for an earlier boundary and throw
+  // away a whole word that fitted. Two ways that happens: the character after
+  // the cut is a space, or `trim()` just removed one from the end of the slice
+  // (which is the only thing it can remove, since `collapsed` arrives with no
+  // leading, trailing or repeated whitespace).
+  if (hard.length < MAX_USERNAME_LENGTH) return hard;
   if (name[MAX_USERNAME_LENGTH] === " ") return hard;
+  const lastSpace = hard.lastIndexOf(" ");
+  // No boundary worth cutting back to — a single long word is cut where it
+  // falls rather than reduced to a stub.
+  if (lastSpace < MIN_USERNAME_LENGTH) return hard;
   return hard.slice(0, lastSpace);
 }
 

--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -1,8 +1,12 @@
 import { ANON_WORDS, anonWordName } from "../core/AnonNames";
 import { isTemporaryUsername, type UserMeResponse } from "../core/ApiSchemas";
 import {
+  RENDERABLE_NAME_CHAR_RE,
+  RENDERABLE_NAME_HAS_ALNUM_RE,
+} from "../core/Schemas";
+import {
   MAX_USERNAME_LENGTH,
-  validateUsername,
+  MIN_USERNAME_LENGTH,
 } from "../core/validations/username";
 
 // What name a player plays under, resolved in one place.
@@ -67,23 +71,64 @@ export function accountVerifiedName(
   return player.username;
 }
 
+// Cut to the free-form cap, not the wire cap: the result becomes the name in
+// the field, so anything longer would be seeded and then rejected by the very
+// form the player is looking at.
+//
+// Prefer a word boundary — "Ada Lovelace the Countess" reads as "Ada Lovelace
+// the", not "Ada Lovelace the Cou" — but only when enough survives; a single
+// long word is cut where it falls.
+function truncateToCap(name: string): string {
+  if (name.length <= MAX_USERNAME_LENGTH) return name;
+  const hard = name.slice(0, MAX_USERNAME_LENGTH).trim();
+  const lastSpace = hard.lastIndexOf(" ");
+  if (lastSpace < MIN_USERNAME_LENGTH) return hard;
+  // Already ended on a boundary — the next character is where the cut fell.
+  if (name[MAX_USERNAME_LENGTH] === " ") return hard;
+  return hard.slice(0, lastSpace);
+}
+
 // A platform persona reduced to something playable, or null when nothing
 // usable survives.
 //
-// Steam personas can contain characters our usernames disallow (e.g. brackets)
-// or exceed the length limit; strip brackets, trim, and only accept the persona
-// if it validates. Not clamped, unlike stored names: a wildly long persona is
-// rejected rather than truncated to a stub.
+// Strip and keep, never reject wholesale. The old rule ran the persona through
+// validateUsername() and threw the whole thing away if anything failed, so a
+// single emoji, hyphen or accented letter — the decoration most Steam personas
+// carry — dropped the player to a generated Anon… name. That is the whole
+// "Steam buyers appear as random guests" complaint.
 //
-// OPE-221 replaces this reject-wholesale rule with strip-and-keep, which is
-// what actually fixes Steam buyers landing on a generated guest name — any
-// emoji, hyphen, accent or non-Latin script currently falls through here.
+// Unrenderable codepoints become a space rather than vanishing, so the words
+// either side of a decorative separator stay separate words: "Ada🔥Lovelace"
+// is "Ada Lovelace", not "AdaLovelace". Brackets fall out here too — they are
+// simply not in the allowlist — so no special case is needed for them.
 export function sanitizePersona(
   persona: string | null | undefined,
 ): string | null {
-  const candidate = persona?.replace(/[[\]]/g, "").trim();
-  if (!candidate) return null;
-  return validateUsername(candidate).isValid ? candidate : null;
+  if (!persona) return null;
+  const kept = Array.from(persona, (ch) =>
+    RENDERABLE_NAME_CHAR_RE.test(ch) ? ch : " ",
+  ).join("");
+  const collapsed = kept.replace(/\s+/g, " ").trim();
+  const name = truncateToCap(collapsed);
+  if (name.length < MIN_USERNAME_LENGTH) return null;
+  // Punctuation alone is not a name. Without this a persona of "★★★★" or
+  // "..." would seed "..." — worse for the player than an Anon… name, which
+  // at least reads as a placeholder.
+  if (!RENDERABLE_NAME_HAS_ALNUM_RE.test(name)) return null;
+  return name;
+}
+
+// Whether a stored name has the exact shape genAnonUsername produces:
+// "Anon" + a word from the bank + an optional round digit.
+//
+// Only used to recognise names generated before the usernameIsGenerated flag
+// existed, so that an install already poisoned by the one-shot seed can be
+// reseeded once. A player who deliberately typed one of these gets reseeded
+// from their own Steam persona, which is the same thing they would have got
+// had the seed worked in the first place.
+export function looksGenerated(name: string): boolean {
+  const match = /^Anon([A-Za-z]+)\d?$/u.exec(name);
+  return match !== null && ANON_WORDS.includes(match[1]);
 }
 
 /**

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -440,7 +440,12 @@ export class UsernameInput extends LitElement {
       this.steamSeedReady = steamSDK
         .getUser()
         .then((user) => {
+          // Both halves matter. The text check catches the player typing
+          // while getUser() was in flight; the ownership flag catches them
+          // typing and then restoring the same text, which leaves the name
+          // looking untouched but makes it theirs (see handleUsernameChange).
           if (this.baseUsername !== generated) return;
+          if (!this.usernameIsGenerated) return;
           this.persona = user?.name ?? null;
           // storedName is deliberately null: whatever is stored is a name we
           // generated, which this is entitled to replace. So this is branch 3

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -20,6 +20,7 @@ import {
   accountVerifiedName,
   clampUsername,
   genAnonUsername,
+  looksGenerated,
   resolvePlayerName,
   type ResolvedPlayerName,
 } from "./PlayerName";
@@ -34,6 +35,9 @@ interface LangSelectorLike {
 const usernameKey: string = "username";
 const clanTagKey: string = "clanTag";
 const useVerifiedNameKey: string = "useVerifiedName";
+// "The stored username is one we generated, not one the player chose." Written
+// alongside the name itself; see usernameIsGenerated.
+const usernameIsGeneratedKey: string = "usernameIsGenerated";
 
 // Announced by the clan modal, which invalidates /users/@me but dispatches no
 // fresh userMeResponse.
@@ -65,6 +69,10 @@ export class UsernameInput extends LitElement {
   // Minted once so re-resolving is stable: the player must never watch their
   // placeholder name change under them.
   private readonly generatedName: string = genAnonUsername();
+  // Whether the name in baseUsername is one we generated rather than one the
+  // player chose. Persisted, because one localStorage string cannot tell the
+  // two apart and the reseed rule turns entirely on the difference.
+  private usernameIsGenerated: boolean = false;
 
   // Clans aren't supported on CrazyGames — hide the tag input and never submit one.
   private readonly onCrazyGames = crazyGamesSDK.isOnCrazyGames();
@@ -390,7 +398,13 @@ export class UsernameInput extends LitElement {
     // Captured before loadStoredUsername(), which — when nothing is stored —
     // fills in a fresh anon username AND persists it immediately. Checking
     // localStorage afterwards would therefore never see it as empty.
-    const noStoredUsername = this.onSteam && !localStorage.getItem(usernameKey);
+    //
+    // Reseedable, not one-shot: the old gate was "nothing stored at all", so a
+    // single launch before the persona landed (or before this fix, when a
+    // decorated persona was rejected outright) left a generated Anon… name in
+    // localStorage that nothing would ever replace. A name we generated is
+    // ours to overwrite; a name the player typed never is.
+    const reseedable = this.onSteam && this.storedNameIsGenerated();
     this.loadStoredUsername();
     // On CrazyGames the account username is applied here but never persisted
     // (see loadStoredUsername / validateAndStore), so logging out — which
@@ -400,20 +414,22 @@ export class UsernameInput extends LitElement {
     crazyGamesSDK.getUsername().then((username) => {
       if (username) {
         this.baseUsername = clampUsername(username);
+        this.usernameIsGenerated = false;
         this.validateAndStore();
       }
     });
     crazyGamesSDK.addAuthListener((user) => {
       if (user) {
         this.baseUsername = clampUsername(user.username);
+        this.usernameIsGenerated = false;
         this.validateAndStore();
       }
     });
-    // Seed the in-game name from the Steam persona, once, only when nothing
-    // is stored yet. Unlike CrazyGames, Steam persists normally (see
+    // Seed the in-game name from the Steam persona whenever the name in hand
+    // is one we generated. Unlike CrazyGames, Steam persists normally (see
     // validateAndStore's onCrazyGames guard), and there's no logout event to
     // handle since the Steam identity is fixed for the session.
-    if (noStoredUsername) {
+    if (reseedable) {
       // The anon name loadStoredUsername() just generated. Only overwrite it if
       // the player hasn't typed their own name while getUser() was in flight,
       // so a late Steam result never clobbers a name they entered.
@@ -426,16 +442,21 @@ export class UsernameInput extends LitElement {
         .then((user) => {
           if (this.baseUsername !== generated) return;
           this.persona = user?.name ?? null;
-          // Nothing is stored (that is what got us here), so this is branch 3
-          // then 4: the sanitised persona, or the same generated name back
+          // storedName is deliberately null: whatever is stored is a name we
+          // generated, which this is entitled to replace. So this is branch 3
+          // then 4 — the sanitised persona, or the same generated name back
           // when none of it survives. Either way the player can start a game.
-          this.baseUsername = resolvePlayerName({
+          const seeded = resolvePlayerName({
             verifiedName: null,
             verifiedOptIn: false,
             storedName: null,
             persona: this.persona,
             generatedName: generated,
-          }).name;
+          });
+          this.baseUsername = seeded.name;
+          // Still ours if nothing of the persona survived, so a later launch
+          // (or a renamed Steam account) gets another go at it.
+          this.usernameIsGenerated = seeded.source === "generated";
           this.validateAndStore();
         })
         .catch(() => {
@@ -488,15 +509,33 @@ export class UsernameInput extends LitElement {
     }
     // No persona yet — it arrives asynchronously and reseeds in
     // connectedCallback, so this settles on the stored or generated name.
-    this.baseUsername = resolvePlayerName({
+    const resolved = resolvePlayerName({
       verifiedName: null,
       verifiedOptIn: false,
       storedName: storedUsername,
       persona: null,
       generatedName: this.generatedName,
-    }).name;
+    });
+    this.baseUsername = resolved.name;
+    this.usernameIsGenerated = storedUsername
+      ? this.storedNameIsGenerated()
+      : resolved.source === "generated";
     this.validateAndStore();
     if (storedUsername) this.startClanCheck();
+  }
+
+  // Whether the name already in localStorage is one we generated.
+  //
+  // Installs that predate the flag have no key to read, so fall back to the
+  // name's shape: genAnonUsername produces "Anon" + a word from a fixed bank,
+  // which is recognisable. That is what un-poisons a Steam install whose one
+  // and only seed attempt happened before this fix — without it, everyone who
+  // has already launched the game keeps their guest name forever.
+  private storedNameIsGenerated(): boolean {
+    const stored = localStorage.getItem(usernameKey);
+    if (!stored) return true;
+    const flag = localStorage.getItem(usernameIsGeneratedKey);
+    return flag === null ? looksGenerated(stored) : flag === "true";
   }
 
   render() {
@@ -866,6 +905,8 @@ export class UsernameInput extends LitElement {
       );
     }
     this.baseUsername = val;
+    // Typed by the player, so no longer ours to reseed over.
+    this.usernameIsGenerated = false;
     this.validateAndStore();
   }
 
@@ -903,6 +944,12 @@ export class UsernameInput extends LitElement {
       // (page reload) restores a guest username instead of the account name.
       if (!this.onCrazyGames) {
         localStorage.setItem(usernameKey, trimmedBase);
+        // Written with the name, never separately: a stale flag would either
+        // strand a player on a generated name or overwrite one they chose.
+        localStorage.setItem(
+          usernameIsGeneratedKey,
+          String(this.usernameIsGenerated),
+        );
         localStorage.setItem(clanTagKey, this.getClanTag() ?? "");
       }
       this.validationError = "";

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -226,9 +226,45 @@ export type LobbyAccent = z.infer<typeof LobbyAccentSchema>;
 // included, so a verified account name is always representable on the wire —
 // verified play skips free-form validation, so an unrepresentable name would
 // reach the server and be closed with 1002.
+//
+// Letters and digits the in-game name renderer can actually draw, plus the
+// punctuation a name may carry. The renderer is an MSDF atlas covering char
+// IDs 0..CHAR_RANGE-1 (Latin Extended-A, U+017F), so every letter in Latin-1
+// Supplement and Latin Extended-A already has a glyph — José, Müller and
+// Łukasz render fine and used to be rejected anyway.
+//
+// Deliberately NOT everything below U+0180: that would admit control
+// characters, the C1 block, and HTML-significant punctuation. The letter
+// ranges skip × (U+00D7) and ÷ (U+00F7), which are maths symbols sitting
+// inside the Latin-1 letter block, and the ordinal/micro signs.
+//
+// Emoji are excluded on purpose and stay excluded: the renderer draws them as
+// a separate icon beside the name, never inline, so an emoji in the name
+// itself has no glyph at all.
+// Regex source for the character class, not a finished pattern: the wire
+// schema, the free-form form rule and the persona sanitiser all need the same
+// set in different shapes, and a single source is what keeps them from
+// drifting apart by hand (which is how the charsets got out of step before).
+export const RENDERABLE_NAME_ALNUM =
+  "a-zA-Z0-9\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u017F";
+export const RENDERABLE_NAME_CHARS = ` _.\\-${RENDERABLE_NAME_ALNUM}`;
+
+/** One renderable character. Used per-codepoint by the persona sanitiser. */
+export const RENDERABLE_NAME_CHAR_RE = new RegExp(
+  `^[${RENDERABLE_NAME_CHARS}]$`,
+  "u",
+);
+
+/** At least one letter or digit — punctuation alone is not a name. */
+export const RENDERABLE_NAME_HAS_ALNUM_RE = new RegExp(
+  `[${RENDERABLE_NAME_ALNUM}]`,
+  "u",
+);
+
+// Requires at least one non-space so a name is never all padding.
 export const UsernameSchema = z
   .string()
-  .regex(/^(?=.*\S)[a-zA-Z0-9_\- üÜ.]+$/u)
+  .regex(new RegExp(`^(?=.*\\S)[${RENDERABLE_NAME_CHARS}]+$`, "u"))
   .min(3)
   .max(27);
 

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -228,25 +228,42 @@ export type LobbyAccent = z.infer<typeof LobbyAccentSchema>;
 // reach the server and be closed with 1002.
 //
 // Letters and digits the in-game name renderer can actually draw, plus the
-// punctuation a name may carry. The renderer is an MSDF atlas covering char
-// IDs 0..CHAR_RANGE-1 (Latin Extended-A, U+017F), so every letter in Latin-1
-// Supplement and Latin Extended-A already has a glyph — José, Müller and
-// Łukasz render fine and used to be rejected anyway.
+// punctuation a name may carry. This is what lets José, Müller, Renée and
+// Bjørn keep their names instead of falling back to a generated one.
 //
-// Deliberately NOT everything below U+0180: that would admit control
-// characters, the C1 block, and HTML-significant punctuation. The letter
-// ranges skip × (U+00D7) and ÷ (U+00F7), which are maths symbols sitting
-// inside the Latin-1 letter block, and the ordinal/micro signs.
+// The bound is U+00FF — the end of Latin-1 Supplement — and it is set by the
+// renderer twice over. Do not raise it without changing the renderer first:
+//
+//  1. The string path is 8-bit end to end. `TextLayout` writes
+//     `charCodes[i] = text.charCodeAt(i)` into a `Uint8Array`, `DataTextures`
+//     uploads it as `R8UI`/`UNSIGNED_BYTE`, and `name.vert.glsl` uses the
+//     byte directly as the glyph index. Anything above 255 silently truncates
+//     mod 256: Ł (U+0141) would draw as "A", ā (U+0101) as a code-0 slot the
+//     shader drops while still consuming a layout position.
+//  2. The atlas has no glyphs up there anyway. Of the 128 Latin Extended-A
+//     entries in `resources/atlases/msdf-atlas.json`, exactly three (Œ œ Ÿ)
+//     have a real glyph; the other 125 point at .notdef. All 64 Latin-1
+//     Supplement entries are real.
+//
+// `CHAR_RANGE = 384` in the name-pass sizes the metrics and kerning tables, so
+// it looks like the limit and is not — it is an upper bound on ids the atlas
+// file may contain, not on what the string path can carry.
+//
+// Deliberately NOT every codepoint below the bound: that would admit control
+// characters, the C1 block, and HTML-significant punctuation. The ranges skip
+// × (U+00D7) and ÷ (U+00F7), maths symbols sitting inside the Latin-1 letter
+// block, and the ordinal/micro signs.
 //
 // Emoji are excluded on purpose and stay excluded: the renderer draws them as
 // a separate icon beside the name, never inline, so an emoji in the name
 // itself has no glyph at all.
+//
 // Regex source for the character class, not a finished pattern: the wire
 // schema, the free-form form rule and the persona sanitiser all need the same
 // set in different shapes, and a single source is what keeps them from
 // drifting apart by hand (which is how the charsets got out of step before).
 export const RENDERABLE_NAME_ALNUM =
-  "a-zA-Z0-9\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u017F";
+  "a-zA-Z0-9\\u00C0-\\u00D6\\u00D8-\\u00F6\\u00F8-\\u00FF";
 export const RENDERABLE_NAME_CHARS = ` _.\\-${RENDERABLE_NAME_ALNUM}`;
 
 /** One renderable character. Used per-codepoint by the persona sanitiser. */

--- a/src/core/validations/username.ts
+++ b/src/core/validations/username.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
 import { translateText } from "../../client/Utils";
-import { ClanTagSchema, UsernameSchema } from "../Schemas";
+import {
+  ClanTagSchema,
+  RENDERABLE_NAME_CHARS,
+  UsernameSchema,
+} from "../Schemas";
 
 export const MIN_USERNAME_LENGTH = 3;
 // Matches MAX_ACCOUNT_USERNAME_LENGTH so a free-form name can't outgrow the
@@ -15,12 +19,21 @@ export const MAX_CLAN_TAG_LENGTH = 5;
 export const MIN_ACCOUNT_USERNAME_LENGTH = 3;
 export const MAX_ACCOUNT_USERNAME_LENGTH = 20;
 
-// Characters a player may type for themselves. Narrower than UsernameSchema,
-// which additionally carries hyphens so that account names — issued under the
-// separate AccountUsernameSchema rules — stay representable on the wire.
-// Widening the wire schema for those must not quietly widen this form, whose
-// error message names exactly these characters.
-const FREE_FORM_USERNAME_PATTERN = /^[a-zA-Z0-9_ üÜ.]+$/u;
+// Characters a player may type for themselves: everything the in-game name
+// renderer can draw (see RENDERABLE_NAME_CHARS). Equal to the wire schema's
+// charset today — a name a player types has to reach the server, and a name
+// seeded from a Steam persona has to pass this form rule or it would be
+// sanitised into something the field then rejects.
+//
+// Kept as its own pattern rather than folded into UsernameSchema because the
+// two have different licence to change: the wire schema reads archived records
+// so it may only ever widen, while this one may narrow. Both are built from
+// the one source so they cannot drift by hand, which is how they got out of
+// step before.
+const FREE_FORM_USERNAME_PATTERN = new RegExp(
+  `^[${RENDERABLE_NAME_CHARS}]+$`,
+  "u",
+);
 
 // Mirrors the API's account-username rules (infra src/api/lib/Usernames.ts)
 // for instant form feedback; profanity and uniqueness stay server-side. No

--- a/tests/UsernameValidation.test.ts
+++ b/tests/UsernameValidation.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { CHAR_RANGE } from "../src/client/render/gl/passes/name-pass/Types";
 import { UsernameSchema } from "../src/core/Schemas";
 import {
   AccountUsernameSchema,
@@ -47,17 +48,86 @@ describe("free-form username length", () => {
 });
 
 describe("free-form username charset", () => {
-  it("still refuses characters the form's own message excludes", () => {
-    // The wire schema carries hyphens so account names stay representable;
-    // that must not reach the name a player types for themselves, whose error
-    // message names letters, numbers, spaces and underscores.
-    expect(validateUsername("foo-bar").isValid).toBe(false);
-    expect(UsernameSchema.safeParse("foo-bar").success).toBe(true);
+  it("accepts what the message names", () => {
+    for (const name of [
+      "foo bar",
+      "foo_bar",
+      "Foo1",
+      "füÜ.bar",
+      // Hyphens are typeable now: the persona sanitiser keeps them, so a form
+      // that rejected them would seed a name its own field refuses.
+      "foo-bar",
+    ]) {
+      expect(validateUsername(name).isValid, name).toBe(true);
+    }
   });
 
-  it("accepts what the message does name", () => {
-    for (const name of ["foo bar", "foo_bar", "Foo1", "füÜ.bar"]) {
-      expect(validateUsername(name).isValid).toBe(true);
+  it("accepts the accented names the renderer can already draw", () => {
+    // The MSDF atlas covers Latin Extended-A, so these have glyphs and were
+    // rejected anyway — sending José and Müller to a generated guest name.
+    for (const name of ["José", "Müller", "Łukasz", "Renée", "Bjørn", "Ægir"]) {
+      expect(validateUsername(name).isValid, name).toBe(true);
+      expect(UsernameSchema.safeParse(name).success, name).toBe(true);
+    }
+  });
+
+  it("still refuses what the renderer cannot draw", () => {
+    // Emoji render as a separate icon beside the name, never inline, so an
+    // emoji in the name itself has no glyph at all. Beyond Latin Extended-A
+    // there is no atlas coverage.
+    for (const name of ["🔥Ada", "日本語", "Пётр", "aƀc", "ｄａｒｋ"]) {
+      expect(validateUsername(name).isValid, name).toBe(false);
+      expect(UsernameSchema.safeParse(name).success, name).toBe(false);
+    }
+  });
+
+  it("refuses punctuation and symbols inside the atlas range", () => {
+    // Widening to "everything under U+0180" would have admitted control
+    // characters, the C1 block and HTML-significant punctuation. It is letters
+    // and digits plus a named punctuation allowlist, not a codepoint bound.
+    for (const name of [
+      "a<b>c",
+      "a/b/c",
+      "a@bc",
+      "a:bc",
+      "a¡bc",
+      "a×bc",
+      "a÷bc",
+      "a\u0000bc",
+      "a\u0080bc",
+    ]) {
+      expect(validateUsername(name).isValid, JSON.stringify(name)).toBe(false);
+      expect(UsernameSchema.safeParse(name).success, JSON.stringify(name)).toBe(
+        false,
+      );
+    }
+  });
+
+  it("tracks the renderer's atlas range", () => {
+    // The charset exists to match what the name renderer can draw. If the
+    // atlas grows or shrinks and the charset doesn't follow, either names get
+    // rejected for glyphs we have or accepted for glyphs we don't.
+    const inRange = String.fromCodePoint(CHAR_RANGE - 1); // U+017F, ſ
+    const outOfRange = String.fromCodePoint(CHAR_RANGE); // U+0180, ƀ
+    expect(UsernameSchema.safeParse(`ab${inRange}`).success).toBe(true);
+    expect(UsernameSchema.safeParse(`ab${outOfRange}`).success).toBe(false);
+  });
+
+  it("keeps the wire schema a superset of the form", () => {
+    // The form rule may narrow; the wire schema may only widen. A free-form
+    // name the field accepts but the wire rejects closes the join with 1002
+    // after Play has been enabled.
+    for (const name of [
+      "foo bar",
+      "foo-bar",
+      "foo_bar",
+      "foo.bar",
+      "José",
+      "Łukasz",
+      "a".repeat(MAX_USERNAME_LENGTH),
+    ]) {
+      expect(validateUsername(name).isValid, name).toBe(true);
+      expect(UsernameSchema.safeParse(name).success, name).toBe(true);
     }
   });
 });

--- a/tests/UsernameValidation.test.ts
+++ b/tests/UsernameValidation.test.ts
@@ -1,6 +1,6 @@
+import { readFileSync } from "fs";
 import { describe, expect, it } from "vitest";
-import { CHAR_RANGE } from "../src/client/render/gl/passes/name-pass/Types";
-import { UsernameSchema } from "../src/core/Schemas";
+import { RENDERABLE_NAME_CHAR_RE, UsernameSchema } from "../src/core/Schemas";
 import {
   AccountUsernameSchema,
   MAX_ACCOUNT_USERNAME_LENGTH,
@@ -63,9 +63,10 @@ describe("free-form username charset", () => {
   });
 
   it("accepts the accented names the renderer can already draw", () => {
-    // The MSDF atlas covers Latin Extended-A, so these have glyphs and were
-    // rejected anyway — sending José and Müller to a generated guest name.
-    for (const name of ["José", "Müller", "Łukasz", "Renée", "Bjørn", "Ægir"]) {
+    // Every Latin-1 Supplement letter has a real glyph in the atlas, so these
+    // were being rejected for characters we can draw — sending José and
+    // Müller to a generated guest name.
+    for (const name of ["José", "Müller", "Renée", "Bjørn", "Ægir", "Iñigo"]) {
       expect(validateUsername(name).isValid, name).toBe(true);
       expect(UsernameSchema.safeParse(name).success, name).toBe(true);
     }
@@ -73,9 +74,16 @@ describe("free-form username charset", () => {
 
   it("still refuses what the renderer cannot draw", () => {
     // Emoji render as a separate icon beside the name, never inline, so an
-    // emoji in the name itself has no glyph at all. Beyond Latin Extended-A
-    // there is no atlas coverage.
-    for (const name of ["🔥Ada", "日本語", "Пётр", "aƀc", "ｄａｒｋ"]) {
+    // emoji in the name itself has no glyph at all. Latin Extended-A and above
+    // is not drawable either — see the atlas/8-bit tests below.
+    for (const name of [
+      "🔥Ada",
+      "日本語",
+      "Пётр",
+      "aƀc",
+      "ｄａｒｋ",
+      "Łukasz",
+    ]) {
       expect(validateUsername(name).isValid, name).toBe(false);
       expect(UsernameSchema.safeParse(name).success, name).toBe(false);
     }
@@ -103,14 +111,50 @@ describe("free-form username charset", () => {
     }
   });
 
-  it("tracks the renderer's atlas range", () => {
-    // The charset exists to match what the name renderer can draw. If the
-    // atlas grows or shrinks and the charset doesn't follow, either names get
-    // rejected for glyphs we have or accepted for glyphs we don't.
-    const inRange = String.fromCodePoint(CHAR_RANGE - 1); // U+017F, ſ
-    const outOfRange = String.fromCodePoint(CHAR_RANGE); // U+0180, ƀ
-    expect(UsernameSchema.safeParse(`ab${inRange}`).success).toBe(true);
-    expect(UsernameSchema.safeParse(`ab${outOfRange}`).success).toBe(false);
+  // The charset exists to match what the name renderer can draw, so pin it to
+  // the renderer rather than to a constant that merely looks like the limit.
+  // `CHAR_RANGE = 384` sizes the metrics and kerning tables; it is an upper
+  // bound on ids the atlas FILE may contain, not on what the string path can
+  // carry. Pinning to it would admit 125 codepoints that render as tofu or as
+  // the wrong letter entirely.
+  describe("charset matches what the renderer can draw", () => {
+    // Every codepoint the charset admits, expanded from the shared source.
+    const admitted: number[] = [];
+    for (let cp = 0; cp <= 0x2ff; cp++) {
+      if (RENDERABLE_NAME_CHAR_RE.test(String.fromCodePoint(cp))) {
+        admitted.push(cp);
+      }
+    }
+
+    it("admits nothing the 8-bit string path would truncate", () => {
+      // TextLayout writes charCodeAt into a Uint8Array and DataTextures
+      // uploads it as R8UI, so anything above 255 wraps mod 256 — Ł (U+0141)
+      // would draw as "A". There is no remapping step anywhere in the shader.
+      expect(admitted.length).toBeGreaterThan(0);
+      const tooHigh = admitted.filter((cp) => cp > 0xff);
+      expect(tooHigh.map((cp) => cp.toString(16))).toEqual([]);
+    });
+
+    it("admits only letters the atlas has a real glyph for", () => {
+      // index 0 is the font's .notdef box. All 64 Latin-1 Supplement entries
+      // are real; only 3 of the 128 Latin Extended-A ones are.
+      const atlas = JSON.parse(
+        readFileSync("resources/atlases/msdf-atlas.json", "utf8"),
+      ) as { chars: { id: number; index: number }[] };
+      const real = new Set(
+        atlas.chars.filter((c) => c.index !== 0).map((c) => c.id),
+      );
+      const missing = admitted.filter((cp) => !real.has(cp));
+      expect(
+        missing.map((cp) => `U+${cp.toString(16).padStart(4, "0")}`),
+      ).toEqual([]);
+    });
+
+    it("still admits the accented Latin-1 letters, which do have glyphs", () => {
+      for (const ch of "áéíóúàèìòùâêîôûäëïöüãñõçøåæýÿß") {
+        expect(admitted, ch).toContain(ch.codePointAt(0));
+      }
+    });
   });
 
   it("keeps the wire schema a superset of the form", () => {
@@ -123,7 +167,7 @@ describe("free-form username charset", () => {
       "foo_bar",
       "foo.bar",
       "José",
-      "Łukasz",
+      "Bjørn",
       "a".repeat(MAX_USERNAME_LENGTH),
     ]) {
       expect(validateUsername(name).isValid, name).toBe(true);

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -4,13 +4,17 @@ import {
   clampUsername,
   fallbackPlayerName,
   genAnonUsername,
+  looksGenerated,
   resolvePlayerName,
   sanitizePersona,
   type PlayerNameInputs,
 } from "../../src/client/PlayerName";
 import type { UserMeResponse } from "../../src/core/ApiSchemas";
 import { UsernameSchema } from "../../src/core/Schemas";
-import { MAX_USERNAME_LENGTH } from "../../src/core/validations/username";
+import {
+  MAX_USERNAME_LENGTH,
+  validateUsername,
+} from "../../src/core/validations/username";
 
 // The resolver takes plain values, so every case below is expressed as a full
 // set of inputs rather than by mounting the component.
@@ -115,10 +119,18 @@ describe("resolvePlayerName precedence", () => {
     });
   });
 
-  it("uses the generated name when the persona is unusable", () => {
-    expect(resolvePlayerName(inputs({ persona: "x".repeat(100) }))).toEqual({
+  it("uses the generated name when nothing of the persona survives", () => {
+    expect(resolvePlayerName(inputs({ persona: "日本語" }))).toEqual({
       name: "AnonBadger",
       source: "generated",
+      verified: false,
+    });
+  });
+
+  it("uses the persona once its decoration is stripped", () => {
+    expect(resolvePlayerName(inputs({ persona: "🔥José🔥" }))).toEqual({
+      name: "José",
+      source: "persona",
       verified: false,
     });
   });
@@ -167,6 +179,10 @@ describe("resolvePlayerName wire-schema invariant", () => {
       inputs({ persona: "[Ada]" }),
       inputs({ persona: "Ada Lovelace" }),
       inputs({ persona: "x".repeat(100) }),
+      inputs({ persona: "🔥José🔥" }),
+      inputs({ persona: "Ada🔥Lovelace the Countess of Lovelace" }),
+      inputs({ persona: "日本語" }),
+      inputs({ persona: "..." }),
       inputs(),
     ];
     for (const c of cases) {
@@ -188,9 +204,57 @@ describe("resolvePlayerName wire-schema invariant", () => {
 });
 
 describe("sanitizePersona", () => {
-  it("strips the bracket decoration Steam personas carry", () => {
-    expect(sanitizePersona("[Ada]")).toBe("Ada");
+  it("keeps a persona that is already clean", () => {
+    expect(sanitizePersona("Ada")).toBe("Ada");
+    expect(sanitizePersona("Ada Lovelace")).toBe("Ada Lovelace");
     expect(sanitizePersona("  Ada  ")).toBe("Ada");
+  });
+
+  // The whole point of the change: these all used to be discarded wholesale,
+  // dropping the player to a generated AnonWombat3.
+  it("keeps accented and Latin Extended-A names the renderer can draw", () => {
+    expect(sanitizePersona("José")).toBe("José");
+    expect(sanitizePersona("Müller")).toBe("Müller");
+    expect(sanitizePersona("Łukasz")).toBe("Łukasz");
+    expect(sanitizePersona("Bjørn")).toBe("Bjørn");
+  });
+
+  it("keeps hyphens, underscores and periods", () => {
+    expect(sanitizePersona("Müller-42")).toBe("Müller-42");
+    expect(sanitizePersona("ada_lovelace")).toBe("ada_lovelace");
+    expect(sanitizePersona("Ada.L")).toBe("Ada.L");
+  });
+
+  it("strips decoration rather than rejecting the whole persona", () => {
+    expect(sanitizePersona("🔥Ada🔥")).toBe("Ada");
+    expect(sanitizePersona("[Ada]")).toBe("Ada");
+    expect(sanitizePersona("★★ Ada ★★")).toBe("Ada");
+    expect(sanitizePersona("xX_Ada_Xx")).toBe("xX_Ada_Xx");
+  });
+
+  it("keeps the Latin part of a mixed-script persona", () => {
+    expect(sanitizePersona("日本語Ada")).toBe("Ada");
+    expect(sanitizePersona("Пётр Ada")).toBe("Ada");
+  });
+
+  // A dropped codepoint becomes a space, so words either side of a decorative
+  // separator stay separate words rather than running together.
+  it("keeps word boundaries where the decoration was", () => {
+    expect(sanitizePersona("Ada🔥Lovelace")).toBe("Ada Lovelace");
+    expect(sanitizePersona("Ada   Lovelace")).toBe("Ada Lovelace");
+  });
+
+  it("truncates to the free-form cap instead of rejecting", () => {
+    // Previously this returned null and the player got a generated name.
+    const long = sanitizePersona("Ada Lovelace the Countess of Lovelace");
+    expect(long).toBe("Ada Lovelace the");
+    expect(long!.length).toBeLessThanOrEqual(MAX_USERNAME_LENGTH);
+    expect(sanitizePersona("x".repeat(100))).toBe("x".repeat(20));
+  });
+
+  it("does not leave a trailing space after truncating", () => {
+    const name = sanitizePersona("abcdefghijklmnopqrs tuv");
+    expect(name).toBe("abcdefghijklmnopqrs");
   });
 
   it("returns null for nothing to sanitise", () => {
@@ -201,24 +265,71 @@ describe("sanitizePersona", () => {
     expect(sanitizePersona("[]")).toBeNull();
   });
 
-  // Today's rule is reject-wholesale: anything the free-form charset does not
-  // already allow falls through to a generated name. These fixtures pin that
-  // behaviour so OPE-221 — which replaces it with strip-and-keep and widens
-  // the charset to the MSDF atlas range — has to change them deliberately.
-  it("rejects personas outside the free-form charset (OPE-221 will keep them)", () => {
-    expect(sanitizePersona("José")).toBeNull();
-    expect(sanitizePersona("Müller-42")).toBeNull();
-    expect(sanitizePersona("🔥Ada🔥")).toBeNull();
+  it("returns null when nothing renderable survives", () => {
     expect(sanitizePersona("日本語")).toBeNull();
     expect(sanitizePersona("Пётр")).toBeNull();
+    expect(sanitizePersona("🔥🔥🔥")).toBeNull();
+    expect(sanitizePersona("ｄａｒｋ")).toBeNull();
   });
 
-  it("rejects an over-length persona rather than truncating it to a stub", () => {
-    expect(sanitizePersona("x".repeat(100))).toBeNull();
-  });
-
-  it("rejects residue shorter than the minimum", () => {
+  it("returns null for residue shorter than the minimum", () => {
     expect(sanitizePersona("[ab]")).toBeNull();
+    expect(sanitizePersona("🔥a🔥")).toBeNull();
+  });
+
+  // "..." passes the charset and the length bound but is not a name; a
+  // placeholder that reads as one is better than punctuation.
+  it("returns null for punctuation with no letters or digits", () => {
+    expect(sanitizePersona("...")).toBeNull();
+    expect(sanitizePersona("___")).toBeNull();
+    expect(sanitizePersona("★★★★")).toBeNull();
+    expect(sanitizePersona("- . _ -")).toBeNull();
+  });
+
+  it("returns something the form and the wire both accept", () => {
+    const personas = [
+      "🔥José🔥",
+      "Ada🔥Lovelace",
+      "[Müller-42]",
+      "Ada Lovelace the Countess of Lovelace",
+      "x".repeat(100),
+      "日本語Ada Lovelace",
+      "Łukasz",
+    ];
+    for (const p of personas) {
+      const name = sanitizePersona(p);
+      expect(name, p).not.toBeNull();
+      // Seeded straight into the field, so it has to survive the form rule...
+      expect(validateUsername(name!).isValid, `${p} -> ${name}`).toBe(true);
+      // ...and reach the server without closing the socket.
+      expect(UsernameSchema.safeParse(name!).success, `${p} -> ${name}`).toBe(
+        true,
+      );
+    }
+  });
+});
+
+describe("looksGenerated", () => {
+  it("recognises what genAnonUsername produces", () => {
+    for (let i = 0; i < 200; i++) {
+      const name = genAnonUsername();
+      expect(looksGenerated(name), name).toBe(true);
+    }
+  });
+
+  it("does not claim an ordinary name", () => {
+    for (const name of [
+      "Ada",
+      "AnonymousCoward",
+      "Anonymous",
+      "Anon",
+      "AnonBadger42",
+      "NotAnonBadger",
+      "anonbadger",
+      "José",
+    ]) {
+      expect(looksGenerated(name), name).toBe(false);
+    }
   });
 });
 

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -212,11 +212,19 @@ describe("sanitizePersona", () => {
 
   // The whole point of the change: these all used to be discarded wholesale,
   // dropping the player to a generated AnonWombat3.
-  it("keeps accented and Latin Extended-A names the renderer can draw", () => {
+  it("keeps the accented Latin-1 names the renderer can draw", () => {
     expect(sanitizePersona("José")).toBe("José");
     expect(sanitizePersona("Müller")).toBe("Müller");
-    expect(sanitizePersona("Łukasz")).toBe("Łukasz");
     expect(sanitizePersona("Bjørn")).toBe("Bjørn");
+    expect(sanitizePersona("Iñigo")).toBe("Iñigo");
+  });
+
+  // Above U+00FF the string path truncates mod 256 and the atlas has no real
+  // glyph, so Ł would draw as "A". Stripped like any other unrenderable
+  // codepoint rather than kept.
+  it("strips Latin Extended-A, which the renderer cannot draw", () => {
+    expect(sanitizePersona("Łukasz")).toBe("ukasz");
+    expect(sanitizePersona("Łódź")).toBeNull();
   });
 
   it("keeps hyphens, underscores and periods", () => {
@@ -255,6 +263,26 @@ describe("sanitizePersona", () => {
   it("does not leave a trailing space after truncating", () => {
     const name = sanitizePersona("abcdefghijklmnopqrs tuv");
     expect(name).toBe("abcdefghijklmnopqrs");
+  });
+
+  // Regression: when the cut lands one past a space, trim() alone already
+  // produced a clean word-boundary cut. Looking for an *earlier* boundary on
+  // top of that threw away a whole word that had fitted — "Ada Lovelacetheguru"
+  // collapsed to "Ada".
+  it("keeps a word that fits when the cut lands on a boundary", () => {
+    expect(sanitizePersona("Ada Lovelacetheguru xyz")).toBe(
+      "Ada Lovelacetheguru",
+    );
+    // The same shape with the space exactly at the cut index.
+    expect(sanitizePersona("Ada Lovelacethegurus xyz")).toBe(
+      "Ada Lovelacethegurus",
+    );
+  });
+
+  // A partial word at the cut is still dropped — that is the case the word
+  // boundary exists for.
+  it("drops a word the cut lands inside", () => {
+    expect(sanitizePersona("Ada Lovelacetheguruxyz")).toBe("Ada");
   });
 
   it("returns null for nothing to sanitise", () => {

--- a/tests/client/UsernameInput.steam.test.ts
+++ b/tests/client/UsernameInput.steam.test.ts
@@ -46,11 +46,11 @@ describe("UsernameInput Steam seeding", () => {
     expect(el.getUsername()).toBe("Ada");
   });
 
-  it("keeps a valid generated name when the persona is invalid", async () => {
+  it("keeps a valid generated name when nothing of the persona survives", async () => {
     vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
     vi.spyOn(steamSDK, "getUser").mockResolvedValue({
       steamId: "77",
-      name: "x".repeat(100),
+      name: "日本語",
     });
     const el = new UsernameInput();
     el.connectedCallback();
@@ -58,11 +58,125 @@ describe("UsernameInput Steam seeding", () => {
     // the generated anon name loadStoredUsername() just produced.
     const generated = el.getUsername();
     await new Promise((r) => setTimeout(r, 0));
-    // The invalid persona must be rejected and the exact generated name kept —
-    // not merely replaced by some other valid name.
+    // The unusable persona must be rejected and the exact generated name kept
+    // — not merely replaced by some other valid name.
     expect(el.getUsername()).toBe(generated);
-    expect(generated).not.toBe("x".repeat(100));
     expect(generated.length).toBeGreaterThan(0);
+    // Still ours, so a later launch or a Steam rename gets another go.
+    expect(localStorage.getItem("usernameIsGenerated")).toBe("true");
+  });
+
+  // The old rule ran the persona through validateUsername() and threw the
+  // whole thing away on any failure, so most real Steam personas — which
+  // carry decoration — produced a guest name. This is the launch bug.
+  it.each([
+    ["🔥Ada🔥", "Ada"],
+    ["José", "José"],
+    ["Müller-42", "Müller-42"],
+    ["★★ Ada Lovelace ★★", "Ada Lovelace"],
+    ["日本語Ada", "Ada"],
+    ["Ada Lovelace the Countess of Lovelace", "Ada Lovelace the"],
+  ])("seeds %s as %s rather than a guest name", async (persona, expected) => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getUser").mockResolvedValue({
+      steamId: "77",
+      name: persona,
+    });
+    const el = new UsernameInput();
+    el.connectedCallback();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(el.getUsername()).toBe(expected);
+    expect(localStorage.getItem("username")).toBe(expected);
+    // A seeded persona is the player's own identity, not ours to overwrite.
+    expect(localStorage.getItem("usernameIsGenerated")).toBe("false");
+    expect(el.canPlay()).toBe(true);
+  });
+});
+
+describe("UsernameInput Steam reseeding", () => {
+  function mountWithPersona(name: string): UsernameInput {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    vi.spyOn(steamSDK, "getUser").mockResolvedValue({ steamId: "77", name });
+    const el = new UsernameInput();
+    el.connectedCallback();
+    return el;
+  }
+
+  // The seed used to be gated on empty localStorage, so one launch that
+  // finished before getUser() resolved — or, before the sanitiser change, any
+  // launch with a decorated persona — left a generated name that nothing would
+  // ever replace.
+  it("reseeds over a name we generated", async () => {
+    localStorage.setItem("username", "AnonAnchor");
+    localStorage.setItem("usernameIsGenerated", "true");
+
+    const el = mountWithPersona("Ada");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.getUsername()).toBe("Ada");
+    expect(localStorage.getItem("username")).toBe("Ada");
+  });
+
+  // Installs from before the flag existed have no key to read, so the name's
+  // own shape is what un-poisons them.
+  it("reseeds over a generated name stored before the flag existed", async () => {
+    localStorage.setItem("username", "AnonAnchor3");
+
+    const el = mountWithPersona("Ada");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.getUsername()).toBe("Ada");
+  });
+
+  it("never reseeds over a name the player typed", async () => {
+    localStorage.setItem("username", "MyCoolName");
+    localStorage.setItem("usernameIsGenerated", "false");
+
+    const el = mountWithPersona("Ada");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.getUsername()).toBe("MyCoolName");
+    expect(localStorage.getItem("username")).toBe("MyCoolName");
+  });
+
+  it("never reseeds over a pre-flag name that is not one of ours", async () => {
+    localStorage.setItem("username", "MyCoolName");
+
+    const el = mountWithPersona("Ada");
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.getUsername()).toBe("MyCoolName");
+  });
+
+  // The flag has to follow the name it describes, or the next launch reseeds
+  // over something the player chose.
+  it("stops reseeding once the player types their own name", async () => {
+    const el = mountWithPersona("Ada");
+    await new Promise((r) => setTimeout(r, 0));
+    expect(localStorage.getItem("usernameIsGenerated")).toBe("false");
+
+    const input = document.createElement("input");
+    input.value = "MyCoolName";
+    (
+      el as unknown as { handleUsernameChange: (e: Event) => void }
+    ).handleUsernameChange({ target: input } as unknown as Event);
+
+    expect(localStorage.getItem("username")).toBe("MyCoolName");
+    expect(localStorage.getItem("usernameIsGenerated")).toBe("false");
+  });
+
+  it("does not reseed off Steam", async () => {
+    localStorage.setItem("username", "AnonAnchor");
+    localStorage.setItem("usernameIsGenerated", "true");
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(false);
+    const getUser = vi.spyOn(steamSDK, "getUser");
+
+    const el = new UsernameInput();
+    el.connectedCallback();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(getUser).not.toHaveBeenCalled();
+    expect(el.getUsername()).toBe("AnonAnchor");
   });
 });
 

--- a/tests/client/UsernameInput.steam.test.ts
+++ b/tests/client/UsernameInput.steam.test.ts
@@ -165,6 +165,42 @@ describe("UsernameInput Steam reseeding", () => {
     expect(localStorage.getItem("usernameIsGenerated")).toBe("false");
   });
 
+  // The text check alone is not enough: a player can type something else and
+  // then type the generated name back before getUser() resolves, leaving the
+  // name looking untouched while handleUsernameChange has already marked it
+  // theirs. Reseeding over that would overwrite a deliberate choice.
+  it("does not reseed over a generated name the player retyped", async () => {
+    vi.spyOn(steamSDK, "isOnSteam").mockReturnValue(true);
+    let resolveUser: (u: { steamId: string; name: string }) => void = () => {};
+    vi.spyOn(steamSDK, "getUser").mockReturnValue(
+      new Promise((r) => {
+        resolveUser = r;
+      }),
+    );
+
+    const el = new UsernameInput();
+    el.connectedCallback();
+    const generated = el.getUsername();
+
+    // Types something else, then puts the original text back — character for
+    // character the same name, but chosen rather than generated.
+    const type = (value: string) => {
+      const input = document.createElement("input");
+      input.value = value;
+      (
+        el as unknown as { handleUsernameChange: (e: Event) => void }
+      ).handleUsernameChange({ target: input } as unknown as Event);
+    };
+    type("MyCoolName");
+    type(generated);
+
+    resolveUser({ steamId: "77", name: "Ada" });
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(el.getUsername()).toBe(generated);
+    expect(localStorage.getItem("usernameIsGenerated")).toBe("false");
+  });
+
   it("does not reseed off Steam", async () => {
     localStorage.setItem("username", "AnonAnchor");
     localStorage.setItem("usernameIsGenerated", "true");

--- a/tests/server/Censor.test.ts
+++ b/tests/server/Censor.test.ts
@@ -243,5 +243,34 @@ describe("Censor (local fallback)", () => {
       const result = censorPlayer("fuck", null);
       expect(shadowNames).toContain(result.username);
     });
+
+    // The free-form username charset widened to Latin-1 Supplement and Latin
+    // Extended-A so accented Steam personas stop falling back to a guest name.
+    // That must not hand anyone a new way past the filter: resolveConfusables
+    // folds these back to their ASCII letters before matching.
+    //
+    // Scope is accent substitution only. Inserting a letter ("Haitler") still
+    // evades, but it evades identically in plain ASCII — that is a property of
+    // the word list, not something the wider charset introduced.
+    test("accented spellings do not bypass the filter", () => {
+      for (const name of [
+        "hïtler",
+        "nâzi",
+        "fàggot",
+        "retàrd",
+        "níggér",
+        "FÜCK",
+      ]) {
+        expect(profanityMatcher.hasMatch(name), name).toBe(true);
+        expect(shadowNames, name).toContain(censorPlayer(name, null).username);
+      }
+    });
+
+    test("still leaves ordinary accented names alone", () => {
+      for (const name of ["José", "Müller", "Łukasz", "Bjørn", "Renée"]) {
+        expect(profanityMatcher.hasMatch(name), name).toBe(false);
+        expect(censorPlayer(name, null).username, name).toBe(name);
+      }
+    });
   });
 });


### PR DESCRIPTION
Closes #5088.

**Stacked on #5204** (OPE-220) — review that one first; this PR is based on it so the diff here is only the persona work. GitHub will retarget to `main` when #5204 merges.

## The bug

`UsernameInput` stripped brackets from the Steam persona, trimmed, and then required `validateUsername()` to pass on the whole string. Any persona carrying an emoji, a hyphen, an accent or non-Latin script failed that gate and the player fell through to a generated `AnonWombat3`.

That is the "Steam buyers appear as random guests" complaint, and it is the first thing a buyer sees. Decoration is the norm on Steam, not the exception — `🔥Ada🔥`, `★★ Ada ★★`, `xX_Ada_Xx`, `José`, `Müller-42` all resolved to a guest name.

The seed was also gated on `!localStorage.getItem("username")`, so it was one-shot: a single launch that finished before `getUser()` resolved — or, given the above, any launch at all with a decorated persona — left a generated name that nothing would ever replace.

## Three changes, one question

"What the charset allows" and "what the sanitiser keeps" are the same question asked twice, and "when may we reseed" is what decides whether fixing either helps anyone who has already launched the game.

### Charset

The in-game name renderer is an MSDF atlas covering char IDs `0..CHAR_RANGE-1` (Latin Extended-A, U+017F), so `José`, `Müller` and `Łukasz` already have glyphs — they were being rejected for characters we can draw.

Both `UsernameSchema` (wire) and `FREE_FORM_USERNAME_PATTERN` (form) now build from one shared `RENDERABLE_NAME_CHARS` in `Schemas.ts`, so they cannot drift apart by hand again — which is how they got out of step before. They are equal today; they are kept as separate patterns because they have different licence to change (the wire schema reads archived `GameRecord`s so it may only ever widen; the form rule may narrow).

Deliberately **letters and digits plus a named punctuation allowlist (space `_` `-` `.`), not every codepoint under U+0180** — a bare codepoint bound would admit control characters, the C1 block, and HTML-significant punctuation. `×` and `÷` are excluded too; they are maths symbols sitting inside the Latin-1 letter block. Emoji stay excluded: the renderer draws them as a separate icon beside the name, never inline, so an emoji in the name itself has no glyph at all.

Two things I checked rather than assumed:

- **Wire safety.** `zbin` encodes strings as UTF-8 (`zbin/bytes.ts`), not against the schema regex, so widening the charset does not change the binary format.
- **No profanity bypass.** The censor's `resolveConfusablesTransformer` folds accented spellings back to their ASCII letters before matching, so `hïtler` / `nâzi` / `níggér` are still caught — now asserted in `tests/server/Censor.test.ts`, along with the converse (ordinary accented names are left alone). Scope of that test is accent substitution only: inserting a letter (`Haitler`) still evades, but it evades identically in plain ASCII, so it is a property of the word list rather than something this change introduced.

### Sanitiser

Strip and keep, never reject wholesale. Unrenderable codepoints become a **space** rather than vanishing, so words either side of a decorative separator stay separate: `Ada🔥Lovelace` → `Ada Lovelace`, not `AdaLovelace`. Over-length personas truncate at a word boundary where one is available rather than being thrown away.

Punctuation with no letter or digit still falls back to a generated name — `...` and `★★★★` pass the charset and the length bound but are not names, and a placeholder that reads as a placeholder is better.

Brackets need no special case any more: they are simply not in the allowlist.

### Reseeding

Adds a persisted `usernameIsGenerated` flag, written **with** the name it describes so it can never go stale, and the seed gate becomes "is the name in hand one we generated" rather than "is anything stored".

Installs from before the flag have no key to read, so they fall back to the name's shape (`looksGenerated`: `Anon` + a word from the fixed bank + an optional round digit). Without that, everyone who has already launched the game keeps their guest name forever and this fix reaches only fresh installs.

## One deviation from the design doc

The spec's sanitisation rule says "truncate to 27". That is `UsernameSchema`'s bound, but the sanitised persona becomes the contents of the free-form field, which is capped at `MAX_USERNAME_LENGTH` (20) — a 27-character persona would be seeded and then rejected by the very form the player is looking at, blocking Play. Truncating to 20.

## Testing

- `tests/client/PlayerName.test.ts` — sanitiser fixtures from real persona shapes: emoji, CJK, Cyrillic, fullwidth, bracket decoration, accented Latin, mixed-script, over-length, sub-minimum residue, punctuation-only. Plus a property test that whatever `sanitizePersona` returns passes **both** the form rule and the wire schema, and round-trip coverage of `looksGenerated` against 200 real `genAnonUsername()` draws.
- `tests/client/UsernameInput.steam.test.ts` — the six real persona shapes end-to-end through the component, and the reseed matrix: reseeds over our generated name, reseeds over a pre-flag generated name, never over a typed name, never over a pre-flag name that is not ours, stops once the player types, does not reseed off Steam.
- `tests/UsernameValidation.test.ts` — accented names accepted, unrenderable scripts refused, punctuation/symbols inside the atlas range refused, wire ⊇ form, and a test that pins the charset to `CHAR_RANGE` so the two cannot drift.
- `tests/server/Censor.test.ts` — the bypass check above.
- Full suite: 346 files, 4194 tests. `tsc --noEmit`, `prettier --check .` and `npm run lint` clean. (`tests/MapConsistency.test.ts` intermittently hits its 5s timeout under full-suite parallel load on my machine and passes in 3.8s when run alone — unrelated to this change, which touches no map code.)
