### PR TITLE
feat(client): tell the player when their reserved name is running out

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1969,6 +1969,7 @@
   },
   "username": {
     "account_invalid_chars": "Username can only contain letters, numbers, underscores, hyphens, and single spaces between words.",
+    "claim_reserved": "\"{name}\" is reserved for you until {date}. Resubscribe before then to keep it.",
     "clan_browse": "Browse clans",
     "clan_clear": "No tag",
     "clan_custom": "Other tag",
@@ -1977,6 +1978,7 @@
     "clan_your_clans": "Your clans",
     "enter_username": "Enter your username",
     "invalid_chars": "Username can only contain letters, numbers, spaces, underscores, hyphens, and periods.",
+    "lapse_notice": "Your subscription ended, so you are no longer playing as \"{name}\". It stays reserved for you until {date} — resubscribe before then to keep it. After that anyone can take it.",
     "not_string": "Username must be a string.",
     "tag": "TAG",
     "tag_invalid_chars": "Clan tag can only contain letters and numbers.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1969,6 +1969,7 @@
   },
   "username": {
     "account_invalid_chars": "Username can only contain letters, numbers, underscores, hyphens, and single spaces between words.",
+    "claim_at_risk": "\"{name}\" is no longer reserved and can be taken by another player at any moment. Resubscribe now to keep it.",
     "claim_reserved": "\"{name}\" is reserved for you until {date}. Resubscribe before then to keep it.",
     "clan_browse": "Browse clans",
     "clan_clear": "No tag",
@@ -1979,6 +1980,7 @@
     "enter_username": "Enter your username",
     "invalid_chars": "Username can only contain letters, numbers, spaces, underscores, hyphens, and periods.",
     "lapse_notice": "Your subscription ended, so you are no longer playing as \"{name}\". It stays reserved for you until {date} — resubscribe before then to keep it. After that anyone can take it.",
+    "lapse_notice_at_risk": "You are no longer playing as \"{name}\", and it is no longer reserved. Another player can take it at any moment — resubscribe now to keep it.",
     "not_string": "Username must be a string.",
     "tag": "TAG",
     "tag_invalid_chars": "Clan tag can only contain letters and numbers.",

--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -127,6 +127,41 @@ export function verifiedNameOptIn(
   return defaultAllowed;
 }
 
+/** A bare name still reserved for a lapsed holder, and when that ends. */
+export interface ClaimGrace {
+  name: string;
+  expiresAt: Date;
+}
+
+// What the player is about to lose, or null when nothing is at stake.
+//
+// `claimed` is the lapsed state: the subscription is gone, so the player no
+// longer plays under the name, but the server keeps the bare claim reserved
+// until `usernameClaimExpiresAt`. Resubscribing inside that window is safe —
+// tryClaimBareUsername sees the holder is still them and clears the deadline.
+//
+// After it expires anyone may take the name, and if they do, a later
+// resubscribe puts the original holder through ensureBareClaim's TEMPORARY####
+// rename. That is the outcome this whole notice exists to prevent, and there
+// is no out-of-game channel to warn a Steam-only account through.
+//
+// Returns null once the deadline has passed: the reservation is over, so a
+// countdown to a date in the past would be worse than saying nothing.
+export function verifiedClaimGrace(
+  userMe: UserMeResponse | false | null,
+  now: Date = new Date(),
+): ClaimGrace | null {
+  if (userMe === null || userMe === false) return null;
+  const player = userMe.player;
+  if (player.usernameStatus !== "claimed") return null;
+  const name = player.usernameBase;
+  const at = player.usernameClaimExpiresAt;
+  if (!name || !at || isTemporaryUsername(name)) return null;
+  const expiresAt = new Date(at);
+  if (!(expiresAt.getTime() > now.getTime())) return null;
+  return { name, expiresAt };
+}
+
 // A platform persona reduced to something playable, or null when nothing
 // usable survives.
 //

--- a/src/client/PlayerName.ts
+++ b/src/client/PlayerName.ts
@@ -127,10 +127,16 @@ export function verifiedNameOptIn(
   return defaultAllowed;
 }
 
-/** A bare name still reserved for a lapsed holder, and when that ends. */
+/** A bare name a lapsed holder can still get back, and when it stops being theirs. */
 export interface ClaimGrace {
   name: string;
   expiresAt: Date;
+  /**
+   * The deadline has passed: the name is takeable by any other subscriber now,
+   * but nobody has taken it yet, so resubscribing still recovers it. This is
+   * the window of highest risk, not the end of one.
+   */
+  atRisk: boolean;
 }
 
 // What the player is about to lose, or null when nothing is at stake.
@@ -145,8 +151,12 @@ export interface ClaimGrace {
 // rename. That is the outcome this whole notice exists to prevent, and there
 // is no out-of-game channel to warn a Steam-only account through.
 //
-// Returns null once the deadline has passed: the reservation is over, so a
-// countdown to a date in the past would be worse than saying nothing.
+// A passed deadline does NOT end this. usernameClaimExpiresAt's own schema
+// comment is explicit: "A past date means 'at risk', not 'lost' — it stays set
+// until the name is actually taken." Going quiet there would switch the warning
+// off at the exact moment the name is most likely to be lost and still cheapest
+// to save. `atRisk` marks that window; the `claimed` guard above is what ends
+// it, because a name actually taken moves the player out of that status.
 export function verifiedClaimGrace(
   userMe: UserMeResponse | false | null,
   now: Date = new Date(),
@@ -158,8 +168,7 @@ export function verifiedClaimGrace(
   const at = player.usernameClaimExpiresAt;
   if (!name || !at || isTemporaryUsername(name)) return null;
   const expiresAt = new Date(at);
-  if (!(expiresAt.getTime() > now.getTime())) return null;
-  return { name, expiresAt };
+  return { name, expiresAt, atRisk: expiresAt.getTime() <= now.getTime() };
 }
 
 // A platform persona reduced to something playable, or null when nothing

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -365,6 +365,11 @@ export class UsernameInput extends LitElement {
       this.claimGraceTimer = null;
       this.claimGrace = verifiedClaimGrace(this.userMe);
       this.scheduleClaimGraceExpiry();
+      // Mirrors applyVerifiedPreference. Without this the live transition only
+      // updates the standing banner, and the one interruption the phase-keyed
+      // marker exists to allow never happens for the player it was written
+      // for: the one sitting on the main menu across their own deadline.
+      this.announceLapse();
     }, delay);
   }
 

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -15,14 +15,16 @@ import { getUserMe, invalidateUserMe } from "./Api";
 import { checkClanTagOwnership } from "./ClanApi";
 import { verifiedBadge } from "./components/ui/VerifiedBadge";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
-import { showInGameConfirm } from "./InGameModal";
+import { showInGameAlert, showInGameConfirm } from "./InGameModal";
 import {
   accountVerifiedName,
   clampUsername,
   genAnonUsername,
   looksGenerated,
   resolvePlayerName,
+  verifiedClaimGrace,
   verifiedNameOptIn,
+  type ClaimGrace,
   type ResolvedPlayerName,
 } from "./PlayerName";
 import { steamSDK } from "./SteamSDK";
@@ -43,6 +45,9 @@ const usernameIsGeneratedKey: string = "usernameIsGenerated";
 // once, the first time this code runs here, and never revisited. See
 // resolveVerifiedDefaultCohort.
 const verifiedDefaultAllowedKey: string = "verifiedNameDefaultAllowed";
+// The reserved name we have already warned this device about; see
+// announceLapse. Holds a name, not a boolean, so a later lapse still speaks up.
+const lapseNoticeKey: string = "verifiedLapseNotice";
 
 // Announced by the clan modal, which invalidates /users/@me but dispatches no
 // fresh userMeResponse.
@@ -84,6 +89,18 @@ function resolveVerifiedDefaultCohort(onCrazyGames: boolean): void {
   );
 }
 
