### PR TITLE
fix(client): default the verified name on for eligible subscribers

### DIFF
--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -98,20 +98,33 @@ function truncateToCap(name: string): string {
 // Does the stored per-device preference mean "play under the verified name"?
 //
 // Tri-state, not a boolean: `"true"` is an explicit opt-in, `"false"` an
-// explicit opt-out, and *absent* is neither. Absent now defaults ON. The old
-// `=== "true"` test collapsed absent into opt-out, so every fresh profile —
-// which is every Steam install, and every new browser — silently declined the
-// perk the subscription was sold on: the player launched, got their persona,
-// and never played under the name they paid for.
+// explicit opt-out, and *absent* is neither. The old `=== "true"` test
+// collapsed absent into opt-out, so a fresh profile — every Steam install, and
+// every new browser — silently declined the perk the subscription was sold on:
+// the player launched, got their persona, and never played under the name they
+// paid for.
 //
-// An explicit opt-out still wins, and always will. This is a privacy default,
-// so it only fills the gap where the player has expressed nothing; one visible
-// click undoes it, and that click is recorded as `"false"`.
+// But absent does NOT mean "new". Before the default existed the toggle
+// rendered off and the only writer of this key was a click, so an existing
+// eligible subscriber who looked at the toggle and left it alone also has no
+// key. Defaulting *them* on would change the name they play under, in public,
+// with no action on their part — the opposite of what a privacy default is
+// for. `defaultAllowed` is what separates the two; see
+// resolveVerifiedDefaultCohort, which decides it once per profile.
+//
+// An explicit answer always wins, in both directions. Anything unrecognised is
+// not an answer the player gave, so it falls through to the cohort rather than
+// silently declining.
 //
 // Eligibility is the caller's business — this answers only what the player
 // asked for, not whether they may have it.
-export function verifiedNameOptIn(stored: string | null): boolean {
-  return stored !== "false";
+export function verifiedNameOptIn(
+  stored: string | null,
+  defaultAllowed: boolean,
+): boolean {
+  if (stored === "true") return true;
+  if (stored === "false") return false;
+  return defaultAllowed;
 }
 
 // A platform persona reduced to something playable, or null when nothing

--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -95,6 +95,25 @@ function truncateToCap(name: string): string {
   return hard.slice(0, lastSpace);
 }
 
+// Does the stored per-device preference mean "play under the verified name"?
+//
+// Tri-state, not a boolean: `"true"` is an explicit opt-in, `"false"` an
+// explicit opt-out, and *absent* is neither. Absent now defaults ON. The old
+// `=== "true"` test collapsed absent into opt-out, so every fresh profile —
+// which is every Steam install, and every new browser — silently declined the
+// perk the subscription was sold on: the player launched, got their persona,
+// and never played under the name they paid for.
+//
+// An explicit opt-out still wins, and always will. This is a privacy default,
+// so it only fills the gap where the player has expressed nothing; one visible
+// click undoes it, and that click is recorded as `"false"`.
+//
+// Eligibility is the caller's business — this answers only what the player
+// asked for, not whether they may have it.
+export function verifiedNameOptIn(stored: string | null): boolean {
+  return stored !== "false";
+}
+
 // A platform persona reduced to something playable, or null when nothing
 // usable survives.
 //

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -285,10 +285,15 @@ export class UsernameInput extends LitElement {
   // Turn the toggle on iff the player has not opted out AND is still eligible;
   // silently off otherwise (logout, lapsed sub, TEMPORARY rename).
   //
-  // "Has not opted out" rather than "opted in": the preference is tri-state
-  // and an absent one defaults on for an eligible player (see
-  // verifiedNameOptIn). Deliberately not persisted here — leaving it absent is
-  // what keeps a later explicit opt-out distinguishable from the default.
+  // "Has not opted out" rather than "opted in": the preference is tri-state,
+  // and an absent one defaults on only for a profile we identified as new
+  // (see verifiedNameOptIn and resolveVerifiedDefaultCohort). An existing
+  // player with no stored preference is treated as having declined.
+  //
+  // The default is deliberately never written back into the preference. The
+  // cohort marker records what we observed about the profile; recording an
+  // opt-in the player never expressed is a different thing, and it is the
+  // value account-level settings sync would later propagate.
   private applyVerifiedPreference() {
     this.verifiedActive =
       !this.onCrazyGames &&

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -39,11 +39,50 @@ const useVerifiedNameKey: string = "useVerifiedName";
 // "The stored username is one we generated, not one the player chose." Written
 // alongside the name itself; see usernameIsGenerated.
 const usernameIsGeneratedKey: string = "usernameIsGenerated";
+// Whether the verified-name default may apply to this profile at all. Decided
+// once, the first time this code runs here, and never revisited. See
+// resolveVerifiedDefaultCohort.
+const verifiedDefaultAllowedKey: string = "verifiedNameDefaultAllowed";
 
 // Announced by the clan modal, which invalidates /users/@me but dispatches no
 // fresh userMeResponse.
 const CLAN_REMOVED_EVENTS = ["clan-left", "clan-disbanded"];
 const CLAN_MEMBERSHIP_EVENTS = ["clan-joined", ...CLAN_REMOVED_EVENTS];
+
+// Decide, once per profile, whether the verified-name default is allowed to
+// apply here — and record it, because the evidence is destroyed moments later.
+//
+// The default exists for players who have never seen the toggle. But "no
+// stored preference" does not mean that on its own: before the default
+// existed the toggle rendered off and the only writer of the preference was a
+// click, so an existing eligible subscriber who looked at it and left it alone
+// is in exactly the same state as a brand-new install. Turning that player's
+// real account name on without them touching anything is a silent public
+// identity change, which is the opposite of what a privacy default is for.
+//
+// A stored username is the only durable trace a profile leaves, and
+// validateAndStore is its only writer — so at construction, before
+// loadStoredUsername runs, "no stored username" means "this profile has never
+// played here". That is the whole discriminator.
+//
+// It has to be recorded rather than recomputed: one boot later the new profile
+// has a stored username too and would be indistinguishable from an old one, so
+// a re-mount or a reload would revoke the default it had just granted.
+function resolveVerifiedDefaultCohort(onCrazyGames: boolean): void {
+  // CrazyGames never persists a username (see validateAndStore), so there is
+  // no history to read, and verifiedActive is gated off there regardless.
+  if (onCrazyGames) return;
+  if (localStorage.getItem(verifiedDefaultAllowedKey) !== null) return;
+  // An answered preference makes the default moot either way; record the
+  // decision anyway so this never re-runs against a profile that has since
+  // acquired a stored username.
+  const answered = localStorage.getItem(useVerifiedNameKey) !== null;
+  const hasPlayedHere = localStorage.getItem(usernameKey) !== null;
+  localStorage.setItem(
+    verifiedDefaultAllowedKey,
+    String(!answered && !hasPlayedHere),
+  );
+}
 
 // Shared by the input and the verified chip, which swap places: any drift in
 // box or text metrics shows up as the name jumping on toggle.
@@ -119,6 +158,9 @@ export class UsernameInput extends LitElement {
 
   constructor() {
     super();
+    // Before anything can write a username: this reads the absence of one as
+    // "this profile is new", and loadStoredUsername destroys that evidence.
+    resolveVerifiedDefaultCohort(this.onCrazyGames);
     // Account state for the verified-name toggle. Same document-level pattern
     // as AccountModal; Main dispatches this after auth resolves and on
     // CrazyGames sign-in.
@@ -250,7 +292,10 @@ export class UsernameInput extends LitElement {
   private applyVerifiedPreference() {
     this.verifiedActive =
       !this.onCrazyGames &&
-      verifiedNameOptIn(localStorage.getItem(useVerifiedNameKey)) &&
+      verifiedNameOptIn(
+        localStorage.getItem(useVerifiedNameKey),
+        localStorage.getItem(verifiedDefaultAllowedKey) === "true",
+      ) &&
       this.verifiedName() !== null;
     this.requestUpdate();
     this.validateAndStore();

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -22,6 +22,7 @@ import {
   genAnonUsername,
   looksGenerated,
   resolvePlayerName,
+  verifiedNameOptIn,
   type ResolvedPlayerName,
 } from "./PlayerName";
 import { steamSDK } from "./SteamSDK";
@@ -239,14 +240,17 @@ export class UsernameInput extends LitElement {
     return accountVerifiedName(this.userMe);
   }
 
-  // Turn the toggle on iff the player opted in previously AND is still
-  // eligible; silently off otherwise (logout, lapsed sub, TEMPORARY rename).
-  // Never auto-enables without a stored opt-in — players who want to stay
-  // anonymous must be able to play under an unrelated name.
+  // Turn the toggle on iff the player has not opted out AND is still eligible;
+  // silently off otherwise (logout, lapsed sub, TEMPORARY rename).
+  //
+  // "Has not opted out" rather than "opted in": the preference is tri-state
+  // and an absent one defaults on for an eligible player (see
+  // verifiedNameOptIn). Deliberately not persisted here — leaving it absent is
+  // what keeps a later explicit opt-out distinguishable from the default.
   private applyVerifiedPreference() {
     this.verifiedActive =
       !this.onCrazyGames &&
-      localStorage.getItem(useVerifiedNameKey) === "true" &&
+      verifiedNameOptIn(localStorage.getItem(useVerifiedNameKey)) &&
       this.verifiedName() !== null;
     this.requestUpdate();
     this.validateAndStore();

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -612,6 +612,55 @@ describe("UsernameInput verified name", () => {
     expect(q(el, TOGGLE)).toBeNull();
   });
 
+  // The regression this guards: before the default existed the toggle rendered
+  // off and only a click wrote the preference, so an existing subscriber who
+  // saw the toggle and left it alone has no key either. Defaulting them on
+  // would change the name they play under, in public, with no action on their
+  // part — which is the harm a privacy default is meant to avoid.
+  it("stays off for an existing profile that never answered", async () => {
+    // A stored username is the trace of a profile that has played here before.
+    localStorage.setItem("username", "MyCoolName");
+    const el = await mount();
+    await signIn(el, premiumUser());
+
+    expect(el.isVerified()).toBe(false);
+    expect(el.getUsername()).toBe("MyCoolName");
+    expect(q(el, TOGGLE)).not.toBeNull();
+  });
+
+  // The cohort has to be recorded, not recomputed: one boot later the new
+  // profile has a stored username too, so re-deriving it would revoke the
+  // default it had just granted.
+  it("keeps the default across a remount, once the profile is known to be new", async () => {
+    const first = await mount();
+    await signIn(first, premiumUser());
+    expect(first.isVerified()).toBe(true);
+    // loadStoredUsername has now written a username, destroying the evidence.
+    expect(localStorage.getItem("username")).not.toBeNull();
+
+    document.body.innerHTML = "";
+    const second = await mount();
+    await signIn(second, premiumUser());
+
+    expect(second.isVerified()).toBe(true);
+  });
+
+  it("decides the cohort once and does not revisit it", async () => {
+    localStorage.setItem("username", "MyCoolName");
+    await mount();
+    expect(localStorage.getItem("verifiedNameDefaultAllowed")).toBe("false");
+
+    // Even if the stored username is later cleared, the profile does not
+    // become "new" again.
+    localStorage.removeItem("username");
+    document.body.innerHTML = "";
+    const second = await mount();
+    await signIn(second, premiumUser());
+
+    expect(localStorage.getItem("verifiedNameDefaultAllowed")).toBe("false");
+    expect(second.isVerified()).toBe(false);
+  });
+
   // The default fills a gap; it never overrides an answer.
   it("stays off when the player has explicitly opted out", async () => {
     localStorage.setItem("useVerifiedName", "false");

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -596,13 +596,56 @@ describe("UsernameInput name length", () => {
 });
 
 describe("UsernameInput verified name", () => {
-  it("renders the free-text field and an off-state toggle by default", async () => {
+  // An eligible subscriber who has expressed no preference plays under the
+  // name they paid for. The preference used to be read as `=== "true"`, which
+  // collapsed "never asked" into "declined" — so every fresh profile, which is
+  // every Steam install, silently opted out of the headline perk.
+  it("plays verified by default when eligible and no preference is stored", async () => {
+    const el = await mount();
+    await signIn(el, premiumUser());
+
+    expect(el.isVerified()).toBe(true);
+    expect(el.getUsername()).toBe("RyanTheGreat");
+    // Only the active trailing button exists, so neither can be tabbed to or
+    // read out while it doesn't apply.
+    expect(q(el, CHANGE)).not.toBeNull();
+    expect(q(el, TOGGLE)).toBeNull();
+  });
+
+  // The default fills a gap; it never overrides an answer.
+  it("stays off when the player has explicitly opted out", async () => {
+    localStorage.setItem("useVerifiedName", "false");
+    localStorage.setItem("username", "MyCoolName");
     const el = await mount();
     await signIn(el, premiumUser());
 
     expect(el.isVerified()).toBe(false);
-    // Only the active trailing button exists, so neither can be tabbed to or
-    // read out while it doesn't apply.
+    expect(el.getUsername()).toBe("MyCoolName");
+    expect(q(el, TOGGLE)).not.toBeNull();
+    expect(q(el, CHANGE)).toBeNull();
+  });
+
+  // Leaving the default unpersisted is what keeps a later opt-out
+  // distinguishable from it.
+  it("does not persist the default, and records an explicit opt-out", async () => {
+    const el = await mount();
+    await signIn(el, premiumUser());
+    expect(localStorage.getItem("useVerifiedName")).toBeNull();
+
+    q(el, CHANGE)!.click();
+    await el.updateComplete;
+
+    expect(localStorage.getItem("useVerifiedName")).toBe("false");
+    expect(el.isVerified()).toBe(false);
+  });
+
+  it("renders the free-text field and an off-state toggle when ineligible", async () => {
+    const el = await mount();
+    await signIn(el, {
+      player: { username: null, usernameBase: null, usernameStatus: "none" },
+    } as unknown as UserMeResponse);
+
+    expect(el.isVerified()).toBe(false);
     expect(q(el, TOGGLE)).not.toBeNull();
     expect(q(el, CHANGE)).toBeNull();
   });
@@ -628,6 +671,9 @@ describe("UsernameInput verified name", () => {
   });
 
   it("restores the stored custom name when switching back", async () => {
+    // Starts opted out so the round trip begins on the free-form name; the
+    // default-on case is covered above.
+    localStorage.setItem("useVerifiedName", "false");
     localStorage.setItem("username", "MyCoolName");
     const el = await mount();
     await signIn(el, premiumUser());

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -398,23 +398,38 @@ describe("accountVerifiedName", () => {
 });
 
 describe("verifiedNameOptIn", () => {
-  it("honours an explicit choice in both directions", () => {
-    expect(verifiedNameOptIn("true")).toBe(true);
-    expect(verifiedNameOptIn("false")).toBe(false);
+  it("honours an explicit choice in both directions, whatever the cohort", () => {
+    expect(verifiedNameOptIn("true", false)).toBe(true);
+    expect(verifiedNameOptIn("true", true)).toBe(true);
+    expect(verifiedNameOptIn("false", true)).toBe(false);
+    expect(verifiedNameOptIn("false", false)).toBe(false);
   });
 
   // The gap this closes: reading the preference as `=== "true"` treated
   // "never asked" as "declined", so a fresh profile — every Steam install —
   // never played under the name the subscription was sold on.
-  it("defaults on when the player has expressed nothing", () => {
-    expect(verifiedNameOptIn(null)).toBe(true);
+  it("defaults on for a profile that has expressed nothing and is new", () => {
+    expect(verifiedNameOptIn(null, true)).toBe(true);
   });
 
-  // Only the exact opt-out string turns it off; anything else is not an answer
-  // the player gave, so it falls to the default rather than silently declining.
+  // The cohort is the whole point: an existing subscriber who looked at the
+  // toggle and left it alone has no stored preference either, and flipping
+  // their public identity without them touching anything is the harm the
+  // default was supposed to avoid.
+  it("stays off for a profile with no preference that is not new", () => {
+    expect(verifiedNameOptIn(null, false)).toBe(false);
+  });
+
+  // Not an answer the player gave, so it falls through to the cohort rather
+  // than being read as either choice.
   it("treats an unrecognised value as no preference", () => {
     for (const stored of ["", "False", "FALSE", "0", "no", "yes"]) {
-      expect(verifiedNameOptIn(stored), JSON.stringify(stored)).toBe(true);
+      expect(verifiedNameOptIn(stored, true), JSON.stringify(stored)).toBe(
+        true,
+      );
+      expect(verifiedNameOptIn(stored, false), JSON.stringify(stored)).toBe(
+        false,
+      );
     }
   });
 });

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -7,6 +7,7 @@ import {
   looksGenerated,
   resolvePlayerName,
   sanitizePersona,
+  verifiedNameOptIn,
   type PlayerNameInputs,
 } from "../../src/client/PlayerName";
 import type { UserMeResponse } from "../../src/core/ApiSchemas";
@@ -393,6 +394,28 @@ describe("accountVerifiedName", () => {
         player({ username: "TEMPORARY7823", usernameBase: "TEMPORARY7823" }),
       ),
     ).toBeNull();
+  });
+});
+
+describe("verifiedNameOptIn", () => {
+  it("honours an explicit choice in both directions", () => {
+    expect(verifiedNameOptIn("true")).toBe(true);
+    expect(verifiedNameOptIn("false")).toBe(false);
+  });
+
+  // The gap this closes: reading the preference as `=== "true"` treated
+  // "never asked" as "declined", so a fresh profile — every Steam install —
+  // never played under the name the subscription was sold on.
+  it("defaults on when the player has expressed nothing", () => {
+    expect(verifiedNameOptIn(null)).toBe(true);
+  });
+
+  // Only the exact opt-out string turns it off; anything else is not an answer
+  // the player gave, so it falls to the default rather than silently declining.
+  it("treats an unrecognised value as no preference", () => {
+    for (const stored of ["", "False", "FALSE", "0", "no", "yes"]) {
+      expect(verifiedNameOptIn(stored), JSON.stringify(stored)).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
Closes #5091.

**Stacked on #5209** (OPE-221) → `main`. Review that one first; this diff is only the toggle change, and it retargets when #5209 lands.

## The bug

The preference is read as one equality test:

```ts
localStorage.getItem(useVerifiedNameKey) === "true"
```

That collapses three states into two. An explicit opt-in, an explicit opt-out, and *never asked* all go through the same test, and "never asked" lands on off. A fresh profile has no key — which is every Steam install and every new browser — so a linked subscriber launches the paid client, gets their Steam persona, and **never plays under the name their subscription was sold on**.

## Who gets the new default, who does not, and why the boundary is there

This is the part worth reading, because the obvious fix is wrong.

Reading the preference as a tri-state and defaulting *absent* to on is **not** scoped to new profiles. Before this change the toggle rendered **off**, and the only writer of `useVerifiedName` was `handleVerifiedToggle` — a click. So an existing eligible subscriber who saw the toggle and deliberately left it alone has **no key either**. They are byte-for-byte indistinguishable from a fresh install.

`applyVerifiedPreference()` re-runs on every auth event, so defaulting on key-absence alone would mean: on their very next session, a subscriber who had been deliberately playing anonymously has their real account name adopted and shown to everyone in the lobby, with no action on their part. That is a silent public identity change — the exact harm a privacy default is supposed to avoid, and the inverse of this PR's own stated principle. (Found by the Claude CI review; it was right.)

So the boundary is **positive evidence that the profile is new**, not absence of a preference:

| profile | stored preference | gets the default? |
| --- | --- | --- |
| fresh install / new browser | absent | **yes** — nobody has ever been asked |
| existing player, never clicked | absent | **no** — indistinguishable from a decline, so assume the decline |
| anyone who clicked | `"true"` / `"false"` | their answer, in both directions |
| ineligible / signed out / `TEMPORARY####` | any | no — eligibility gates everything, unchanged |

**The discriminator** is a stored `username`. `validateAndStore` is its only writer, and nothing writes one before `loadStoredUsername()` — so read at *construction*, "no stored username" means "this profile has never played here". That is why `resolveVerifiedDefaultCohort` runs in the constructor rather than in `connectedCallback`.

**It has to be recorded, not recomputed.** One boot later the new profile has a stored username too and is indistinguishable from an old one — so a remount or a reload would revoke the default it had just granted, and the player would watch their name flip back. `verifiedNameDefaultAllowed` records the decision once and it is never revisited. There is a test for the remount case specifically, because that is the failure mode this shape invites.

**The preference itself is still never written by the default.** The cohort marker records *what we observed about the profile*; it does not fabricate an answer the player never gave. Writing `"true"` into `useVerifiedName` would have been simpler and would have recorded them as having opted in — which is the value OPE-227 would later sync to their account.

An explicit answer always wins in both directions. Anything unrecognised (`""`, `"False"`, `"0"`) is not an answer the player gave, so it falls through to the cohort rather than being read as either choice.

## Testing

- `tests/client/PlayerName.test.ts` — the tri-state × cohort matrix directly: explicit choices honoured regardless of cohort, absent+new defaults on, absent+not-new stays off, unrecognised values fall through to the cohort in both directions.
- `tests/UsernameInput.test.ts` — through the component: an existing profile that never answered stays off; a fresh profile gets the default **and keeps it across a remount**; the cohort is decided once and survives the stored username later being cleared; an explicit opt-out stays off; the default is not written to `useVerifiedName` while an explicit opt-out is; an ineligible player still gets the off-state toggle.

Mutation-checked rather than assumed: forcing `verifiedNameOptIn` to return `true` for the absent case fails 4 tests, including both component-level cohort tests.

Two pre-existing tests pinned the old default and now assert the new one. `restores the stored custom name when switching back` starts from an explicit opt-out so it still exercises the off→on→off round trip; `renders the free-text field and an off-state toggle by default` became `…when ineligible`, which is the case that still produces that rendering.

Full suite: 346 files, **4228 tests, zero failures**. `tsc --noEmit`, `prettier --check .`, `npm run lint` clean.

## Worth flagging for the reviewer

Linear notes that Evan has proposed a better root fix — storing user settings as jsonb on the account so the preference follows the player rather than living in per-device `localStorage`. That is tracked separately and would supersede this, including the cohort marker. This is queued ahead of it only because it is small against the RC date; if the account-settings work lands first, this should be re-scoped rather than kept as written.
