### PR TITLE
fix(store): match custom amount card to pack card layout

### DIFF
--- a/src/client/components/CustomCurrencyCard.ts
+++ b/src/client/components/CustomCurrencyCard.ts
@@ -48,30 +48,39 @@ export class CustomCurrencyCard extends LitElement {
 
   render() {
     const price = `$${this.priceDollars}`;
+    // Mirrors cosmetic-card: the name leads, the artwork box is square, and
+    // the width comes from the host so the card shrinks with the grid on
+    // phones instead of overflowing it.
     return html`
       <article
         data-custom-currency-card
         data-cosmetic-shell
         data-cosmetic-rarity="common"
         style="background:linear-gradient(to top, rgba(80,80,80,0.55) 0%, rgba(15,15,20,0.85) 100%);border-color:rgba(255,255,255,0.15)"
-        class="relative flex h-full w-48 flex-col items-center overflow-visible rounded-xl border border-white/20 transition-all duration-200 ease-out hover:-translate-y-1 hover:z-10 hover:shadow-[0_0_10px_rgba(255,255,255,0.5)]"
+        class="relative flex h-full w-full flex-col items-center overflow-visible rounded-xl border border-white/20 transition-all duration-200 ease-out hover:-translate-y-1 hover:z-10 hover:shadow-[0_0_10px_rgba(255,255,255,0.5)]"
       >
+        <span
+          data-custom-currency-name
+          class="w-full whitespace-normal break-words px-3 pt-3 text-center text-sm font-bold leading-tight text-white"
+          >${translateText("store.custom_amount")}</span
+        >
+
         <div
           data-cosmetic-main
-          class="group relative flex w-full flex-col items-center gap-2 rounded-xl p-3"
+          class="group relative flex w-full flex-col items-center gap-2 rounded-xl px-3 pb-3 pt-2"
         >
           <div
             data-custom-currency-preview
-            class="relative flex w-full aspect-square flex-col items-center justify-center gap-1 overflow-hidden rounded-lg border border-white/10 bg-white/5 p-2"
+            class="relative flex w-full aspect-square flex-col items-center justify-center gap-1 overflow-hidden rounded-lg bg-white/5 p-2"
           >
-            <plutonium-icon .size=${64}></plutonium-icon>
+            <plutonium-icon class="block shrink-0" .size=${64}></plutonium-icon>
             <label for="custom-plutonium-amount" class="sr-only"
               >${translateText("store.plutonium_amount")}</label
             >
             <input
               id="custom-plutonium-amount"
               type="number"
-              class="custom-plutonium-input w-24 text-center bg-black/30 border border-green-500/30 rounded px-1 py-0.5 text-lg font-black text-green-400 outline-none focus:border-green-400 focus:ring-1 focus:ring-green-400/40"
+              class="custom-plutonium-input w-full min-w-0 max-w-24 text-center bg-black/30 border border-green-500/30 rounded px-1 py-0.5 text-lg font-black leading-none text-green-400 outline-none focus:border-green-400 focus:ring-1 focus:ring-green-400/40"
               aria-label=${translateText("store.plutonium_amount")}
               min=${MIN_PLUTONIUM}
               max=${MAX_PLUTONIUM}
@@ -79,26 +88,22 @@ export class CustomCurrencyCard extends LitElement {
               .value=${String(this.amount)}
               @change=${this.onInputChange}
             />
-            <span class="text-[10px] font-bold text-white/50 uppercase"
+            <span
+              class="text-[10px] font-bold leading-none text-white/50 uppercase"
               >${translateText("cosmetics.hard")}</span
             >
-            <input
-              type="range"
-              class="w-[90%] accent-green-500 cursor-pointer"
-              aria-label=${translateText("store.plutonium_amount")}
-              min=${MIN_PLUTONIUM}
-              max=${MAX_PLUTONIUM}
-              step="1"
-              .value=${String(this.amount)}
-              @input=${this.onSlider}
-            />
           </div>
 
-          <span
-            data-custom-currency-name
-            class="w-full whitespace-normal break-words text-center text-sm font-bold leading-tight text-white"
-            >${translateText("store.custom_amount")}</span
-          >
+          <input
+            type="range"
+            class="w-full accent-green-500 cursor-pointer"
+            aria-label=${translateText("store.plutonium_amount")}
+            min=${MIN_PLUTONIUM}
+            max=${MAX_PLUTONIUM}
+            step="1"
+            .value=${String(this.amount)}
+            @input=${this.onSlider}
+          />
         </div>
 
         <div data-cosmetic-action class="mt-auto w-full px-3 pb-3 pt-2">

--- a/tests/client/CustomCurrencyCard.test.ts
+++ b/tests/client/CustomCurrencyCard.test.ts
@@ -36,9 +36,12 @@ describe("CustomCurrencyCard", () => {
 
     expect(card!.querySelector("[data-custom-currency-card]")).toBeTruthy();
     expect(card!.querySelector("purchase-button")).toBeTruthy();
-    expect(
-      card!.querySelector("[data-custom-currency-card]")?.className,
-    ).toMatch(/w-48/);
+    // Width comes from the host element so the card shrinks with the pack
+    // grid on phones instead of overflowing it.
+    const shellClass =
+      card!.querySelector("[data-custom-currency-card]")?.className ?? "";
+    expect(shellClass).toMatch(/w-full/);
+    expect(shellClass).not.toMatch(/w-48/);
     expect(
       card!.querySelector<HTMLElement>("[data-custom-currency-card]")?.dataset
         .cosmeticShell,
@@ -53,7 +56,15 @@ describe("CustomCurrencyCard", () => {
     expect(
       card!.querySelector("[data-custom-currency-name]")?.className,
     ).not.toMatch(/pt-2/);
-    expect(card!.querySelector("[data-cosmetic-main]")).toBeTruthy();
+    // The name leads the card, as it does on cosmetic-card.
+    const main = card!.querySelector("[data-cosmetic-main]");
+    expect(main).toBeTruthy();
+    const name = card!.querySelector("[data-custom-currency-name]");
+    expect(name?.className).toMatch(/pt-3/);
+    expect(
+      name!.compareDocumentPosition(main!) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(main!.contains(name)).toBe(false);
     expect(card!.querySelector("[data-cosmetic-action]")?.className).toMatch(
       /w-full/,
     );


### PR DESCRIPTION
## Summary

The "Choose Amount" card in the store's Packs tab rendered wrong, especially on mobile:

- The card shell hard-coded `w-48` while its host in the pack grid is `w-[calc(50%-0.5rem)] max-w-48 sm:w-48`, so on phones the card overflowed the grid.
- The "Choose Amount" title sat underneath the artwork, unlike every other card where the name leads.
- The slider was squeezed inside the square preview box, and the box had an extra border the other cards lack.

## Changes

`src/client/components/CustomCurrencyCard.ts`
- Shell is `w-full`; width now comes from the host so the card shrinks with the grid.
- Name moved above the main block with the same classes as `cosmetic-card`.
- Main block padding matches `cosmetic-card` (`px-3 pb-3 pt-2`).
- Square preview holds only the icon, amount input and currency label, matching the fixed pack preview. Input is `w-full min-w-0 max-w-24` so it cannot overflow a narrow card.
- Slider moved below the preview at full width.

`tests/client/CustomCurrencyCard.test.ts`
- Asserts `w-full` rather than `w-48`, and that the name precedes and sits outside the main block.

## Testing

- `npx vitest tests/client/CustomCurrencyCard.test.ts tests/client/StoreModal.test.ts --run` — 25 passed
- `npx tsc --noEmit` and ESLint clean
- Not verified visually in a browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)