### PR TITLE
Reduce Labyrinth public rotation frequency 6=>2

### DIFF
--- a/map-generator/assets/maps/labyrinth/info.json
+++ b/map-generator/assets/maps/labyrinth/info.json
@@ -3,7 +3,7 @@
   "name": "Labyrinth",
   "translation_key": "map.labyrinth",
   "categories": ["arcade"],
-  "multiplayer_frequency": 3,
+  "multiplayer_frequency": 2,
   "nations": [
     {
       "coordinates": [50, 50],

--- a/map-generator/assets/maps/labyrinth/info.json
+++ b/map-generator/assets/maps/labyrinth/info.json
@@ -3,7 +3,7 @@
   "name": "Labyrinth",
   "translation_key": "map.labyrinth",
   "categories": ["arcade"],
-  "multiplayer_frequency": 6,
+  "multiplayer_frequency": 3,
   "nations": [
     {
       "coordinates": [50, 50],

--- a/resources/maps/labyrinth/manifest.json
+++ b/resources/maps/labyrinth/manifest.json
@@ -243,7 +243,7 @@
     "num_land_tiles": 372162,
     "width": 680
   },
-  "multiplayer_frequency": 3,
+  "multiplayer_frequency": 2,
   "name": "Labyrinth",
   "nations": [
     {

--- a/resources/maps/labyrinth/manifest.json
+++ b/resources/maps/labyrinth/manifest.json
@@ -243,7 +243,7 @@
     "num_land_tiles": 372162,
     "width": 680
   },
-  "multiplayer_frequency": 6,
+  "multiplayer_frequency": 3,
   "name": "Labyrinth",
   "nations": [
     {

--- a/src/core/game/Maps.gen.ts
+++ b/src/core/game/Maps.gen.ts
@@ -1339,7 +1339,7 @@ export const maps: readonly MapInfo[] = [
     type: GameMapType.Labyrinth,
     translationKey: "map.labyrinth",
     categories: ["arcade"],
-    multiplayerFrequency: 6,
+    multiplayerFrequency: 3,
     ffaFrequency: -1,
     teamFrequency: -1,
     specialFrequency: -1,

--- a/src/core/game/Maps.gen.ts
+++ b/src/core/game/Maps.gen.ts
@@ -1339,7 +1339,7 @@ export const maps: readonly MapInfo[] = [
     type: GameMapType.Labyrinth,
     translationKey: "map.labyrinth",
     categories: ["arcade"],
-    multiplayerFrequency: 3,
+    multiplayerFrequency: 2,
     ffaFrequency: -1,
     teamFrequency: -1,
     specialFrequency: -1,


### PR DESCRIPTION
## Summary
- Lower Labyrinth's `multiplayer_frequency` from 6 to 2 so it appears about a third as often in public FFA/team/special lobbies (it was weighted above the typical 4–5 most maps use).
- Luna needs no change: it is already at `0` (removed from public rotation in #5123).
- Source of truth is `map-generator/assets/maps/labyrinth/info.json`; `src/core/game/Maps.gen.ts` and `resources/maps/labyrinth/manifest.json` were regenerated with `npm run gen-maps`.

## Test plan
- `npm run gen-maps` — generator output matches the committed files (no further diff).
- `npx vitest MapPlaylist --run` — 6/6 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)