### PR TITLE
fix(client): copy page styles into modals on DOMContentLoaded, not load

### DIFF
--- a/src/client/components/baseComponents/SharedStyles.ts
+++ b/src/client/components/baseComponents/SharedStyles.ts
@@ -40,14 +40,19 @@ export function documentStylesSheet(): CSSStyleSheet {
     sheet = new CSSStyleSheet();
     void populate(sheet);
     // In dev this module evaluates before Vite injects the page's <style>
-    // tags, so the read above sees almost nothing — re-read once the page
-    // has fully loaded (constructed sheets are live, so components pick up
-    // the styles without re-rendering).
+    // tags (Main.ts imports the components ahead of styles.css), so the read
+    // above sees almost nothing — re-read once the module graph has finished
+    // executing (constructed sheets are live, so components pick up the
+    // styles without re-rendering). DOMContentLoaded fires right after the
+    // deferred module scripts; `load` is not usable here — the header ad's
+    // iframes can keep it from ever firing, which left modals unstyled.
     if (document.readyState !== "complete") {
       const populated = sheet;
-      window.addEventListener("load", () => void populate(populated), {
-        once: true,
-      });
+      document.addEventListener(
+        "DOMContentLoaded",
+        () => void populate(populated),
+        { once: true },
+      );
     }
   }
   return sheet;


### PR DESCRIPTION
Regression surfaced by #5009 / #5237 (the flex header ad). No approved issue — reporting and fixing in one go.

## Description:

With the Playwire flex header ad on the page, opening any modal (Help, Store, Settings, …) rendered it **unstyled and unscrollable**.

**Cause.** `o-modal` is shadow DOM and gets the page's Tailwind by copying the document's stylesheets into a constructed sheet (`SharedStyles.ts`). In dev, `Main.ts` imports the components ahead of `styles.css`, so the first copy runs before Vite has injected the `<style>` tags (~18 rules), and the module re-read on `window` **`load`**. The GumGum creative keeps an iframe loading indefinitely, so `load` never fires — measured `document.readyState === "interactive"` 65s+ after the unit rendered. The re-read never happened, so the modal had no `overflow-y-auto` / `flex-1` / `min-h-0`, grew to its full content height inside the clipped page (`[data-modal-scroll]` computed `overflow-y: visible`, `clientHeight == scrollHeight`), and could not scroll.

**Fix.** Re-read on `DOMContentLoaded` instead. It fires right after the deferred module scripts finish executing (verified there is no top-level `await` in the client graph), and ad iframes cannot hold it up. Prod is unaffected either way: the `<link rel="stylesheet">` is already in `<head>` at module-evaluation time, so the initial copy works there and this path is dev-only insurance — but the `load` dependency was a footgun regardless.

Not touched: `SharedStyles` also copies whatever `<style>`/`<link>` ad scripts have injected by the time it runs (`#pwCSSstyling`, the Playwire config stylesheet). That was already the case on `load`; with `DOMContentLoaded` it now runs *before* those exist, which is if anything cleaner.

## Verification

Headed Chromium against `npm run dev` with the real creative (GAM preview URL + Playwire requesting the `flex` unit), 1400×900:

- **Before:** Help open under the ad → shadow sheet has 18 rules, no `.overflow-y-auto`; scroll box `overflow-y: visible`, 6463px tall; wheel does nothing.
- **After:** shadow sheet fully populated; scroll box `overflow-y: auto`, 259px tall with 6704px of content; wheel moves `scrollTop` 0 → 1500, document stays put. Store page scrolls too.
- **No ad** (headless, desktop 1400×900 + mobile 390×844): unchanged — Help scrolls inside the modal, document locked, as after #5148.
- Prettier + ESLint clean.

## Please complete the following:

- [x] I have added screenshots for all UI updates — no visual change; the fix restores the modal's existing styling
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — N/A
- [x] I have added relevant tests to the test directory — N/A, depends on the live Playwire script / document load timing; verified e2e as above

## Please put your Discord username so you can be contacted if a bug or regression is found:

evanpelle

🤖 Generated with [Claude Code](https://claude.com/claude-code)
