### PR TITLE
fix(core): use the same win threshold in team games as FFA

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -444,10 +444,10 @@ export const DoomsdayClockConfigSchema = z.object({
 });
 
 // Overtime (anti-stalemate). After startMinutes of game time the tile share
-// required to win drops steadily from the base (80% FFA / 95% team) at a fixed
-// rate (see OVERTIME_DEFAULTS in Config.ts), so the leading side eventually
-// crosses the shrinking bar and a stalled game is guaranteed to end. Only
-// `enabled` and `startMinutes` are wire-configurable.
+// required to win drops steadily from the 80% base at a fixed rate (see
+// OVERTIME_DEFAULTS in Config.ts), so the leading side eventually crosses the
+// shrinking bar and a stalled game is guaranteed to end. Only `enabled` and
+// `startMinutes` are wire-configurable.
 export const OvertimeConfigSchema = z.object({
   enabled: z.boolean().optional(),
   startMinutes: zb.uint({ min: 1, max: 120 }).optional(),

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -6,7 +6,6 @@ import { DoomsdayClockSpeed } from "../game/DoomsdayClock";
 import {
   Difficulty,
   Game,
-  GameMode,
   GameType,
   Gold,
   Player,
@@ -216,11 +215,14 @@ const DOOMSDAY_CLOCK_DEFAULTS = {
   warshipDrainCurveExponent: 8, // >1 = convex: stays gentle early, then spikes
 };
 
+// Share of the land a side must hold to win, in every game mode.
+const PERCENT_TILES_OWNED_TO_WIN = 80;
+
 // Overtime tunables (anti-stalemate). Off unless enabled in GameConfig.
 // After startMinutes the percentage of tiles required to win falls from the
-// base (80% FFA / 95% team) by dropPercentPerMinute, with no floor: the bar
-// keeps sinking until the leading side crosses it, so a stalled game always
-// ends. Only `enabled` and `startMinutes` are wire-configurable.
+// base by dropPercentPerMinute, with no floor: the bar keeps sinking until the
+// leading side crosses it, so a stalled game always ends. Only `enabled` and
+// `startMinutes` are wire-configurable.
 const OVERTIME_DEFAULTS = {
   enabled: false,
   startMinutes: 30,
@@ -728,7 +730,7 @@ export class Config {
   }
 
   percentageTilesOwnedToWin(elapsedGameSeconds: number): number {
-    const base = this._gameConfig.gameMode === GameMode.Team ? 95 : 80;
+    const base = PERCENT_TILES_OWNED_TO_WIN;
     const sd = this.overtimeConfig();
     if (!sd.enabled) {
       return base;

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -129,9 +129,12 @@ export class WinCheckExecution implements Execution {
     }
     const numTilesWithoutFallout =
       this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    // Cross-multiplied instead of dividing: the threshold is always a whole
+    // percentage, so this is exact integer math (src/core stays deterministic).
     return (
-      (tilesOwned / numTilesWithoutFallout) * 100 >
-      this.mg.config().percentageTilesOwnedToWin(timeElapsed)
+      tilesOwned * 100 >
+      numTilesWithoutFallout *
+        this.mg.config().percentageTilesOwnedToWin(timeElapsed)
     );
   }
 

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -110,8 +110,8 @@ export class WinCheckExecution implements Execution {
     }
   }
 
-  // The one win bar, shared by every game mode: hold more than the required
-  // share of the (non-fallout) land, or outlast the lobby timer / hard limit.
+  // Hold more than the required share of non-fallout land, or outlast the
+  // lobby timer / hard limit.
   private hasWon(tilesOwned: number): boolean {
     if (this.mg === null) throw new Error("Not initialized");
     const timeElapsed = this.mg.elapsedGameSeconds();
@@ -129,8 +129,8 @@ export class WinCheckExecution implements Execution {
     }
     const numTilesWithoutFallout =
       this.mg.numLandTiles() - this.mg.numTilesWithFallout();
-    // Cross-multiplied instead of dividing: the threshold is always a whole
-    // percentage, so this is exact integer math (src/core stays deterministic).
+    // Cross-multiplied: the threshold is a whole percentage, so this is
+    // exact integer math.
     return (
       tilesOwned * 100 >
       numTilesWithoutFallout *

--- a/src/core/execution/WinCheckExecution.ts
+++ b/src/core/execution/WinCheckExecution.ts
@@ -103,20 +103,36 @@ export class WinCheckExecution implements Execution {
     }
 
     const max = sorted[0];
-    const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout =
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
-    if (
-      (max.numTilesOwned() / numTilesWithoutFallout) * 100 >
-        this.mg.config().percentageTilesOwnedToWin(timeElapsed) ||
-      (this.mg.config().gameConfig().maxTimerValue !== undefined &&
-        timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0) ||
-      timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS
-    ) {
+    if (this.hasWon(max.numTilesOwned())) {
       this.mg.setWinner(max, this.mg.stats().stats());
       console.log(`${max.name()} has won the game`);
       this.active = false;
     }
+  }
+
+  // The one win bar, shared by every game mode: hold more than the required
+  // share of the (non-fallout) land, or outlast the lobby timer / hard limit.
+  private hasWon(tilesOwned: number): boolean {
+    if (this.mg === null) throw new Error("Not initialized");
+    const timeElapsed = this.mg.elapsedGameSeconds();
+    // null (host lobby, timer off) means no timer, same as undefined.
+    const maxTimerValue = this.mg.config().gameConfig().maxTimerValue;
+    if (
+      maxTimerValue !== undefined &&
+      maxTimerValue !== null &&
+      timeElapsed >= maxTimerValue * 60
+    ) {
+      return true;
+    }
+    if (timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS) {
+      return true;
+    }
+    const numTilesWithoutFallout =
+      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
+    return (
+      (tilesOwned / numTilesWithoutFallout) * 100 >
+      this.mg.config().percentageTilesOwnedToWin(timeElapsed)
+    );
   }
 
   checkWinnerTeam(): void {
@@ -161,16 +177,7 @@ export class WinCheckExecution implements Execution {
       return;
     }
     const max = sorted[0];
-    const timeElapsed = this.mg.elapsedGameSeconds();
-    const numTilesWithoutFallout =
-      this.mg.numLandTiles() - this.mg.numTilesWithFallout();
-    const percentage = (max[1] / numTilesWithoutFallout) * 100;
-    if (
-      percentage > this.mg.config().percentageTilesOwnedToWin(timeElapsed) ||
-      (this.mg.config().gameConfig().maxTimerValue !== undefined &&
-        timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0) ||
-      timeElapsed >= WinCheckExecution.HARD_TIME_LIMIT_SECONDS
-    ) {
+    if (this.hasWon(max[1])) {
       if (max[0] === ColoredTeams.Bot) return;
       this.mg.setWinner(max[0], this.mg.stats().stats());
       console.log(`${max[0]} has won the game`);

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -52,23 +52,10 @@ export class NationMIRVBehavior {
     }
   }
 
-  private get victoryDenialTeamThreshold(): number {
-    const { difficulty } = this.game.config().gameConfig();
-    switch (difficulty) {
-      case Difficulty.Easy:
-        return 0.9; // Only react right before the game ends (95%)
-      case Difficulty.Medium:
-        return 0.8;
-      case Difficulty.Hard:
-        return 0.7;
-      case Difficulty.Impossible:
-        return 0.6; // Reacts early
-      default:
-        assertNever(difficulty);
-    }
-  }
-
-  private get victoryDenialIndividualThreshold(): number {
+  // One ladder for teams and lone players alike: the win bar is the same 80%
+  // in every game mode (Config.percentageTilesOwnedToWin), so a separate,
+  // higher team ladder would only sit above the bar and never fire.
+  private get victoryDenialThreshold(): number {
     const { difficulty } = this.game.config().gameConfig();
     switch (difficulty) {
       case Difficulty.Easy:
@@ -179,7 +166,7 @@ export class NationMIRVBehavior {
           .map((x) => x.numTilesOwned())
           .reduce((a, b) => a + b, 0);
         const teamShare = teamTerritory / totalLand;
-        if (teamShare >= this.victoryDenialTeamThreshold) {
+        if (teamShare >= this.victoryDenialThreshold) {
           // Only consider the largest team member as the target when team exceeds threshold
           let largestMember: Player | null = null;
           let largestTiles = -1;
@@ -198,7 +185,7 @@ export class NationMIRVBehavior {
         }
       } else {
         const share = p.numTilesOwned() / totalLand;
-        if (share >= this.victoryDenialIndividualThreshold) severity = share;
+        if (share >= this.victoryDenialThreshold) severity = share;
       }
       if (severity > 0) {
         if (best === null || severity > best.severity) best = { p, severity };

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -52,20 +52,22 @@ export class NationMIRVBehavior {
     }
   }
 
+  // Whole percent of the land, so the comparison can be cross-multiplied
+  // against tile counts and stay exact integer math (src/core is deterministic).
   // One ladder for teams and lone players alike: the win bar is the same 80%
   // in every game mode (Config.percentageTilesOwnedToWin), so a separate,
   // higher team ladder would only sit above the bar and never fire.
-  private get victoryDenialThreshold(): number {
+  private get victoryDenialThresholdPercent(): number {
     const { difficulty } = this.game.config().gameConfig();
     switch (difficulty) {
       case Difficulty.Easy:
-        return 0.75; // Only react right before the game ends (80%)
+        return 75; // Only react right before the game ends (80%)
       case Difficulty.Medium:
-        return 0.65;
+        return 65;
       case Difficulty.Hard:
-        return 0.55;
+        return 55;
       case Difficulty.Impossible:
-        return 0.4; // Reacts early
+        return 40; // Reacts early
       default:
         assertNever(difficulty);
     }
@@ -154,6 +156,12 @@ export class NationMIRVBehavior {
     if (this.player === null) throw new Error("not initialized");
     const totalLand = this.game.numLandTiles();
     if (totalLand === 0) return null;
+    // Severity is a TILE COUNT, not a share: every candidate divides by the
+    // same totalLand, so ranking by tiles ranks them exactly as shares would,
+    // without the division.
+    // Both sides of the comparison are scaled by 100: tiles * 100 against
+    // totalLand * percent.
+    const scaledThreshold = totalLand * this.victoryDenialThresholdPercent;
     let best: { p: Player; severity: number } | null = null;
     for (const p of this.getValidMirvTargetPlayers()) {
       let severity = 0;
@@ -165,8 +173,7 @@ export class NationMIRVBehavior {
         const teamTerritory = teamMembers
           .map((x) => x.numTilesOwned())
           .reduce((a, b) => a + b, 0);
-        const teamShare = teamTerritory / totalLand;
-        if (teamShare >= this.victoryDenialThreshold) {
+        if (teamTerritory * 100 >= scaledThreshold) {
           // Only consider the largest team member as the target when team exceeds threshold
           let largestMember: Player | null = null;
           let largestTiles = -1;
@@ -178,14 +185,14 @@ export class NationMIRVBehavior {
             }
           }
           if (largestMember === p) {
-            severity = teamShare;
+            severity = teamTerritory;
           } else {
             severity = 0; // Skip non-largest members
           }
         }
       } else {
-        const share = p.numTilesOwned() / totalLand;
-        if (share >= this.victoryDenialThreshold) severity = share;
+        const tiles = p.numTilesOwned();
+        if (tiles * 100 >= scaledThreshold) severity = tiles;
       }
       if (severity > 0) {
         if (best === null || severity > best.severity) best = { p, severity };

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -52,11 +52,8 @@ export class NationMIRVBehavior {
     }
   }
 
-  // Whole percent of the land, so the comparison can be cross-multiplied
-  // against tile counts and stay exact integer math (src/core is deterministic).
-  // One ladder for teams and lone players alike: the win bar is the same 80%
-  // in every game mode (Config.percentageTilesOwnedToWin), so a separate,
-  // higher team ladder would only sit above the bar and never fire.
+  // Whole percent of the land, for exact integer comparison. One ladder for
+  // teams and lone players: the win bar is 80% in every game mode.
   private get victoryDenialThresholdPercent(): number {
     const { difficulty } = this.game.config().gameConfig();
     switch (difficulty) {
@@ -156,11 +153,8 @@ export class NationMIRVBehavior {
     if (this.player === null) throw new Error("not initialized");
     const totalLand = this.game.numLandTiles();
     if (totalLand === 0) return null;
-    // Severity is a TILE COUNT, not a share: every candidate divides by the
-    // same totalLand, so ranking by tiles ranks them exactly as shares would,
-    // without the division.
-    // Both sides of the comparison are scaled by 100: tiles * 100 against
-    // totalLand * percent.
+    // Compared against tiles * 100; severity ranks by tile count, which
+    // orders candidates the same as by share (same denominator).
     const scaledThreshold = totalLand * this.victoryDenialThresholdPercent;
     let best: { p: Player; severity: number } | null = null;
     for (const p of this.getValidMirvTargetPlayers()) {

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -53,7 +53,9 @@ export class NationMIRVBehavior {
   }
 
   // Whole percent of the land, for exact integer comparison. One ladder for
-  // teams and lone players: the win bar is 80% in every game mode.
+  // teams and lone players: the win bar is 80% in every game mode. Rough
+  // alignment only: the win check divides by non-fallout land and its bar
+  // sinks during overtime; this divides by all land and stays fixed.
   private get victoryDenialThresholdPercent(): number {
     const { difficulty } = this.game.config().gameConfig();
     switch (difficulty) {

--- a/tests/NationMIRV.test.ts
+++ b/tests/NationMIRV.test.ts
@@ -588,8 +588,7 @@ describe("Nation MIRV Retaliation", () => {
   });
 
   test("nation launches MIRV to prevent team victory when team approaches victory denial threshold (targets biggest team member)", async () => {
-    // 70% is above the shared victory-denial threshold (0.65 on Medium) but
-    // below the old team-only 0.8 ladder, which sat above the win bar itself.
+    // 70% share: above the Medium threshold (65%), below the old team-only 80%.
     // Setup game
     const teamPlayer1Info = new PlayerInfo(
       "team_player_1",

--- a/tests/NationMIRV.test.ts
+++ b/tests/NationMIRV.test.ts
@@ -588,6 +588,8 @@ describe("Nation MIRV Retaliation", () => {
   });
 
   test("nation launches MIRV to prevent team victory when team approaches victory denial threshold (targets biggest team member)", async () => {
+    // 70% is above the shared victory-denial threshold (0.65 on Medium) but
+    // below the old team-only 0.8 ladder, which sat above the win bar itself.
     // Setup game
     const teamPlayer1Info = new PlayerInfo(
       "team_player_1",
@@ -652,7 +654,7 @@ describe("Nation MIRV Retaliation", () => {
     // Give team players a large amount of territory to exceed team threshold,
     // but skew so teamPlayer1 is clearly the largest member
     const totalLandTiles = game.map().numLandTiles();
-    const teamTargetTiles = Math.floor(totalLandTiles * 0.82);
+    const teamTargetTiles = Math.floor(totalLandTiles * 0.7);
 
     let conqueredTiles = 0;
     for (
@@ -694,7 +696,8 @@ describe("Nation MIRV Retaliation", () => {
     const teamTerritory =
       teamPlayer1.numTilesOwned() + teamPlayer2.numTilesOwned();
     const teamShare = teamTerritory / game.map().numLandTiles();
-    expect(teamShare).toBeGreaterThan(0.8); //
+    expect(teamShare).toBeGreaterThan(0.65);
+    expect(teamShare).toBeLessThan(0.8);
 
     // Track MIRVs before nation considers team victory denial
     const mirvCountBefore = nation.units(UnitType.MIRV).length;

--- a/tests/core/executions/WinCheckExecution.test.ts
+++ b/tests/core/executions/WinCheckExecution.test.ts
@@ -315,7 +315,7 @@ describe("WinCheckExecution - Nation Winners", () => {
 
     // Skip spawn phase
 
-    // Assign 96% of land to bot team (above 95% Team mode threshold)
+    // Assign 96% of land to bot team (above the 80% win threshold)
     const totalLand = game.numLandTiles();
     const botTeamTiles = Math.ceil(totalLand * 0.96);
     let bot1Assigned = 0;
@@ -336,9 +336,9 @@ describe("WinCheckExecution - Nation Winners", () => {
       }
     });
 
-    // Verify territory ownership (bot team has > 95%)
+    // Verify territory ownership (bot team is above the 80% win threshold)
     const botTeamTotal = bot1.numTilesOwned() + bot2.numTilesOwned();
-    expect(botTeamTotal / totalLand).toBeGreaterThan(0.95);
+    expect(botTeamTotal / totalLand).toBeGreaterThan(0.8);
 
     // Mock setWinner to capture calls
     const setWinnerSpy = vi.fn();

--- a/tests/core/executions/WinCheckExecution.test.ts
+++ b/tests/core/executions/WinCheckExecution.test.ts
@@ -613,12 +613,10 @@ describe("WinCheckExecution - Overtime", () => {
       assigned++;
     });
 
-    const setWinnerSpy = vi.fn();
-    game.setWinner = setWinnerSpy;
     const winCheck = new WinCheckExecution();
     winCheck.init(game, 0);
     winCheck.checkWinnerFFA();
-    expect(setWinnerSpy).not.toHaveBeenCalled();
+    expect(game.getWinner()).toBeNull();
     expect(winCheck.isActive()).toBe(true);
   });
 

--- a/tests/core/executions/WinCheckExecution.test.ts
+++ b/tests/core/executions/WinCheckExecution.test.ts
@@ -591,8 +591,7 @@ describe("WinCheckExecution - Overtime", () => {
   });
 
   test("a null maxTimerValue is no timer, not a zero-minute one", async () => {
-    // Host lobbies send null when the max-timer toggle is off; treating that
-    // as 0 minutes would hand the leader an instant win on the first check.
+    // Host lobbies send null when the max-timer toggle is off.
     const game = await setup("big_plains", {
       gameMode: GameMode.FFA,
       maxTimerValue: null,

--- a/tests/core/executions/WinCheckExecution.test.ts
+++ b/tests/core/executions/WinCheckExecution.test.ts
@@ -580,14 +580,46 @@ describe("WinCheckExecution - Overtime", () => {
     expect(game.config().percentageTilesOwnedToWin(10_000)).toBe(80);
   });
 
-  test("team games decay from the 95% base", async () => {
+  test("team games use the same base and decay as FFA", async () => {
     const game = await setup("big_plains", {
       gameMode: GameMode.Team,
       playerTeams: 2,
       overtime: { enabled: true, startMinutes: 1 },
     });
-    expect(game.config().percentageTilesOwnedToWin(0)).toBe(95);
-    expect(game.config().percentageTilesOwnedToWin(60 + 5 * 60)).toBe(85);
+    expect(game.config().percentageTilesOwnedToWin(0)).toBe(80);
+    expect(game.config().percentageTilesOwnedToWin(60 + 5 * 60)).toBe(70);
+  });
+
+  test("a null maxTimerValue is no timer, not a zero-minute one", async () => {
+    // Host lobbies send null when the max-timer toggle is off; treating that
+    // as 0 minutes would hand the leader an instant win on the first check.
+    const game = await setup("big_plains", {
+      gameMode: GameMode.FFA,
+      maxTimerValue: null,
+    });
+    const nationInfo = new PlayerInfo(
+      "TestNation",
+      PlayerType.Nation,
+      null,
+      "nation_id",
+    );
+    game.addPlayer(nationInfo);
+    const nation = game.player("nation_id");
+    let assigned = 0;
+    game.map().forEachTile((tile) => {
+      if (assigned >= 10) return;
+      if (!game.map().isLand(tile)) return;
+      nation.conquer(tile);
+      assigned++;
+    });
+
+    const setWinnerSpy = vi.fn();
+    game.setWinner = setWinnerSpy;
+    const winCheck = new WinCheckExecution();
+    winCheck.init(game, 0);
+    winCheck.checkWinnerFFA();
+    expect(setWinnerSpy).not.toHaveBeenCalled();
+    expect(winCheck.isActive()).toBe(true);
   });
 
   test("leader wins once the shrinking bar drops below their share", async () => {


### PR DESCRIPTION
## What

Team games required a side to hold **95%** of the land to win, while FFA required **80%**. No apparent reason for the split, so both now use one base of 80% (`PERCENT_TILES_OWNED_TO_WIN` in `Config.ts`). The overtime (anti-stalemate) decay consequently starts from a single base too.

## Cleanup

- `WinCheckExecution.checkWinnerFFA` and `checkWinnerTeam` each carried their own copy of the same win condition. Extracted into one `hasWon(tilesOwned)`: tile share over the threshold, the lobby max timer, or the 170 minute hard limit.
- `hasWon()` compares by integer cross-multiplication (`tiles * 100 > land * pct`) instead of float division — the threshold is always a whole percentage, so this is exact.

## AI follow-up: MIRV victory denial

`NationMIRVBehavior` had a separate, higher team threshold ladder (0.9/0.8/0.7/0.6) tuned against the old 95% team bar. With both modes at 80%, the Easy rung sat above the win bar and could never fire, and the Medium rung coincided with it. Teams and lone players now share one ladder, expressed as whole percents (75/65/55/40) and compared by integer cross-multiplication; candidate ranking uses tile counts instead of float shares (same denominator, same ordering).

## Bug fixed along the way

Extracting the shared win condition surfaced a real bug in it:

```ts
this.mg.config().gameConfig().maxTimerValue !== undefined &&
  timeElapsed - this.mg.config().gameConfig().maxTimerValue! * 60 >= 0
```

`maxTimerValue` is `.nullable().optional()`, and `HostLobbyModal` sends **`null`** when the max-timer toggle is off. The check only tested `!== undefined`, and `null * 60` is `0`, so `timeElapsed - 0 >= 0` was always true — a host lobby with the timer off declared the leader the winner on the first check after the spawn phase. `hasWon()` now treats `null` as no timer.

## Tests

- Team-base test updated to assert the shared 80% base and decay.
- New regression test for the `null` timer case (real `Game.setWinner`, asserts via `getWinner()`); verified it fails against the old check.
- Team MIRV victory-denial test lowered to a 70% share — above the shared Medium rung (65%), below the old team-only 80% — so it fails against the old ladder.
- Full suite: 4262 passed. Lint, format, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)