### PR TITLE
i18n(desktop): add the Steam rich presence status frames

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -486,6 +486,10 @@
     "verified_name": "Verified username",
     "verified_name_info": "Your username is reserved for your account and shows a verified badge in-game."
   },
+  "desktop_presence": {
+    "in_game": "In game",
+    "spectating": "Spectating"
+  },
   "desktop_session": {
     "generic": "Couldn't sign in to your OpenFront account",
     "network": "Can't reach OpenFront. Check your connection.",

--- a/tests/TranslationSystem.test.ts
+++ b/tests/TranslationSystem.test.ts
@@ -37,6 +37,13 @@ const DYNAMIC_KEY_PATTERNS: RegExp[] = [
  */
 const IGNORED_UNUSED_KEY_PATTERNS: RegExp[] = [
   /^lang\./, // language metadata, not a UI translation key
+  // Steam rich presence status frames. Never rendered by the client, so there
+  // is no translateText() call to find: the Electron shell reads them out of
+  // resources/lang/*.json at build time and writes them into the localization
+  // file Steam resolves against, in the *viewing* friend's language rather
+  // than the player's. They live here so Crowdin picks them up like any other
+  // string.
+  /^desktop_presence\./,
 ];
 
 type NestedTranslations = Record<string, unknown>;


### PR DESCRIPTION
## What

Adds two strings for the Steam friends-list status line:

```json
"desktop_presence": {
  "in_game": "In game",
  "spectating": "Spectating"
}
```

## Why these two and no others

Steam builds its status line from tokens in a localization file, and resolves them in the **viewing friend's** language rather than the player's. Almost everything that file needs already exists in `en.json` and is already translated:

| Needed | Sourced from | Coverage across the 24 languages Steam supports |
|---|---|---|
| 118 map names | `map.*` | exact 1:1 with `GameMapType` |
| Lobby status | `host_modal.waiting` | 24/24 |
| Game modes | `game_mode.*` | 22/24 genuinely translated |

The "in game" and "spectating" frames had no equivalent. `host_modal.spectator` exists but reads as a **button** label — "click to spectate" — which is wrong as a third-person status in French, German and the Slavic languages, so reusing it would have shipped a subtle register error rather than saved work.

So this is the entire translator ask for the feature: two short strings.

## Why they need an unused-key exemption

The client never renders these. The Electron desktop shell reads them out of `resources/lang/*.json` at build time and writes them into the file Steam resolves against — so there is no `translateText()` call for `TranslationSystem.test.ts` to find, and it would report them as unused.

They're exempted the same way `lang.*` already is, for the same reason: present in `en.json` so Crowdin picks them up, but not a UI translation key.

I confirmed the exemption is load-bearing rather than assuming it — with the pattern removed the check fails naming exactly these two keys, and passes with it restored.

## Impact

None on anything rendered today. The shell already falls back to English for both, and I verified end-to-end that adding them leaves the generated Steam file byte-identical for every existing token — the English values match the fallbacks exactly. They start mattering once translations come back.
