### PR TITLE
fix(client): restore the menu after leaving a started game in place

### DIFF
--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -193,6 +193,24 @@ export class GameModeSelector extends LitElement {
     this.lobbySocket.stop();
   }
 
+  /**
+   * Re-open the public-lobby socket after stop().
+   *
+   * connectedCallback() used to be the only caller of lobbySocket.start(),
+   * which was fine while every exit from a started game reloaded the page. It
+   * is not fine for an exit that leaves in place (openInvite, OPE-255): this
+   * element is never disconnected, so connectedCallback never runs again and
+   * the lobby list stayed frozen on whatever it last received.
+   *
+   * Safe to call when already running -- PublicLobbySocket.start() closes any
+   * existing socket before opening a new one -- but callers should still only
+   * use it to undo a stop(), since a needless reconnect drops the cached
+   * snapshot and re-primes the list from the server.
+   */
+  public start() {
+    this.lobbySocket.start();
+  }
+
   private handleLobbiesUpdate(lobbies: PublicGames) {
     this.lobbies = lobbies;
     this.serverTimeOffset = calculateServerTimeOffset(lobbies.serverTime);

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -61,7 +61,11 @@ import { initLayout } from "./Layout";
 import "./LeaderboardModal";
 import "./Matchmaking";
 import { MatchmakingModal } from "./Matchmaking";
-import { hideMenuChrome, inStartedGame, restoreMenuChrome } from "./MenuChrome";
+import {
+  hideMenuChrome,
+  menuChromeIsTornDown,
+  restoreMenuChrome,
+} from "./MenuChrome";
 import { modalRouter } from "./ModalRouter";
 import { updateAccountNavButton } from "./NavAccountButton";
 import { initNavigation } from "./Navigation";
@@ -1419,21 +1423,20 @@ class Client {
       console.warn("Failed to restore URL on leave:", e);
     }
 
-    // Read before setInGameSignal(false) clears it: the class is only set once
-    // the join resolves, so it is the record of whether a game actually
-    // STARTED. Only a started game had its menu chrome torn down, and only
-    // that case needs putting back -- a pre-start leave never hid anything,
-    // and restarting a live lobby socket would drop its snapshot for nothing.
-    const wasInStartedGame = inStartedGame();
-
     setInGameSignal(false);
 
     // The inverse of the game-start teardown. Every other exit from a started
     // game navigates, and the reload did this implicitly; this path leaves in
     // place, so it has to do it explicitly (OPE-255). It lives here rather
-    // than in openInvite() because handleLeaveLobby is dispatched from four
-    // places and any of them could be the next to reach it post-start.
-    if (wasInStartedGame) {
+    // than in openInvite() because handleLeaveLobby is reached from several
+    // places and any of them could be the next to hit it after a teardown.
+    //
+    // The gate asks whether the chrome is torn down, NOT whether we were
+    // in-game: the teardown happens at prestart while the in-game signal is
+    // only set at join, so gating on the signal missed a leave landing in the
+    // window between them. Because the gate no longer reads that signal, it
+    // does not matter that setInGameSignal(false) has already run above.
+    if (menuChromeIsTornDown()) {
       this.gameModeSelector?.start();
       restoreMenuChrome();
     }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -61,6 +61,7 @@ import { initLayout } from "./Layout";
 import "./LeaderboardModal";
 import "./Matchmaking";
 import { MatchmakingModal } from "./Matchmaking";
+import { hideMenuChrome, inStartedGame, restoreMenuChrome } from "./MenuChrome";
 import { modalRouter } from "./ModalRouter";
 import { updateAccountNavButton } from "./NavAccountButton";
 import { initNavigation } from "./Navigation";
@@ -1234,9 +1235,7 @@ class Client {
         }
       });
       this.gameModeSelector.stop();
-      document.querySelectorAll(".ad").forEach((ad) => {
-        (ad as HTMLElement).style.display = "none";
-      });
+      hideMenuChrome();
 
       crazyGamesSDK.loadingStart();
 
