### PR TITLE
Add optional territory sorting to quick chat

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -210,6 +210,7 @@
     "player": "Player",
     "search": "Search player...",
     "send": "Send",
+    "sort_by_territory": "Sort by territory",
     "title": "Quick Chat",
     "to": "Sent {user}: {msg}",
     "warnings": {

--- a/src/client/hud/layers/ChatModal.ts
+++ b/src/client/hud/layers/ChatModal.ts
@@ -33,6 +33,7 @@ export class ChatModal extends LitElement {
   private players: PlayerView[] = [];
 
   private playerSearchQuery: string = "";
+  private sortByTerritory = false;
   private previewText: string | null = null;
   private requiresPlayerSelection: boolean = false;
   private selectedCategory: string | null = null;
@@ -125,6 +126,15 @@ export class ChatModal extends LitElement {
                   <div class="column-title">
                     ${translateText("chat.player")}
                   </div>
+
+                  <label class="flex items-center gap-2 text-sm cursor-pointer">
+                    <input
+                      type="checkbox"
+                      .checked=${this.sortByTerritory}
+                      @change=${this.onPlayerSortChange}
+                    />
+                    ${translateText("chat.sort_by_territory")}
+                  </label>
 
                   <input
                     class="player-search-input"
@@ -254,9 +264,16 @@ export class ChatModal extends LitElement {
     this.requestUpdate();
   }
 
+  private onPlayerSortChange(e: Event) {
+    this.sortByTerritory = (e.target as HTMLInputElement).checked;
+    this.requestUpdate();
+  }
+
   private getSortedFilteredPlayers(): PlayerView[] {
-    const sorted = [...this.players].sort(
-      (a, b) => b.numTilesOwned() - a.numTilesOwned(),
+    const sorted = [...this.players].sort((a, b) =>
+      this.sortByTerritory
+        ? b.numTilesOwned() - a.numTilesOwned()
+        : a.displayName().localeCompare(b.displayName()),
     );
     const filtered = sorted.filter((p) =>
       p.displayName().toLowerCase().includes(this.playerSearchQuery),

--- a/src/client/hud/layers/ChatModal.ts
+++ b/src/client/hud/layers/ChatModal.ts
@@ -255,8 +255,8 @@ export class ChatModal extends LitElement {
   }
 
   private getSortedFilteredPlayers(): PlayerView[] {
-    const sorted = [...this.players].sort((a, b) =>
-      a.displayName().localeCompare(b.displayName()),
+    const sorted = [...this.players].sort(
+      (a, b) => b.numTilesOwned() - a.numTilesOwned(),
     );
     const filtered = sorted.filter((p) =>
       p.displayName().toLowerCase().includes(this.playerSearchQuery),

--- a/tests/client/ChatModal.test.ts
+++ b/tests/client/ChatModal.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, expect, it, vi } from "vitest";
+import { ChatModal } from "../../src/client/hud/layers/ChatModal";
+import { makeGameView, makePlayerView } from "../util/viewStubs";
+
+vi.mock("../../src/client/Utils", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/client/Utils")>();
+  return { ...actual, translateText: (key: string) => key };
+});
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.restoreAllMocks();
+});
+
+it("orders chat players by territory and preserves that order within search results", async () => {
+  const players = [
+    { displayName: "Alpha", tilesOwned: 400 },
+    { displayName: "Zulu", tilesOwned: 1200 },
+    { displayName: "Bravo", tilesOwned: 600 },
+    { displayName: "Zebra", tilesOwned: 1200 },
+  ].map((data) => makePlayerView({ data }));
+  const modal = new ChatModal();
+  modal.g = makeGameView();
+  vi.spyOn(modal.g, "players").mockReturnValue(players);
+  document.body.append(modal);
+  modal.openWithSelection("attack", "attack", players[0], players[1]);
+  await modal.updateComplete;
+
+  const names = () =>
+    Array.from(modal.querySelectorAll(".player-scroll-area button"), (button) =>
+      button.textContent?.trim(),
+    );
+  expect(names()).toEqual(["Zulu", "Zebra", "Bravo", "Alpha"]);
+
+  const search = modal.querySelector<HTMLInputElement>(".player-search-input")!;
+  search.value = "A";
+  search.dispatchEvent(new Event("input", { bubbles: true }));
+  await modal.updateComplete;
+  expect(names()).toEqual(["Zebra", "Bravo", "Alpha", "Zulu"]);
+
+  search.value = "";
+  search.dispatchEvent(new Event("input", { bubbles: true }));
+  await modal.updateComplete;
+  expect(names()).toEqual(["Zulu", "Zebra", "Bravo", "Alpha"]);
+});

--- a/tests/client/ChatModal.test.ts
+++ b/tests/client/ChatModal.test.ts
@@ -13,7 +13,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-it("orders chat players by territory and preserves that order within search results", async () => {
+it("toggles chat player sorting while preserving search and selection", async () => {
   const players = [
     { displayName: "Alpha", tilesOwned: 400 },
     { displayName: "Zulu", tilesOwned: 1200 },
@@ -31,6 +31,12 @@ it("orders chat players by territory and preserves that order within search resu
     Array.from(modal.querySelectorAll(".player-scroll-area button"), (button) =>
       button.textContent?.trim(),
     );
+  const sort = modal.querySelector<HTMLInputElement>('input[type="checkbox"]')!;
+  expect(sort.checked).toBe(false);
+  expect(names()).toEqual(["Alpha", "Bravo", "Zebra", "Zulu"]);
+
+  sort.click();
+  await modal.updateComplete;
   expect(names()).toEqual(["Zulu", "Zebra", "Bravo", "Alpha"]);
 
   const search = modal.querySelector<HTMLInputElement>(".player-search-input")!;
@@ -39,8 +45,27 @@ it("orders chat players by territory and preserves that order within search resu
   await modal.updateComplete;
   expect(names()).toEqual(["Zebra", "Bravo", "Alpha", "Zulu"]);
 
+  sort.click();
+  await modal.updateComplete;
+  expect(names()).toEqual(["Alpha", "Bravo", "Zebra", "Zulu"]);
+
+  sort.click();
+  await modal.updateComplete;
+  expect(names()).toEqual(["Zebra", "Bravo", "Alpha", "Zulu"]);
+
   search.value = "";
   search.dispatchEvent(new Event("input", { bubbles: true }));
   await modal.updateComplete;
   expect(names()).toEqual(["Zulu", "Zebra", "Bravo", "Alpha"]);
+
+  modal.querySelector<HTMLButtonElement>(".player-scroll-area button")!.click();
+  await modal.updateComplete;
+  const preview = modal.querySelector(".chat-preview")!.textContent;
+  sort.click();
+  await modal.updateComplete;
+  expect(names()).toEqual(["Alpha", "Bravo", "Zebra", "Zulu"]);
+  expect(
+    modal.querySelector(".player-scroll-area .selected")?.textContent?.trim(),
+  ).toBe("Zulu");
+  expect(modal.querySelector(".chat-preview")!.textContent).toBe(preview);
 });


### PR DESCRIPTION
Adds a “Sort by territory” checkbox to the chat player list. Alphabetical order stays the default; turning it on puts the largest players first. The choice is kept when reopening chat.

- [x] [Screenshot included](https://raw.githubusercontent.com/KomyakDevelopment/OpenFrontIO/831cc592dc2113b4d0e5b53190e59627e52fbe4d/chat-sort-territory.jpg)
- [x] Added regression tests; tests, lint and build pass
- [x] New label uses `translateText()` and has an entry in `en.json`

**Discord:** komyak
