### PR TITLE
fix(desktop): make an unrecognised update-error kind gate multiplayer

### DIFF
--- a/src/client/DesktopShell.ts
+++ b/src/client/DesktopShell.ts
@@ -64,11 +64,39 @@ export type DesktopUpdateStatus =
   | "blocked"
   | "failed";
 
+/**
+ * The update-error kinds this client knows how to reason about.
+ *
+ * openfront-desktop's src/main/update/state.ts (`UpdateErrorKind`) is the
+ * SOURCE OF TRUTH -- the shell produces these values and this client only
+ * consumes them. The two repositories cannot import from each other, so this
+ * must track that one by hand, the same arrangement multiplayerAllowed below
+ * already relies on.
+ */
+export type DesktopUpdateErrorKind = "network" | "refused" | "verify" | "parse";
+
+/**
+ * A `kind` as it actually arrives over IPC.
+ *
+ * Deliberately permissive rather than the closed union above. The shell ships
+ * in the Steam depot and updates on Steam's schedule while this client updates
+ * at runtime, so running against a shell NEWER than the client is ordinary --
+ * and such a shell may classify a failure into a kind this client has never
+ * heard of.
+ *
+ * Typing the wire value as the closed union would be a lie about data we do
+ * not control, and TypeScript would then narrow the unrecognised branch of
+ * multiplayerAllowed to `never` and treat it as dead code -- which is exactly
+ * the branch that has to exist. `(string & {})` admits any string while
+ * keeping editor completion for the four known literals.
+ */
+export type DesktopUpdateErrorKindWire = DesktopUpdateErrorKind | (string & {});
+
 export interface DesktopUpdateState {
   status: DesktopUpdateStatus;
   bytes: number;
   total: number;
-  error?: { kind: string; message: string };
+  error?: { kind: DesktopUpdateErrorKindWire; message: string };
 }
 
 export interface DesktopUpdateBridge {
@@ -125,10 +153,13 @@ export function desktopUpdate(): DesktopUpdateBridge | null {
  * Takes the whole state rather than the bare status because the error kind is
  * load-bearing in that decision.
  *
- * This duplicates multiplayerAllowed in openfront-desktop's
+ * This mirrors multiplayerAllowed in openfront-desktop's
  * src/main/update/state.ts. The two repositories cannot import from each other;
- * if you change one, change the other. Both are covered by tests asserting all
- * four error kinds.
+ * if you change the rule, change it in both. Both are covered by tests
+ * asserting all four error kinds.
+ *
+ * The one place the two DELIBERATELY differ is the unrecognised-kind branch
+ * below, which has no counterpart in the shell -- see failedAllowsMultiplayer.
  */
 export function multiplayerAllowed(state: DesktopUpdateState): boolean {
   const { status } = state;
@@ -136,11 +167,62 @@ export function multiplayerAllowed(state: DesktopUpdateState): boolean {
     return true;
   }
   if (status === "failed") {
-    const kind = state.error?.kind;
-    return kind !== "network" && kind !== "verify";
+    return failedAllowsMultiplayer(state.error?.kind);
   }
   // downloading (wait) and staged (reload) both have a real remedy.
   return false;
+}
+
+/**
+ * The `failed` half of the rule above, as an ALLOW-LIST.
+ *
+ * It was previously a deny-list (`kind !== "network" && kind !== "verify"`),
+ * which meant anything unrecognised fell through to ungated. Two problems with
+ * that, and they are the reason for OPE-194:
+ *
+ *   1. It answered "I don't know what went wrong" with "then play on". For the
+ *      one safety property this subsystem exists to provide, the default
+ *      belongs the other way round.
+ *   2. A typo on either side of that comparison -- "NETWORK", "verify " --
+ *      compiled cleanly and silently ungated multiplayer. A one-character
+ *      mistake became a safety hole with no compile error.
+ *
+ * Written as an explicit switch rather than a set lookup so each kind states
+ * its own reason, and so adding a kind to DesktopUpdateErrorKind without
+ * deciding its gating is a visible omission rather than a silent default.
+ */
+function failedAllowsMultiplayer(
+  kind: DesktopUpdateErrorKindWire | undefined,
+): boolean {
+  switch (kind) {
+    // `error` is optional on DesktopUpdateState, so a malformed `failed` state
+    // can carry no kind at all. Every shell emit site classifies before
+    // emitting, so this is unreachable from a real shell rather than a
+    // forward-compatibility case -- unlike the default branch below, this is
+    // absence of evidence, not evidence we cannot read. Kept ungated, which is
+    // the pre-existing deliberate behaviour: an entirely unclassified failure
+    // should not lock a player out.
+    case undefined:
+      return true;
+    // Deterministic and entirely server-side: Retry re-runs the identical
+    // failure, so gating is punishment without recourse.
+    case "refused":
+    case "parse":
+      return true;
+    // Retry is a real remedy, so gating buys something.
+    case "network":
+    case "verify":
+      return false;
+    // A kind from a shell newer than this client. The shell decided this
+    // failure was worth naming and we cannot read the name -- so we cannot
+    // reason about whether the player has a remedy. Fail safe: gate.
+    //
+    // This branch is reachable only because DesktopUpdateErrorKindWire is
+    // permissive. Narrowing that type to the closed union would make this
+    // `never` and delete the safety net.
+    default:
+      return false;
+  }
 }
 
 export type DesktopSessionStatus =

--- a/src/client/DesktopShell.ts
+++ b/src/client/DesktopShell.ts
@@ -159,7 +159,12 @@ export function desktopUpdate(): DesktopUpdateBridge | null {
  * asserting all four error kinds.
  *
  * The one place the two DELIBERATELY differ is the unrecognised-kind branch
- * below, which has no counterpart in the shell -- see failedAllowsMultiplayer.
+ * below, which has no counterpart in the shell. The asymmetry follows from
+ * which direction the values travel: THE CLIENT MAY RECEIVE FROM A NEWER
+ * SHELL, BUT THE SHELL CANNOT RECEIVE FROM A NEWER CLIENT. The shell only
+ * ever classifies errors it raised itself, against a closed union, so an
+ * unrecognised kind is unreachable there by construction. Do not "restore
+ * symmetry" by deleting the branch here.
  */
 export function multiplayerAllowed(state: DesktopUpdateState): boolean {
   const { status } = state;
@@ -188,8 +193,13 @@ export function multiplayerAllowed(state: DesktopUpdateState): boolean {
  *      mistake became a safety hole with no compile error.
  *
  * Written as an explicit switch rather than a set lookup so each kind states
- * its own reason, and so adding a kind to DesktopUpdateErrorKind without
- * deciding its gating is a visible omission rather than a silent default.
+ * its own reason next to it.
+ *
+ * Note this switch is NOT exhaustiveness-checked, and cannot be: `kind` is the
+ * permissive wire type, so a new member added to DesktopUpdateErrorKind and
+ * left uncased here is not a compile error. It falls to `default` and gates,
+ * which is the safe answer but a silent one. Adding a kind means adding a case
+ * here deliberately.
  */
 function failedAllowsMultiplayer(
   kind: DesktopUpdateErrorKindWire | undefined,

--- a/tests/DesktopShellUpdate.test.ts
+++ b/tests/DesktopShellUpdate.test.ts
@@ -2,6 +2,8 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   desktopUpdate,
   multiplayerAllowed,
+  type DesktopUpdateErrorKind,
+  type DesktopUpdateErrorKindWire,
   type DesktopUpdateState,
   type DesktopUpdateStatus,
 } from "../src/client/DesktopShell";
@@ -79,5 +81,57 @@ describe("multiplayerAllowed", () => {
     expect(
       multiplayerAllowed(st("failed", { kind: "parse", message: "bad json" })),
     ).toBe(true);
+  });
+});
+
+// OPE-194. The shell ships in the Steam depot and updates on Steam's
+// schedule; this client updates at runtime. A shell NEWER than the client is
+// therefore ordinary, and it can classify a failure into a kind this client
+// has never heard of.
+//
+// The old rule was a deny-list -- `kind !== "network" && kind !== "verify"` --
+// so any unrecognised kind fell through to ungated. That is the wrong default
+// for a safety property: it means the client's answer to "I don't know what
+// went wrong" was "then play on". A one-character typo on either side of that
+// comparison had the same effect, with no compile error to catch it.
+describe("multiplayerAllowed with an unrecognised error kind", () => {
+  const failedWith = (kind: string): DesktopUpdateState => ({
+    status: "failed",
+    bytes: 0,
+    total: 0,
+    error: { kind, message: "from a newer shell" },
+  });
+
+  // Compile-time guard on the type itself, not just the behaviour. If someone
+  // narrows DesktopUpdateErrorKindWire to the closed DesktopUpdateErrorKind,
+  // this assignment stops compiling -- and the default branch it protects
+  // would become `never` and be silently dropped.
+  it("types the wire kind permissively enough to carry an unknown value", () => {
+    const fromANewerShell: DesktopUpdateErrorKindWire = "quota-exceeded";
+    const known: DesktopUpdateErrorKind = "network";
+
+    expect(multiplayerAllowed(failedWith(fromANewerShell))).toBe(false);
+    expect(multiplayerAllowed(failedWith(known))).toBe(false);
+  });
+
+  it("gates a kind this client does not know about", () => {
+    // A future shell classifying something we cannot reason about. We know
+    // it decided the failure was worth naming; we just cannot read the name.
+    expect(multiplayerAllowed(failedWith("quota-exceeded"))).toBe(false);
+  });
+
+  it("gates regardless of what the unknown kind is called", () => {
+    for (const kind of ["", "disk-full", "NETWORK", "verify ", "refused2"]) {
+      expect(multiplayerAllowed(failedWith(kind))).toBe(false);
+    }
+  });
+
+  // The four known kinds keep their existing behaviour -- the allow-list must
+  // not have quietly changed any of them while flipping the default.
+  it("leaves the four known kinds exactly as they were", () => {
+    expect(multiplayerAllowed(failedWith("network"))).toBe(false);
+    expect(multiplayerAllowed(failedWith("verify"))).toBe(false);
+    expect(multiplayerAllowed(failedWith("refused"))).toBe(true);
+    expect(multiplayerAllowed(failedWith("parse"))).toBe(true);
   });
 });

--- a/tests/DesktopStatusBar.test.ts
+++ b/tests/DesktopStatusBar.test.ts
@@ -42,6 +42,26 @@ describe("barSource", () => {
     ).toBe("session");
   });
 
+  // OPE-194 pairs with this: an unrecognised error kind now GATES multiplayer,
+  // so it must never gate silently. The bar's visibility and its label/action
+  // key off `status`, not `error.kind`, so a failure this client cannot
+  // classify still surfaces "couldn't download the update" plus Retry -- a
+  // visible reason and an action, which is what keeps gating from being
+  // punishment without recourse.
+  it("surfaces a failure whose error kind is unrecognised", () => {
+    expect(
+      barSource(
+        {
+          status: "failed",
+          bytes: 0,
+          total: 0,
+          error: { kind: "quota-exceeded", message: "from a newer shell" },
+        },
+        { status: "signed-in" },
+      ),
+    ).toBe("update");
+  });
+
   it("shows nothing on the web, where neither bridge exists", () => {
     expect(barSource(null, null)).toBe("none");
   });


### PR DESCRIPTION
Fixes **OPE-194**. OpenFrontIO half only — `openfront-desktop` needs no change (verified below).

## The headline: two plausible typos ungate multiplayer on `main` today

The multiplayer gating rule turned on `error.kind` with a **deny-list**:

```ts
return kind !== "network" && kind !== "verify";
```

`"NETWORK"` and `"verify "` are both in this PR's test set, and on `main` **both currently allow multiplayer through a state that should gate it**. A one-character mistake on either side of that comparison compiled cleanly and became a safety hole with no compile error. That makes this a live correctness fix, not a typing tidy-up.

The same deny-list shape causes the second, larger problem: **any kind the client did not recognise fell through to UNGATED.** The client's answer to *"I don't know what went wrong"* was *"then play on"* — the wrong default for the one safety property this subsystem exists to provide.

That is not hypothetical. The shell ships in the Steam depot and updates on Steam's schedule while this client updates at runtime, so running against a **newer** shell is ordinary — and such a shell can classify a failure into a kind this client has never heard of.

## The fix

A permissive boundary plus an allow-list:

- **`DesktopUpdateErrorKind`** — the closed union of the four kinds we reason about, documented as tracking `openfront-desktop`'s `UpdateErrorKind` by hand (the same arrangement `multiplayerAllowed` already relies on, since the repos cannot import from each other).
- **`DesktopUpdateErrorKindWire`** — that union widened with `(string & {})`, and what `error.kind` is now typed as. This is **load-bearing, not sloppy typing**: with the closed union, TypeScript narrows the unrecognised branch to `never` and deletes the safety net. There is a comment in the code saying so.
- **`failedAllowsMultiplayer()`** — an explicit `switch`, so each kind states its own reason and the `default` gates.

**The four known kinds keep their existing behaviour exactly**, asserted by a test.

Note the switch is *not* exhaustiveness-checked and cannot be — `kind` is the permissive type, so a new union member left uncased falls to `default` and gates. Safe, but silent. The docblock says this rather than implying a compile error that cannot happen.

## Gating an unknown kind is not a silent lockout

Worth stating, because gating without a visible reason would be exactly the punishment-without-recourse the design avoids elsewhere: `DesktopStatusBar`'s visibility (`barSource`), label and action all key off `status`, **not** `error.kind`. So a failure this client cannot classify still shows "couldn't download the update" plus a **Retry** button. Pinned by a new `barSource` test.

## Two judgement calls, both deliberate

**1. `error: undefined` on a `failed` state stays UNGATED, unchanged.**

The issue's wording ("an error we cannot classify is one we cannot reason about, so it should gate") could be read to cover this, but it is a *different situation* and was already a considered decision — there is an existing test pinning it with the rationale *"an unclassified failure should not lock a player out. Pinned explicitly so a later edit can't flip that default silently."*

Every shell emit site calls `classify(err)` before emitting `failed`, so a missing kind is unreachable from a real shell — it is **absence of evidence**. An unrecognised kind is **evidence we cannot read**: a newer shell decided the failure was worth naming and we cannot read the name.

**2. The client and the shell now differ on the unrecognised branch.**

Deliberate, and the direction is what explains it: **the client may receive from a newer shell, but the shell cannot receive from a newer client.** The shell only ever classifies errors it raised itself, against a closed union, so an unrecognised kind is unreachable there by construction. The comment naming the duplication now says this, so the next reader does not "restore symmetry" by deleting the branch.

## The desktop side needs no change — verified

`src/main/update/state.ts` already has `error?: { kind: UpdateErrorKind; message: string }` with `UpdateErrorKind` a proper union, and `src/main/update/state.test.ts` already asserts all four kinds explicitly. Step 1 of the issue's shape was "likely already true; verify" — it is true.

## Tests

New in `tests/DesktopShellUpdate.test.ts`: an unrecognised kind gates; it gates whatever it is called (including `""`, `"NETWORK"` and `"verify "`); the four known kinds are unchanged; and a compile-time guard asserting the wire type still admits an unknown value, which stops compiling if someone narrows it to the closed union.

Mutation-checked: reverting the `default` branch to `return true` fails exactly the three unrecognised-kind tests and nothing else — the known kinds and the `undefined` case are provably untouched.

Local: `tsc --noEmit` clean, `npm run lint` clean, `prettier --check .` clean, full suite **4143/4143 client and 588/588 server**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFZGRXBMRSNyicA7V2MhtU
