### PR TITLE
fix(client): explain the suffixed name when a bare claim is unavailable

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -72,6 +72,8 @@
     "tab_stats": "Stats",
     "title": "Account",
     "unclaimed_rewards": "Unclaimed Rewards",
+    "username_bare_unavailable": "\"{requested}\" is already taken, so your name is now \"{name}\". This used your name change — you can change it again on {date}.",
+    "username_bare_unavailable_no_date": "\"{requested}\" is already taken, so your name is now \"{name}\". This used your name change.",
     "username_change_ready": "Change available",
     "username_confirm_abandon": "You will permanently give up your reserved name \"{name}\".",
     "username_confirm_body": "Your new name will be locked for 30 days.",

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -333,10 +333,16 @@ export type UpdateUsernameResult =
   | { ok: false; code: "failed" };
 
 // PUT /users/@me/username — renames the account username. Every failure is
-// atomic (no name change, no cooldown consumed). Both 409 bodies ("name
-// exclusively held" and "suffix space exhausted") map to "taken": the user
-// remedy is the same — pick another name. Invalidates the cached /users/@me
-// on success so the next read reflects the new name.
+// atomic (no name change, no cooldown consumed). The surviving 409 bodies
+// ("name equals an existing public id" and "suffix space exhausted") map to
+// "taken": the user remedy is the same — pick another name. Invalidates the
+// cached /users/@me on success so the next read reflects the new name.
+//
+// A premium player whose chosen bare name is already held no longer 409s: the
+// API grants the suffixed form and returns 200 with `bareClaim:
+// "unavailable"`. That is a real rename and it consumes the cooldown, so `ok:
+// true` alone is not enough to act on — callers must read `data.bareClaim`
+// and tell the player (see UsernamePanel).
 export async function updateUsername(
   username: string,
 ): Promise<UpdateUsernameResult> {

--- a/src/client/components/UsernamePanel.ts
+++ b/src/client/components/UsernamePanel.ts
@@ -1,13 +1,17 @@
 import { html, LitElement, nothing, TemplateResult } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
-import { isTemporaryUsername, UserMeResponse } from "../../core/ApiSchemas";
+import {
+  isTemporaryUsername,
+  PutUsernameResponse,
+  UserMeResponse,
+} from "../../core/ApiSchemas";
 import {
   MAX_ACCOUNT_USERNAME_LENGTH,
   MIN_ACCOUNT_USERNAME_LENGTH,
   validateAccountUsername,
 } from "../../core/validations/username";
 import { updateUsername, UpdateUsernameResult } from "../Api";
-import { showInGameConfirm } from "../InGameModal";
+import { showInGameAlert, showInGameConfirm } from "../InGameModal";
 import { translateText } from "../Utils";
 import "./baseComponents/Button";
 import { usernameText } from "./ui/UsernameText";
@@ -120,6 +124,12 @@ export class UsernamePanel extends LitElement {
     const result = await updateUsername(name);
 
     if (result.ok) {
+      // A premium player whose bare name is held gets the suffixed form
+      // instead — a 200, not a 409. Say so before the reload: otherwise the
+      // modal simply reopens showing a name they never chose, with nothing to
+      // explain it and their 30-day rename already spent. Awaited so the
+      // reload cannot race the dialog away.
+      await this.warnBareClaimUnavailable(name, result.data);
       // Reload so every consumer starts from a fresh /users/@me; this modal
       // reopens via #modal=change-username showing the new name. Keep the
       // form locked (busy) while the reload happens.
@@ -128,6 +138,30 @@ export class UsernamePanel extends LitElement {
     }
     this.busy = false;
     this.error = this.errorMessage(result);
+  }
+
+  // Nothing to say for `claimed` (they got what they asked for) or
+  // `not_eligible` (a suffix is just how free names work — a message there
+  // would be noise on an ordinary rename). `undefined` means the API predates
+  // the field, so behaviour is unchanged.
+  private async warnBareClaimUnavailable(
+    requested: string,
+    data: PutUsernameResponse,
+  ): Promise<void> {
+    if (data.bareClaim !== "unavailable") return;
+    const next = data.nextUsernameChangeAt;
+    await showInGameAlert(
+      next === null
+        ? translateText("account_modal.username_bare_unavailable_no_date", {
+            requested,
+            name: data.username,
+          })
+        : translateText("account_modal.username_bare_unavailable", {
+            requested,
+            name: data.username,
+            date: this.formatDate(new Date(next)),
+          }),
+    );
   }
 
   private errorMessage(

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -272,12 +272,37 @@ export type UserSubscription = NonNullable<
 // PUT /users/@me/username success payload. `username` is the resolved display
 // form (safe for optimistic UI). The suffix is re-rolled on every rename and
 // the response carries the fresh 30-day cooldown.
+// What happened to the bare-name claim on a successful rename.
+//
+// `claimed` — premium, got the bare name ("Ninja").
+// `unavailable` — premium, someone else holds the bare name, so the suffixed
+//   form was granted instead ("Ninja.4471"). A 200, not a 409: the rename
+//   happened and the cooldown was consumed. This is the case worth telling
+//   the player about.
+// `not_eligible` — not premium, so a suffix is simply how free names work.
+//   Nothing to say.
+//
+// Three values rather than a boolean so callers don't have to re-derive
+// eligibility from usernameStatus to avoid showing a free player a "fallback"
+// message on a perfectly ordinary rename.
+export const BareClaimSchema = z.enum([
+  "claimed",
+  "unavailable",
+  "not_eligible",
+]);
+export type BareClaim = z.infer<typeof BareClaimSchema>;
+
 export const PutUsernameResponseSchema = z.object({
   username: z.string(),
   base: z.string(),
   discriminator: z.string(),
   usernameStatus: UsernameStatusSchema,
   nextUsernameChangeAt: z.iso.datetime().nullable(),
+  // Optional because this client ships BEFORE the API that sends it. The
+  // response is parsed with safeParse, so requiring the field would make every
+  // rename against the current API fail validation and surface as a generic
+  // "failed". Treat `undefined` as "the API predates this" and say nothing.
+  bareClaim: BareClaimSchema.optional(),
 });
 export type PutUsernameResponse = z.infer<typeof PutUsernameResponseSchema>;
 

--- a/tests/client/UsernameBareClaim.test.ts
+++ b/tests/client/UsernameBareClaim.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PutUsernameResponseSchema } from "../../src/core/ApiSchemas";
+
+// The panel reaches the API and the in-game dialog; stub both boundaries so
+// these exercise the branch on the response body rather than the network.
+const updateUsername = vi.fn();
+vi.mock("../../src/client/Api", () => ({
+  updateUsername: (name: string) => updateUsername(name),
+}));
+const showInGameConfirm = vi.fn(
+  async (_message: string, _options?: unknown) => true,
+);
+const showInGameAlert = vi.fn(async (_message: string) => true);
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameConfirm: (message: string, options?: unknown) =>
+    showInGameConfirm(message, options),
+  showInGameAlert: (message: string) => showInGameAlert(message),
+}));
+vi.mock("../../src/client/Utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Utils")>()),
+  // Echo the key and its interpolations so assertions can read both.
+  translateText: (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+import "../../src/client/components/UsernamePanel";
+import type { UsernamePanel } from "../../src/client/components/UsernamePanel";
+import type { UserMeResponse } from "../../src/core/ApiSchemas";
+
+function okBody(overrides: Record<string, unknown> = {}) {
+  return {
+    username: "Ninja.4471",
+    base: "Ninja",
+    discriminator: "4471",
+    usernameStatus: "premium",
+    nextUsernameChangeAt: "2026-10-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("PutUsernameResponseSchema bareClaim", () => {
+  // This client is deliberately deployed BEFORE the API change that adds the
+  // field. Requiring it would make every rename against today's API fail
+  // safeParse and surface as a generic "failed".
+  it("parses a response from an API that does not send the field", () => {
+    const parsed = PutUsernameResponseSchema.safeParse(okBody());
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data.bareClaim).toBeUndefined();
+  });
+
+  it("keeps the field once the API sends it", () => {
+    for (const value of ["claimed", "unavailable", "not_eligible"] as const) {
+      const parsed = PutUsernameResponseSchema.safeParse(
+        okBody({ bareClaim: value }),
+      );
+      expect(parsed.success, value).toBe(true);
+      expect(parsed.success && parsed.data.bareClaim).toBe(value);
+    }
+  });
+
+  it("rejects a value outside the enum rather than passing it through", () => {
+    expect(
+      PutUsernameResponseSchema.safeParse(okBody({ bareClaim: "nope" }))
+        .success,
+    ).toBe(false);
+  });
+});
+
+describe("UsernamePanel bare-claim fallback", () => {
+  let reload: ReturnType<typeof vi.fn>;
+
+  function player(
+    overrides: Record<string, unknown> = {},
+  ): UserMeResponse["player"] {
+    return {
+      publicId: "p",
+      username: "Ninja",
+      usernameBase: "Ninja",
+      usernameStatus: "premium",
+      nextUsernameChangeAt: null,
+      usernameClaimExpiresAt: null,
+      ...overrides,
+    } as unknown as UserMeResponse["player"];
+  }
+
+  // Drives the real path a player takes: type a name, press Enter. The panel
+  // has no <form> — Enter on the input and the save button both call
+  // handleSave directly.
+  async function submit(el: UsernamePanel, name: string) {
+    const input = el.querySelector<HTMLInputElement>("#username-panel-input")!;
+    input.value = name;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+    await el.updateComplete;
+    input.dispatchEvent(
+      new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+    );
+    // Lets the confirm dialog, the update call and any alert all settle.
+    for (let i = 0; i < 4; i++) await new Promise((r) => setTimeout(r, 0));
+    await el.updateComplete;
+  }
+
+  async function mount(): Promise<UsernamePanel> {
+    const el = document.createElement("username-panel") as UsernamePanel;
+    el.player = player();
+    document.body.appendChild(el);
+    await el.updateComplete;
+    return el;
+  }
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    updateUsername.mockReset();
+    showInGameConfirm.mockReset();
+    showInGameConfirm.mockResolvedValue(true);
+    showInGameAlert.mockReset();
+    showInGameAlert.mockResolvedValue(true);
+    reload = vi.fn();
+    // jsdom's location.reload is not implemented; replace it outright.
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, reload, hash: "" },
+    });
+  });
+
+  // The whole point of this change: a fallback is a 200, so without it the
+  // player reloads into a name they never chose with nothing to explain it —
+  // and the rename has already consumed their 30-day cooldown.
+  it("explains the suffixed name before reloading", async () => {
+    updateUsername.mockResolvedValue({
+      ok: true,
+      data: okBody({ bareClaim: "unavailable" }),
+    });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    const message = showInGameAlert.mock.calls[0][0];
+    // Names both what they asked for and what they actually got...
+    expect(message).toContain("Ninja.4471");
+    // ...and says the rename was spent, which is the part that stings.
+    expect(message).toContain("username_bare_unavailable");
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("names the date they can change again when the API supplies one", async () => {
+    updateUsername.mockResolvedValue({
+      ok: true,
+      data: okBody({ bareClaim: "unavailable" }),
+    });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert.mock.calls[0][0]).toContain(
+      "username_bare_unavailable:",
+    );
+    expect(showInGameAlert.mock.calls[0][0]).not.toContain("no_date");
+  });
+
+  it("drops the date rather than showing a blank one", async () => {
+    updateUsername.mockResolvedValue({
+      ok: true,
+      data: okBody({ bareClaim: "unavailable", nextUsernameChangeAt: null }),
+    });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert.mock.calls[0][0]).toContain(
+      "username_bare_unavailable_no_date",
+    );
+  });
+
+  // A free player always gets a suffix — that is how free names work, and
+  // saying something about it would be noise on a perfectly normal rename.
+  it.each(["claimed", "not_eligible"] as const)(
+    "says nothing extra for bareClaim %s",
+    async (bareClaim) => {
+      updateUsername.mockResolvedValue({
+        ok: true,
+        data: okBody({ bareClaim }),
+      });
+      const el = await mount();
+
+      await submit(el, "Ninja");
+
+      expect(showInGameAlert).not.toHaveBeenCalled();
+      expect(reload).toHaveBeenCalled();
+    },
+  );
+
+  // Before the API change ships, the field is simply absent. Behaviour must be
+  // identical to today: reload, no dialog.
+  it("says nothing when the API does not send the field", async () => {
+    updateUsername.mockResolvedValue({ ok: true, data: okBody() });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalled();
+  });
+
+  it("still surfaces the 409s that survive as an inline error", async () => {
+    updateUsername.mockResolvedValue({ ok: false, code: "taken" });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(reload).not.toHaveBeenCalled();
+    expect(el.textContent).toContain("username_error_taken");
+  });
+});

--- a/tests/client/UsernameBareClaim.test.ts
+++ b/tests/client/UsernameBareClaim.test.ts
@@ -1,16 +1,24 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { PutUsernameResponseSchema } from "../../src/core/ApiSchemas";
 
 // The panel reaches the API and the in-game dialog; stub both boundaries so
 // these exercise the branch on the response body rather than the network.
-const updateUsername = vi.fn();
+//
+// vi.hoisted because vi.mock is hoisted above the imports: the spies have to
+// exist before the factories can close over them. Same shape as
+// UsernameVerifiedRoute.test.ts.
+const { updateUsername, showInGameConfirm, showInGameAlert } = vi.hoisted(
+  () => ({
+    updateUsername: vi.fn(),
+    showInGameConfirm: vi.fn(async (_message: string, _options?: unknown) =>
+      Promise.resolve(true),
+    ),
+    showInGameAlert: vi.fn(async (_message: string) => Promise.resolve(true)),
+  }),
+);
 vi.mock("../../src/client/Api", () => ({
   updateUsername: (name: string) => updateUsername(name),
 }));
-const showInGameConfirm = vi.fn(
-  async (_message: string, _options?: unknown) => true,
-);
-const showInGameAlert = vi.fn(async (_message: string) => true);
 vi.mock("../../src/client/InGameModal", () => ({
   showInGameConfirm: (message: string, options?: unknown) =>
     showInGameConfirm(message, options),
@@ -68,6 +76,11 @@ describe("PutUsernameResponseSchema bareClaim", () => {
 
 describe("UsernamePanel bare-claim fallback", () => {
   let reload: ReturnType<typeof vi.fn>;
+  const realLocation = window.location;
+  const realLocationDescriptor = Object.getOwnPropertyDescriptor(
+    window,
+    "location",
+  )!;
 
   function player(
     overrides: Record<string, unknown> = {},
@@ -115,11 +128,19 @@ describe("UsernamePanel bare-claim fallback", () => {
     showInGameAlert.mockReset();
     showInGameAlert.mockResolvedValue(true);
     reload = vi.fn();
-    // jsdom's location.reload is not implemented; replace it outright.
+    // jsdom's location.reload throws "not implemented", and `reload` itself is
+    // a non-configurable own property — vi.spyOn(window.location, "reload")
+    // fails with "Cannot redefine property". `window.location` as a whole IS
+    // configurable here, so replacing the object is the way in.
     Object.defineProperty(window, "location", {
       configurable: true,
-      value: { ...window.location, reload, hash: "" },
+      value: { ...realLocation, reload, hash: "" },
     });
+  });
+
+  afterEach(() => {
+    // Put the real one back rather than leaving a global replaced.
+    Object.defineProperty(window, "location", realLocationDescriptor);
   });
 
   // The whole point of this change: a fallback is a 200, so without it the


### PR DESCRIPTION
Prepares the client for infra #593 (OPE-225), which stops 409-ing a premium player whose chosen bare name is already held. After that change the API grants the suffixed form and returns **200** with `bareClaim: "unavailable"`.

**This must land before #593.** It is not a nice-to-have ordering preference — without it the deployed client is strictly *worse off* than the bug #593 fixes.

## Why

`UsernamePanel.handleSave` calls `window.location.reload()` on any 200 without inspecting the body. So once #593 ships to an unprepared client:

- premium player types `Ninja` → 200 → reload → modal reopens showing `Ninja.4471` → **no message at all**
- and because the fallback is a *real* rename, their 30-day cooldown is spent, locking them to a name they never chose

What that replaces is a 409 that said plainly "that username is already taken — try another", with no rename and no cooldown consumed. Trading a clear error for a silent month-long loss is a regression.

It is forward-compatible, so landing it first has no bad window in either direction: with #593 unmerged the API simply never sends the field and behaviour is byte-for-byte what it is today.

## Changes

1. **`bareClaim` added to `PutUsernameResponseSchema`** (`src/core/ApiSchemas.ts`) as a 3-value enum — `claimed` / `unavailable` / `not_eligible`. Three values rather than a boolean so callers don't have to re-derive eligibility from `usernameStatus` in order to avoid telling a free player that their perfectly ordinary suffixed rename "fell back". Zod strips unknown keys rather than erroring, which is why the field is silently dropped today and nothing looks broken.

2. **`UsernamePanel` explains the fallback before reloading** — naming what they asked for, what they actually got, and that the change used their rename. Awaited, so the reload cannot race the dialog away. Silent for `claimed` and `not_eligible`.

3. **The stale comment on `updateUsername`** (`src/client/Api.ts`) no longer claims both 409s are claim conflicts. The claim-conflict 409 is gone; the "name equals an existing public id" and "discriminator exhausted" ones remain and still map to `taken`.

## One deviation from the brief, and it matters

**`bareClaim` is `.optional()`, not required.**

The contract says the field is always present and never undefined — true, but only *after* #593 deploys. This PR ships first, and `updateUsername` reads the response with `safeParse`:

```ts
const parsed = PutUsernameResponseSchema.safeParse(await response.json());
if (!parsed.success) {
  return { ok: false, code: "failed" };
}
```

A required field would therefore make **every rename against the current API** fail validation and surface as a generic "failed" — breaking renames outright for everyone in exactly the window this PR exists to protect. Optional is what makes it safe to land first, and `undefined` is read as "the API predates this field, say nothing". The first test in the new file pins that.

## The date

The message names the date they can next rename, taken from `nextUsernameChangeAt` in the same response rather than hardcoding 30 days — the server is authoritative and the panel already formats dates this way for the grace warning. `nextUsernameChangeAt` is nullable, so there is a second key without the clause rather than a message with a blank date in it.

## Testing

`tests/client/UsernameBareClaim.test.ts` — 10 cases:

- schema parses a response **without** the field (the pre-#593 case that must not break), keeps all three values once sent, and rejects a value outside the enum rather than passing it through
- the panel explains the fallback and names both the requested and granted names before reloading
- it uses the date when supplied and drops the clause rather than rendering a blank one when null
- it says nothing for `claimed`, `not_eligible`, or an absent field — each asserting the reload still happens
- the surviving 409s still surface as an inline error with no dialog and no reload

Full suite: 347 files, 4175 tests. `tsc --noEmit`, `prettier --check .`, `npm run lint` clean. (`tests/client/InventoryModal.test.ts` intermittently fails under full-suite parallel load on this machine and passes when run alone — the known flake, unrelated to this change.)

Deliberately **not** the OPE-222 claim prompt. This is only the explanation that stops a silent loss; resolve-before-submit comes with OPE-222.