+// Same format the account modal's grace warning uses, so the two places that
+// name this deadline read alike. Local rather than shared: every component in
+// this codebase that shows a date formats its own (FriendsList, TribesPanel,
+// SubscriptionPanel, UsernamePanel).
+function formatClaimDate(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
 // Shared by the input and the verified chip, which swap places: any drift in
 // box or text metrics shows up as the name jumping on toggle.
 const NAME_BOX =
@@ -113,6 +130,9 @@ export class UsernameInput extends LitElement {
   // player chose. Persisted, because one localStorage string cannot tell the
   // two apart and the reseed rule turns entirely on the difference.
   private usernameIsGenerated: boolean = false;
+  // The bare name still reserved for this player and its deadline, while a
+  // lapsed subscription's grace clock runs. Null whenever nothing is at stake.
+  @state() private claimGrace: ClaimGrace | null = null;
 
   // Clans aren't supported on CrazyGames — hide the tag input and never submit one.
   private readonly onCrazyGames = crazyGamesSDK.isOnCrazyGames();
@@ -302,8 +322,42 @@ export class UsernameInput extends LitElement {
         localStorage.getItem(verifiedDefaultAllowedKey) === "true",
       ) &&
       this.verifiedName() !== null;
+    this.claimGrace = verifiedClaimGrace(this.userMe);
+    this.announceLapse();
     this.requestUpdate();
     this.validateAndStore();
+  }
+
+  // Say it once, the first time we see a reservation with a clock running.
+  //
+  // Keyed on the name rather than a bare "already announced" flag, and cleared
+  // whenever the player is eligible again, so a resubscribe-then-lapse cycle
+  // announces the second lapse too. A flag alone would announce once per
+  // install and then stay quiet through every later lapse.
+  //
+  // Deliberately scoped to the case where something is actually at stake. A
+  // logout or a TEMPORARY#### rename also turns the toggle off, but neither
+  // has a deadline attached and neither costs the player a name, so neither
+  // interrupts them.
+  private announceLapse() {
+    if (this.onCrazyGames) return;
+    if (this.verifiedName() !== null) {
+      localStorage.removeItem(lapseNoticeKey);
+      return;
+    }
+    const grace = this.claimGrace;
+    if (grace === null) return;
+    if (localStorage.getItem(lapseNoticeKey) === grace.name) return;
+    // Recorded before the dialog, not after: the alert resolves only when the
+    // player dismisses it, and an unawaited promise that never settles would
+    // let a second announcement through.
+    localStorage.setItem(lapseNoticeKey, grace.name);
+    void showInGameAlert(
+      translateText("username.lapse_notice", {
+        name: grace.name,
+        date: formatClaimDate(grace.expiresAt),
+      }),
+    );
   }
 
   private async handleVerifiedToggle() {
@@ -613,8 +667,31 @@ export class UsernameInput extends LitElement {
           </div>`
         : this.clanTagOwnershipError
           ? this.renderClanTagOwnershipError()
-          : null}
+          : this.renderClaimGrace()}
     `;
+  }
+
+  // A standing reminder for as long as the reservation lasts. The one-time
+  // notice announces the change; this is what a player who dismissed it — or
+  // who was not at the keyboard when it fired — still sees, every launch,
+  // until either they resubscribe or the name is gone.
+  //
+  // Amber rather than red: nothing is broken and play is not blocked. It sits
+  // in the same slot as the validation error, which cannot be showing at the
+  // same time (that would mean the player is mid-edit on their free-form name,
+  // and this notice would be the less urgent of the two).
+  private renderClaimGrace() {
+    const grace = this.claimGrace;
+    if (grace === null) return null;
+    return html`<div
+      id="username-claim-grace"
+      class="absolute top-full left-0 z-40 w-full mt-1 px-3 py-2 text-sm font-medium border border-amber-500/40 rounded-lg bg-amber-950/90 text-amber-200 backdrop-blur-md shadow-lg"
+    >
+      ${translateText("username.claim_reserved", {
+        name: grace.name,
+        date: formatClaimDate(grace.expiresAt),
+      })}
+    </div>`;
   }
 
   // Members pick from their own clans rather than guessing a tag and waiting

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -330,11 +330,21 @@ export class UsernameInput extends LitElement {
         localStorage.getItem(verifiedDefaultAllowedKey) === "true",
       ) &&
       this.verifiedName() !== null;
+    this.refreshClaimGrace();
+    this.requestUpdate();
+    this.validateAndStore();
+  }
+
+  // Re-derive the reservation, re-arm the clock, and speak up if the phase
+  // changed. Every path that can move this state goes through here — an
+  // account event, the expiry timer, and reconnecting — so none of them can
+  // do two of the three and silently skip the other. That is exactly how the
+  // banner once escalated with no alert behind it, and how reconnecting past
+  // a deadline left the stale wording in place.
+  private refreshClaimGrace() {
     this.claimGrace = verifiedClaimGrace(this.userMe);
     this.scheduleClaimGraceExpiry();
     this.announceLapse();
-    this.requestUpdate();
-    this.validateAndStore();
   }
 
   // Escalate the notice the moment the reservation lapses.
@@ -363,13 +373,7 @@ export class UsernameInput extends LitElement {
     const delay = Math.min(ms, MAX_TIMEOUT_MS);
     this.claimGraceTimer = setTimeout(() => {
       this.claimGraceTimer = null;
-      this.claimGrace = verifiedClaimGrace(this.userMe);
-      this.scheduleClaimGraceExpiry();
-      // Mirrors applyVerifiedPreference. Without this the live transition only
-      // updates the standing banner, and the one interruption the phase-keyed
-      // marker exists to allow never happens for the player it was written
-      // for: the one sitting on the main menu across their own deadline.
-      this.announceLapse();
+      this.refreshClaimGrace();
     }, delay);
   }
 
@@ -410,8 +414,14 @@ export class UsernameInput extends LitElement {
     // translation files, and auth can resolve first. Announcing here would
     // show the player the literal string "username.lapse_notice" AND burn the
     // marker, so the real notice would never fire — for a one-shot warning
-    // that is the only channel a Steam-only account has. Bail instead;
-    // applyVerifiedPreference runs again on later account events.
+    // that is the only channel a Steam-only account has.
+    //
+    // Bailing costs the alert for this session, not for good: the marker is
+    // left unwritten, so it fires normally on the next launch. Nothing
+    // re-enters this when the language files land — applyVerifiedPreference
+    // only re-runs on account events, and LangSelector's requestUpdate
+    // re-renders the standing banner without coming back through here. Only
+    // reachable on a non-English locale, since `en` is a static import.
     if (message === key) return;
     // Recorded before the dialog, not after: the alert resolves only when the
     // player dismisses it, and an unawaited promise that never settles would
@@ -556,14 +566,18 @@ export class UsernameInput extends LitElement {
     for (const type of CLAN_MEMBERSHIP_EVENTS) {
       document.addEventListener(type, this.handleClanMembershipChange);
     }
-    // Re-arm unconditionally, before the fetch below can short-circuit.
+    // Refresh unconditionally, before the fetch below can short-circuit.
     // disconnectedCallback clears the timer but leaves userMe set, so a
     // detach/reattach of the same instance takes the `userMe !== null` early
-    // return and never reaches applyVerifiedPreference — leaving a stale
-    // claimGrace with nothing scheduled to clear it, which is the exact
-    // failure the timer exists to prevent. Safe when nothing is pending: it
-    // clears any existing timer and no-ops on a null grace.
-    this.scheduleClaimGraceExpiry();
+    // return and never reaches applyVerifiedPreference. Re-arming alone was
+    // not enough: if the deadline passed while detached, the stale grace made
+    // the scheduler bail on `ms <= 0` without ever flipping to the at-risk
+    // wording or announcing it. Re-deriving first is what closes that.
+    //
+    // This path looks unreachable today — <play-page> is hidden by class
+    // toggling rather than removed — so treat it as keeping the comment
+    // honest rather than fixing a live bug.
+    this.refreshClaimGrace();
     // userMeResponse is dispatched once and can fire before this connects.
     // Cached, so this re-reads that response rather than refetching.
     void getUserMe().then((me) => {

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -337,13 +337,13 @@ export class UsernameInput extends LitElement {
     this.validateAndStore();
   }
 
-  // Drop the notice the moment the reservation actually ends.
+  // Escalate the notice the moment the reservation lapses.
   //
   // verifiedClaimGrace is evaluated only when account state changes, and a
   // client sitting on the main menu receives none — so without this the notice
-  // would keep naming a deadline that had already passed. Re-deriving from the
-  // same userMe is what clears it: verifiedClaimGrace returns null once the
-  // deadline is behind us.
+  // would keep saying "reserved until {date}" after that date. Re-deriving from
+  // the same userMe flips it to the at-risk wording; nothing arms afterwards,
+  // because at-risk has no further deadline to wait for.
   //
   // The delay must be clamped by us. A 30-day reservation exceeds setTimeout's
   // 32-bit millisecond field, and Node does not saturate — it warns and fires
@@ -387,17 +387,32 @@ export class UsernameInput extends LitElement {
     }
     const grace = this.claimGrace;
     if (grace === null) return;
-    if (localStorage.getItem(lapseNoticeKey) === grace.name) return;
+    // Keyed on the phase as well as the name: crossing the deadline is a
+    // material change to what the player must do (resubscribe "before then"
+    // becomes "now, before someone takes it"), so it earns one more
+    // interruption. Without the phase a player warned while it was still
+    // reserved would never hear that it no longer is.
+    const marker = `${grace.name}:${grace.atRisk ? "atrisk" : "reserved"}`;
+    if (localStorage.getItem(lapseNoticeKey) === marker) return;
+    const key = grace.atRisk
+      ? "username.lapse_notice_at_risk"
+      : "username.lapse_notice";
+    const message = translateText(key, {
+      name: grace.name,
+      date: formatClaimDate(grace.expiresAt),
+    });
+    // translateText echoes the key back until <lang-selector> has fetched its
+    // translation files, and auth can resolve first. Announcing here would
+    // show the player the literal string "username.lapse_notice" AND burn the
+    // marker, so the real notice would never fire — for a one-shot warning
+    // that is the only channel a Steam-only account has. Bail instead;
+    // applyVerifiedPreference runs again on later account events.
+    if (message === key) return;
     // Recorded before the dialog, not after: the alert resolves only when the
     // player dismisses it, and an unawaited promise that never settles would
     // let a second announcement through.
-    localStorage.setItem(lapseNoticeKey, grace.name);
-    void showInGameAlert(
-      translateText("username.lapse_notice", {
-        name: grace.name,
-        date: formatClaimDate(grace.expiresAt),
-      }),
-    );
+    localStorage.setItem(lapseNoticeKey, marker);
+    void showInGameAlert(message);
   }
 
   private async handleVerifiedToggle() {
@@ -536,6 +551,14 @@ export class UsernameInput extends LitElement {
     for (const type of CLAN_MEMBERSHIP_EVENTS) {
       document.addEventListener(type, this.handleClanMembershipChange);
     }
+    // Re-arm unconditionally, before the fetch below can short-circuit.
+    // disconnectedCallback clears the timer but leaves userMe set, so a
+    // detach/reattach of the same instance takes the `userMe !== null` early
+    // return and never reaches applyVerifiedPreference — leaving a stale
+    // claimGrace with nothing scheduled to clear it, which is the exact
+    // failure the timer exists to prevent. Safe when nothing is pending: it
+    // clears any existing timer and no-ops on a null grace.
+    this.scheduleClaimGraceExpiry();
     // userMeResponse is dispatched once and can fire before this connects.
     // Cached, so this re-reads that response rather than refetching.
     void getUserMe().then((me) => {
@@ -743,10 +766,10 @@ export class UsernameInput extends LitElement {
       id="username-claim-grace"
       class="w-full px-3 py-2 text-sm font-medium border border-amber-500/40 rounded-lg bg-amber-950/90 text-amber-200 backdrop-blur-md shadow-lg"
     >
-      ${translateText("username.claim_reserved", {
-        name: grace.name,
-        date: formatClaimDate(grace.expiresAt),
-      })}
+      ${translateText(
+        grace.atRisk ? "username.claim_at_risk" : "username.claim_reserved",
+        { name: grace.name, date: formatClaimDate(grace.expiresAt) },
+      )}
     </div>`;
   }
 

--- a/src/client/UsernameInput.ts
+++ b/src/client/UsernameInput.ts
@@ -48,6 +48,9 @@ const verifiedDefaultAllowedKey: string = "verifiedNameDefaultAllowed";
 // The reserved name we have already warned this device about; see
 // announceLapse. Holds a name, not a boolean, so a later lapse still speaks up.
 const lapseNoticeKey: string = "verifiedLapseNotice";
+// setTimeout stores its delay in a 32-bit signed int. Anything larger does not
+// saturate — Node warns and fires after 1ms.
+const MAX_TIMEOUT_MS = 2_147_483_647;
 
 // Announced by the clan modal, which invalidates /users/@me but dispatches no
 // fresh userMeResponse.
@@ -133,6 +136,11 @@ export class UsernameInput extends LitElement {
   // The bare name still reserved for this player and its deadline, while a
   // lapsed subscription's grace clock runs. Null whenever nothing is at stake.
   @state() private claimGrace: ClaimGrace | null = null;
+  // Fires once, at the reservation's deadline, so a client left open across it
+  // drops the notice instead of counting down to a date already past. The
+  // grace value itself only changes on account events, which a sitting client
+  // never receives.
+  private claimGraceTimer: ReturnType<typeof setTimeout> | null = null;
 
   // Clans aren't supported on CrazyGames — hide the tag input and never submit one.
   private readonly onCrazyGames = crazyGamesSDK.isOnCrazyGames();
@@ -323,9 +331,41 @@ export class UsernameInput extends LitElement {
       ) &&
       this.verifiedName() !== null;
     this.claimGrace = verifiedClaimGrace(this.userMe);
+    this.scheduleClaimGraceExpiry();
     this.announceLapse();
     this.requestUpdate();
     this.validateAndStore();
+  }
+
+  // Drop the notice the moment the reservation actually ends.
+  //
+  // verifiedClaimGrace is evaluated only when account state changes, and a
+  // client sitting on the main menu receives none — so without this the notice
+  // would keep naming a deadline that had already passed. Re-deriving from the
+  // same userMe is what clears it: verifiedClaimGrace returns null once the
+  // deadline is behind us.
+  //
+  // The delay must be clamped by us. A 30-day reservation exceeds setTimeout's
+  // 32-bit millisecond field, and Node does not saturate — it warns and fires
+  // after 1ms, which would re-arm in a tight loop. Capping below the limit
+  // makes an over-long wait fire early, re-derive to the same non-null value
+  // and re-arm for the remainder: two timers across a 30-day grace, not
+  // millions.
+  private scheduleClaimGraceExpiry() {
+    if (this.claimGraceTimer !== null) {
+      clearTimeout(this.claimGraceTimer);
+      this.claimGraceTimer = null;
+    }
+    const grace = this.claimGrace;
+    if (grace === null) return;
+    const ms = grace.expiresAt.getTime() - Date.now();
+    if (ms <= 0) return;
+    const delay = Math.min(ms, MAX_TIMEOUT_MS);
+    this.claimGraceTimer = setTimeout(() => {
+      this.claimGraceTimer = null;
+      this.claimGrace = verifiedClaimGrace(this.userMe);
+      this.scheduleClaimGraceExpiry();
+    }, delay);
   }
 
   // Say it once, the first time we see a reservation with a clock running.
@@ -590,6 +630,10 @@ export class UsernameInput extends LitElement {
       document.removeEventListener(type, this.handleClanMembershipChange);
     }
     this.clanMenuOpen = false;
+    if (this.claimGraceTimer !== null) {
+      clearTimeout(this.claimGraceTimer);
+      this.claimGraceTimer = null;
+    }
     super.disconnectedCallback();
   }
 
@@ -658,16 +702,28 @@ export class UsernameInput extends LitElement {
       <div class="flex items-center w-full h-full gap-1.5 sm:gap-2">
         ${this.renderClanControl()} ${this.renderNameControl()}
       </div>
-      ${this.validationError
+      <!-- One positioned slot, stacked. An error and the reservation reminder
+           are not alternatives: the error is transient and self-inflicted
+           (mid-edit on a free-form name), while the reminder is a 30-day
+           countdown the player cannot recover once it lapses. Hiding the
+           second behind the first put the time-critical one last. -->
+      ${this.validationError || this.clanTagOwnershipError || this.claimGrace
         ? html`<div
-            id="username-validation-error"
-            class="absolute top-full left-0 z-50 w-full mt-1 px-3 py-2 text-sm font-medium border border-red-500/50 rounded-lg bg-red-900/90 text-red-200 backdrop-blur-md shadow-lg"
+            class="absolute top-full left-0 z-50 w-full mt-1 flex flex-col gap-1"
           >
-            ${this.validationError}
+            ${this.validationError
+              ? html`<div
+                  id="username-validation-error"
+                  class="w-full px-3 py-2 text-sm font-medium border border-red-500/50 rounded-lg bg-red-900/90 text-red-200 backdrop-blur-md shadow-lg"
+                >
+                  ${this.validationError}
+                </div>`
+              : this.clanTagOwnershipError
+                ? this.renderClanTagOwnershipError()
+                : null}
+            ${this.renderClaimGrace()}
           </div>`
-        : this.clanTagOwnershipError
-          ? this.renderClanTagOwnershipError()
-          : this.renderClaimGrace()}
+        : null}
     `;
   }
 
@@ -676,16 +732,16 @@ export class UsernameInput extends LitElement {
   // who was not at the keyboard when it fired — still sees, every launch,
   // until either they resubscribe or the name is gone.
   //
-  // Amber rather than red: nothing is broken and play is not blocked. It sits
-  // in the same slot as the validation error, which cannot be showing at the
-  // same time (that would mean the player is mid-edit on their free-form name,
-  // and this notice would be the less urgent of the two).
+  // Amber rather than red: nothing is broken and play is not blocked. It
+  // stacks under any validation error rather than replacing it — a player
+  // mid-edit on an invalid name is exactly who still needs to know their
+  // reserved name is expiring. Positioning lives on the shared wrapper.
   private renderClaimGrace() {
     const grace = this.claimGrace;
     if (grace === null) return null;
     return html`<div
       id="username-claim-grace"
-      class="absolute top-full left-0 z-40 w-full mt-1 px-3 py-2 text-sm font-medium border border-amber-500/40 rounded-lg bg-amber-950/90 text-amber-200 backdrop-blur-md shadow-lg"
+      class="w-full px-3 py-2 text-sm font-medium border border-amber-500/40 rounded-lg bg-amber-950/90 text-amber-200 backdrop-blur-md shadow-lg"
     >
       ${translateText("username.claim_reserved", {
         name: grace.name,
@@ -966,7 +1022,7 @@ export class UsernameInput extends LitElement {
       tag: this.clanTag,
     });
     const className =
-      "absolute top-full left-0 z-50 mt-1 px-3 py-2 text-sm font-medium border border-red-500/50 rounded-lg bg-red-900/90 text-red-200 backdrop-blur-md shadow-lg lg:whitespace-nowrap";
+      "self-start px-3 py-2 text-sm font-medium border border-red-500/50 rounded-lg bg-red-900/90 text-red-200 backdrop-blur-md shadow-lg lg:whitespace-nowrap";
 
     if (this.clanTagOwnershipError !== "username.tag_not_member") {
       return html`<div id="clan-tag-validation-error" class=${className}>

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -952,6 +952,14 @@ describe("UsernameInput claim grace, live behaviour", () => {
     const line = q(el, GRACE);
     expect(line).not.toBeNull();
     expect(line!.textContent).toContain("username.claim_at_risk");
+
+    // And the interruption actually fires. Asserting only on the banner missed
+    // that the timer updated it silently: the one player the timer exists for
+    // — sitting on the menu across their own deadline — got no alert at all.
+    expect(showInGameAlert).toHaveBeenCalledTimes(2);
+    expect(showInGameAlert.mock.calls[1][0]).toContain(
+      "username.lapse_notice_at_risk",
+    );
   });
 
   // usernameClaimExpiresAt's schema comment: "A past date means 'at risk', not

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserMeResponse } from "../src/core/ApiSchemas";
 import { MAX_USERNAME_LENGTH } from "../src/core/validations/username";
 
@@ -33,15 +33,21 @@ vi.mock("../src/client/CrazyGamesSDK", () => ({
 vi.mock("../src/client/SteamSDK", () => ({
   steamSDK: { isOnSteam: () => false, getUser: async () => null },
 }));
+const { showInGameAlert } = vi.hoisted(() => ({
+  showInGameAlert: vi.fn(async (_message: string) => Promise.resolve(true)),
+}));
 vi.mock("../src/client/InGameModal", () => ({
   showInGameConfirm: vi.fn(async () => false),
+  showInGameAlert: (message: string) => showInGameAlert(message),
 }));
 // Partial: only translateText is stubbed (echoing keys so assertions read as
 // i18n keys). The rest of Utils stays real, so an unrelated import added to
 // this graph later doesn't fail on a missing export.
 vi.mock("../src/client/Utils", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../src/client/Utils")>()),
-  translateText: (key: string) => key,
+  // Interpolations are echoed after the key so assertions can read both.
+  translateText: (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
 }));
 
 // Side-effect import registers <username-input>; vi.mock is hoisted above it.
@@ -95,6 +101,7 @@ beforeEach(() => {
     tag,
     error: null,
   }));
+  showInGameAlert.mockClear();
 });
 
 // Lets a handler's `await getUserMe()` continuation run before asserting.
@@ -749,5 +756,153 @@ describe("UsernameInput verified name", () => {
 
     expect(el.isVerified()).toBe(false);
     expect(el.getUsername()).toBe("MyCoolName");
+  });
+});
+
+describe("UsernameInput lapse notice", () => {
+  const SOON = "2026-10-01T00:00:00.000Z";
+  const GRACE = "#username-claim-grace";
+
+  // Lapsed: no longer premium, so the name reverts — but the server still
+  // reserves the bare claim until the deadline.
+  function lapsedUser(overrides: Record<string, unknown> = {}): UserMeResponse {
+    return {
+      player: {
+        username: "RyanTheGreat",
+        usernameBase: "RyanTheGreat",
+        usernameStatus: "claimed",
+        usernameClaimExpiresAt: SOON,
+        ...overrides,
+      },
+    } as unknown as UserMeResponse;
+  }
+
+  beforeEach(() => {
+    vi.setSystemTime(new Date("2026-09-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The whole point: the toggle used to switch itself off and the name revert
+  // with nothing said. This is the only channel a Steam-only account has.
+  it("announces the lapse once, naming the name and the date", async () => {
+    localStorage.setItem("useVerifiedName", "true");
+    localStorage.setItem("username", "MyCoolName");
+    const el = await mount();
+    await signIn(el, lapsedUser());
+
+    expect(el.isVerified()).toBe(false);
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    const message = showInGameAlert.mock.calls[0][0];
+    expect(message).toContain("username.lapse_notice");
+    expect(message).toContain("RyanTheGreat");
+  });
+
+  it("does not announce it again on the next launch", async () => {
+    localStorage.setItem("username", "MyCoolName");
+    const first = await mount();
+    await signIn(first, lapsedUser());
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+
+    // A second launch on the same device: same reservation, nothing new.
+    showInGameAlert.mockClear();
+    document.body.innerHTML = "";
+    const second = await mount();
+    await signIn(second, lapsedUser());
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+  });
+
+  // Resubscribe clears the record, so a later lapse speaks up again. A bare
+  // "already announced" flag would stay quiet for the life of the install.
+  it("announces again after a resubscribe and a second lapse", async () => {
+    const el = await mount();
+    await signIn(el, lapsedUser());
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+
+    showInGameAlert.mockClear();
+    await signIn(el, premiumUser());
+    await signIn(el, lapsedUser());
+
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+  });
+
+  // Neither has a deadline attached and neither costs the player a name, so
+  // neither is worth interrupting them for.
+  it("stays silent for a sign-out or a TEMPORARY rename", async () => {
+    localStorage.setItem("useVerifiedName", "true");
+    const el = await mount();
+
+    await signIn(el, premiumUser());
+    document.dispatchEvent(
+      new CustomEvent("userMeResponse", { detail: false }),
+    );
+    await el.updateComplete;
+    expect(showInGameAlert).not.toHaveBeenCalled();
+
+    await signIn(
+      el,
+      lapsedUser({
+        username: "TEMPORARY7823",
+        usernameBase: "TEMPORARY7823",
+      }),
+    );
+    expect(showInGameAlert).not.toHaveBeenCalled();
+  });
+
+  // Silent when the server sends no deadline. infra#594 sets
+  // usernameClaimExpiresAt, so this is not the common case any more — but a
+  // lapse recorded before that shipped still has no date on it.
+  it("stays silent while the server sends no deadline", async () => {
+    const el = await mount();
+    await signIn(el, lapsedUser({ usernameClaimExpiresAt: null }));
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(q(el, GRACE)).toBeNull();
+  });
+
+  it("keeps a standing line while the reservation lasts", async () => {
+    const el = await mount();
+    await signIn(el, lapsedUser());
+
+    const line = q(el, GRACE);
+    expect(line).not.toBeNull();
+    expect(line!.textContent).toContain("username.claim_reserved");
+    expect(line!.textContent).toContain("RyanTheGreat");
+  });
+
+  // The player dismissed the one-time notice; the standing line is what they
+  // still see every launch until they act or the name is gone.
+  it("still shows the line on a later launch, after the notice is spent", async () => {
+    const first = await mount();
+    await signIn(first, lapsedUser());
+    document.body.innerHTML = "";
+
+    const second = await mount();
+    await signIn(second, lapsedUser());
+
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    expect(q(second, GRACE)).not.toBeNull();
+  });
+
+  it("drops the line once the deadline has passed", async () => {
+    vi.setSystemTime(new Date("2026-10-02T00:00:00.000Z"));
+    const el = await mount();
+    await signIn(el, lapsedUser());
+
+    expect(q(el, GRACE)).toBeNull();
+    expect(showInGameAlert).not.toHaveBeenCalled();
+  });
+
+  it("shows nothing while the subscription is still active", async () => {
+    localStorage.setItem("useVerifiedName", "true");
+    const el = await mount();
+    await signIn(el, premiumUser());
+
+    expect(el.isVerified()).toBe(true);
+    expect(q(el, GRACE)).toBeNull();
+    expect(showInGameAlert).not.toHaveBeenCalled();
   });
 });

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -962,6 +962,32 @@ describe("UsernameInput claim grace, live behaviour", () => {
     );
   });
 
+  // Reconnecting after the deadline passed while detached. connectedCallback
+  // short-circuits the getUserMe continuation when userMe is already set, so
+  // this path never reaches applyVerifiedPreference: re-arming the timer alone
+  // left the stale "reserved until {past date}" wording in place. Unreachable
+  // in the app today — <play-page> is hidden by class toggling, not removed —
+  // but the code claims to handle it, so something should hold that.
+  it("escalates on reconnect when the deadline passed while detached", async () => {
+    vi.setSystemTime(new Date("2026-09-01T00:00:00.000Z"));
+    const el = await mount();
+    await signIn(el, lapsedUser());
+    expect(q(el, GRACE)!.textContent).toContain("username.claim_reserved");
+    showInGameAlert.mockClear();
+
+    const parent = el.parentElement!;
+    parent.removeChild(el);
+    vi.setSystemTime(new Date("2026-10-02T00:00:00.000Z"));
+    parent.appendChild(el);
+    await el.updateComplete;
+
+    expect(q(el, GRACE)!.textContent).toContain("username.claim_at_risk");
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    expect(showInGameAlert.mock.calls[0][0]).toContain(
+      "username.lapse_notice_at_risk",
+    );
+  });
+
   // usernameClaimExpiresAt's schema comment: "A past date means 'at risk', not
   // 'lost' — it stays set until the name is actually taken." The banner has to
   // follow that, not a clock.

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -906,3 +906,56 @@ describe("UsernameInput lapse notice", () => {
     expect(showInGameAlert).not.toHaveBeenCalled();
   });
 });
+
+describe("UsernameInput claim grace, live behaviour", () => {
+  const SOON = "2026-10-01T00:00:00.000Z";
+  const GRACE = "#username-claim-grace";
+  const ERROR = "#username-validation-error";
+
+  function lapsedUser(overrides: Record<string, unknown> = {}): UserMeResponse {
+    return {
+      player: {
+        username: "RyanTheGreat",
+        usernameBase: "RyanTheGreat",
+        usernameStatus: "claimed",
+        usernameClaimExpiresAt: SOON,
+        ...overrides,
+      },
+    } as unknown as UserMeResponse;
+  }
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // The grace value is only re-derived on account events, and a client sitting
+  // on the main menu receives none. Without the timer the notice would keep
+  // naming a deadline that had already passed.
+  it("drops the notice when the deadline passes while mounted", async () => {
+    vi.useFakeTimers({ now: new Date("2026-09-30T23:59:00.000Z") });
+    const el = await mount();
+    await signIn(el, lapsedUser());
+    expect(q(el, GRACE)).not.toBeNull();
+
+    await vi.advanceTimersByTimeAsync(61_000);
+    await el.updateComplete;
+
+    expect(q(el, GRACE)).toBeNull();
+  });
+
+  // The error is transient and self-inflicted; the reservation is a 30-day
+  // countdown the player cannot recover. Rendering them as alternatives put
+  // the time-critical one last.
+  it("keeps the reservation notice visible alongside a validation error", async () => {
+    vi.setSystemTime(new Date("2026-09-01T00:00:00.000Z"));
+    const el = await mount();
+    await signIn(el, lapsedUser());
+    expect(q(el, GRACE)).not.toBeNull();
+
+    el.validationError = "username.invalid_chars";
+    await el.updateComplete;
+
+    expect(q(el, ERROR)).not.toBeNull();
+    expect(q(el, GRACE)).not.toBeNull();
+  });
+});

--- a/tests/UsernameInput.test.ts
+++ b/tests/UsernameInput.test.ts
@@ -887,13 +887,20 @@ describe("UsernameInput lapse notice", () => {
     expect(q(second, GRACE)).not.toBeNull();
   });
 
-  it("drops the line once the deadline has passed", async () => {
+  // Inverted from "drops the line once the deadline has passed". That was
+  // wrong: usernameClaimExpiresAt's schema comment says a past date means "at
+  // risk", not "lost" — the field stays set until the name is actually taken,
+  // and resubscribing still recovers it. Going silent switched the warning off
+  // at the point of highest risk and lowest cost to act. The `claimed` guard in
+  // verifiedClaimGrace is what ends the notice, because a name actually taken
+  // moves the player out of that status.
+  it("keeps warning past the deadline, in stronger terms", async () => {
     vi.setSystemTime(new Date("2026-10-02T00:00:00.000Z"));
     const el = await mount();
     await signIn(el, lapsedUser());
 
-    expect(q(el, GRACE)).toBeNull();
-    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(q(el, GRACE)!.textContent).toContain("username.claim_at_risk");
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
   });
 
   it("shows nothing while the subscription is still active", async () => {
@@ -930,17 +937,56 @@ describe("UsernameInput claim grace, live behaviour", () => {
 
   // The grace value is only re-derived on account events, and a client sitting
   // on the main menu receives none. Without the timer the notice would keep
-  // naming a deadline that had already passed.
-  it("drops the notice when the deadline passes while mounted", async () => {
+  // saying "reserved until {date}" after that date had passed.
+  it("escalates the notice when the deadline passes while mounted", async () => {
     vi.useFakeTimers({ now: new Date("2026-09-30T23:59:00.000Z") });
     const el = await mount();
     await signIn(el, lapsedUser());
-    expect(q(el, GRACE)).not.toBeNull();
+    expect(q(el, GRACE)!.textContent).toContain("username.claim_reserved");
 
     await vi.advanceTimersByTimeAsync(61_000);
     await el.updateComplete;
 
-    expect(q(el, GRACE)).toBeNull();
+    // Still shown, and now saying the name can be taken at any moment. Going
+    // silent here would switch the warning off at the point of highest risk.
+    const line = q(el, GRACE);
+    expect(line).not.toBeNull();
+    expect(line!.textContent).toContain("username.claim_at_risk");
+  });
+
+  // usernameClaimExpiresAt's schema comment: "A past date means 'at risk', not
+  // 'lost' — it stays set until the name is actually taken." The banner has to
+  // follow that, not a clock.
+  it("still warns after the deadline, while the name is takeable but not taken", async () => {
+    vi.setSystemTime(new Date("2026-10-02T00:00:00.000Z"));
+    const el = await mount();
+    await signIn(el, lapsedUser());
+
+    expect(q(el, GRACE)!.textContent).toContain("username.claim_at_risk");
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    expect(showInGameAlert.mock.calls[0][0]).toContain(
+      "username.lapse_notice_at_risk",
+    );
+  });
+
+  // Crossing the deadline changes what the player has to do, so it earns one
+  // more interruption — the marker is keyed on the phase, not just the name.
+  it("announces again when a warned reservation lapses into at-risk", async () => {
+    vi.setSystemTime(new Date("2026-09-01T00:00:00.000Z"));
+    const first = await mount();
+    await signIn(first, lapsedUser());
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+
+    showInGameAlert.mockClear();
+    document.body.innerHTML = "";
+    vi.setSystemTime(new Date("2026-10-02T00:00:00.000Z"));
+    const second = await mount();
+    await signIn(second, lapsedUser());
+
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    expect(showInGameAlert.mock.calls[0][0]).toContain(
+      "username.lapse_notice_at_risk",
+    );
   });
 
   // The error is transient and self-inflicted; the reservation is a 30-day

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -418,6 +418,7 @@ describe("verifiedClaimGrace", () => {
     expect(verifiedClaimGrace(lapsed(), NOW)).toEqual({
       name: "RyanTheGreat",
       expiresAt: new Date(SOON),
+      atRisk: false,
     });
   });
 
@@ -453,11 +454,22 @@ describe("verifiedClaimGrace", () => {
 
   // The reservation is over — a countdown to a past date is worse than
   // silence, and the name may already belong to someone else.
-  it("says nothing once the deadline has passed", () => {
+  // Inverted deliberately. usernameClaimExpiresAt's schema comment says a past
+  // date means "at risk", not "lost": the field stays set until the name is
+  // actually taken, and resubscribing still recovers it until then. Returning
+  // null here switched the warning off at the point of highest risk. What ends
+  // the notice is the `claimed` guard — a name actually taken moves the player
+  // out of that status.
+  it("flags at-risk once the deadline has passed, rather than going silent", () => {
     expect(
       verifiedClaimGrace(lapsed(), new Date("2026-10-01T00:00:01.000Z")),
-    ).toBeNull();
-    expect(verifiedClaimGrace(lapsed(), new Date(SOON))).toBeNull();
+    ).toEqual({
+      name: "RyanTheGreat",
+      expiresAt: new Date(SOON),
+      atRisk: true,
+    });
+    // Exactly on the deadline counts as at risk: the reservation is over.
+    expect(verifiedClaimGrace(lapsed(), new Date(SOON))?.atRisk).toBe(true);
   });
 
   it("says nothing for a TEMPORARY#### rename", () => {

--- a/tests/client/PlayerName.test.ts
+++ b/tests/client/PlayerName.test.ts
@@ -7,6 +7,7 @@ import {
   looksGenerated,
   resolvePlayerName,
   sanitizePersona,
+  verifiedClaimGrace,
   verifiedNameOptIn,
   type PlayerNameInputs,
 } from "../../src/client/PlayerName";
@@ -392,6 +393,79 @@ describe("accountVerifiedName", () => {
     expect(
       accountVerifiedName(
         player({ username: "TEMPORARY7823", usernameBase: "TEMPORARY7823" }),
+      ),
+    ).toBeNull();
+  });
+});
+
+describe("verifiedClaimGrace", () => {
+  const NOW = new Date("2026-09-01T00:00:00.000Z");
+  const SOON = "2026-10-01T00:00:00.000Z";
+
+  function lapsed(overrides: Record<string, unknown> = {}): UserMeResponse {
+    return {
+      player: {
+        username: "RyanTheGreat",
+        usernameBase: "RyanTheGreat",
+        usernameStatus: "claimed",
+        usernameClaimExpiresAt: SOON,
+        ...overrides,
+      },
+    } as unknown as UserMeResponse;
+  }
+
+  it("reports the reserved name and the date it stops being reserved", () => {
+    expect(verifiedClaimGrace(lapsed(), NOW)).toEqual({
+      name: "RyanTheGreat",
+      expiresAt: new Date(SOON),
+    });
+  });
+
+  it("says nothing while the subscription is still active", () => {
+    // Nothing at stake: premium and indefinite holders keep the claim.
+    expect(
+      verifiedClaimGrace(lapsed({ usernameStatus: "premium" }), NOW),
+    ).toBeNull();
+    expect(
+      verifiedClaimGrace(lapsed({ usernameStatus: "indefinite" }), NOW),
+    ).toBeNull();
+    expect(
+      verifiedClaimGrace(lapsed({ usernameStatus: "unclaimed" }), NOW),
+    ).toBeNull();
+  });
+
+  it("says nothing when there is no profile", () => {
+    expect(verifiedClaimGrace(null, NOW)).toBeNull();
+    expect(verifiedClaimGrace(false, NOW)).toBeNull();
+  });
+
+  // No date, nothing to say. This is the state a player is in when nothing
+  // has set usernameClaimExpiresAt — not a hypothetical: it is every lapsed
+  // player whose deadline predates infra#594.
+  it("says nothing without a deadline", () => {
+    expect(
+      verifiedClaimGrace(lapsed({ usernameClaimExpiresAt: null }), NOW),
+    ).toBeNull();
+    expect(
+      verifiedClaimGrace(lapsed({ usernameClaimExpiresAt: undefined }), NOW),
+    ).toBeNull();
+  });
+
+  // The reservation is over — a countdown to a past date is worse than
+  // silence, and the name may already belong to someone else.
+  it("says nothing once the deadline has passed", () => {
+    expect(
+      verifiedClaimGrace(lapsed(), new Date("2026-10-01T00:00:01.000Z")),
+    ).toBeNull();
+    expect(verifiedClaimGrace(lapsed(), new Date(SOON))).toBeNull();
+  });
+
+  it("says nothing for a TEMPORARY#### rename", () => {
+    // Already past the point this warns about; there is no name to keep.
+    expect(
+      verifiedClaimGrace(
+        lapsed({ username: "TEMPORARY7823", usernameBase: "TEMPORARY7823" }),
+        NOW,
       ),
     ).toBeNull();
   });


### PR DESCRIPTION
Closes #5090. Implements the "lapse loudly" decision.

**Stacked on #5214** (OPE-224) → #5209 → `main`. Review the stack in order; this PR's diff is only the lapse work and it retargets automatically as each lands.

## The bug

`applyVerifiedPreference` recomputes `verifiedActive` from eligibility. When a subscription lapses, the toggle turns itself off, the player's in-game identity changes and the badge disappears — with nothing said. The source comment documented it as intended behaviour: *"silently off otherwise (logout, lapsed sub, TEMPORARY rename)"*.

`username_grace_warning` exists, but only inside the account modal. A day-30 Steam buyer has no reason to open it.

## What this adds

Two things, both keyed off state `/users/@me` already returns:

1. **A one-time notice** the first time we see a reservation with a clock running — naming the name and the date it stops being reserved, not a generic "your subscription ended".
2. **A standing line** in the identity bar for as long as the reservation lasts. This is what a player who dismissed the notice, or who was not at the keyboard when it fired, still sees on every launch.

The rule itself is a pure `verifiedClaimGrace()` in `PlayerName.ts` alongside the other identity rules, so the whole matrix is testable without mounting anything.

## Deliberately narrow

A sign-out and a `TEMPORARY####` rename also turn the toggle off. Neither has a deadline attached and neither costs the player a name, so neither interrupts them — only the case where something is genuinely at stake is loud. Being noisy about a logout is how a notice like this gets trained out of people before the one that matters arrives.

The "once" is recorded **against the name**, not as a boolean flag, and cleared whenever the player is eligible again. A flag would announce once per install and then stay quiet through every later lapse; keyed on the name, a resubscribe-then-lapse cycle correctly speaks up again. It is also written *before* the dialog rather than after, because the alert only resolves on dismissal and an un-dismissed dialog would otherwise let a second announcement through.

Once the deadline passes, both the notice and the line go quiet: the reservation is over, the name may already belong to someone else, and a countdown to a date in the past is worse than silence.

## Why this is heavier than it looks

The sequence **lapse → grace expires → someone takes the name → resubscribe** ends with `ensureBareClaim` renaming the player to `TEMPORARY7823`. Every Standard buyer lapses at day 30 by design, so the Steam cohort is precisely the cohort that meets it.

And a Steam-only account has no out-of-game channel — no email, and Steam's notification API is scoped to async game-turn notifications, not lifecycle messaging. This notice is the only reach we have, which is why the copy names the name and the date rather than saying "your subscription ended".

## It is live now — an earlier version of this description said otherwise

I originally wrote that this ships inert until OPE-18. **That is wrong.** infra#594 is merged and sets `usernameClaimExpiresAt`, so the notice and the standing line fire **today** for any account whose subscription has been ended — admin-comped and revoked accounts included.

What OPE-18 changes is that granted Steam subscriptions start expiring on their own, which turns this from occasional into routine. It does not gate it.

The no-deadline path is still covered by a test, because it is still reachable: a lapse recorded before #594 shipped has no date on it, and `verifiedClaimGrace` correctly stays silent rather than rendering a blank date.

Corrected here and in the code comments that made the same claim.

## One judgement call worth a reviewer's eye

The one-time notice is a **modal** (`showInGameAlert`), not a toast. A toast can be missed entirely, and for a Steam-only account this is the only channel that exists.

The cost is that it fires on the main menu, where `Main.ts` already has a `cleanHomepage` boot interrupt and a rewards popup. It is narrow enough that the collision is unlikely — it fires once, for a lapsed subscriber, on the launch after the grace clock starts — but **OPE-222 owns boot sequencing and should fold this into that ordering** rather than leaving three contenders racing. Flagging rather than solving it here, since OPE-222 is where that decision belongs.

## Testing

- `tests/client/PlayerName.test.ts` — `verifiedClaimGrace` across the matrix: active subscription (all three non-lapsed statuses), no profile, no deadline, deadline passed, deadline exactly now, and the `TEMPORARY####` case.
- `tests/UsernameInput.test.ts` — through the component: announces once naming name and date; silent on a second launch; announces again after resubscribe-then-lapse; silent for sign-out and `TEMPORARY####`; silent with no deadline; the standing line renders, survives into a later launch after the notice is spent, and disappears once the deadline passes; and nothing at all while the subscription is active.

The `InGameModal` mock in `tests/UsernameInput.test.ts` gained `showInGameAlert`, and its `translateText` stub now echoes interpolations so assertions can read the name and date rather than just the key. Both are additive — all 28 pre-existing tests in that file pass unchanged.

Full suite: 346 files, **4220 tests, zero failures**. `tsc --noEmit`, `prettier --check .`, `npm run lint` clean.
