### PR TITLE
fix(client): give the lobby host the Invite Friends button

### DIFF
--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -232,7 +232,12 @@ export class HostLobbyModal extends BaseModal {
           .lobbySuffix=${this.lobbyUrlSuffix}
           include-lobby-query
         ></copy-button>`;
-        const invite = inviteFriendsButton();
+        // Not until there is a lobby to invite anyone into. createLobby()
+        // assigns lobbyId asynchronously and the modal renders before it
+        // lands, so without this the button is live during that window with
+        // no shadow lobby behind it — the invite would silently no-op. The
+        // join modal gets this free from its own !currentLobbyId early return.
+        const invite = this.lobbyId ? inviteFriendsButton() : undefined;
         return invite
           ? html`<div class="flex items-center gap-2">${copy}${invite}</div>`
           : copy;

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -35,6 +35,7 @@ import "./components/GameConfigSettings";
 import "./components/InputCard";
 import "./components/LobbyPlayerView";
 import "./components/ToggleInputCard";
+import { inviteFriendsButton } from "./components/ui/InviteFriendsButton";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import { JoinLobbyEvent } from "./Main";
@@ -220,13 +221,22 @@ export class HostLobbyModal extends BaseModal {
         this.close();
       },
       ariaLabel: translateText("common.back"),
-      rightContent: html`
-        <copy-button
+      // Both answer "get my friends into this lobby", so they sit together —
+      // the host is the player holding the code and deciding who joins, and
+      // was the one surface the invite button originally missed. Paired behind
+      // a wrapper only when the invite is present, so a browser renders exactly
+      // the markup it did before.
+      rightContent: (() => {
+        const copy = html`<copy-button
           .lobbyId=${this.lobbyId}
           .lobbySuffix=${this.lobbyUrlSuffix}
           include-lobby-query
-        ></copy-button>
-      `,
+        ></copy-button>`;
+        const invite = inviteFriendsButton();
+        return invite
+          ? html`<div class="flex items-center gap-2">${copy}${invite}</div>`
+          : copy;
+      })(),
     });
   }
 

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -29,7 +29,6 @@ import {
 } from "../core/game/Game";
 import { getApiBase } from "./Api";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
-import { desktopPresence } from "./DesktopPresence";
 import { PublicLobbySocket } from "./LobbySocket";
 import { JoinLobbyEvent } from "./Main";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
@@ -40,6 +39,7 @@ import { BaseModal } from "./components/BaseModal";
 import "./components/CopyButton";
 import "./components/LobbyConfigItem";
 import "./components/LobbyPlayerView";
+import { inviteFriendsButton } from "./components/ui/InviteFriendsButton";
 import { modalHeader } from "./components/ui/ModalHeader";
 import { nationsConfigToSlider } from "./utilities/GameConfigHelpers";
 
@@ -103,36 +103,6 @@ export class JoinLobbyModal extends BaseModal {
     });
   };
 
-  // Steam's invite dialog is reachable only through the in-game overlay, so
-  // this is desktop-shell-only: isAvailable() checks shell.api >= 2, which is
-  // false in a browser and on an older depot's shell. The click is
-  // best-effort — the bridge resolves false when Steam is absent or the
-  // overlay refuses, and a lobby must not break on that.
-  private renderInviteFriends() {
-    if (!desktopPresence.isAvailable()) return undefined;
-    const label = translateText("public_lobby.invite_friends");
-    return html`<button
-      data-test-invite-friends
-      type="button"
-      @click=${() => void desktopPresence.openInviteDialog()}
-      class="flex items-center gap-1.5 bg-white/5 hover:bg-white/10 rounded-lg px-2 py-1 border border-white/10 text-white/60 hover:text-white text-xs font-bold uppercase tracking-widest transition-colors"
-      title=${label}
-      aria-label=${label}
-    >
-      <svg
-        class="w-4 h-4"
-        viewBox="0 0 20 20"
-        fill="currentColor"
-        aria-hidden="true"
-      >
-        <path
-          d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM16 7a1 1 0 00-2 0v2h-2a1 1 0 000 2h2v2a1 1 0 002 0v-2h2a1 1 0 000-2h-2V7z"
-        ></path>
-      </svg>
-      ${label}
-    </button>`;
-  }
-
   protected renderHeaderSlot() {
     if (!this.currentLobbyId) {
       return modalHeader({
@@ -149,7 +119,7 @@ export class JoinLobbyModal extends BaseModal {
       this.currentLobbyId && this.isPrivateLobby()
         ? html`<copy-button .lobbyId=${this.currentLobbyId}></copy-button>`
         : undefined;
-    const invite = this.renderInviteFriends();
+    const invite = inviteFriendsButton();
     return modalHeader({
       title: translateText("public_lobby.title"),
       onBack: () => this.closeAndLeave(),

--- a/src/client/components/ui/InviteFriendsButton.ts
+++ b/src/client/components/ui/InviteFriendsButton.ts
@@ -1,0 +1,44 @@
+import { html, TemplateResult } from "lit";
+import { desktopPresence } from "../../DesktopPresence";
+import { translateText } from "../../Utils";
+
+/**
+ * "Invite Friends", or nothing when Steam's invite dialog is not reachable.
+ *
+ * Shared by every lobby surface rather than living on one of them. It first
+ * shipped inline in JoinLobbyModal, which meant the host of a private lobby —
+ * the player holding the code and deciding who joins — was the only one who
+ * never got it. Two copies would drift the same way; one cannot.
+ *
+ * Desktop-shell-only: isAvailable() checks shell.api >= 2, which is false in a
+ * browser and on an older depot's shell. Returning undefined rather than an
+ * empty template lets callers keep rendering byte-identical markup where the
+ * button is absent.
+ *
+ * The click is best-effort. The bridge resolves false when Steam is absent or
+ * the overlay refuses, and a lobby must not break on that.
+ */
+export function inviteFriendsButton(): TemplateResult | undefined {
+  if (!desktopPresence.isAvailable()) return undefined;
+  const label = translateText("public_lobby.invite_friends");
+  return html`<button
+    data-test-invite-friends
+    type="button"
+    @click=${() => void desktopPresence.openInviteDialog()}
+    class="flex items-center gap-1.5 bg-white/5 hover:bg-white/10 rounded-lg px-2 py-1 border border-white/10 text-white/60 hover:text-white text-xs font-bold uppercase tracking-widest transition-colors"
+    title=${label}
+    aria-label=${label}
+  >
+    <svg
+      class="w-4 h-4"
+      viewBox="0 0 20 20"
+      fill="currentColor"
+      aria-hidden="true"
+    >
+      <path
+        d="M8 9a3 3 0 100-6 3 3 0 000 6zM8 11a6 6 0 00-6 6v1h12v-1a6 6 0 00-6-6zM16 7a1 1 0 00-2 0v2h-2a1 1 0 000 2h2v2a1 1 0 002 0v-2h2a1 1 0 000-2h-2V7z"
+      ></path>
+    </svg>
+    ${label}
+  </button>`;
+}

--- a/tests/client/HostLobbyModal.test.ts
+++ b/tests/client/HostLobbyModal.test.ts
@@ -64,6 +64,16 @@ describe("HostLobbyModal Steam invite button", () => {
     expect(header.querySelector(COPY)).not.toBeNull();
   });
 
+  // createLobby() assigns lobbyId asynchronously and this modal renders before
+  // it lands. A button live in that window has no shadow lobby behind it, so
+  // the invite would silently no-op.
+  it("is absent until the lobby id lands, even on the desktop shell", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    const modal = new HostLobbyModal();
+
+    expect(renderHeader(modal).querySelector(INVITE)).toBeNull();
+  });
+
   it("appears beside the copy button on the desktop shell", () => {
     presenceMocks.isAvailable.mockReturnValue(true);
     const header = renderHeader(hostModal());

--- a/tests/client/HostLobbyModal.test.ts
+++ b/tests/client/HostLobbyModal.test.ts
@@ -1,0 +1,84 @@
+import { render } from "lit";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const presenceMocks = vi.hoisted(() => ({
+  isAvailable: vi.fn(() => false),
+  openInviteDialog: vi.fn(async () => true),
+}));
+
+// The desktop bridge is absent in a browser and in jsdom. Mocking the module
+// lets each test state which shell it is running in, which is the only thing
+// the invite button is gated on.
+vi.mock("../../src/client/DesktopPresence", () => ({
+  desktopPresence: {
+    isAvailable: presenceMocks.isAvailable,
+    openInviteDialog: presenceMocks.openInviteDialog,
+    set: vi.fn(),
+    consumePendingInvite: vi.fn(async () => null),
+    subscribeInvites: vi.fn(() => () => undefined),
+  },
+}));
+
+import { HostLobbyModal } from "../../src/client/HostLobbyModal";
+
+// The host holds the lobby code and decides who joins, so they are the player
+// most likely to want this — and they were the one surface the button missed
+// when it first shipped, because it lived inline in JoinLobbyModal. The
+// gating and wiring are pinned here; whether Steam's dialog actually renders
+// needs a packaged build, per OPE-200's acceptance criterion.
+describe("HostLobbyModal Steam invite button", () => {
+  const INVITE = "[data-test-invite-friends]";
+  const COPY = "copy-button";
+
+  function renderHeader(modal: HostLobbyModal): HTMLElement {
+    const container = document.createElement("div");
+    render(
+      (
+        modal as unknown as { renderHeaderSlot(): unknown }
+      ).renderHeaderSlot() as never,
+      container,
+    );
+    return container;
+  }
+
+  function hostModal(): HostLobbyModal {
+    const modal = new HostLobbyModal();
+    (modal as unknown as { lobbyId: string }).lobbyId = "ABCD1234";
+    return modal;
+  }
+
+  beforeEach(() => {
+    presenceMocks.isAvailable.mockReset().mockReturnValue(false);
+    presenceMocks.openInviteDialog.mockReset().mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is absent in a browser, leaving the copy button alone", () => {
+    presenceMocks.isAvailable.mockReturnValue(false);
+    const header = renderHeader(hostModal());
+
+    expect(header.querySelector(INVITE)).toBeNull();
+    expect(header.querySelector(COPY)).not.toBeNull();
+  });
+
+  it("appears beside the copy button on the desktop shell", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    const header = renderHeader(hostModal());
+
+    expect(header.querySelector(INVITE)).not.toBeNull();
+    expect(header.querySelector(COPY)).not.toBeNull();
+  });
+
+  it("opens the Steam invite dialog when clicked", () => {
+    presenceMocks.isAvailable.mockReturnValue(true);
+    const button =
+      renderHeader(hostModal()).querySelector<HTMLButtonElement>(INVITE);
+
+    button?.click();
+
+    expect(presenceMocks.openInviteDialog).toHaveBeenCalledOnce();
+  });
+});


### PR DESCRIPTION
The Invite Friends button shipped inline in `JoinLobbyModal`, so it reached everyone **except the player most likely to want it**: the host of a private lobby, who holds the code and decides who joins. `HostLobbyModal` never had it.

Found while testing a real Steam build — the button was missing while hosting, and `document.querySelector('join-lobby-modal').currentLobbyId` came back empty because that modal was not the one on screen.

## Extracted rather than copied

Two inline definitions is how this diverged in the first place. There is now one `inviteFriendsButton()` in `src/client/components/ui/InviteFriendsButton.ts` that both modals call, so they cannot drift apart again.

It still returns `undefined` off the desktop shell rather than an empty template, so a browser renders **byte-identical markup** to before — the same property the original had.

`JoinLobbyModal` no longer imports `desktopPresence` at all; its only use was this button.

## Host header

The invite pairs with the existing copy-code control behind a flex wrapper, and only when the invite is present — mirroring the join modal, and leaving the browser path untouched.

## Testing

New `tests/client/HostLobbyModal.test.ts` mirroring the join modal's:

- absent in a browser, with the copy button still rendered
- present beside the copy button on the desktop shell
- click opens the Steam invite dialog

**Mutation-checked:** removing the button fails exactly the two positive tests and leaves the browser case passing.

Full suite: 350 files, 4290 tests, zero failures. `tsc`, prettier and lint clean.

## Not verified here

Whether Steam's dialog actually **opens from a hosted lobby** needs a packaged build. It should — `presenceDetail` carries `lobbyId: event.lobby.gameID` and `reconcileShadowLobby` builds the shadow lobby from the presence payload — but that is reasoned from the code rather than observed, and the acceptance test is a human hosting a private lobby on the Steam build and clicking it.

Refs: OPE-205