### PR TITLE
fix(desktop): send the map's translation key to rich presence, not its name

### DIFF
--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -92,7 +92,7 @@ import {
 import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
 import { UsernameInput } from "./UsernameInput";
-import { incrementGamesPlayed, translateText } from "./Utils";
+import { incrementGamesPlayed, presenceMapKey, translateText } from "./Utils";
 import { isReplayShellHost } from "./VersionedReplay";
 import "./components/BannedModal";
 import "./components/DesktopStatusBar";
@@ -401,7 +401,7 @@ class Client {
       this.presenceDetail = {
         gameType: config?.gameType,
         gameMode: config?.gameMode,
-        map: config?.gameMap,
+        map: presenceMapKey(config?.gameMap),
         // Seats, not connections: spectators are in the roster but hold none
         // (mirrors LobbyPlayerView and the join modal's own count).
         playerCount: event.lobby.clients?.filter((c) => !c.spectator).length,
@@ -1104,7 +1104,7 @@ class Client {
     this.presenceDetail = {
       gameType: joinConfig?.gameType,
       gameMode: joinConfig?.gameMode,
-      map: joinConfig?.gameMap,
+      map: presenceMapKey(joinConfig?.gameMap),
       playerCount:
         joinInfo === undefined
           ? undefined

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -25,6 +25,23 @@ export function normaliseMapKey(mapName: string): string {
   return (id ?? mapName).toLowerCase().replace(/[\s.]+/g, "");
 }
 
+/**
+ * The map key desktop rich presence carries.
+ *
+ * Steam's localization file composes `#Map_<key>` and resolves it in the
+ * *viewing* user's language, so presence has to send the normalised id -- the
+ * same key `map.<id>` uses in our own translations, which keeps the two from
+ * drifting apart -- rather than the display name, which would compose a token
+ * that does not exist. Steam hides the entire status line when a token fails
+ * to resolve, so getting this wrong is a total failure rather than a partial
+ * one. Absent stays absent.
+ */
+export function presenceMapKey(
+  gameMap: string | undefined,
+): string | undefined {
+  return gameMap === undefined ? undefined : normaliseMapKey(gameMap);
+}
+
 export function getMapName(mapName: string | undefined): string | null {
   if (!mapName) return null;
   const translationKey =

--- a/tests/client/Utils.mapKey.test.ts
+++ b/tests/client/Utils.mapKey.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { normaliseMapKey } from "../../src/client/Utils";
+import { normaliseMapKey, presenceMapKey } from "../../src/client/Utils";
 import { GameMapType, maps } from "../../src/core/game/Game";
 
 describe("normaliseMapKey", () => {
@@ -18,5 +18,27 @@ describe("normaliseMapKey", () => {
 
   it("falls back to stripping spaces and dots for unknown map names", () => {
     expect(normaliseMapKey("Some. Unknown Map")).toBe("someunknownmap");
+  });
+});
+
+describe("presenceMapKey", () => {
+  // Desktop rich presence sends this as a token suffix: the Steam
+  // localization file composes "#Map_<key>" and resolves it in the VIEWING
+  // user's language. A display name would compose a token that does not
+  // exist, and Steam hides the whole status line when a token fails to
+  // resolve rather than dropping that one field.
+  it("normalises a map name to its translation key", () => {
+    expect(presenceMapKey(GameMapType.Europe)).toBe("europe");
+    expect(presenceMapKey(GameMapType.Tourney1)).toBe("tourney1");
+  });
+
+  it("produces a key containing only characters Steam allows in a token", () => {
+    for (const map of maps) {
+      expect(presenceMapKey(map.type)).toMatch(/^[a-z0-9_]+$/);
+    }
+  });
+
+  it("leaves an absent map absent rather than inventing a key", () => {
+    expect(presenceMapKey(undefined)).toBeUndefined();
   });
 });


### PR DESCRIPTION
## What

Desktop rich presence was sending the map's **display name** to Steam. It needs to send the map's **translation key**.

## Why it's broken

Steam's rich presence localization file composes a token name out of the value the game sets:

```
"#Status_Game"  "{#Frame_InGame} — {#Mode_%mode%}, {#Map_%map%}"
```

Steam substitutes `%map%` into the token *name*, then resolves the result in the **viewing** user's language — that's what makes a French player's map name show up in Japanese for their Japanese friend.

Presence was sending `config.gameMap`, which is `GameMapType`'s display value. So `"Amazon River"` composed `#Map_Amazon River` — a token that doesn't exist, and one containing a space, which Steam doesn't permit in a substitution regardless.

Steam hides the **entire status line** when a token fails to resolve, rather than dropping that one field. So a friend saw no status at all, not a partial one.

## The fix

Sends `normaliseMapKey()`'s output. That's deliberately the same function `getMapName()` already uses to derive the `map.<id>` translation key, so the Steam token and our own i18n key can't drift apart — and it resolves the tourney maps to their asset directory (`tourney1`) rather than a lowercased display name.

The new `presenceMapKey()` wrapper exists because both call sites take `string | undefined`, and "absent" has to stay absent rather than becoming `"undefined"`.

## Scope

Both presence sites are covered — the `lobby_info` subscription and the join path — verified by grepping every `presenceDetail` assignment. Nothing else in the client feeds presence.

This is inert in the browser build: `desktopPresence.set()` no-ops unless the Electron shell's bridge is present.

## Testing

- 3 new cases in `tests/client/Utils.mapKey.test.ts`, including one asserting every known map produces a key matching `/^[a-z0-9_]+$/` — the character class Steam accepts in a substitution.
- Full suite green: 4255 tests across 348 files.
- `prettier --check`, `tsc --noEmit` and `eslint` all clean.
