### PR TITLE
Auto-format map generator output with Prettier 🗺️

### DIFF
--- a/map-generator/README.md
+++ b/map-generator/README.md
@@ -35,12 +35,10 @@ Maps are discovered automatically from the `assets/maps/` folders — `info.json
    `go run . --maps=northamerica,world`
 
 5. Find the output folder at `../resources/maps/<map_name>`
-6. Go back to the root directory: `cd ..`
-7. Run Prettier: `npm run format`
-   This rewrites ALL files in place. Git figures out which files are actually changed, don't worry.
-   Alternatively, you can either run Prettier per file: `npx prettier --write resources/maps/<map_name>/<file_name>` or in VSCode install the Prettier extension and per file do Show and run Commands > Format Document.
 
-Alternatively, `npm run gen-maps` (from the root directory) runs the generator for all maps and formats the output in one step.
+`go run .` formats every file it writes with Prettier as its last step (shelling out to `npx prettier --write`), so the output already matches `npm run format` — no separate formatting step needed. If `npx prettier` isn't available (e.g. `npm ci` hasn't been run), generation still succeeds but prints a warning; run `npm run format` from the root directory to format manually in that case.
+
+`npm run gen-maps` (from the root directory) is equivalent to `go run .` for all maps.
 
 ## Output Files
 

--- a/map-generator/codegen.go
+++ b/map-generator/codegen.go
@@ -307,10 +307,11 @@ func loadMapInfos() ([]mapInfo, error) {
 
 // generateMapsTS writes the GameMapType enum, the MapCategory union, the
 // MapInfo interface, and the maps list to src/core/game/Maps.gen.ts.
-func generateMapsTS(infos []mapInfo) error {
+// It returns the path written.
+func generateMapsTS(infos []mapInfo) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
+		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 	outPath := filepath.Join(cwd, "..", "src", "core", "game", "Maps.gen.ts")
 
@@ -507,9 +508,9 @@ func generateMapsTS(infos []mapInfo) error {
 	b.WriteString("];\n")
 
 	if err := os.WriteFile(outPath, []byte(b.String()), 0644); err != nil {
-		return fmt.Errorf("failed to write %s: %w", outPath, err)
+		return "", fmt.Errorf("failed to write %s: %w", outPath, err)
 	}
-	return nil
+	return outPath, nil
 }
 
 // generateEnJSON rewrites the "map" section of resources/lang/en.json with
@@ -519,24 +520,25 @@ func generateMapsTS(infos []mapInfo) error {
 // The whole file is round-tripped through encoding/json, which marshals
 // object keys in sorted order — a no-op for everything but the map section
 // because en.json is kept sorted (see tests/EnJsonSorted.test.ts).
-func generateEnJSON(infos []mapInfo) error {
+// It returns the path written.
+func generateEnJSON(infos []mapInfo) (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
+		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 	enPath := filepath.Join(cwd, "..", "resources", "lang", "en.json")
 	content, err := os.ReadFile(enPath)
 	if err != nil {
-		return fmt.Errorf("failed to read en.json: %w", err)
+		return "", fmt.Errorf("failed to read en.json: %w", err)
 	}
 
 	var root map[string]interface{}
 	if err := json.Unmarshal(content, &root); err != nil {
-		return fmt.Errorf("failed to parse en.json: %w", err)
+		return "", fmt.Errorf("failed to parse en.json: %w", err)
 	}
 	oldSection, ok := root["map"].(map[string]interface{})
 	if !ok {
-		return fmt.Errorf("en.json has no top-level \"map\" object")
+		return "", fmt.Errorf("en.json has no top-level \"map\" object")
 	}
 
 	mapFolders := make(map[string]bool, len(infos))
@@ -578,10 +580,10 @@ func generateEnJSON(infos []mapInfo) error {
 	enc.SetEscapeHTML(false)
 	enc.SetIndent("", "  ")
 	if err := enc.Encode(root); err != nil {
-		return fmt.Errorf("failed to serialize en.json: %w", err)
+		return "", fmt.Errorf("failed to serialize en.json: %w", err)
 	}
 	if err := os.WriteFile(enPath, b.Bytes(), 0644); err != nil {
-		return fmt.Errorf("failed to write en.json: %w", err)
+		return "", fmt.Errorf("failed to write en.json: %w", err)
 	}
-	return nil
+	return enPath, nil
 }

--- a/map-generator/main.go
+++ b/map-generator/main.go
@@ -88,34 +88,35 @@ func inputMapDir(isTest bool) (string, error) {
 
 // processMap handles the end-to-end generation for a single map.
 // It reads the source image and JSON, generates the terrain data, and writes the binary outputs and updated manifest.
-func processMap(ctx context.Context, name string, isTest bool) error {
+// On success it returns the path of the manifest.json it wrote, so callers can format it with Prettier.
+func processMap(ctx context.Context, name string, isTest bool) (string, error) {
 	outputMapBaseDir, err := outputMapDir(isTest)
 	if err != nil {
-		return fmt.Errorf("failed to get map directory: %w", err)
+		return "", fmt.Errorf("failed to get map directory: %w", err)
 	}
 
 	inputMapDir, err := inputMapDir(isTest)
 	if err != nil {
-		return fmt.Errorf("failed to get input map directory: %w", err)
+		return "", fmt.Errorf("failed to get input map directory: %w", err)
 	}
 
 	inputPath := filepath.Join(inputMapDir, name, "image.png")
 	imageBuffer, err := os.ReadFile(inputPath)
 	if err != nil {
-		return fmt.Errorf("failed to read map file %s: %w", inputPath, err)
+		return "", fmt.Errorf("failed to read map file %s: %w", inputPath, err)
 	}
 
 	// Read the info.json file
 	manifestPath := filepath.Join(inputMapDir, name, "info.json")
 	manifestBuffer, err := os.ReadFile(manifestPath)
 	if err != nil {
-		return fmt.Errorf("failed to read info file %s: %w", manifestPath, err)
+		return "", fmt.Errorf("failed to read info file %s: %w", manifestPath, err)
 	}
 
 	// Parse the info buffer as dynamic JSON
 	var manifest map[string]interface{}
 	if err := json.Unmarshal(manifestBuffer, &manifest); err != nil {
-		return fmt.Errorf("failed to parse info.json for %s: %w", name, err)
+		return "", fmt.Errorf("failed to parse info.json for %s: %w", name, err)
 	}
 
 	// Generate maps
@@ -125,7 +126,7 @@ func processMap(ctx context.Context, name string, isTest bool) error {
 		Name:        name,
 	})
 	if err != nil {
-		return fmt.Errorf("failed to generate map for %s: %w", name, err)
+		return "", fmt.Errorf("failed to generate map for %s: %w", name, err)
 	}
 
 	manifest["map"] = map[string]interface{}{
@@ -146,19 +147,19 @@ func processMap(ctx context.Context, name string, isTest bool) error {
 
 	mapDir := filepath.Join(outputMapBaseDir, name)
 	if err := os.MkdirAll(mapDir, 0755); err != nil {
-		return fmt.Errorf("failed to create output directory for %s: %w", name, err)
+		return "", fmt.Errorf("failed to create output directory for %s: %w", name, err)
 	}
 	if err := os.WriteFile(filepath.Join(mapDir, "map.bin"), result.Map.Data, 0644); err != nil {
-		return fmt.Errorf("failed to write combined binary for %s: %w", name, err)
+		return "", fmt.Errorf("failed to write combined binary for %s: %w", name, err)
 	}
 	if err := os.WriteFile(filepath.Join(mapDir, "map4x.bin"), result.Map4x.Data, 0644); err != nil {
-		return fmt.Errorf("failed to write combined binary for %s: %w", name, err)
+		return "", fmt.Errorf("failed to write combined binary for %s: %w", name, err)
 	}
 	if err := os.WriteFile(filepath.Join(mapDir, "map16x.bin"), result.Map16x.Data, 0644); err != nil {
-		return fmt.Errorf("failed to write combined binary for %s: %w", name, err)
+		return "", fmt.Errorf("failed to write combined binary for %s: %w", name, err)
 	}
 	if err := os.WriteFile(filepath.Join(mapDir, "thumbnail.webp"), result.Thumbnail, 0644); err != nil {
-		return fmt.Errorf("failed to write thumbnail for %s: %w", name, err)
+		return "", fmt.Errorf("failed to write thumbnail for %s: %w", name, err)
 	}
 
 	// Copy layer PNGs and validate them.
@@ -176,25 +177,25 @@ func processMap(ctx context.Context, name string, isTest bool) error {
 				// Validate placement.
 				placement, _ := layer["placement"].(string)
 				if placement != "land" && placement != "water" {
-					return fmt.Errorf("map %s: layer %q has invalid placement %q (must be \"land\" or \"water\")", name, layerID, placement)
+					return "", fmt.Errorf("map %s: layer %q has invalid placement %q (must be \"land\" or \"water\")", name, layerID, placement)
 				}
 				// Copy the layer PNG.
 				srcPng := filepath.Join(inputMapDir, name, layerID+".png")
 				dstPng := filepath.Join(mapDir, layerID+".png")
 				pngData, err := os.ReadFile(srcPng)
 				if err != nil {
-					return fmt.Errorf("map %s: layer %q PNG not found at %s: %w", name, layerID, srcPng, err)
+					return "", fmt.Errorf("map %s: layer %q PNG not found at %s: %w", name, layerID, srcPng, err)
 				}
 				// Validate dimensions match image.png.
 				img, _, err := image.DecodeConfig(bytes.NewReader(pngData))
 				if err != nil {
-					return fmt.Errorf("map %s: layer %q PNG failed to decode: %w", name, layerID, err)
+					return "", fmt.Errorf("map %s: layer %q PNG failed to decode: %w", name, layerID, err)
 				}
 				if img.Width != result.Map.Width || img.Height != result.Map.Height {
-					return fmt.Errorf("map %s: layer %q PNG dimensions (%dx%d) do not match map (%dx%d)", name, layerID, img.Width, img.Height, result.Map.Width, result.Map.Height)
+					return "", fmt.Errorf("map %s: layer %q PNG dimensions (%dx%d) do not match map (%dx%d)", name, layerID, img.Width, img.Height, result.Map.Width, result.Map.Height)
 				}
 				if err := os.WriteFile(dstPng, pngData, 0644); err != nil {
-					return fmt.Errorf("failed to write layer PNG for %s/%s: %w", name, layerID, err)
+					return "", fmt.Errorf("failed to write layer PNG for %s/%s: %w", name, layerID, err)
 				}
 			}
 		}
@@ -203,13 +204,14 @@ func processMap(ctx context.Context, name string, isTest bool) error {
 	// Serialize the updated manifest to JSON
 	updatedManifest, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to serialize manifest for %s: %w", name, err)
+		return "", fmt.Errorf("failed to serialize manifest for %s: %w", name, err)
 	}
 
-	if err := os.WriteFile(filepath.Join(mapDir, "manifest.json"), updatedManifest, 0644); err != nil {
-		return fmt.Errorf("failed to write manifest for %s: %w", name, err)
+	manifestOutPath := filepath.Join(mapDir, "manifest.json")
+	if err := os.WriteFile(manifestOutPath, updatedManifest, 0644); err != nil {
+		return "", fmt.Errorf("failed to write manifest for %s: %w", name, err)
 	}
-	return nil
+	return manifestOutPath, nil
 }
 
 // parseMapsFlag validates and parses the --maps command-line argument.
@@ -237,16 +239,21 @@ func parseMapsFlag() (map[string]bool, error) {
 // loadTerrainMaps manages the concurrent generation of all selected maps.
 // It spins up goroutines for each map and aggregates any errors.
 // Concurrency is bounded by --workers to cap peak memory usage.
-func loadTerrainMaps() error {
+// On success it returns the manifest.json path written for every map processed.
+func loadTerrainMaps() ([]string, error) {
 	if workersFlag < 1 {
-		return fmt.Errorf("--workers must be >= 1, got %d", workersFlag)
+		return nil, fmt.Errorf("--workers must be >= 1, got %d", workersFlag)
 	}
 	selectedMaps, err := parseMapsFlag()
 	if err != nil {
-		return err
+		return nil, err
 	}
 	var wg sync.WaitGroup
-	errChan := make(chan error, len(maps))
+	type result struct {
+		manifestPath string
+		err          error
+	}
+	resultChan := make(chan result, len(maps))
 	sem := make(chan struct{}, workersFlag)
 
 	// Process maps concurrently, bounded by the semaphore
@@ -264,24 +271,25 @@ func loadTerrainMaps() error {
 			testLogTag := slog.Bool("isTest", mapItem.IsTest)
 			logger := slog.Default().With(mapLogTag).With(testLogTag)
 			ctx := ContextWithLogger(context.Background(), logger)
-			if err := processMap(ctx, mapItem.Name, mapItem.IsTest); err != nil {
-				errChan <- err
-			}
+			manifestPath, err := processMap(ctx, mapItem.Name, mapItem.IsTest)
+			resultChan <- result{manifestPath, err}
 		}()
 	}
 
 	// Wait for all goroutines to complete
 	wg.Wait()
-	close(errChan)
+	close(resultChan)
 
-	// Check for errors
-	for err := range errChan {
-		if err != nil {
-			return err
+	// Check for errors and collect the manifest paths written.
+	var manifestPaths []string
+	for r := range resultChan {
+		if r.err != nil {
+			return nil, r.err
 		}
+		manifestPaths = append(manifestPaths, r.manifestPath)
 	}
 
-	return nil
+	return manifestPaths, nil
 }
 
 // main is the entry point for the map generator tool.
@@ -312,7 +320,8 @@ func main() {
 	}
 	maps = discovered
 
-	if err := loadTerrainMaps(); err != nil {
+	manifestPaths, err := loadTerrainMaps()
+	if err != nil {
 		log.Fatalf("Error generating terrain maps: %v", err)
 	}
 
@@ -320,11 +329,22 @@ func main() {
 	if err != nil {
 		log.Fatalf("Error loading map info: %v", err)
 	}
-	if err := generateMapsTS(infos); err != nil {
+	mapsTSPath, err := generateMapsTS(infos)
+	if err != nil {
 		log.Fatalf("Error generating Maps.gen.ts: %v", err)
 	}
-	if err := generateEnJSON(infos); err != nil {
+	enJSONPath, err := generateEnJSON(infos)
+	if err != nil {
 		log.Fatalf("Error generating en.json map section: %v", err)
+	}
+
+	// Format every file we just wrote with the repo's Prettier config, so
+	// `go run .` alone leaves a clean diff — no separate `npm run format`
+	// step to remember. Regenerated map manifests are the same JSON `go fmt`
+	// produces for Maps.gen.ts and en.json: valid, but not Prettier-shaped.
+	formatFiles := append(manifestPaths, mapsTSPath, enJSONPath)
+	if err := runPrettier(formatFiles); err != nil {
+		slog.Warn("Failed to auto-format generated files with Prettier; run `npm run format` manually", "error", err)
 	}
 
 	fmt.Println("Terrain maps generated successfully")

--- a/map-generator/prettier.go
+++ b/map-generator/prettier.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// runPrettier formats the given files in place using the repo's Prettier
+// config (../.prettierrc), the same tool `npm run format` and CI's
+// `npx prettier --check .` job use. It runs from the repo root so relative
+// paths and config discovery behave exactly as they do for `npm run format`.
+//
+// Only the given files are touched — unlike `npm run format`, this does not
+// reformat the whole repo, so it's safe to run on every `go run .`,
+// including `--maps=<one map>` runs.
+func runPrettier(files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	repoRoot := filepath.Join(cwd, "..")
+
+	args := []string{"--no-install", "prettier", "--write"}
+	for _, f := range files {
+		rel, err := filepath.Rel(repoRoot, f)
+		if err != nil {
+			return fmt.Errorf("failed to compute relative path for %s: %w", f, err)
+		}
+		args = append(args, filepath.ToSlash(rel))
+	}
+
+	cmd := exec.Command("npx", args...)
+	cmd.Dir = repoRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("npx prettier --write failed (is `npm ci` up to date?): %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Description:

The map generator's raw output (Maps.gen.ts and each map's manifest.json) never matched Prettier's formatting, so contributors following the README's per-map workflow (go run . --maps=<map_name>) would get Prettier CI failures on their PR unless they remembered to separately run npm run format.

go run . now shells out to npx prettier --write on exactly the files it just wrote (each processed map's manifest.json, Maps.gen.ts, and en.json) as its last step, so the output already matches npm run format with no extra step. Only those specific files are touched, so this stays cheap even for single-map runs. If npx prettier isn't available (e.g. npm ci hasn't been run), generation still succeeds but prints a warning telling you to format manually.

Verified go run . for a single map and for every map produces zero diff against the already-formatted committed files. Updated map-generator/README.md to drop the now-unnecessary manual formatting step.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
