### PR TITLE
Feat/clan team names

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1771,6 +1771,7 @@
     "none": "You don't have an active subscription.",
     "title": "Your Subscription"
   },
+  "clan_team_label": "Clan [{clanTag}] ({team})",
   "team_colors": {
     "blue": "Blue",
     "bot": "Tribes",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1771,7 +1771,6 @@
     "none": "You don't have an active subscription.",
     "title": "Your Subscription"
   },
-  "clan_team_label": "Clan [{clanTag}] ({team})",
   "team_colors": {
     "blue": "Blue",
     "bot": "Tribes",

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -701,7 +701,10 @@ async function createClientGame(
     // so they switch live, like the leaderboard.
     globalThis.addEventListener(
       `${USER_SETTINGS_CHANGED_EVENT}:settings.anonymousNames`,
-      () => webglBuilder.refreshNames(gameView),
+      () => {
+        webglBuilder.refreshNames(gameView);
+        gameView.invalidateTeamClanTags();
+      },
       { signal: graphicsListenerAbort.signal },
     );
 

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -605,19 +605,12 @@ export function getTranslatedPlayerTeamLabel(
   clanTag?: string | null,
 ): string {
   if (!team) return "";
+  if (clanTag) {
+    return `[${clanTag}]`;
+  }
   const translationKey = `team_colors.${team.toLowerCase()}`;
   const translated = translateText(translationKey);
-  const baseLabel = translated === translationKey ? team : translated;
-  if (clanTag) {
-    const clanLabel = translateText("clan_team_label", {
-      clanTag,
-      team: baseLabel,
-    });
-    return clanLabel === "clan_team_label"
-      ? `Clan [${clanTag}] (${baseLabel})`
-      : clanLabel;
-  }
-  return baseLabel;
+  return translated === translationKey ? team : translated;
 }
 
 /**

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -531,11 +531,93 @@ export const translateText = (
   }
 };
 
-export function getTranslatedPlayerTeamLabel(team: Team | null): string {
+export interface HasClanTag {
+  clanTag?: string | null | (() => string | null);
+}
+
+type TopClans = {
+  topTag: string | null;
+  topCount: number;
+  secondTag: string | null;
+  secondCount: number;
+  thirdCount: number;
+};
+
+function getTopClans(players: readonly HasClanTag[]): TopClans {
+  const counts = new Map<string, number>();
+  for (const p of players) {
+    const tag = typeof p.clanTag === "function" ? p.clanTag() : p.clanTag;
+    if (tag && tag.trim().length > 0) {
+      counts.set(tag, (counts.get(tag) ?? 0) + 1);
+    }
+  }
+  let topTag: string | null = null,
+    topCount = 0;
+  let secondTag: string | null = null,
+    secondCount = 0;
+  let thirdCount = 0;
+
+  for (const [tag, count] of counts) {
+    if (count > topCount) {
+      thirdCount = secondCount;
+      secondTag = topTag;
+      secondCount = topCount;
+      topTag = tag;
+      topCount = count;
+    } else if (count > secondCount) {
+      thirdCount = secondCount;
+      secondTag = tag;
+      secondCount = count;
+    } else if (count > thirdCount) {
+      thirdCount = count;
+    }
+  }
+  return { topTag, topCount, secondTag, secondCount, thirdCount };
+}
+
+export function resolveTeamClanTag(
+  players: Iterable<HasClanTag>,
+): string | null {
+  const list = Array.isArray(players) ? players : Array.from(players);
+  const n = list.length;
+  if (n === 0) return null;
+
+  const { topTag, topCount, secondTag, secondCount, thirdCount } =
+    getTopClans(list);
+
+  if (topTag && topCount > n / 2) {
+    return topTag;
+  }
+  if (
+    topTag &&
+    secondTag &&
+    secondCount > thirdCount &&
+    (topCount + secondCount) / n >= 0.7 &&
+    secondCount / n >= 0.3
+  ) {
+    return [topTag, secondTag].sort().join(" / ");
+  }
+  return null;
+}
+
+export function getTranslatedPlayerTeamLabel(
+  team: Team | null,
+  clanTag?: string | null,
+): string {
   if (!team) return "";
   const translationKey = `team_colors.${team.toLowerCase()}`;
   const translated = translateText(translationKey);
-  return translated === translationKey ? team : translated;
+  const baseLabel = translated === translationKey ? team : translated;
+  if (clanTag) {
+    const clanLabel = translateText("clan_team_label", {
+      clanTag,
+      team: baseLabel,
+    });
+    return clanLabel === "clan_team_label"
+      ? `Clan [${clanTag}] (${baseLabel})`
+      : clanLabel;
+  }
+  return baseLabel;
 }
 
 /**

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -17,11 +17,16 @@ import { UserSettings } from "../../core/game/UserSettings";
 import { ClientInfo, TeamCountConfig } from "../../core/Schemas";
 import { createRandomName, formatPlayerDisplayName } from "../../core/Util";
 import { Theme, themeProvider } from "../theme/ThemeProvider";
-import { getTranslatedPlayerTeamLabel, translateText } from "../Utils";
+import {
+  getTranslatedPlayerTeamLabel,
+  resolveTeamClanTag,
+  translateText,
+} from "../Utils";
 
 export interface TeamPreviewData {
   team: Team;
   players: ClientInfo[];
+  clanTag?: string | null;
 }
 
 @customElement("lobby-player-view")
@@ -44,6 +49,8 @@ export class LobbyTeamView extends LitElement {
     return themeProvider.current();
   }
   @state() private showTeamColors: boolean = false;
+  private _clanUpdateTimeout: number | null = null;
+  private _teamClanTags: Map<Team, string | null> = new Map();
 
   // Spectators are in the lobby roster (flagged) but hold no seat and never
   // reach the simulation — so the count header, the team preview and both
@@ -81,6 +88,14 @@ export class LobbyTeamView extends LitElement {
       const teamsList = this.getTeamList();
       this.computeTeamPreview(teamsList);
       this.showTeamColors = teamsList.length <= 7;
+    }
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this._clanUpdateTimeout !== null) {
+      window.clearTimeout(this._clanUpdateTimeout);
+      this._clanUpdateTimeout = null;
     }
   }
 
@@ -283,7 +298,8 @@ export class LobbyTeamView extends LitElement {
         ? this.effectiveNationCount
         : this.teamMaxSize;
 
-    const teamLabel = getTranslatedPlayerTeamLabel(preview.team);
+    const clanTag = this._teamClanTags.get(preview.team) ?? null;
+    const teamLabel = getTranslatedPlayerTeamLabel(preview.team, clanTag);
 
     return html`
       <div
@@ -396,6 +412,11 @@ export class LobbyTeamView extends LitElement {
     if (this.gameMode !== GameMode.Team) {
       this.teamPreview = [];
       this.teamMaxSize = 0;
+      this._teamClanTags.clear();
+      if (this._clanUpdateTimeout !== null) {
+        window.clearTimeout(this._clanUpdateTimeout);
+        this._clanUpdateTimeout = null;
+      }
       return;
     }
 
@@ -406,6 +427,7 @@ export class LobbyTeamView extends LitElement {
         { team: ColoredTeams.Humans, players: [...this.activePlayers] },
         { team: ColoredTeams.Nations, players: [] },
       ];
+      this.triggerClanUpdate();
       return;
     }
 
@@ -459,6 +481,32 @@ export class LobbyTeamView extends LitElement {
       team: t,
       players: buckets.get(t) ?? [],
     }));
+    this.triggerClanUpdate();
+  }
+
+  private triggerClanUpdate() {
+    if (this._teamClanTags.size === 0) {
+      this.updateTeamClanTags();
+    } else {
+      this.scheduleClanUpdate();
+    }
+  }
+
+  private scheduleClanUpdate() {
+    if (this._clanUpdateTimeout !== null) return;
+    this._clanUpdateTimeout = window.setTimeout(() => {
+      this.updateTeamClanTags();
+      this._clanUpdateTimeout = null;
+      this.requestUpdate();
+    }, 500);
+  }
+
+  private updateTeamClanTags() {
+    this._teamClanTags.clear();
+    for (const preview of this.teamPreview) {
+      const tag = resolveTeamClanTag(preview.players);
+      this._teamClanTags.set(preview.team, tag);
+    }
   }
 
   private isCurrentPlayer(client: ClientInfo): boolean {

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -311,14 +311,18 @@ export class LobbyTeamView extends LitElement {
         <div
           class="px-2 py-1 font-bold flex items-center justify-between text-white rounded-t-xl text-[13px] gap-2 bg-gray-700/70"
         >
-          ${this.showTeamColors
-            ? html` <span
-                class="inline-block w-2.5 h-2.5 rounded-full border-2 border-white/90 shadow-inner bg-(--bg)"
-                style="--bg:${this.teamHeaderColor(preview.team)};"
-              ></span>`
-            : null}
-          <span class="truncate">${teamLabel}</span>
-          <span class="text-white/90">${displayCount}/${maxTeamSize}</span>
+          <div class="flex items-center gap-1.5 min-w-0">
+            ${this.showTeamColors
+              ? html` <span
+                  class="inline-block w-2.5 h-2.5 rounded-full border-2 border-white/90 shadow-inner bg-(--bg) shrink-0"
+                  style="--bg:${this.teamHeaderColor(preview.team)};"
+                ></span>`
+              : null}
+            <span class="truncate">${teamLabel}</span>
+          </div>
+          <span class="text-white/90 font-bold text-[13px] shrink-0"
+            >${displayCount}/${maxTeamSize}</span
+          >
         </div>
         <div class="p-2 ${isEmpty ? "" : "flex flex-col gap-1.5"}">
           ${isEmpty

--- a/src/client/hud/layers/GameLeftSidebar.ts
+++ b/src/client/hud/layers/GameLeftSidebar.ts
@@ -190,7 +190,10 @@ export class GameLeftSidebar extends LitElement implements Controller {
                   style="--color: ${this.playerColor.toRgbString()}"
                   class="text-(--color)"
                 >
-                  &nbsp;${getTranslatedPlayerTeamLabel(this.playerTeam)}
+                  &nbsp;${getTranslatedPlayerTeamLabel(
+                    this.playerTeam,
+                    this.game?.teamClanTag(this.playerTeam),
+                  )}
                   &#10687;
                 </span>
               </div>

--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -378,7 +378,8 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
         playerType = translateText("player_type.player");
         break;
     }
-    const playerTeam = getTranslatedPlayerTeamLabel(player.team());
+    const clanTag = this.game.teamClanTag(player.team());
+    const playerTeam = getTranslatedPlayerTeamLabel(player.team(), clanTag);
 
     const { fontSize, isAllianceWrapped } = this.getNameFontSize({
       nameLength: player.displayName().length,

--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -265,7 +265,7 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     hasFlag: boolean;
     hasBetrayal: boolean;
     hasAlliance: boolean;
-    hasTeam: boolean;
+    typeAndTeamLen: number;
   }): { fontSize: string; isAllianceWrapped: boolean } {
     const {
       nameLength,
@@ -273,30 +273,26 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
       hasFlag,
       hasBetrayal,
       hasAlliance,
-      hasTeam,
+      typeAndTeamLen,
     } = params;
 
     // Approximate char-widths each element occupies at --text-lg.
     const DESKTOP_PRESSURE = {
-      playerType: 3.5,
       perIcon: 2.0,
       icon: 0.5,
       flag: 3.5,
       betrayal: 4.2,
       alliance: 6.7,
       allianceWrapped: 3.9,
-      team: 1.0,
     } as const;
 
     const MOBILE_PRESSURE = {
-      playerType: 3.5,
       perIcon: 2.2,
       icon: 0.5,
       flag: 4.2,
       betrayal: 4.6,
       alliance: 8.6,
       allianceWrapped: 4.8,
-      team: 1.0,
     } as const;
 
     const width = window.innerWidth;
@@ -304,13 +300,19 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
 
     const PRESSURE = isDesktop ? DESKTOP_PRESSURE : MOBILE_PRESSURE;
 
+    // Convert text-xs (12px) mono chars to name font mono chars:
+    // Desktop (text-lg = 18px): ratio is 12/18 = 0.666 + gap(8px/10.8px = 0.74)
+    // Mobile (text-sm = 14px): ratio is 12/14 = 0.857 + gap(4px/8.4px = 0.47)
+    const typeAndTeamPressure = isDesktop
+      ? typeAndTeamLen * (12 / 18) + 8 / 10.8
+      : typeAndTeamLen * (12 / 14) + 4 / 8.4;
+
     const basePressure =
-      PRESSURE.playerType +
+      typeAndTeamPressure +
       iconCount * PRESSURE.perIcon +
       (iconCount ? PRESSURE.icon : 0) +
       (hasFlag ? PRESSURE.flag : 0) +
-      (hasBetrayal ? PRESSURE.betrayal : 0) +
-      (hasTeam ? PRESSURE.team : 0);
+      (hasBetrayal ? PRESSURE.betrayal : 0);
 
     let capacity: number;
 
@@ -381,13 +383,21 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
     const clanTag = this.game.teamClanTag(player.team());
     const playerTeam = getTranslatedPlayerTeamLabel(player.team(), clanTag);
 
+    const typeLen = playerType.length;
+    const hasTeam = playerTeam !== "" && player.type() !== PlayerType.Bot;
+    const teamStr = clanTag ?? playerTeam;
+    const teamLen = hasTeam ? teamStr.length + 2 : 0; // +2 for brackets
+
+    // The column width is determined by the longest string in the flex-col
+    const typeAndTeamLen = Math.max(typeLen, teamLen);
+
     const { fontSize, isAllianceWrapped } = this.getNameFontSize({
       nameLength: player.displayName().length,
       iconCount: playerIcons.length,
       hasFlag: !!player.cosmetics.flag,
       hasBetrayal: traitorTicks > 0,
       hasAlliance: isAllied ?? false,
-      hasTeam: playerTeam !== "" && player.type() !== PlayerType.Bot,
+      typeAndTeamLen,
     });
 
     if (isAllied) {
@@ -501,21 +511,26 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
             </div>
             ${this.getRelationSmiley(player, myPlayer)}
             ${playerTeam !== "" && player.type() !== PlayerType.Bot
-              ? html`<div class="flex flex-col leading-tight">
-                  <span class="text-gray-400 text-xs font-normal"
+              ? html`<div
+                  class="flex flex-col items-center leading-tight shrink-0"
+                >
+                  <span
+                    class="text-gray-400 text-xs font-mono font-normal whitespace-nowrap"
                     >${playerType}</span
                   >
-                  <span class="text-xs font-normal text-gray-400"
+                  <span
+                    class="text-xs font-mono font-normal text-gray-400 whitespace-nowrap"
                     >[<span
                       style="color: ${themeProvider
                         .current()
                         .teamColor(player.team()!)
                         .toHex()}"
-                      >${playerTeam}</span
+                      >${clanTag ?? playerTeam}</span
                     >]</span
                   >
                 </div>`
-              : html`<span class="text-gray-400 text-xs font-normal"
+              : html`<span
+                  class="text-gray-400 text-xs font-mono font-normal shrink-0 whitespace-nowrap"
                   >${playerType}</span
                 >`}
             ${this.renderPlayerNameIcons(playerIcons)} ${betrayalHtml ?? ""}

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -10,6 +10,7 @@ import {
   Unit,
   UnitInfo,
   UnitType,
+  Team,
 } from "../../core/game/Game";
 import { GameMap, TileRef } from "../../core/game/GameMap";
 import {
@@ -25,9 +26,15 @@ import {
 import { TerrainMapData } from "../../core/game/TerrainMapLoader";
 import { TerraNulliusImpl } from "../../core/game/TerraNulliusImpl";
 import { UnitGrid, UnitPredicate } from "../../core/game/UnitGrid";
-import { ClientID, GameID, Player, PlayerCosmetics } from "../../core/Schemas";
+import {
+  ClientID,
+  GameID,
+  Player,
+  PlayerCosmetics,
+} from "../../core/Schemas";
 import { formatPlayerDisplayName } from "../../core/Util";
 import { WorkerClient } from "../../core/worker/WorkerClient";
+import { resolveTeamClanTag } from "../Utils";
 import { computeAllianceClusters } from "../render/frame/derive/AllianceClusters";
 import { extractAttackRings } from "../render/frame/derive/AttackRings";
 import { extractNukeTelegraphs } from "../render/frame/derive/NukeTelegraphs";
@@ -82,6 +89,7 @@ export class GameView implements GameMap {
   private _unitStates = new Map<number, import("../render/types").UnitState>();
   /** smallID → team, for the renderer's relation matrix (team games). */
   private _teams = new Map<number, string>();
+  private _teamClanTags: Map<Team, string | null> | null = null;
   private updatedTiles: TileRef[] = [];
   private updatedTerrainTiles: TileRef[] = [];
   private nukeImpactTiles: TileRef[] = [];
@@ -1031,6 +1039,35 @@ export class GameView implements GameMap {
 
   players(): PlayerView[] {
     return Array.from(this._players.values());
+  }
+
+  teamClanTag(team: Team | null): string | null {
+    if (!team) return null;
+    if (this._teamClanTags === null) {
+      if (this._players.size === 0) return null;
+      this._teamClanTags = this.initTeamClanTags();
+    }
+    return this._teamClanTags.get(team) ?? null;
+  }
+
+  private initTeamClanTags(): Map<Team, string | null> {
+    const teams = new Map<Team, PlayerView[]>();
+    for (const player of this._players.values()) {
+      const t = player.team();
+      if (t) {
+        let list = teams.get(t);
+        if (!list) {
+          list = [];
+          teams.set(t, list);
+        }
+        list.push(player);
+      }
+    }
+    const result = new Map<Team, string | null>();
+    for (const [t, players] of teams.entries()) {
+      result.set(t, resolveTeamClanTag(players));
+    }
+    return result;
   }
 
   /**

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -402,6 +402,7 @@ export class GameView implements GameMap {
         this._namesDirty = true;
         this._relationsDirty = true;
         this._clustersDirty = true;
+        this._teamClanTags = null;
       }
     });
 
@@ -1043,6 +1044,10 @@ export class GameView implements GameMap {
       this._teamClanTags = this.initTeamClanTags();
     }
     return this._teamClanTags.get(team) ?? null;
+  }
+
+  invalidateTeamClanTags(): void {
+    this._teamClanTags = null;
   }
 
   private initTeamClanTags(): Map<Team, string | null> {

--- a/src/client/view/GameView.ts
+++ b/src/client/view/GameView.ts
@@ -4,13 +4,13 @@ import {
   GameUpdates,
   PlayerID,
   PlayerType,
+  Team,
   TerrainType,
   TerraNullius,
   Tick,
   Unit,
   UnitInfo,
   UnitType,
-  Team,
 } from "../../core/game/Game";
 import { GameMap, TileRef } from "../../core/game/GameMap";
 import {
@@ -26,15 +26,9 @@ import {
 import { TerrainMapData } from "../../core/game/TerrainMapLoader";
 import { TerraNulliusImpl } from "../../core/game/TerraNulliusImpl";
 import { UnitGrid, UnitPredicate } from "../../core/game/UnitGrid";
-import {
-  ClientID,
-  GameID,
-  Player,
-  PlayerCosmetics,
-} from "../../core/Schemas";
+import { ClientID, GameID, Player, PlayerCosmetics } from "../../core/Schemas";
 import { formatPlayerDisplayName } from "../../core/Util";
 import { WorkerClient } from "../../core/worker/WorkerClient";
-import { resolveTeamClanTag } from "../Utils";
 import { computeAllianceClusters } from "../render/frame/derive/AllianceClusters";
 import { extractAttackRings } from "../render/frame/derive/AttackRings";
 import { extractNukeTelegraphs } from "../render/frame/derive/NukeTelegraphs";
@@ -46,6 +40,7 @@ import { SpiralTrails } from "../render/frame/SpiralTrails";
 import { TrailManager } from "../render/frame/TrailManager";
 import type { FrameData, NameEntry } from "../render/types";
 import { STRUCTURE_TYPES } from "../render/types";
+import { resolveTeamClanTag } from "../Utils";
 import { PlayerView } from "./PlayerView";
 import { UnitView } from "./UnitView";
 

--- a/tests/client/ClanTeamLabel.test.ts
+++ b/tests/client/ClanTeamLabel.test.ts
@@ -38,9 +38,9 @@ describe("resolveTeamClanTag", () => {
     });
 
     it("returns coalition when 2 players have different clans (100% >= 70%, 50% >= 30%)", () => {
-      expect(
-        resolveTeamClanTag([{ clanTag: "UN" }, { clanTag: "MARS" }]),
-      ).toBe("MARS / UN");
+      expect(resolveTeamClanTag([{ clanTag: "UN" }, { clanTag: "MARS" }])).toBe(
+        "MARS / UN",
+      );
     });
   });
 
@@ -210,11 +210,9 @@ describe("getTranslatedPlayerTeamLabel", () => {
   });
 
   it("formats clan team label when clan tag is present", () => {
-    expect(getTranslatedPlayerTeamLabel("Red", "MARS")).toBe(
-      "Clan [MARS] (Red)",
-    );
+    expect(getTranslatedPlayerTeamLabel("Red", "MARS")).toBe("[MARS]");
     expect(getTranslatedPlayerTeamLabel("Team 1", "MARS / UN")).toBe(
-      "Clan [MARS / UN] (Team 1)",
+      "[MARS / UN]",
     );
   });
 });

--- a/tests/client/ClanTeamLabel.test.ts
+++ b/tests/client/ClanTeamLabel.test.ts
@@ -1,0 +1,220 @@
+import { describe, expect, it } from "vitest";
+import {
+  getTranslatedPlayerTeamLabel,
+  resolveTeamClanTag,
+} from "../../src/client/Utils";
+
+describe("resolveTeamClanTag", () => {
+  it("returns null for empty team", () => {
+    expect(resolveTeamClanTag([])).toBeNull();
+  });
+
+  it("returns null when no players have clan tags", () => {
+    expect(
+      resolveTeamClanTag([
+        { clanTag: null },
+        { clanTag: undefined },
+        { clanTag: "" },
+        { clanTag: "   " },
+      ]),
+    ).toBeNull();
+  });
+
+  it("qualifies solo player with clan tag (100% > 50%)", () => {
+    expect(resolveTeamClanTag([{ clanTag: "MARS" }])).toBe("MARS");
+  });
+
+  describe("Duos (2 players)", () => {
+    it("returns null when 1 player has clan and 1 is un-clanned (50% is not > 50%)", () => {
+      expect(
+        resolveTeamClanTag([{ clanTag: "MARS" }, { clanTag: null }]),
+      ).toBeNull();
+    });
+
+    it("returns clan tag when both players share clan (100% > 50%)", () => {
+      expect(
+        resolveTeamClanTag([{ clanTag: "MARS" }, { clanTag: "MARS" }]),
+      ).toBe("MARS");
+    });
+
+    it("returns coalition when 2 players have different clans (100% >= 70%, 50% >= 30%)", () => {
+      expect(
+        resolveTeamClanTag([{ clanTag: "UN" }, { clanTag: "MARS" }]),
+      ).toBe("MARS / UN");
+    });
+  });
+
+  describe("Trios (3 players)", () => {
+    it("returns majority clan when 2 out of 3 match (66.7% > 50%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+        ]),
+      ).toBe("MARS");
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: null },
+        ]),
+      ).toBe("MARS");
+    });
+
+    it("returns null when 1 MARS, 1 UN, 1 un-clanned (66.7% < 70% coalition threshold)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: null },
+        ]),
+      ).toBeNull();
+    });
+
+    it("returns null for 3-way split with 1 player each", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "A" },
+          { clanTag: "B" },
+          { clanTag: "C" },
+        ]),
+      ).toBeNull();
+    });
+  });
+
+  describe("Quads (4 players)", () => {
+    it("returns null when 2 have clan and 2 are un-clanned (50% is not > 50%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: null },
+          { clanTag: null },
+        ]),
+      ).toBeNull();
+    });
+
+    it("returns majority clan when 3 out of 4 match (75% > 50%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+        ]),
+      ).toBe("MARS");
+    });
+
+    it("returns coalition when split 2 vs 2 between two clans (100% >= 70%, 50% >= 30%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+        ]),
+      ).toBe("MARS / UN");
+    });
+
+    it("returns null when 2 MARS, 1 UN, 1 un-clanned (UN is 25% < 30% individual floor)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: null },
+        ]),
+      ).toBeNull();
+    });
+  });
+
+  describe("Model C Proportional Coalition (5+ players)", () => {
+    it("recognizes near-tie 3 vs 2 in 6-player team (83.3% >= 70%, 33.3% >= 30%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+          { clanTag: null },
+        ]),
+      ).toBe("MARS / UN");
+    });
+
+    it("recognizes 2 vs 2 in 5-player team (80% >= 70%, 40% >= 30%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+          { clanTag: null },
+        ]),
+      ).toBe("MARS / UN");
+    });
+
+    it("returns null in 10-player team when coalition only has 60% (60% < 70%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+          { clanTag: null },
+          { clanTag: null },
+          { clanTag: null },
+          { clanTag: null },
+        ]),
+      ).toBeNull();
+    });
+
+    it("recognizes coalition in 10-player team when 4 MARS + 3 UN (70% >= 70%, 30% >= 30%)", () => {
+      expect(
+        resolveTeamClanTag([
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "MARS" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+          { clanTag: "UN" },
+          { clanTag: null },
+          { clanTag: null },
+          { clanTag: null },
+        ]),
+      ).toBe("MARS / UN");
+    });
+  });
+
+  it("supports getter functions for clanTag (PlayerView-like interface)", () => {
+    expect(
+      resolveTeamClanTag([
+        { clanTag: () => "MARS" },
+        { clanTag: () => "MARS" },
+      ]),
+    ).toBe("MARS");
+  });
+});
+
+describe("getTranslatedPlayerTeamLabel", () => {
+  it("returns base team label when clan tag is omitted or null", () => {
+    expect(getTranslatedPlayerTeamLabel("Red")).toBe("Red");
+    expect(getTranslatedPlayerTeamLabel("Red", null)).toBe("Red");
+    expect(getTranslatedPlayerTeamLabel("Team 1")).toBe("Team 1");
+    expect(getTranslatedPlayerTeamLabel("Team 1", null)).toBe("Team 1");
+    expect(getTranslatedPlayerTeamLabel(null)).toBe("");
+  });
+
+  it("formats clan team label when clan tag is present", () => {
+    expect(getTranslatedPlayerTeamLabel("Red", "MARS")).toBe(
+      "Clan [MARS] (Red)",
+    );
+    expect(getTranslatedPlayerTeamLabel("Team 1", "MARS / UN")).toBe(
+      "Clan [MARS / UN] (Team 1)",
+    );
+  });
+});

--- a/tests/client/view/GameView.test.ts
+++ b/tests/client/view/GameView.test.ts
@@ -140,6 +140,42 @@ describe("GameView.update — players", () => {
     );
     expect(game.myPlayer()?.name()).toBe("RealName");
   });
+
+  it("invalidates the teamClanTag cache when a new player is added", () => {
+    const game = makeGameView();
+    // 1. Initial state with 1 player in team 1
+    game.update(
+      withPlayers(1, [
+        makePlayerUpdate({ id: "p1", smallID: 1, team: "1", clanTag: "MARS" }),
+      ]),
+    );
+    expect(game.teamClanTag("1")).toBe("MARS");
+
+    // 2. Add second player to team 1 in tick 2
+    game.update(
+      withPlayers(2, [
+        makePlayerUpdate({ id: "p2", smallID: 2, team: "1", clanTag: "UN" }),
+      ]),
+    );
+    // Cache should have been invalidated, and recalculation should see both players
+    expect(game.teamClanTag("1")).toBe("MARS / UN");
+  });
+
+  it("can explicitly invalidate teamClanTag cache (e.g. for anonymous names toggle)", () => {
+    const game = makeGameView();
+    game.update(
+      withPlayers(1, [
+        makePlayerUpdate({ id: "p1", smallID: 1, team: "1", clanTag: "MARS" }),
+      ]),
+    );
+    expect(game.teamClanTag("1")).toBe("MARS");
+
+    // Explicitly invalidate cache
+    game.invalidateTeamClanTags();
+
+    // The next lookup will lazily re-evaluate it based on current player state
+    expect(game.teamClanTag("1")).toBe("MARS");
+  });
 });
 
 describe("GameView.update — packed channels", () => {

--- a/tests/client/view/GameView.test.ts
+++ b/tests/client/view/GameView.test.ts
@@ -170,11 +170,16 @@ describe("GameView.update — players", () => {
     );
     expect(game.teamClanTag("1")).toBe("MARS");
 
+    // Simulate the streamer mode toggle bypassing GameUpdate logic
+    // by silently mutating the static player clan tag
+    game.player("p1").static.clanTag = "EARTH";
+
     // Explicitly invalidate cache
     game.invalidateTeamClanTags();
 
     // The next lookup will lazily re-evaluate it based on current player state
-    expect(game.teamClanTag("1")).toBe("MARS");
+    // If invalidation is broken, this would incorrectly return "MARS"
+    expect(game.teamClanTag("1")).toBe("EARTH");
   });
 });
 


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #3300

## Description:

Adds clan tags as team names, with choices between one clan >50%, hydrid for majority from 2 clan [UN / AST], or normal teams. Also edited pressure on playername based on clan length, both pc and mobile layouts.
<img width="460" height="148" alt="image" src="https://github.com/user-attachments/assets/34b9ad9d-6a94-4e08-81de-a42aaea08f62" />
<img width="621" height="97" alt="image" src="https://github.com/user-attachments/assets/eb4b76be-8cee-4490-bb9d-f0df60a1ccca" />
<img width="308" height="90" alt="image" src="https://github.com/user-attachments/assets/c99635dc-fec8-41a7-92b0-28ee5b42007d" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
