### PR TITLE
fix(ads): actually request the flex header ad, destroy it at game start

### DIFF
--- a/src/client/HomepagePromos.ts
+++ b/src/client/HomepagePromos.ts
@@ -170,13 +170,17 @@ export class HomepagePromos extends LitElement {
   public close(): void {
     this.adLoaded = false;
     try {
-      // Destroy gutter rails; bottom_rail persists into spawn phase. Rails are
-      // no-selector units, registered under pw-oop- ids (see destroyBottomRail).
+      // Destroy gutter rails and the header ad; bottom_rail persists into
+      // spawn phase. These are no-selector units, registered under pw-oop-
+      // ids (see destroyBottomRail). The header ad must go too: nothing hides
+      // #pw-oop-flex_container in-game and its docked state is fixed at the
+      // viewport top, so it would sit over the map.
       window.ramp.destroyUnits("pw-oop-left_rail");
       window.ramp.destroyUnits("pw-oop-right_rail");
-      console.log("successfully destroyed gutter rails");
+      window.ramp.destroyUnits("pw-oop-flex");
+      console.log("successfully destroyed gutter rails and header ad");
     } catch (e) {
-      console.error("error destroying gutter rails", e);
+      console.error("error destroying gutter rails and header ad", e);
     }
     // Adblock-detected users get NO in-game ads (the AdGatekeeper latch is
     // permanent, surviving the blocker being disabled), so the corner video
@@ -225,7 +229,7 @@ export class HomepagePromos extends LitElement {
   }
 
   private loadGutterAds(): void {
-    console.log("loading ramp gutter rails");
+    console.log("loading ramp gutter rails and header ad");
     if (!window.ramp) {
       console.warn("Playwire RAMP not available");
       return;
@@ -242,15 +246,18 @@ export class HomepagePromos extends LitElement {
           window.ramp.spaAddAds([
             { type: "left_rail" },
             { type: "right_rail" },
+            // Header ad (GumGum flex leaderboard); the page shifts below it
+            // via --top-ad-height / --top-ad-pad (see syncTopAd).
+            { type: "flex" },
           ]);
           this.adLoaded = true;
-          console.log("Gutter rails loaded");
+          console.log("Gutter rails and header ad loaded");
         } catch (e) {
           console.log(e);
         }
       });
     } catch (error) {
-      console.error("Failed to load gutter rails:", error);
+      console.error("Failed to load gutter rails and header ad:", error);
     }
   }
 


### PR DESCRIPTION
## Description:

Follow-up to #5009. That PR added the CSS and the `--top-ad-height` measurement for the Playwire out-of-page `flex` leaderboard (GumGum header ad), but never requested the unit — the only homepage `spaAddAds` call was the gutter-rail pair, and the PR's verification invoked `spaAddAds({type:'flex'})` by hand from the console. This adds `{ type: "flex" }` to that batch so the header ad is requested with the rails when `adsEnabled` fires.

It also destroys the unit in `close()` at game start, next to the rail teardown. Nothing in the `body.in-game` rules hides `#pw-oop-flex_container`, and the docked banner is `position: fixed` at the viewport top (z-index 150), so without this it would sit over the map. Once Playwire removes the node, the existing body `MutationObserver` re-runs `syncTopAd` and clears `--top-ad-height` / `--top-ad-pad` / the container `min-height` on its own, so no additional cleanup is needed.

The `pw-oop-flex` destroy id follows the same naming as `pw-oop-left_rail` / `pw-oop-bottom_rail` (the unit's DOM id is `pw-oop-flex`).

## Verification

- `tsc`, oxlint, eslint, prettier clean.
- RAMP won't initialize headless, so like #5009 this needs a headed check against the real creative: the unit fills from the `flex` request on the homepage, and `#pw-oop-flex` / `#adBanner` are both gone after game start.

## Open follow-ups (flagged in review, not in this PR)

- The queued `spaAddAds` callback can still fire after `close()` if ramp.js finishes loading during a fast singleplayer start; the corner video guards the same race with `cornerAdDestroyed`, this batch doesn't.
- `destroyUnits` returns a promise nobody observes (pre-existing for the rails), so an unrecognised id would surface only as an unhandled rejection while the log claims success.
- `HomepagePromos.ts` has no unit test; a `window.ramp` stub under jsdom (as `FeaturedStreamPanel.test.ts` does for `window.Twitch`) would cover both changes.

## Please complete the following:

- [ ] I have added screenshots for all UI updates — N/A, no visual change when no ad serves
- [ ] I process any text displayed to the user through translateText() — N/A, no user-visible text added
- [ ] I have added relevant tests to the test directory — N/A, behaviour depends on the live Playwire script; see follow-ups

🤖 Generated with [Claude Code](https://claude.com/claude-code)
