### PR TITLE
refactor(client): replace native browser dialogs with in-game UI

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -600,11 +600,13 @@
     "copy_clipboard": "Copy to clipboard",
     "crashed": "Game crashed!",
     "desync_notice": "You are desynced from other players. What you see might differ from other players.",
+    "login_failed": "Login failed. Please try again later.",
     "paste_discord": "Please paste the following in your bug report in Discord:",
     "spawn_failed": {
       "description": "Automatic spawn selection failed. You can't play this game.",
       "title": "Spawn failed"
-    }
+    },
+    "turnstile_error": "Verification error: {code}. Please refresh and try again."
   },
   "events_display": {
     "about_to_expire": "Your alliance with {name} is about to expire!",

--- a/src/client/AccountModal.ts
+++ b/src/client/AccountModal.ts
@@ -30,6 +30,7 @@ import { googleLinkButton } from "./components/ui/GoogleLinkButton";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { crazyGamesSDK, type CrazyGamesUser } from "./CrazyGamesSDK";
 import { consumeGoogleLinkResult } from "./GoogleLinkResult";
+import { showInGameAlert } from "./InGameModal";
 import { consumeLoginResult, LoginResult } from "./LoginResult";
 import { playerProfileUrl } from "./utilities/PlayerProfileUrl";
 import { translateText } from "./Utils";
@@ -691,20 +692,18 @@ export class AccountModal extends BaseModal {
 
   private async handleSubmit() {
     if (!this.email) {
-      alert(translateText("account_modal.enter_email_address"));
+      await showInGameAlert(translateText("account_modal.enter_email_address"));
       return;
     }
 
     const success = await sendMagicLink(this.email);
-    if (success) {
-      alert(
-        translateText("account_modal.recovery_email_sent", {
-          email: this.email,
-        }),
-      );
-    } else {
-      alert(translateText("account_modal.failed_to_send_recovery_email"));
-    }
+    await showInGameAlert(
+      success
+        ? translateText("account_modal.recovery_email_sent", {
+            email: this.email,
+          })
+        : translateText("account_modal.failed_to_send_recovery_email"),
+    );
   }
 
   // CrazyGames sign-in: after their prompt completes, exchange the new token
@@ -735,7 +734,7 @@ export class AccountModal extends BaseModal {
     // means we couldn't start it.
     const started = await linkGoogle();
     if (!started) {
-      alert(translateText("account_modal.link_google_failed"));
+      await showInGameAlert(translateText("account_modal.link_google_failed"));
     }
   };
 

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -193,7 +193,7 @@ export async function purchaseCosmetic(
     method === "hard" ? (priced.priceHard ?? 0) : (priced.priceSoft ?? 0);
   const userMe = await getUserMe();
   if (userMe === false) {
-    alert(translateText("store.login_required"));
+    await showInGameAlert(translateText("store.login_required"));
     return;
   }
   const balance =
@@ -244,10 +244,12 @@ export async function purchaseCosmetic(
     colorPaletteName,
   );
   if (!success) {
-    alert(translateText("store.purchase_failed"));
+    await showInGameAlert(translateText("store.purchase_failed"));
     return;
   }
-  alert(translateText("store.purchase_success", { name: c.name }));
+  await showInGameAlert(
+    translateText("store.purchase_success", { name: c.name }),
+  );
   invalidateUserMe();
   window.location.reload();
 }
@@ -267,7 +269,7 @@ async function purchasePack(
   }
   const userMe = await getUserMe();
   if (userMe === false) {
-    alert(translateText("store.login_required"));
+    await showInGameAlert(translateText("store.login_required"));
     return;
   }
   const insufficient = (balance: number): InsufficientCurrency => ({
@@ -283,7 +285,9 @@ async function purchasePack(
 
   const result = await purchaseCosmeticPack(pack.name);
   if (result.ok) {
-    alert(translateText("store.purchase_success", { name: pack.displayName }));
+    await showInGameAlert(
+      translateText("store.purchase_success", { name: pack.displayName }),
+    );
     invalidateUserMe();
     window.location.reload();
     return;
@@ -298,12 +302,14 @@ async function purchasePack(
       );
     }
     case "debt":
-      alert(translateText("store.pack_debt", { debt: result.debt }));
+      await showInGameAlert(
+        translateText("store.pack_debt", { debt: result.debt }),
+      );
       return;
     case "already_owned":
       // Either a genuine conflict or a retry of a purchase that did go
       // through: both mean the local ownership state is stale, so refetch.
-      alert(
+      await showInGameAlert(
         translateText("store.pack_already_owned", {
           items: result.ownedFlareNames.map(flareDisplayName).join(", "),
         }),
@@ -312,10 +318,10 @@ async function purchasePack(
       window.location.reload();
       return;
     case "unavailable":
-      alert(translateText("store.pack_unavailable"));
+      await showInGameAlert(translateText("store.pack_unavailable"));
       return;
     default:
-      alert(translateText("store.purchase_failed"));
+      await showInGameAlert(translateText("store.purchase_failed"));
       return;
   }
 }

--- a/src/client/GoogleLinkResult.ts
+++ b/src/client/GoogleLinkResult.ts
@@ -1,3 +1,4 @@
+import { showInGameAlert } from "./InGameModal";
 import { translateText } from "./Utils";
 
 /**
@@ -23,8 +24,7 @@ export function consumeGoogleLinkResult(args?: Record<string, unknown>): void {
     rest ? `#${rest}` : window.location.pathname + window.location.search,
   );
 
-  // Defer so the modal paints before the (blocking) alert. "cancel" needs no
-  // feedback — the user chose to back out.
+  // "cancel" needs no feedback — the user chose to back out.
   const messageKey =
     link === "google"
       ? "account_modal.link_google_success"
@@ -34,5 +34,5 @@ export function consumeGoogleLinkResult(args?: Record<string, unknown>): void {
           ? "account_modal.link_google_error"
           : null;
   if (messageKey === null) return;
-  setTimeout(() => alert(translateText(messageKey)), 0);
+  void showInGameAlert(translateText(messageKey));
 }

--- a/src/client/LobbySocket.ts
+++ b/src/client/LobbySocket.ts
@@ -1,6 +1,8 @@
 import { ClientEnv } from "src/client/ClientEnv";
 import { PublicGames } from "../core/Schemas";
 import { decodeLobbyMessage } from "../core/ZbinWire";
+import { showInGameAlert } from "./InGameModal";
+import { translateText } from "./Utils";
 
 interface LobbySocketOptions {
   reconnectDelay?: number;
@@ -163,7 +165,7 @@ export class PublicLobbySocket {
       this.wsConnectionAttempts++;
     }
     if (this.wsConnectionAttempts >= this.maxWsAttempts) {
-      alert("error connecting to game service");
+      void showInGameAlert(translateText("error_modal.connection_error"));
     } else {
       this.scheduleReconnect();
     }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -52,7 +52,7 @@ import "./GameStatsModal";
 import { HelpModal } from "./HelpModal";
 import "./HomepagePromos";
 import { HostLobbyModal as HostPrivateLobbyModal } from "./HostLobbyModal";
-import { showInGameConfirm } from "./InGameModal";
+import { showInGameAlert, showInGameConfirm } from "./InGameModal";
 import "./InventoryModal";
 import { JoinLobbyModal } from "./JoinLobbyModal";
 import "./LangSelector";
@@ -853,7 +853,7 @@ class Client {
       );
 
     const alertAndStrip = (message: string) => {
-      alert(message);
+      void showInGameAlert(message);
       strip();
     };
 
@@ -869,7 +869,7 @@ class Client {
       const status = params.get("status");
 
       if (status !== "true") {
-        alertAndStrip("purchase failed");
+        alertAndStrip(translateText("store.purchase_failed"));
         return;
       }
 
@@ -887,16 +887,19 @@ class Client {
       }
 
       if (type === "subscription_tier") {
-        alert(translateText("store.subscription_purchase_success"));
         strip();
         invalidateUserMe();
-        window.location.reload();
+        // Reload only once the dialog is dismissed, like the blocking alert
+        // this replaced.
+        void showInGameAlert(
+          translateText("store.subscription_purchase_success"),
+        ).then(() => window.location.reload());
         return;
       }
 
       const cosmeticName = params.get("cosmetic");
       if (!cosmeticName) {
-        alert("Something went wrong. Please contact support.");
+        void showInGameAlert(translateText("common.error_generic"));
         console.error("purchase-completed but no pattern name");
         return;
       }
@@ -914,9 +917,7 @@ class Client {
       const token = params.get("token-login");
 
       if (!token) {
-        alertAndStrip(
-          `login failed! Please try again later or contact support.`,
-        );
+        alertAndStrip(translateText("error_modal.login_failed"));
         return;
       }
 
@@ -1630,7 +1631,9 @@ async function getTurnstileToken(): Promise<{
       "error-callback": (errorCode: string) => {
         window.turnstile.remove(widgetId);
         console.error(`Turnstile error: ${errorCode}`);
-        alert(`Turnstile error: ${errorCode}. Please refresh and try again.`);
+        void showInGameAlert(
+          translateText("error_modal.turnstile_error", { code: errorCode }),
+        );
         reject(new Error(`Turnstile failed: ${errorCode}`));
       },
     });

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -25,6 +25,7 @@ import "./components/ToggleInputCard";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { getPlayerCosmetics } from "./Cosmetics";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
+import { showInGameAlert } from "./InGameModal";
 import { JoinLobbyEvent } from "./Main";
 import { fallbackPlayerName } from "./PlayerName";
 import { UsernameInput } from "./UsernameInput";
@@ -850,7 +851,7 @@ export class SinglePlayerModal extends BaseModal {
     if (this.maxTimer) {
       if (!this.maxTimerValue || this.maxTimerValue <= 0) {
         console.error("Max timer is enabled but no valid value is set");
-        alert(
+        await showInGameAlert(
           translateText("single_modal.max_timer_invalid") ||
             "Please enter a valid max timer value (1-120 minutes)",
         );

--- a/src/client/TokenLoginModal.ts
+++ b/src/client/TokenLoginModal.ts
@@ -4,6 +4,7 @@ import { tempTokenLogin } from "./Auth";
 import { BaseModal } from "./components/BaseModal";
 import "./components/Difficulties";
 import { modalHeader } from "./components/ui/ModalHeader";
+import { showInGameAlert } from "./InGameModal";
 import { translateText } from "./Utils";
 
 @customElement("token-login")
@@ -110,7 +111,7 @@ export class TokenLoginModal extends BaseModal {
     }
     if (this.attemptCount > 3) {
       this.close();
-      alert("Login failed. Please try again later.");
+      void showInGameAlert(translateText("error_modal.login_failed"));
       return;
     }
     this.attemptCount++;

--- a/src/client/components/CopyButton.ts
+++ b/src/client/components/CopyButton.ts
@@ -82,7 +82,7 @@ export class CopyButton extends LitElement {
   async handleCopy() {
     const text = await this.resolveCopyText();
     if (!text) {
-      alert("Error copying game id");
+      showToast(translateText("common.failed_copy"), "red");
       return;
     }
 

--- a/src/client/components/CustomCurrencyCard.ts
+++ b/src/client/components/CustomCurrencyCard.ts
@@ -1,6 +1,7 @@
 import { html, LitElement } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { createCustomCurrencyCheckout } from "../Api";
+import { showInGameAlert } from "../InGameModal";
 import { translateText } from "../Utils";
 import "./PlutoniumIcon";
 import "./PurchaseButton";
@@ -39,7 +40,7 @@ export class CustomCurrencyCard extends LitElement {
   private buy = async () => {
     const url = await createCustomCurrencyCheckout(this.amount);
     if (url === false) {
-      alert(translateText("store.checkout_failed"));
+      await showInGameAlert(translateText("store.checkout_failed"));
       return;
     }
     window.location.href = url;

--- a/src/client/components/FriendsList.ts
+++ b/src/client/components/FriendsList.ts
@@ -9,6 +9,7 @@ import {
   removeFriend,
   sendFriendRequest,
 } from "../FriendsApi";
+import { showInGameConfirm } from "../InGameModal";
 import { showToast, translateText } from "../Utils";
 import { playerNameLink } from "./ui/PlayerNameLink";
 
@@ -212,7 +213,7 @@ export class FriendsList extends LitElement {
 
   private async handleRemove(publicId: string): Promise<void> {
     if (this.actionPending) return;
-    const confirmed = window.confirm(
+    const confirmed = await showInGameConfirm(
       translateText("friends.confirm_remove", { publicId }),
     );
     if (!confirmed) return;

--- a/src/client/components/PurchaseButton.ts
+++ b/src/client/components/PurchaseButton.ts
@@ -2,6 +2,7 @@ import { html, LitElement, nothing } from "lit";
 import { customElement, property, state } from "lit/decorators.js";
 import { Product } from "../../core/CosmeticSchemas";
 import type { InsufficientCurrency, PurchaseResult } from "../Cosmetics";
+import { showInGameAlert } from "../InGameModal";
 import { translateText } from "../Utils";
 import "./CapIcon";
 import "./ConfirmDialog";
@@ -316,7 +317,7 @@ export class PurchaseButton extends LitElement {
       })
       .catch((error: unknown) => {
         console.error("Purchase callback failed", error);
-        alert(translateText("store.purchase_failed"));
+        void showInGameAlert(translateText("store.purchase_failed"));
       })
       .finally(() => (this.busy = false));
   }

--- a/src/client/components/RewardsPanel.ts
+++ b/src/client/components/RewardsPanel.ts
@@ -7,6 +7,7 @@ import {
   getUserMe,
   invalidateUserMe,
 } from "../Api";
+import { showInGameAlert } from "../InGameModal";
 import { translateText } from "../Utils";
 import "./baseComponents/Button";
 import "./CapIcon";
@@ -47,7 +48,7 @@ export class RewardsPanel extends LitElement {
     try {
       const result = await claimReward(reward.id);
       if (result === false) {
-        alert(translateText("account_modal.claim_failed"));
+        await showInGameAlert(translateText("account_modal.claim_failed"));
         return;
       }
       invalidateUserMe();
@@ -79,7 +80,7 @@ export class RewardsPanel extends LitElement {
     try {
       const result = await claimAllRewards();
       if (result === false) {
-        alert(translateText("account_modal.claim_failed"));
+        await showInGameAlert(translateText("account_modal.claim_failed"));
         return;
       }
       invalidateUserMe();

--- a/tests/client/CosmeticPackPurchase.test.ts
+++ b/tests/client/CosmeticPackPurchase.test.ts
@@ -11,8 +11,14 @@ vi.mock("../../src/client/Api", async (importOriginal) => ({
   purchaseCosmeticPack: vi.fn(),
 }));
 
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: vi.fn().mockResolvedValue(true),
+  showInGameConfirm: vi.fn().mockResolvedValue(true),
+}));
+
 const { getUserMe, invalidateUserMe, purchaseCosmeticPack } =
   await import("../../src/client/Api");
+const { showInGameAlert } = await import("../../src/client/InGameModal");
 
 const translations = {
   "cosmetics.hard": "plutonium",
@@ -52,7 +58,6 @@ function userWithHard(hard: number) {
 
 describe("purchaseCosmetic for a cosmetic pack", () => {
   let languageFixture: HTMLElement;
-  let alertMock: ReturnType<typeof vi.fn>;
   let reloadMock: ReturnType<typeof vi.fn>;
   const originalLocation = window.location;
 
@@ -64,8 +69,6 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
       currentLang: "en",
     });
     document.body.appendChild(languageFixture);
-    alertMock = vi.fn();
-    vi.stubGlobal("alert", alertMock);
     reloadMock = vi.fn();
     Object.defineProperty(window, "location", {
       configurable: true,
@@ -75,7 +78,6 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
 
   afterEach(() => {
     languageFixture.remove();
-    vi.unstubAllGlobals();
     Object.defineProperty(window, "location", {
       configurable: true,
       value: originalLocation,
@@ -83,6 +85,7 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
     vi.mocked(getUserMe).mockReset();
     vi.mocked(invalidateUserMe).mockReset();
     vi.mocked(purchaseCosmeticPack).mockReset();
+    vi.mocked(showInGameAlert).mockClear();
   });
 
   it("buys the pack by slug for plutonium and reloads to show the grants", async () => {
@@ -100,7 +103,7 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
     await expect(purchaseCosmetic(starter, "hard")).resolves.toBeUndefined();
 
     expect(purchaseCosmeticPack).toHaveBeenCalledWith("starter");
-    expect(alertMock).toHaveBeenCalledWith("bought Starter Pack");
+    expect(showInGameAlert).toHaveBeenCalledWith("bought Starter Pack");
     expect(invalidateUserMe).toHaveBeenCalled();
     expect(reloadMock).toHaveBeenCalled();
   });
@@ -147,7 +150,7 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
 
     // Translated where a name exists, title-cased otherwise; a coloured
     // pattern names its colour.
-    expect(alertMock).toHaveBeenCalledWith(
+    expect(showInGameAlert).toHaveBeenCalledWith(
       "already own Jolly Roger, Camo (Crimson)",
     );
     expect(invalidateUserMe).toHaveBeenCalled();
@@ -163,21 +166,21 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
       debt: "300",
     });
     await purchaseCosmetic(starter, "hard");
-    expect(alertMock).toHaveBeenLastCalledWith("debt 300");
+    expect(showInGameAlert).toHaveBeenLastCalledWith("debt 300");
 
     vi.mocked(purchaseCosmeticPack).mockResolvedValueOnce({
       ok: false,
       code: "unavailable",
     });
     await purchaseCosmetic(starter, "hard");
-    expect(alertMock).toHaveBeenLastCalledWith("gone");
+    expect(showInGameAlert).toHaveBeenLastCalledWith("gone");
 
     vi.mocked(purchaseCosmeticPack).mockResolvedValueOnce({
       ok: false,
       code: "failed",
     });
     await purchaseCosmetic(starter, "hard");
-    expect(alertMock).toHaveBeenLastCalledWith("failed");
+    expect(showInGameAlert).toHaveBeenLastCalledWith("failed");
 
     expect(reloadMock).not.toHaveBeenCalled();
   });
@@ -185,7 +188,7 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
   it("requires a signed-in player and only sells packs for plutonium", async () => {
     vi.mocked(getUserMe).mockResolvedValue(false);
     await purchaseCosmetic(starter, "hard");
-    expect(alertMock).toHaveBeenCalledWith("log in");
+    expect(showInGameAlert).toHaveBeenCalledWith("log in");
 
     vi.spyOn(console, "error").mockImplementation(() => {});
     vi.mocked(getUserMe).mockResolvedValue(userWithHard(300));

--- a/tests/client/CustomCurrencyCard.test.ts
+++ b/tests/client/CustomCurrencyCard.test.ts
@@ -8,14 +8,20 @@ vi.mock("../../src/client/Api", async (importOriginal) => ({
   createCustomCurrencyCheckout: vi.fn(),
 }));
 
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: vi.fn().mockResolvedValue(true),
+  showInGameConfirm: vi.fn().mockResolvedValue(true),
+}));
+
+const { showInGameAlert } = await import("../../src/client/InGameModal");
+
 describe("CustomCurrencyCard", () => {
   let card: CustomCurrencyCard | undefined;
-  let alertSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.mocked(createCustomCurrencyCheckout).mockReset();
     vi.mocked(createCustomCurrencyCheckout).mockResolvedValue(false);
-    alertSpy = vi.spyOn(window, "alert").mockImplementation(() => {});
+    vi.mocked(showInGameAlert).mockClear();
     card = document.createElement("custom-currency-card") as CustomCurrencyCard;
     document.body.appendChild(card);
   });
@@ -23,7 +29,6 @@ describe("CustomCurrencyCard", () => {
   afterEach(() => {
     card?.remove();
     card = undefined;
-    alertSpy.mockRestore();
   });
 
   it("uses the shared card anatomy without obsolete wrapper ancestry", async () => {
@@ -94,6 +99,6 @@ describe("CustomCurrencyCard", () => {
     await vi.waitFor(() =>
       expect(createCustomCurrencyCheckout).toHaveBeenCalledWith(240),
     );
-    expect(alertSpy).toHaveBeenCalledWith("store.checkout_failed");
+    expect(showInGameAlert).toHaveBeenCalledWith("store.checkout_failed");
   });
 });

--- a/tests/client/PurchaseButton.test.ts
+++ b/tests/client/PurchaseButton.test.ts
@@ -2,6 +2,13 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PurchaseButton } from "../../src/client/components/PurchaseButton";
 import { alignPurchaseRows } from "../../src/client/components/PurchaseButton";
 
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: vi.fn().mockResolvedValue(true),
+  showInGameConfirm: vi.fn().mockResolvedValue(true),
+}));
+
+const { showInGameAlert } = await import("../../src/client/InGameModal");
+
 describe("PurchaseButton", () => {
   let button: PurchaseButton | undefined;
 
@@ -75,8 +82,7 @@ describe("PurchaseButton", () => {
   });
 
   it("clears busy state and reports a synchronous purchase throw", async () => {
-    const alertMock = vi.fn();
-    vi.stubGlobal("alert", alertMock);
+    vi.mocked(showInGameAlert).mockClear();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     button = document.createElement("purchase-button") as PurchaseButton;
     button.dollarPrice = "$5";
@@ -89,7 +95,7 @@ describe("PurchaseButton", () => {
     button.querySelector<HTMLButtonElement>(".purchase-sparkle-btn")!.click();
 
     await vi.waitFor(() =>
-      expect(alertMock).toHaveBeenCalledWith("store.purchase_failed"),
+      expect(showInGameAlert).toHaveBeenCalledWith("store.purchase_failed"),
     );
     expect(
       button.querySelector(".purchase-btn-wrap")?.getAttribute("aria-busy"),
@@ -97,8 +103,7 @@ describe("PurchaseButton", () => {
   });
 
   it("clears busy state and handles a rejected purchase callback", async () => {
-    const alertMock = vi.fn();
-    vi.stubGlobal("alert", alertMock);
+    vi.mocked(showInGameAlert).mockClear();
     vi.spyOn(console, "error").mockImplementation(() => undefined);
     button = document.createElement("purchase-button") as PurchaseButton;
     button.dollarPrice = "$5";
@@ -111,7 +116,7 @@ describe("PurchaseButton", () => {
     button.querySelector<HTMLButtonElement>(".purchase-sparkle-btn")!.click();
 
     await vi.waitFor(() =>
-      expect(alertMock).toHaveBeenCalledWith("store.purchase_failed"),
+      expect(showInGameAlert).toHaveBeenCalledWith("store.purchase_failed"),
     );
     expect(
       button.querySelector(".purchase-btn-wrap")?.getAttribute("aria-busy"),


### PR DESCRIPTION
## Summary

- Replaces every `alert()` and the one `window.confirm()` in the client with the game's own styled dialogs, so the Steam/desktop build never shows native browser popups (store purchase results, account recovery/Google-link, reward claims, lobby connection failure, Turnstile errors, token login, single-player timer validation, friend removal).
- Uses the existing primitives throughout: `showInGameAlert`/`showInGameConfirm` from `InGameModal.ts` (the pattern Transport and AccountSettingsPanel already use), and a `showToast` for CopyButton's copy error to match its sibling toasts. `AccountModal.handleSubmit` now mirrors its migrated twin in `AccountSettingsPanel` exactly.
- Where a blocking `alert()` used to gate a `window.location.reload()` (cosmetic/pack/subscription purchase success, stale-ownership refetch), the reload now waits for the dialog to be dismissed, preserving the original ordering.
- Four previously hardcoded English strings now go through `translateText`: reused `store.purchase_failed`, `common.error_generic`, `common.failed_copy`, and `error_modal.connection_error`, and added `error_modal.login_failed` and `error_modal.turnstile_error` (worded "Verification error" rather than "Turnstile") to `en.json`.
- Updates the three test files that stubbed the global `alert` to mock the `InGameModal` module instead.

## Test plan

- `npx vitest --run` — full suite, 4267 tests pass (including the updated CosmeticPackPurchase, CustomCurrencyCard, and PurchaseButton tests).
- `npx tsc --noEmit`, `npm run lint`, and `npx prettier --check` on the touched files — all clean.
- Verified no `alert(`/`window.confirm(`/`window.prompt(` calls remain in `src/`, and that the `beforeunload` handlers don't trigger the native leave-page prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)