### PR TITLE
fix(client): show Streaming Now after resizing to desktop

### DIFF
--- a/src/client/components/StreamingNow.ts
+++ b/src/client/components/StreamingNow.ts
@@ -25,6 +25,20 @@ export function formatViewers(n: number): string {
 export class StreamingNow extends LitElement {
   @state() private streams: LiveStream[] = [];
   private unsubscribe: (() => void) | null = null;
+  private desktopMediaQuery: MediaQueryList | null = null;
+
+  private readonly onViewportChange = (event: MediaQueryListEvent) => {
+    if (event.matches) {
+      this.subscribe();
+      return;
+    }
+
+    this.unsubscribe?.();
+    this.unsubscribe = null;
+    this.streams = [];
+    this.style.display = "none";
+    this.classList.remove("streaming-live");
+  };
 
   // Light DOM so Tailwind classes apply (matches NewsBox).
   createRenderRoot() {
@@ -34,13 +48,23 @@ export class StreamingNow extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.style.display = "none"; // hidden until the feed reports a live stream (no flash)
-    // Desktop only (host carries `hidden lg:block`); below lg, don't even subscribe.
-    if (
-      typeof window.matchMedia === "function" &&
-      !window.matchMedia("(min-width: 1024px)").matches
-    ) {
-      return;
+    // Desktop only (host carries `hidden lg:block`). Keep this responsive: the element
+    // itself stays mounted, so a mobile-first visit can later expand to desktop width.
+    if (typeof window.matchMedia === "function") {
+      this.desktopMediaQuery = window.matchMedia("(min-width: 1024px)");
+      if (typeof this.desktopMediaQuery.addEventListener === "function") {
+        this.desktopMediaQuery.addEventListener(
+          "change",
+          this.onViewportChange,
+        );
+      }
+      if (!this.desktopMediaQuery.matches) return;
     }
+    this.subscribe();
+  }
+
+  private subscribe() {
+    if (this.unsubscribe !== null) return;
     // The shared poller owns the cadence and stops itself in-game and while the tab is
     // hidden. This previously ran its own setInterval and only cleared it in
     // disconnectedCallback — which never fires, because <play-page> is never removed
@@ -57,9 +81,19 @@ export class StreamingNow extends LitElement {
   }
 
   disconnectedCallback() {
-    super.disconnectedCallback();
+    if (
+      this.desktopMediaQuery !== null &&
+      typeof this.desktopMediaQuery.removeEventListener === "function"
+    ) {
+      this.desktopMediaQuery.removeEventListener(
+        "change",
+        this.onViewportChange,
+      );
+    }
+    this.desktopMediaQuery = null;
     this.unsubscribe?.();
     this.unsubscribe = null;
+    super.disconnectedCallback();
   }
 
   render() {

--- a/tests/client/components/StreamingNow.test.ts
+++ b/tests/client/components/StreamingNow.test.ts
@@ -151,6 +151,45 @@ describe("StreamingNow", () => {
       expect(el.querySelectorAll("a")).toHaveLength(0);
     });
 
+    it("subscribes when a mobile-first visit expands to desktop width", async () => {
+      const listeners = new Set<(event: MediaQueryListEvent) => void>();
+      let matches = false;
+      vi.stubGlobal("matchMedia", () => ({
+        get matches() {
+          return matches;
+        },
+        addEventListener: (
+          type: string,
+          listener: (event: MediaQueryListEvent) => void,
+        ) => {
+          if (type === "change") listeners.add(listener);
+        },
+        removeEventListener: (
+          type: string,
+          listener: (event: MediaQueryListEvent) => void,
+        ) => {
+          if (type === "change") listeners.delete(listener);
+        },
+      }));
+
+      const el = document.createElement("streaming-now") as HTMLElement & {
+        updateComplete: Promise<boolean>;
+      };
+      document.body.appendChild(el);
+      await el.updateComplete;
+      expect(getStreams).not.toHaveBeenCalled();
+
+      matches = true;
+      for (const listener of listeners) {
+        listener({ matches: true } as MediaQueryListEvent);
+      }
+
+      await vi.waitFor(() => expect(getStreams).toHaveBeenCalledTimes(1));
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      await el.updateComplete;
+      expect(el.style.display).not.toBe("none");
+    });
+
     it("owns no timer: disconnecting stops all polling", async () => {
       const el = await mount();
       const before = getStreams.mock.calls.length;


### PR DESCRIPTION
## Summary

Fixes the Streaming Now panel remaining inactive when the homepage is first opened on a mobile-sized viewport and later resized to desktop width.

- Listen for `(min-width: 1024px)` media-query changes.
- Subscribe to the shared stream feed when entering desktop width.
- Unsubscribe, clear stale streams, and hide the panel when leaving desktop width.
- Remove the media-query listener when the component disconnects.
- Add coverage for mobile-first visits resized to desktop

## Testing

- `npx --no-install vitest run tests/client/components/StreamingNow.test.ts`
- `npx --no-install tsc --noEmit`

Manual check:

1. Open the homepage below 1024px
2. Resize above 1024px without reloading
3. Confirm the Streaming Now panel appears when live streams are available.
4. Resize below 1024px and confirm it hide