### PR TITLE
fix(core): align factory rail preview path direction

### DIFF
--- a/src/core/game/RailNetworkImpl.ts
+++ b/src/core/game/RailNetworkImpl.ts
@@ -302,12 +302,13 @@ export class RailNetworkImpl implements RailNetwork {
         continue;
       }
 
-      // Non-station structures are promoted after the factory and initiate
-      // the real connection back to it. Match that direction because rail
-      // pathfinding tie-breaking is direction-sensitive.
-      const path = neighborStation
-        ? this.pathService.findTilePath(tile, targetTile)
-        : this.pathService.findTilePath(targetTile, tile);
+      // A completed city has already made its one-time station check, so the
+      // factory promotes it after creating its own station. The city then
+      // initiates the real connection back to the factory.
+      const path =
+        !neighborStation && neighbor.unit.type() === UnitType.City
+          ? this.pathService.findTilePath(targetTile, tile)
+          : this.pathService.findTilePath(tile, targetTile);
       if (path.length > 0 && path.length < maxPathSize) {
         paths.push(path);
         if (neighborStation) {

--- a/src/core/game/RailNetworkImpl.ts
+++ b/src/core/game/RailNetworkImpl.ts
@@ -302,7 +302,12 @@ export class RailNetworkImpl implements RailNetwork {
         continue;
       }
 
-      const path = this.pathService.findTilePath(tile, targetTile);
+      // Non-station structures are promoted after the factory and initiate
+      // the real connection back to it. Match that direction because rail
+      // pathfinding tie-breaking is direction-sensitive.
+      const path = neighborStation
+        ? this.pathService.findTilePath(tile, targetTile)
+        : this.pathService.findTilePath(targetTile, tile);
       if (path.length > 0 && path.length < maxPathSize) {
         paths.push(path);
         if (neighborStation) {

--- a/tests/core/game/RailNetwork.test.ts
+++ b/tests/core/game/RailNetwork.test.ts
@@ -1,10 +1,13 @@
-import { Unit, UnitType } from "../../../src/core/game/Game";
+import { FactoryExecution } from "../../../src/core/execution/FactoryExecution";
+import { PlayerType, Unit, UnitType } from "../../../src/core/game/Game";
 import {
   RailNetworkImpl,
   StationManagerImpl,
 } from "../../../src/core/game/RailNetworkImpl";
 import { Railroad } from "../../../src/core/game/Railroad";
 import { Cluster } from "../../../src/core/game/TrainStation";
+import { playerInfo } from "../../util/Setup";
+import { createGame, L } from "../pathfinding/_fixtures";
 
 // Mock types
 const createMockStation = (unitId: number): any => {
@@ -389,12 +392,12 @@ describe("RailNetworkImpl", () => {
       const cityUnit = { id: 1, tile: vi.fn(() => 100) };
       game.nearbyUnits.mockReturnValue([{ unit: cityUnit, distSquared: 400 }]);
 
-      const mockPath = [42, 50, 60, 100];
+      const mockPath = [100, 60, 50, 42];
       pathService.findTilePath.mockReturnValue(mockPath);
 
       const result = network.computeGhostRailPaths(UnitType.Factory, tile);
       expect(result).toEqual([mockPath]);
-      expect(pathService.findTilePath).toHaveBeenCalledWith(tile, 100);
+      expect(pathService.findTilePath).toHaveBeenCalledWith(100, tile);
     });
 
     test("city does not connect to non-station neighbors without a factory", () => {
@@ -407,5 +410,52 @@ describe("RailNetworkImpl", () => {
       const result = network.computeGhostRailPaths(UnitType.City, tile);
       expect(result).toEqual([]);
     });
+  });
+});
+
+describe("factory rail preview path consistency", () => {
+  test("matches the railway created for a promoted non-station city", () => {
+    const width = 40;
+    const height = 40;
+    const game = createGame({
+      width,
+      height,
+      grid: new Array(width * height).fill(L),
+    });
+    const player = game.addPlayer(playerInfo("player", PlayerType.Human));
+    game.endSpawnPhase();
+
+    const cityTile = game.ref(5, 5);
+    const factoryTile = game.ref(25, 25);
+    const city = player.buildUnit(UnitType.City, cityTile, {});
+
+    expect(city.hasTrainStation()).toBe(false);
+    const previewPath = game
+      .railNetwork()
+      .computeGhostRailPaths(UnitType.Factory, factoryTile)[0];
+    expect(previewPath).toBeDefined();
+
+    const factory = player.buildUnit(UnitType.Factory, factoryTile, {});
+    game.addExecution(new FactoryExecution(factory));
+    for (let i = 0; i < 5; i++) {
+      game.executeNextTick();
+    }
+
+    const manager = game.railNetwork().stationManager();
+    const cityStation = manager.findStation(city);
+    const factoryStation = manager.findStation(factory);
+    expect(cityStation).not.toBeNull();
+    expect(factoryStation).not.toBeNull();
+
+    const railroad = cityStation!.getRailroadTo(factoryStation!);
+    expect(railroad).not.toBeNull();
+    const actualPath = railroad!.tiles;
+    const sameGeometry =
+      previewPath.length === actualPath.length &&
+      (previewPath.every((tile, index) => tile === actualPath[index]) ||
+        previewPath.every(
+          (tile, index) => tile === actualPath[actualPath.length - 1 - index],
+        ));
+    expect(sameGeometry).toBe(true);
   });
 });

--- a/tests/core/game/RailNetwork.test.ts
+++ b/tests/core/game/RailNetwork.test.ts
@@ -1,5 +1,7 @@
 import { FactoryExecution } from "../../../src/core/execution/FactoryExecution";
+import { PortExecution } from "../../../src/core/execution/PortExecution";
 import { PlayerType, Unit, UnitType } from "../../../src/core/game/Game";
+import { TileRef } from "../../../src/core/game/GameMap";
 import {
   RailNetworkImpl,
   StationManagerImpl,
@@ -388,7 +390,11 @@ describe("RailNetworkImpl", () => {
       game.hasUnitNearby.mockReturnValue(false);
       stationManager.findStation.mockReturnValue(null);
 
-      const cityUnit = { id: 1, tile: vi.fn(() => 100) };
+      const cityUnit = {
+        id: 1,
+        tile: vi.fn(() => 100),
+        type: vi.fn(() => UnitType.City),
+      };
       game.nearbyUnits.mockReturnValue([{ unit: cityUnit, distSquared: 400 }]);
 
       const mockPath = [100, 60, 50, 42];
@@ -397,6 +403,29 @@ describe("RailNetworkImpl", () => {
       const result = network.computeGhostRailPaths(UnitType.Factory, tile);
       expect(result).toEqual([mockPath]);
       expect(pathService.findTilePath).toHaveBeenCalledWith(100, tile);
+    });
+
+    test("factory preserves path direction to a non-station port", () => {
+      const tile = 42 as any;
+      const railGridMock = { query: vi.fn(() => new Set()) };
+      (network as any).railGrid = railGridMock;
+
+      game.hasUnitNearby.mockReturnValue(false);
+      stationManager.findStation.mockReturnValue(null);
+
+      const portUnit = {
+        id: 1,
+        tile: vi.fn(() => 100),
+        type: vi.fn(() => UnitType.Port),
+      };
+      game.nearbyUnits.mockReturnValue([{ unit: portUnit, distSquared: 400 }]);
+
+      const mockPath = [42, 50, 60, 100];
+      pathService.findTilePath.mockReturnValue(mockPath);
+
+      const result = network.computeGhostRailPaths(UnitType.Factory, tile);
+      expect(result).toEqual([mockPath]);
+      expect(pathService.findTilePath).toHaveBeenCalledWith(tile, 100);
     });
 
     test("city does not connect to non-station neighbors without a factory", () => {
@@ -411,6 +440,19 @@ describe("RailNetworkImpl", () => {
     });
   });
 });
+
+function expectSameRailGeometry(
+  previewPath: TileRef[],
+  actualPath: TileRef[],
+): void {
+  const sameGeometry =
+    previewPath.length === actualPath.length &&
+    (previewPath.every((tile, index) => tile === actualPath[index]) ||
+      previewPath.every(
+        (tile, index) => tile === actualPath[actualPath.length - 1 - index],
+      ));
+  expect(sameGeometry).toBe(true);
+}
 
 describe("factory rail preview path consistency", () => {
   test("matches the railway created for a promoted non-station city", async () => {
@@ -443,13 +485,42 @@ describe("factory rail preview path consistency", () => {
 
     const railroad = cityStation!.getRailroadTo(factoryStation!);
     expect(railroad).not.toBeNull();
-    const actualPath = railroad!.tiles;
-    const sameGeometry =
-      previewPath.length === actualPath.length &&
-      (previewPath.every((tile, index) => tile === actualPath[index]) ||
-        previewPath.every(
-          (tile, index) => tile === actualPath[actualPath.length - 1 - index],
-        ));
-    expect(sameGeometry).toBe(true);
+    expectSameRailGeometry(previewPath, railroad!.tiles);
+  });
+
+  test("matches the railway created for a pre-existing port", async () => {
+    const game = await setup("plains", {}, [
+      playerInfo("player", PlayerType.Human),
+    ]);
+    const player = game.player("player")!;
+
+    const portTile = game.ref(5, 5);
+    const factoryTile = game.ref(25, 25);
+    const port = player.buildUnit(UnitType.Port, portTile, {});
+    game.addExecution(new PortExecution(port));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(port.hasTrainStation()).toBe(false);
+    const previewPath = game
+      .railNetwork()
+      .computeGhostRailPaths(UnitType.Factory, factoryTile)[0];
+    expect(previewPath).toBeDefined();
+
+    const factory = player.buildUnit(UnitType.Factory, factoryTile, {});
+    game.addExecution(new FactoryExecution(factory));
+    for (let i = 0; i < 5; i++) {
+      game.executeNextTick();
+    }
+
+    const manager = game.railNetwork().stationManager();
+    const portStation = manager.findStation(port);
+    const factoryStation = manager.findStation(factory);
+    expect(portStation).not.toBeNull();
+    expect(factoryStation).not.toBeNull();
+
+    const railroad = factoryStation!.getRailroadTo(portStation!);
+    expect(railroad).not.toBeNull();
+    expectSameRailGeometry(previewPath, railroad!.tiles);
   });
 });

--- a/tests/core/game/RailNetwork.test.ts
+++ b/tests/core/game/RailNetwork.test.ts
@@ -6,8 +6,7 @@ import {
 } from "../../../src/core/game/RailNetworkImpl";
 import { Railroad } from "../../../src/core/game/Railroad";
 import { Cluster } from "../../../src/core/game/TrainStation";
-import { playerInfo } from "../../util/Setup";
-import { createGame, L } from "../pathfinding/_fixtures";
+import { playerInfo, setup } from "../../util/Setup";
 
 // Mock types
 const createMockStation = (unitId: number): any => {
@@ -414,16 +413,11 @@ describe("RailNetworkImpl", () => {
 });
 
 describe("factory rail preview path consistency", () => {
-  test("matches the railway created for a promoted non-station city", () => {
-    const width = 40;
-    const height = 40;
-    const game = createGame({
-      width,
-      height,
-      grid: new Array(width * height).fill(L),
-    });
-    const player = game.addPlayer(playerInfo("player", PlayerType.Human));
-    game.endSpawnPhase();
+  test("matches the railway created for a promoted non-station city", async () => {
+    const game = await setup("plains", {}, [
+      playerInfo("player", PlayerType.Human),
+    ]);
+    const player = game.player("player")!;
 
     const cityTile = game.ref(5, 5);
     const factoryTile = game.ref(25, 25);


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose) You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed

**Add approved & assigned issue number here:**

Resolves #5018

## Description:

Factory rail previews could use a different corridor from the railway created after construction, even when the world state had not changed

### Root cause

Preview and construction use the same deterministic rail A* implementation, but the initiating endpoint depends on how the neighboring structure becomes a station

A completed City performs a one-time station check before the proposed Factory exists, so `FactoryExecution` later promotes it after creating the Factory station and the City initiates the connection back to the Factory

A Port keeps checking for nearby Factories and can promote before the Factory station is created, so the Factory later initiates the connection to the Port

Rail pathfinding is direction-sensitive when equal-cost routes are available, so using the wrong initiating endpoint can select a different corridor

### Fix

Preview non-station City connections from the City toward the proposed Factory

Existing stations, non-station Ports, and non-station Factories keep the Factory-to-target direction used by authoritative construction

Authoritative railway construction behavior is unchanged

### Testing

- Added integration regressions covering both City promotion and a pre-existing `PortExecution`
- Added focused unit expectations for City-to-Factory and Factory-to-Port pathfinding directions
- Verified the Port regression fails against the previous PR implementation and passes with this fix
- Relevant rail, station, train, pathfinding, port, and preview suites passed with 63 tests
- `npx tsc --noEmit`, `npm run lint`, Prettier, and `git diff --check` passed
- A local Windows `npm test` run has three failures that reproduce on clean `main`: two `GenerateNginxUpstream` tests require `sh`, and one locale-sensitive `ClanDonateDialog` assertion formats `1000` instead of `1,000`

### Scope

This aligns endpoint orientation for the stable City and Port promotion flows under unchanged world state

It does not simulate sequential promotion of multiple nearby structures or guarantee identical final rails when game state changes during construction

## Please complete the following:

- [x] I have added screenshots for all UI updates — N/A, no UI components or assets changed
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — N/A, no user-facing text added
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

Niketion