@@ -1254,9 +1253,7 @@ class Client {
       this.gameModeSelector.stop();
       incrementGamesPlayed();
 
-      document.querySelectorAll(".ad").forEach((ad) => {
-        (ad as HTMLElement).style.display = "none";
-      });
+      hideMenuChrome();
 
       if (window.PageOS?.session?.newPageView) {
         window.PageOS.session.newPageView();
@@ -1422,7 +1419,24 @@ class Client {
       console.warn("Failed to restore URL on leave:", e);
     }
 
+    // Read before setInGameSignal(false) clears it: the class is only set once
+    // the join resolves, so it is the record of whether a game actually
+    // STARTED. Only a started game had its menu chrome torn down, and only
+    // that case needs putting back -- a pre-start leave never hid anything,
+    // and restarting a live lobby socket would drop its snapshot for nothing.
+    const wasInStartedGame = inStartedGame();
+
     setInGameSignal(false);
+
+    // The inverse of the game-start teardown. Every other exit from a started
+    // game navigates, and the reload did this implicitly; this path leaves in
+    // place, so it has to do it explicitly (OPE-255). It lives here rather
+    // than in openInvite() because handleLeaveLobby is dispatched from four
+    // places and any of them could be the next to reach it post-start.
+    if (wasInStartedGame) {
+      this.gameModeSelector?.start();
+      restoreMenuChrome();
+    }
 
     if (this.joinModal.isOpen()) {
       this.joinModal.close();

--- a/src/client/MenuChrome.ts
+++ b/src/client/MenuChrome.ts
@@ -1,0 +1,67 @@
+/**
+ * The menu chrome that a starting game hides, and its inverse.
+ *
+ * These two functions live together on purpose. Starting a game hid the ad
+ * rails and closed the promos, and for a long time nothing put them back --
+ * it did not need to, because every exit from a STARTED game was a full
+ * `window.location.href = "/"` navigation and the reload rebuilt the page.
+ * `openInvite()` (OPE-204) became the first exit that leaves in place, and the
+ * missing inverse surfaced as a homepage with no promos behind a frozen lobby
+ * list (OPE-255). Keeping the hide and the restore in one module is what stops
+ * them drifting apart again.
+ *
+ * Note what is NOT here: the public lobby socket. That belongs to
+ * <game-mode-selector>, which owns its lifecycle -- see its start()/stop().
+ */
+
+/**
+ * Whether a started game's teardown is what we are leaving, and therefore
+ * whether there is anything to put back.
+ *
+ * The `in-game` body class is set only once the join resolves (setInGameSignal
+ * in Main.ts), so it is the record of a game having actually STARTED rather
+ * than merely being joined. That distinction is the whole gate: a pre-start
+ * leave never hid the chrome and never stopped the lobby socket, so restoring
+ * there would reconnect a live socket and throw away its snapshot for nothing.
+ *
+ * Callers must read this BEFORE clearing the signal.
+ */
+export function inStartedGame(): boolean {
+  return document.body.classList.contains("in-game");
+}
+
+/** Hide the menu chrome for a game that is starting. */
+export function hideMenuChrome(): void {
+  document.querySelectorAll(".ad").forEach((ad) => {
+    (ad as HTMLElement).style.display = "none";
+  });
+}
+
+/**
+ * Put back what hideMenuChrome took away, plus the promos section that the
+ * game-start modal sweep closes.
+ *
+ * Clears the inline display rather than forcing "block": these slots take
+ * their real layout from the stylesheet, and a slot the page had its own
+ * reason to hide must not be forced visible by us.
+ *
+ * Everything here is best-effort and must not throw. On the desktop shell --
+ * the only place the in-place leave path can currently be reached -- ads never
+ * load (`window.adsEnabled` is false there), so <homepage-promos> may not be
+ * upgraded and may expose no show() at all. A throw here would take down the
+ * lobby-socket restart that runs beside it, which is the part players actually
+ * see.
+ */
+export function restoreMenuChrome(): void {
+  document.querySelectorAll(".ad").forEach((ad) => {
+    (ad as HTMLElement).style.display = "";
+  });
+  const promos = document.querySelector("homepage-promos") as
+    | (HTMLElement & { show?: () => void })
+    | null;
+  try {
+    promos?.show?.();
+  } catch (e) {
+    console.warn("failed to restore homepage promos", e);
+  }
+}

--- a/src/client/MenuChrome.ts
+++ b/src/client/MenuChrome.ts
@@ -1,39 +1,78 @@
 /**
  * The menu chrome that a starting game hides, and its inverse.
  *
- * These two functions live together on purpose. Starting a game hid the ad
- * rails and closed the promos, and for a long time nothing put them back --
- * it did not need to, because every exit from a STARTED game was a full
- * `window.location.href = "/"` navigation and the reload rebuilt the page.
- * `openInvite()` (OPE-204) became the first exit that leaves in place, and the
- * missing inverse surfaced as a homepage with no promos behind a frozen lobby
- * list (OPE-255). Keeping the hide and the restore in one module is what stops
- * them drifting apart again.
+ * These live together on purpose. Starting a game hid the ad rails, and for a
+ * long time nothing put them back -- it did not need to, because every exit
+ * from a STARTED game was a full `window.location.href = "/"` navigation and
+ * the reload rebuilt the page. `openInvite()` (OPE-204) became the first exit
+ * that leaves in place, and the missing inverse surfaced as a homepage with no
+ * promos behind a frozen lobby list (OPE-255).
  *
- * Note what is NOT here: the public lobby socket. That belongs to
- * <game-mode-selector>, which owns its lifecycle -- see its start()/stop().
+ * The pairing here is deliberately NOT symmetrical, and it is worth being
+ * honest about which halves live where:
+ *
+ *   - Ad slots: hidden by hideMenuChrome(), restored by restoreMenuChrome().
+ *     Both halves are here.
+ *   - <homepage-promos>: closed by the game-start MODAL SWEEP in Main.ts (it
+ *     has a close() and so is caught by that list), reopened by
+ *     restoreMenuChrome(). Only the restoring half is here. Reaching into the
+ *     sweep to special-case it would be worse than documenting the split.
+ *   - The public lobby socket: neither half is here. It belongs to
+ *     <game-mode-selector>, which owns its own lifecycle -- see start()/stop().
+ *     restoreMenuChrome() deliberately does not touch it.
  */
 
 /**
- * Whether a started game's teardown is what we are leaving, and therefore
- * whether there is anything to put back.
+ * Has the chrome been torn down and not yet put back?
  *
- * The `in-game` body class is set only once the join resolves (setInGameSignal
- * in Main.ts), so it is the record of a game having actually STARTED rather
- * than merely being joined. That distinction is the whole gate: a pre-start
- * leave never hid the chrome and never stopped the lobby socket, so restoring
- * there would reconnect a live socket and throw away its snapshot for nothing.
+ * This is the gate for the whole restore, and it is keyed on the teardown
+ * ITSELF rather than on any separate signal that happens to correlate with it.
+ * That distinction is load-bearing.
  *
- * Callers must read this BEFORE clearing the signal.
+ * The first version read the `in-game` body class, which looked equivalent and
+ * was not: the teardown runs in `prestart.then(...)`, while setInGameSignal(true)
+ * runs later in `join.then(...)`. For multiplayer those are two distinct server
+ * messages with a real gap between them while terrain loads -- the
+ * "prestart->start window" ClientGameRunner names. A leave inside that window
+ * (Back, or a hash change, both reachable because `currentUrl` is also unset
+ * until join) found the chrome torn down but the class never set, so nothing
+ * restored. That is the bug OPE-255 exists to fix, arriving through a narrower
+ * door.
+ *
+ * Keying on the teardown makes the gate true for exactly as long as there is
+ * something to undo, whatever the join lifecycle is doing, and removes any
+ * ordering constraint on the caller.
  */
-export function inStartedGame(): boolean {
-  return document.body.classList.contains("in-game");
+let tornDown = false;
+
+export function menuChromeIsTornDown(): boolean {
+  return tornDown;
 }
+
+/**
+ * What each slot's inline `display` was before we hid it, so restore can put
+ * that back rather than assuming every slot wants the stylesheet default. A
+ * slot may already carry one for reasons of its own -- an ad the page decided
+ * not to show -- and blanking it would reveal something deliberately hidden.
+ *
+ * Recorded per element on FIRST hide only. hideMenuChrome() runs twice on a
+ * real join (prestart.then and join.then in Main.ts), and re-recording on the
+ * second pass would capture our own "none" and restore a permanently hidden
+ * slot. Keyed weakly so a removed slot does not pin a detached node.
+ */
+const displacedAdDisplay = new WeakMap<HTMLElement, string>();
 
 /** Hide the menu chrome for a game that is starting. */
 export function hideMenuChrome(): void {
+  tornDown = true;
   document.querySelectorAll(".ad").forEach((ad) => {
-    (ad as HTMLElement).style.display = "none";
+    const el = ad as HTMLElement;
+    // has() rather than a first-call flag: a slot added to the page between
+    // the two hide passes still needs its own value recorded.
+    if (!displacedAdDisplay.has(el)) {
+      displacedAdDisplay.set(el, el.style.display);
+    }
+    el.style.display = "none";
   });
 }
 
@@ -45,16 +84,24 @@ export function hideMenuChrome(): void {
  * their real layout from the stylesheet, and a slot the page had its own
  * reason to hide must not be forced visible by us.
  *
- * Everything here is best-effort and must not throw. On the desktop shell --
+ * The promos call is best-effort and must not throw. On the desktop shell --
  * the only place the in-place leave path can currently be reached -- ads never
  * load (`window.adsEnabled` is false there), so <homepage-promos> may not be
- * upgraded and may expose no show() at all. A throw here would take down the
- * lobby-socket restart that runs beside it, which is the part players actually
- * see.
+ * upgraded and may expose no show() at all, and its own close() reaches into
+ * Playwire globals that are a bare stub on the app:// origin. A throw here
+ * would abort handleLeaveLobby partway: not the lobby-socket restart, which
+ * has already run by this point, but the joinModal.close() and the
+ * `full-lobby` message that follow it -- leaving a stale modal open and the
+ * player unaware of why their join failed.
  */
 export function restoreMenuChrome(): void {
+  tornDown = false;
   document.querySelectorAll(".ad").forEach((ad) => {
-    (ad as HTMLElement).style.display = "";
+    const el = ad as HTMLElement;
+    // Falls back to "" -- the stylesheet default -- for a slot we never hid.
+    el.style.display = displacedAdDisplay.get(el) ?? "";
+    // Drop the record so the next teardown captures the value afresh.
+    displacedAdDisplay.delete(el);
   });
   const promos = document.querySelector("homepage-promos") as
     | (HTMLElement & { show?: () => void })

--- a/tests/GameModeSelectorRestart.test.ts
+++ b/tests/GameModeSelectorRestart.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PublicGames } from "../src/core/Schemas";
+
+// OPE-255. The component stops its public-lobby socket when a game starts
+// (Main.ts calls gameModeSelector.stop()), and `start()` lived ONLY in
+// connectedCallback(). Nothing reconnects an element that is never
+// disconnected, so an exit that does not reload the page left the lobby
+// browser frozen: a stale list that never updates again.
+//
+// jsdom has no WebSocket worth talking to and this test is about the
+// lifecycle, not the wire, so the socket is a spy -- following the same
+// pattern as GameModeSelectorGatingWiring.test.ts.
+const { socketCalls } = vi.hoisted(() => ({
+  socketCalls: { started: 0, stopped: 0 },
+}));
+
+vi.mock("../src/client/LobbySocket", () => ({
+  PublicLobbySocket: class {
+    constructor(_onUpdate: (g: PublicGames) => void) {}
+    start(): void {
+      socketCalls.started++;
+    }
+    stop(): void {
+      socketCalls.stopped++;
+    }
+  },
+}));
+
+import { GameModeSelector } from "../src/client/GameModeSelector";
+
+describe("GameModeSelector lobby-socket lifecycle", () => {
+  beforeEach(() => {
+    socketCalls.started = 0;
+    socketCalls.stopped = 0;
+  });
+
+  it("exposes a start() that is the inverse of stop()", () => {
+    const selector = new GameModeSelector();
+
+    selector.stop();
+    expect(socketCalls.stopped).toBe(1);
+
+    selector.start();
+    expect(socketCalls.started).toBe(1);
+  });
+
+  // The actual regression: a stopped socket must be able to come back without
+  // the element being torn down and recreated, because in this flow it never
+  // is -- <game-mode-selector> stays connected the whole time.
+  it("reconnects after a stop without any disconnect/reconnect of the element", () => {
+    const selector = new GameModeSelector();
+
+    selector.stop();
+    selector.start();
+    selector.stop();
+    selector.start();
+
+    expect(socketCalls.stopped).toBe(2);
+    expect(socketCalls.started).toBe(2);
+  });
+});

--- a/tests/MenuChrome.test.ts
+++ b/tests/MenuChrome.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  hideMenuChrome,
+  inStartedGame,
+  restoreMenuChrome,
+} from "../src/client/MenuChrome";
+
+// OPE-255. Starting a game hides the menu's ad rails and closes the promos.
+// Every exit from a STARTED game used to be a full `window.location.href = "/"`
+// navigation, and it was the reload -- not any code -- that put them back.
+// openInvite() leaves in place instead, so the teardown needed a real inverse.
+// These two live in one module precisely so they cannot drift apart again.
+
+function ad(): HTMLElement {
+  const el = document.createElement("div");
+  el.className = "ad";
+  document.body.appendChild(el);
+  return el;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  document.body.classList.remove("in-game");
+});
+
+describe("hideMenuChrome", () => {
+  it("hides every ad slot", () => {
+    const a = ad();
+    const b = ad();
+
+    hideMenuChrome();
+
+    expect(a.style.display).toBe("none");
+    expect(b.style.display).toBe("none");
+  });
+
+  it("is a no-op when there is nothing to hide", () => {
+    expect(() => hideMenuChrome()).not.toThrow();
+  });
+});
+
+describe("restoreMenuChrome", () => {
+  it("un-hides every ad slot", () => {
+    const a = ad();
+    const b = ad();
+    hideMenuChrome();
+
+    restoreMenuChrome();
+
+    expect(a.style.display).toBe("");
+    expect(b.style.display).toBe("");
+  });
+
+  // Clearing the inline style rather than forcing "block" matters: these slots
+  // get their real layout from the stylesheet, and a slot the page had its own
+  // reason to keep hidden must not be forced visible by our restore.
+  it("clears the inline style instead of forcing a display value", () => {
+    const el = ad();
+    hideMenuChrome();
+
+    restoreMenuChrome();
+
+    expect(el.getAttribute("style")).not.toContain("display");
+  });
+
+  it("round-trips an untouched slot back to how it started", () => {
+    const el = ad();
+    const before = el.getAttribute("style");
+
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(el.getAttribute("style") ?? "").toBe(before ?? "");
+  });
+
+  it("reopens the promos section", () => {
+    const promos = document.createElement("homepage-promos") as HTMLElement & {
+      show: () => void;
+    };
+    promos.show = vi.fn();
+    document.body.appendChild(promos);
+
+    restoreMenuChrome();
+
+    expect(promos.show).toHaveBeenCalledOnce();
+  });
+
+  // The promos element is ad machinery. On the Steam shell -- the only place
+  // this restore path can be reached -- ads never load, so it may not be
+  // upgraded and may expose no show() at all. That must not throw and take the
+  // lobby-socket restart below it down with it.
+  it("tolerates a promos element that has no show()", () => {
+    document.body.appendChild(document.createElement("homepage-promos"));
+
+    expect(() => restoreMenuChrome()).not.toThrow();
+  });
+
+  it("tolerates the promos element being absent entirely", () => {
+    expect(() => restoreMenuChrome()).not.toThrow();
+  });
+});
+
+// The gate that decides whether any of the above runs. handleLeaveLobby is
+// dispatched from several places -- the `leave-lobby` listener (fed by
+// ClientGameRunner, HostLobbyModal and JoinLobbyModal), a direct call on the
+// join path, and openInvite -- and they all converge on one body, so what
+// varies between them is not the restore but whether a game had STARTED.
+describe("inStartedGame", () => {
+  it("is false at the menu, so a pre-start leave restores nothing", () => {
+    expect(inStartedGame()).toBe(false);
+  });
+
+  it("is true once the in-game signal is set", () => {
+    document.body.classList.add("in-game");
+
+    expect(inStartedGame()).toBe(true);
+  });
+
+  // Joining a lobby is not starting a game. Restoring here would reconnect a
+  // socket that was never stopped and drop its snapshot for nothing.
+  it("stays false for a lobby that was joined but never started", () => {
+    document.body.classList.remove("in-game");
+
+    expect(inStartedGame()).toBe(false);
+  });
+});

--- a/tests/MenuChrome.test.ts
+++ b/tests/MenuChrome.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   hideMenuChrome,
-  inStartedGame,
+  menuChromeIsTornDown,
   restoreMenuChrome,
 } from "../src/client/MenuChrome";
 
@@ -21,6 +21,8 @@ function ad(): HTMLElement {
 afterEach(() => {
   document.body.innerHTML = "";
   document.body.classList.remove("in-game");
+  // Module-level teardown flag: reset so state cannot leak between tests.
+  restoreMenuChrome();
 });
 
 describe("hideMenuChrome", () => {
@@ -100,27 +102,109 @@ describe("restoreMenuChrome", () => {
   });
 });
 
-// The gate that decides whether any of the above runs. handleLeaveLobby is
-// dispatched from several places -- the `leave-lobby` listener (fed by
-// ClientGameRunner, HostLobbyModal and JoinLobbyModal), a direct call on the
-// join path, and openInvite -- and they all converge on one body, so what
-// varies between them is not the restore but whether a game had STARTED.
-describe("inStartedGame", () => {
+// The gate that decides whether any of the above runs.
+//
+// It is keyed on "did we tear the chrome down?" rather than on any separate
+// signal that happens to correlate. The first version of this gate read the
+// `in-game` body class, and that was subtly wrong: the teardown runs in
+// `prestart.then(...)` while setInGameSignal(true) runs later in
+// `join.then(...)`. For multiplayer those are two distinct server messages
+// with a real window between them while terrain loads -- the "prestart->start
+// window" ClientGameRunner names. A leave inside that window found the chrome
+// torn down but the class unset, so nothing restored: the exact bug this PR
+// exists to fix, arriving through a narrower door.
+describe("menuChromeIsTornDown", () => {
   it("is false at the menu, so a pre-start leave restores nothing", () => {
-    expect(inStartedGame()).toBe(false);
+    expect(menuChromeIsTornDown()).toBe(false);
   });
 
-  it("is true once the in-game signal is set", () => {
+  it("is true as soon as the chrome is hidden", () => {
+    hideMenuChrome();
+
+    expect(menuChromeIsTornDown()).toBe(true);
+  });
+
+  // The regression. The teardown has happened; the in-game signal has not
+  // been set and will not be until the join resolves. Restore must still fire.
+  it("is true during the prestart->start window, before any in-game signal", () => {
+    hideMenuChrome();
+    expect(document.body.classList.contains("in-game")).toBe(false);
+
+    expect(menuChromeIsTornDown()).toBe(true);
+  });
+
+  it("is false again once the chrome has been restored", () => {
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(menuChromeIsTornDown()).toBe(false);
+  });
+
+  // Deliberately independent of the body class, so the two cannot drift.
+  it("does not consult the in-game class", () => {
     document.body.classList.add("in-game");
 
-    expect(inStartedGame()).toBe(true);
+    expect(menuChromeIsTornDown()).toBe(false);
+  });
+});
+
+// A slot may already carry an inline display for reasons of its own -- an ad
+// the page decided not to show, or a layout the stylesheet does not describe.
+// Blanking it on restore would reveal a slot somebody deliberately hid, so
+// hide records what it displaced and restore puts that value back.
+describe("restoreMenuChrome preserves a slot's own inline display", () => {
+  it("leaves a slot that was already hidden hidden", () => {
+    const el = ad();
+    el.style.display = "none";
+
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(el.style.display).toBe("none");
   });
 
-  // Joining a lobby is not starting a game. Restoring here would reconnect a
-  // socket that was never stopped and drop its snapshot for nothing.
-  it("stays false for a lobby that was joined but never started", () => {
-    document.body.classList.remove("in-game");
+  it("puts back a non-default display value", () => {
+    const el = ad();
+    el.style.display = "flex";
 
-    expect(inStartedGame()).toBe(false);
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(el.style.display).toBe("flex");
+  });
+
+  // The trap. hideMenuChrome() runs TWICE on a real join -- once in
+  // prestart.then() and again in join.then() (Main.ts). A naive "record the
+  // current value on every hide" would capture "none" from its own first pass
+  // and then restore a permanently hidden slot.
+  it("does not record its own handiwork when hide runs twice", () => {
+    const el = ad();
+    el.style.display = "flex";
+
+    hideMenuChrome();
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(el.style.display).toBe("flex");
+  });
+
+  // A slot added to the page between the two hide passes still gets recorded.
+  it("records a slot that appears after the first hide", () => {
+    hideMenuChrome();
+    const late = ad();
+    late.style.display = "block";
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(late.style.display).toBe("block");
+  });
+
+  it("still clears the style for a slot that had none", () => {
+    const el = ad();
+
+    hideMenuChrome();
+    restoreMenuChrome();
+
+    expect(el.style.display).toBe("");
   });
 });


### PR DESCRIPTION
Fixes **OPE-255**. Client-only — nothing in `openfront-desktop` changes.

## The bug

Starting a game tears down menu state: it stops the public-lobby socket (`gameModeSelector.stop()`), hides the ad slots, and closes `<homepage-promos>` in the modal sweep. Nothing ever put any of that back — and nothing needed to, because every exit from a **started** game was a full `window.location.href = "/"` navigation and the reload rebuilt the page.

`openInvite()` (OPE-204, merged in #5194) is the first exit that leaves in place. Accept a Steam invite mid-match, then don't complete the join — close the modal, or the target lobby is full — and you land on a homepage whose lobby list is **frozen on its last snapshot and never updates again**.

The lobby socket is the real symptom: `GameModeSelector` exposed `stop()`, but `start()` existed only inside `connectedCallback()`, and this element is never disconnected. Once stopped, it stayed stopped for the life of the page.

## Scope — smaller than the issue says, and I'd rather say so

**The ad half is not observable, and there is no revenue impact.** `Main.ts:512-513` sets `window.adsEnabled = !isAdFree && !crazyGamesSDK.isOnCrazyGames() && !isDesktopShell()`, and `openInvite()` is reachable only via the desktop invite bridge (`consumePendingInvite`/`subscribeInvites`, both no-ops unless `shell.api >= 2`). So the sole trigger for this bug occurs exactly where ads never load. `<homepage-promos>` is the same story — Playwire machinery, and `index.html` only installs a `window.ramp` stub on the `app://openfront/` origin.

**So the ad and promos restores here are defensive symmetry that protects the next caller, not a fix for anything a player sees today.** The visible bug on Steam is the frozen lobby browser. I corrected the issue's revenue claim on OPE-255 directly, since it was the main argument for its priority.

## Why fix `handleLeaveLobby`, not `openInvite`

This is the issue's option 2. `handleLeaveLobby` is reached from several places — the `leave-lobby` listener (fed by `ClientGameRunner.ts:301/310/326`, `HostLobbyModal.ts:761`, `JoinLobbyModal.ts:554`), the direct call at `Main.ts:781`, and `openInvite`. `openInvite` is merely the **first** to reach it after a teardown.

Option 1 (navigate instead) fixes that one caller and leaves the teardown still without an inverse for whichever caller reaches it next. It would also undo the in-place design #5194 chose deliberately, and would require the invite id to survive a navigation.

## The change

- **`GameModeSelector.start()`** — the missing counterpart to `stop()`.
- **`MenuChrome.ts`** — `hideMenuChrome`/`restoreMenuChrome`, plus `menuChromeIsTornDown()` as the gate. `Main.ts`'s two duplicated `.ad` hide blocks now call the former.
- **`handleLeaveLobby`** restores when the chrome is torn down.

### The gate is keyed on the teardown, not on `in-game` — and that matters

An earlier revision of this PR gated on the `in-game` body class. Review (both CodeRabbit and the Claude CI review) caught that this was subtly wrong, and they were right:

`gameModeSelector.stop()` + `hideMenuChrome()` run in `prestart.then(...)`, but `setInGameSignal(true)` runs later in `join.then(...)`. For multiplayer those are **two distinct server messages** with a real gap between them while terrain loads — the "prestart→start window" `ClientGameRunner` names. `this.currentUrl` is also unset until `join`, so a Back press or hash change in that window reaches `handleLeaveLobby` with `lobbyHandle` non-null.

Result: chrome torn down, class never set, gate false, nothing restored — **this PR's own bug, through a narrower door.** Since the entire argument for fixing `handleLeaveLobby` was that it fixes the *class* of bug, a gate keyed on a merely-correlated signal left that argument half-true.

`menuChromeIsTornDown()` now reads a flag `hideMenuChrome()` sets and `restoreMenuChrome()` clears. The gate is true for exactly as long as there is something to undo, and the caller no longer has to read it before `setInGameSignal(false)`.

### Restore preserves a slot's own inline display

Also from review: blanking every `.ad` slot's inline `display` would reveal a slot something else deliberately hid. `hideMenuChrome()` now records what it displaced and restore puts it back.

Recorded **per element, first hide only** — `hideMenuChrome()` runs twice on a real join, and re-recording on the second pass would capture its own `"none"` and hide the slot permanently. Guarded with `has()` rather than a call-count flag so a slot appearing between the two passes is still recorded.

## Documented rather than implied away

- The module header no longer claims hide and restore are paired here. Only the ad slots are: `<homepage-promos>` is closed by the modal sweep in `Main.ts` and only *reopened* here, and the lobby socket is neither.
- The `try/catch` comment named the wrong risk. A throw cannot take down the lobby-socket restart — that runs first. It would skip the `joinModal.close()` and `full-lobby` message below it, leaving a stale modal and no explanation. The guard earns its place for that reason instead.

## A note on precedent

`FeaturedStream`'s `onLeave` already restores itself on `leave-lobby`, the same pattern — but it is a **code precedent, not an active one**: `FeaturedStream` returns early on `isDesktopShell()`, so it never runs in the Steam build where this bug occurs.

## Tests

20 tests across `tests/MenuChrome.test.ts` and `tests/GameModeSelectorRestart.test.ts`, including the **prestart→start window**, which had never been covered, and the double-hide trap above.

Mutation-checked three times: reverting the gate to the `in-game` class fails the prestart-window test and two others; forcing `"block"` instead of restoring the recorded value fails the round-trip tests; an always-true gate fails the pre-start tests. Nothing else moves in any case.

**On covering all four dispatch sites**, which was asked for: they converge on a single `handleLeaveLobby` body, so the restore is reached from all of them by construction and a per-site test would be asserting that `document.dispatchEvent` works. Testing `handleLeaveLobby` end-to-end is not feasible today — `Main.ts` runs `bootstrap()` at module level and `Client` is not exported, so importing it boots the whole app. Filed as **OPE-268**.

Local: `tsc --noEmit` clean, `npm run lint` clean, `prettier --check .` clean, full suite **4207/4207 client and 588/588 server, zero failures**. Rebased on current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UFZGRXBMRSNyicA7V2MhtU
