### PR TITLE
feat(homepage): put the upcoming lobbies in a column under a heading

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1117,7 +1117,6 @@
     "clans": "Clans",
     "copyright": "© OpenFront™ and Contributors",
     "create": "Create Lobby",
-    "detailed_view": "Detailed View",
     "discord_avatar_alt": "Discord profile avatar",
     "github": "GitHub",
     "go_to_troubleshooting": "Go to our troubleshooting page",
@@ -1574,6 +1573,7 @@
     "invite_friends": "Invite Friends",
     "join_timeout": "You didn't enter the game in time.",
     "players_per_team": "of {num}",
+    "see_all": "See all {count}",
     "started": "Started",
     "starting_game": "Starting…",
     "starting_in": "Starting in {time}",
@@ -1588,6 +1588,7 @@
     "trust_required_title": "Trusted account required",
     "trusted_locked": "Trusted accounts only. Your account isn't trusted yet.",
     "trusted_unlocked": "Trusted accounts only. Your account is trusted.",
+    "upcoming": "Upcoming",
     "waiting_for_players": "Waiting for players"
   },
   "purchase_nudge": {

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -43,7 +43,11 @@ import {
   translateText,
 } from "./Utils";
 
-const CARD_BG = "bg-surface";
+const PRIMARY_ACTION =
+  "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 hover:scale-y-105 hover:scale-x-[1.01]";
+const SECONDARY_ACTION =
+  "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]";
+const DISABLED = "opacity-50 cursor-not-allowed pointer-events-none";
 
 /**
  * Whether a multiplayer entry point should refuse to act. Exported for tests
@@ -233,143 +237,92 @@ export class GameModeSelector extends LitElement {
     const ffa = this.lobbies?.games?.["ffa"]?.[0];
     const teams = this.lobbies?.games?.["team"]?.[0];
     const special = this.lobbies?.games?.["special"]?.[0];
+    // The hero slot holds the spinner, then the FFA card; loaded without one
+    // it goes and the upcoming column takes the whole row.
+    const heroSlot = this.lobbies === null || ffa !== undefined;
+    // A lone secondary card takes both of the column's card rows.
+    const cardRows =
+      teams && special
+        ? { special: "sm:row-start-2", teams: "sm:row-start-3" }
+        : {
+            special: "sm:row-start-2 sm:row-span-2",
+            teams: "sm:row-start-2 sm:row-span-2",
+          };
 
+    // DOM is in phone order; sm+ places the same elements onto a grid and
+    // reading-flow keeps focus order following the rows (Chromium only).
     return html`
-      <div class="flex flex-col gap-4 w-full px-4 sm:px-0 mx-auto pb-4 sm:pb-0">
-        <!-- Solo + detailed view: mobile only, top. The lobby browser is one
-             column wide, matching Join Lobby below it. -->
-        <div class="sm:hidden grid grid-cols-3 gap-4 h-14">
-          <div class="col-span-2">
-            ${this.renderSmallActionCard(
-              translateText("main.solo"),
-              this.openSinglePlayerModal,
-              "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 hover:scale-y-105 hover:scale-x-[1.01]",
-            )}
-          </div>
-          ${this.renderSmallActionCard(
-            translateText("main.detailed_view"),
-            this.openDetailedView,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-          )}
-        </div>
-        <!-- Create/ranked/join: mobile only, below solo -->
-        <div class="sm:hidden grid grid-cols-3 gap-4 h-14">
-          ${this.renderSmallActionCard(
-            translateText("main.create"),
-            this.openHostLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            undefined,
-            true,
-          )}
-          ${this.renderSmallActionCard(
-            translateText("mode_selector.ranked_title"),
-            this.openRankedMenu,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            undefined,
-            true,
-          )}
-          ${this.renderSmallActionCard(
-            translateText("main.join"),
-            this.openJoinLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
-            this.hostedLobbyCount(),
-            true,
-          )}
-        </div>
-        <!-- iOS Add to Home Screen banner -->
+      <div
+        class="flex flex-col gap-4 w-full px-4 pb-4 mx-auto sm:px-0 sm:pb-0 sm:grid sm:grid-cols-[2fr_1fr] sm:grid-rows-[auto_min(24rem,40vh)_auto_auto] sm:[reading-flow:grid-rows]"
+      >
         <ios-add-to-home-screen-banner
-          class="no-crazygames"
+          class="no-crazygames [&:empty]:hidden sm:col-span-2 sm:row-start-1"
         ></ios-add-to-home-screen-banner>
 
-        <!-- Game cards grid -->
-        ${this.lobbies === null
-          ? html`<div
-              class="flex items-center justify-center h-44 sm:h-[min(24rem,40vh)]"
-            >
-              <span
-                class="w-24 h-24 border-[6px] border-blue-500/30 border-t-blue-500 rounded-full animate-spin"
-              ></span>
-            </div>`
-          : html`<div
-              class="grid grid-cols-1 sm:grid-cols-[2fr_1fr] gap-4 sm:h-[min(24rem,40vh)]"
-            >
-              <!-- Left col: main card (desktop only) -->
-              ${ffa
-                ? html`<div class="hidden sm:block">
-                    ${this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))}
-                  </div>`
-                : nothing}
-
-              <!-- Right col: special + teams (desktop only) -->
-              <div class="hidden sm:flex sm:flex-col sm:gap-4">
-                ${special
-                  ? html`<div class="flex-1 min-h-0">
-                      ${this.renderSpecialLobbyCard(special)}
-                    </div>`
-                  : nothing}
-                ${teams
-                  ? html`<div class="flex-1 min-h-0">
-                      ${this.renderLobbyCard(teams, this.getLobbyTitle(teams))}
-                    </div>`
-                  : nothing}
-              </div>
-
-              <!-- Mobile: special, ffa, teams inline -->
-              <div class="sm:hidden">
-                ${special ? this.renderSpecialLobbyCard(special) : nothing}
-              </div>
-              <div class="sm:hidden">
-                ${ffa
-                  ? this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))
-                  : nothing}
-              </div>
-              <div class="sm:hidden">
-                ${teams
-                  ? this.renderLobbyCard(teams, this.getLobbyTitle(teams))
-                  : nothing}
-              </div>
-            </div>`}
-
-        <!-- Solo + detailed view, desktop only. Solo spans two columns; the
-             lobby browser is one, the same width as Join Lobby below it. -->
-        <div class="hidden sm:grid grid-cols-3 gap-4 h-14">
-          <div class="col-span-2">
-            ${this.renderSmallActionCard(
-              translateText("main.solo"),
-              this.openSinglePlayerModal,
-              "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 hover:scale-y-105 hover:scale-x-[1.01]",
-            )}
-          </div>
+        <div class="h-14 sm:col-span-2 sm:row-start-3">
           ${this.renderSmallActionCard(
-            translateText("main.detailed_view"),
-            this.openDetailedView,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
+            translateText("main.solo"),
+            this.openSinglePlayerModal,
+            PRIMARY_ACTION,
           )}
         </div>
-        <!-- Bottom row: create + ranked + join (desktop only) -->
-        <div class="hidden sm:grid grid-cols-3 gap-4 h-14">
+        <div class="grid grid-cols-3 gap-4 h-14 sm:col-span-2 sm:row-start-4">
           ${this.renderSmallActionCard(
             translateText("main.create"),
             this.openHostLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
+            SECONDARY_ACTION,
             undefined,
             true,
           )}
           ${this.renderSmallActionCard(
             translateText("mode_selector.ranked_title"),
             this.openRankedMenu,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
+            SECONDARY_ACTION,
             undefined,
             true,
           )}
           ${this.renderSmallActionCard(
             translateText("main.join"),
             this.openJoinLobby,
-            "bg-surface hover:brightness-[1.08] active:brightness-[0.95] hover:scale-105 hover:shadow-[var(--shadow-action-card-hover)]",
+            SECONDARY_ACTION,
             this.hostedLobbyCount(),
             true,
           )}
         </div>
+
+        ${heroSlot
+          ? html`<div class="min-w-0 sm:col-start-1 sm:row-start-2">
+              ${ffa
+                ? this.renderLobbyCard(ffa, this.getLobbyTitle(ffa))
+                : html`<div
+                    class="flex items-center justify-center h-44 sm:h-full"
+                  >
+                    <span
+                      class="size-24 rounded-full border-[6px] border-blue-500/30 border-t-blue-500 animate-spin"
+                    ></span>
+                  </div>`}
+            </div>`
+          : nothing}
+
+        <!-- Always rendered: the heading is the only way into the lobby browser. -->
+        <section
+          class="flex flex-col gap-4 min-w-0 sm:grid sm:grid-rows-[auto_1fr_1fr] sm:row-start-2 sm:min-h-0 sm:[reading-flow:grid-rows] ${heroSlot
+            ? "sm:col-start-2"
+            : "sm:col-start-1 sm:col-span-2"}"
+        >
+          ${teams
+            ? html`<div class="min-w-0 sm:min-h-0 ${cardRows.teams}">
+                ${this.renderLobbyCard(teams, this.getLobbyTitle(teams))}
+              </div>`
+            : nothing}
+          ${special
+            ? html`<div class="min-w-0 sm:min-h-0 ${cardRows.special}">
+                ${this.renderLobbyCard(special, this.getLobbyTitle(special))}
+              </div>`
+            : nothing}
+          ${this.renderUpcomingHeading()}
+        </section>
+
         ${this.showTrustRequired
           ? trustRequiredDialog(
               this.viewerSignedIn,
@@ -378,10 +331,6 @@ export class GameModeSelector extends LitElement {
           : nothing}
       </div>
     `;
-  }
-
-  private renderSpecialLobbyCard(lobby: PublicGameInfo) {
-    return this.renderLobbyCard(lobby, this.getLobbyTitle(lobby));
   }
 
   /**
@@ -446,6 +395,63 @@ export class GameModeSelector extends LitElement {
 
   // Number of open hosted lobbies waiting in the browser; shown as a chip
   // on the Join button.
+  /**
+   * The heading over the upcoming column, and the way to the lobby browser now
+   * that the Detailed View button is gone. Heading and link are one control:
+   * side by side they were two runs of small uppercase text, and neither read
+   * as clickable. A heading may hold a button, so the h2 survives.
+   *
+   * Dims and stops responding on an invalid username, as the button it
+   * replaces did: openDetailedView's own check is a silent backstop that
+   * assumes its control already looks disabled.
+   */
+  /** Heading over the upcoming column; also the link to the lobby browser. */
+  private renderUpcomingHeading() {
+    const count = this.advertisedLobbyCount();
+    return html`
+      <h2 class="min-w-0 sm:row-start-1">
+        <button
+          @click=${this.openDetailedView}
+          ?disabled=${!this.inputValid}
+          class="group/upcoming flex w-full items-center justify-between gap-2 rounded-lg border border-white/10 bg-white/[0.04] py-1.5 pl-2.5 pr-1.5 transition-colors hover:border-malibu-blue/50 hover:bg-malibu-blue/15 ${this
+            .inputValid
+            ? ""
+            : DISABLED}"
+        >
+          <span
+            class="truncate text-sm font-bold uppercase tracking-widest text-white/70 group-hover/upcoming:text-white"
+            >${translateText("public_lobby.upcoming")}</span
+          >
+          <span
+            class="flex shrink-0 items-center gap-0.5 rounded bg-malibu-blue py-0.5 pl-2 pr-1 text-xs font-bold uppercase tracking-wider text-white group-hover/upcoming:bg-aquarius"
+          >
+            ${count > 0
+              ? translateText("public_lobby.see_all", { count })
+              : nothing}
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+              class="size-4"
+              aria-hidden="true"
+            >
+              <path
+                fill-rule="evenodd"
+                d="M8.22 5.22a.75.75 0 0 1 1.06 0l4.25 4.25a.75.75 0 0 1 0 1.06l-4.25 4.25a.75.75 0 0 1-1.06-1.06L11.94 10 8.22 6.28a.75.75 0 0 1 0-1.06Z"
+                clip-rule="evenodd"
+              />
+            </svg>
+          </span>
+        </button>
+      </h2>
+    `;
+  }
+
+  /** Every lobby the browser lists, hosted included. */
+  private advertisedLobbyCount(): number {
+    return Object.values(this.lobbies?.games ?? {}).flat().length;
+  }
+
   private hostedLobbyCount(): number {
     return this.lobbies?.games?.hosted?.length ?? 0;
   }
@@ -453,7 +459,7 @@ export class GameModeSelector extends LitElement {
   private renderSmallActionCard(
     title: string,
     onClick: () => void,
-    bgClass: string = CARD_BG,
+    bgClass: string = SECONDARY_ACTION,
     badge?: number,
     // Only the three multiplayer action cards (create/ranked/join) pass this;
     // the solo card is never gated (see openSinglePlayerModal) and must never
@@ -473,7 +479,7 @@ export class GameModeSelector extends LitElement {
         aria-disabled=${blocked}
         class="relative flex items-center justify-center w-full h-full rounded-lg ${bgClass} transition-all duration-200 text-sm lg:text-base font-medium text-white uppercase tracking-wider text-center ${!this
           .inputValid
-          ? "opacity-50 cursor-not-allowed pointer-events-none"
+          ? DISABLED
           : blocked
             ? "opacity-50 cursor-not-allowed"
             : ""}"

--- a/tests/GameModeSelectorGatingWiring.test.ts
+++ b/tests/GameModeSelectorGatingWiring.test.ts
@@ -98,6 +98,18 @@ function lobbyCardButton(): HTMLButtonElement | null {
   return selector.querySelector("button.group");
 }
 
+/** The UPCOMING heading, which is itself the link to the lobby browser. */
+function upcomingHeadingButton(): HTMLButtonElement | null {
+  return selector.querySelector("h2 button");
+}
+
+async function setUsernameValid(isValid: boolean): Promise<void> {
+  window.dispatchEvent(
+    new CustomEvent("username-validity-change", { detail: { isValid } }),
+  );
+  await selector.updateComplete;
+}
+
 beforeEach(async () => {
   // connectedCallback reads ClientEnv.gameCreationRate(), which throws without
   // the config the server normally injects into index.html.
@@ -305,5 +317,106 @@ describe("the public lobby card (validateAndJoin)", () => {
     card!.click();
 
     expect(joinLobby).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * The heading over the upcoming column replaced the Detailed View card, so it
+ * is the homepage's only route to the lobby browser. openDetailedView's own
+ * username check is a silent backstop -- it returns without telling anyone --
+ * so the control has to carry the disabled state itself, as the card it
+ * replaced did.
+ */
+describe("the upcoming heading (the route to the lobby browser)", () => {
+  beforeEach(async () => {
+    await pushLobbies({ ffa: [publicLobby("game-1")] });
+  });
+
+  it("is there before any snapshot, so a dead feed can't strand the player", async () => {
+    // No pushLobbies() here on purpose: `lobbies` is still null, which used to
+    // replace this whole block with a spinner. The browser opens its own
+    // socket, so it is worth reaching even when the homepage's never connects.
+    const fresh = document.createElement(
+      "game-mode-selector",
+    ) as HTMLElement & {
+      updateComplete: Promise<unknown>;
+    };
+    document.body.appendChild(fresh);
+    await fresh.updateComplete;
+
+    const heading = fresh.querySelector("h2 button");
+    expect(heading).not.toBeNull();
+    (heading as HTMLButtonElement).click();
+
+    expect(window.showPage).toHaveBeenCalledWith("page-detailed-view");
+  });
+
+  it("opens the browser while the username is valid", async () => {
+    await setUsernameValid(true);
+
+    const heading = upcomingHeadingButton();
+    expect(heading).not.toBeNull();
+    expect(heading!.disabled).toBe(false);
+    heading!.click();
+
+    expect(window.showPage).toHaveBeenCalledWith("page-detailed-view");
+  });
+
+  it("dims and stops responding once the username is invalid", async () => {
+    await setUsernameValid(false);
+
+    const heading = upcomingHeadingButton();
+    expect(heading).not.toBeNull();
+    expect(heading!.disabled).toBe(true);
+    expect(heading!.className).toContain("cursor-not-allowed");
+    heading!.click();
+
+    expect(window.showPage).not.toHaveBeenCalledWith("page-detailed-view");
+  });
+});
+
+/**
+ * At sm+ the block is a placed grid, so the class strings are the layout.
+ * These pin the three states where an unconditional placement collided or
+ * left a track empty: loading, a snapshot with no FFA lobby, and a column
+ * with only one of its two cards.
+ */
+describe("grid placement", () => {
+  const section = () => selector.querySelector("section")!;
+  const heroSlot = () =>
+    selector.querySelector(":scope > div > div.sm\\:col-start-1");
+
+  it("keeps the upcoming column beside the spinner while loading", () => {
+    expect(heroSlot()).not.toBeNull();
+    expect(section().className).toContain("sm:col-start-2");
+    expect(section().className).not.toContain("sm:col-span-2");
+  });
+
+  it("drops the hero slot and spans the row when there is no FFA lobby", async () => {
+    await pushLobbies({ team: [publicLobby("team-1")] });
+    expect(heroSlot()).toBeNull();
+    expect(section().className).toContain("sm:col-start-1 sm:col-span-2");
+  });
+
+  it("lets a lone card take both card rows", async () => {
+    await pushLobbies({
+      ffa: [publicLobby("ffa-1")],
+      team: [publicLobby("t")],
+    });
+    const card = section().querySelector("div.sm\\:min-h-0")!;
+    expect(card.className).toContain("sm:row-start-2 sm:row-span-2");
+  });
+
+  it("stacks two cards on their own rows", async () => {
+    await pushLobbies({
+      ffa: [publicLobby("ffa-1")],
+      team: [publicLobby("t")],
+      special: [publicLobby("s")],
+    });
+    const rows = Array.from(section().querySelectorAll("div.sm\\:min-h-0")).map(
+      (c) => c.className,
+    );
+    expect(rows.some((c) => c.includes("sm:row-start-3"))).toBe(true);
+    expect(rows.some((c) => c.includes("sm:row-span-2"))).toBe(false);
   });
 });


### PR DESCRIPTION
Markup and Tailwind classes only. Two files, no wire, server or lobby-selection changes — which lobbies appear, and in what order, is exactly what `main` does today.

## What changes

- **The FFA lobby leads** at twice the width, with team and special stacked beside it under an `UPCOMING` heading. `main` already used a `2fr 1fr` grid; the column beside the hero now says what it is.
- **The heading is the link to the lobby browser**, label left, `SEE ALL n` and a chevron right, the whole strip lighting up on hover. Two adjacent runs of small uppercase text read as one label and neither looked clickable, so it is one button — wrapped in the `h2`, which a heading may hold, so the landmark survives. The count covers everything the browser lists, hosted included.
- **`DETAILED VIEW` goes**, since the heading now does its job, and it was sitting beside `SOLO` competing with it for attention. Its translation key is removed too; the repo fails a test on unused keys.
- **`SOLO` takes the full width** as the one action that always works, with `CREATE`, `RANKED` and `JOIN` in a row under it. Their text was already centred.
- **One set of blocks serves both widths.** `main` rendered the cards twice (a desktop grid and three `sm:hidden` copies) and the button rows twice. There is now one markup, placed onto a grid at `sm+`.

  The DOM is in the order a phone reads: `SOLO`, the three actions, FFA, team, special, then the link. At `sm+` the same elements are placed onto explicit grid rows and columns, which reads in a different order — so `reading-flow: grid-rows` tells focus and the accessibility tree to follow the rows there. Neither width ends up with a tab order that disagrees with the screen, and nothing is rendered twice. `reading-flow` is Chromium-only so far; elsewhere `sm+` falls back to the source order, which is the same mismatch a single markup would have had anyway. Verified the property survives the build rather than being dropped as an unknown arbitrary value.

## What this deliberately leaves alone

Earlier attempts at this screen grew a promotion rotation on the master and a `queuePosition` field on the wire, so the client could render one authoritative queue. None of that is here: with `main`'s per-bucket cards there is no ordering question to answer. That work is parked on [`homepage-rotation`](https://github.com/openfrontio/OpenFrontIO/tree/homepage-rotation) if it is ever wanted.

The lobby card itself is untouched — its corner rim and modifier pills are #5095.

## Testing

`npm test` — 349 files / 4274 tests, plus 57 / 590 on the server pass, exit 0. `tsc`, `oxlint`, `eslint` and Prettier clean.

No browser pass: the machine this was written on is arm64 and the pinned headless Chromium is x86-64, so the harness won't run there. Since this is all layout, it wants a look at 1920, ~1280 and a phone width before merging — in particular that the two stacked cards still fill the column now that the heading takes a slice of its height.

