### PR TITLE
feat: scaling train money from leveling structures

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -231,13 +231,31 @@ const OVERTIME_DEFAULTS = {
 
 export class Config {
   private unitInfoCache = new Map<UnitType, UnitInfo>();
+  private _factoryMultCache = new Float64Array(256);
+  private _stationMultCache = new Float64Array(256);
+
   constructor(
     private _gameConfig: GameConfig,
     private _userSettings: UserSettings | null,
     private _isReplay: boolean,
     public readonly listed: boolean = false,
     private _spectator: boolean = false,
-  ) {}
+  ) {
+    for (let level = 1; level < 256; level++) {
+      this._factoryMultCache[level] = 1 + 0.25 * (1 - pow(0.85, level - 1));
+      this._stationMultCache[level] = 1.0 + 0.4 * (log(level) * Math.LOG2E);
+    }
+  }
+
+  factoryStackMultiplier(level: number): number {
+    if (level < 256) return this._factoryMultCache[level];
+    return 1.25;
+  }
+
+  stationStackMultiplier(level: number): number {
+    if (level < 256) return this._stationMultCache[level];
+    return 1.0 + 0.4 * (log(level) * Math.LOG2E);
+  }
 
   isReplay(): boolean {
     return this._isReplay;
@@ -412,6 +430,8 @@ export class Config {
     rel: "self" | "team" | "ally" | "other",
     citiesVisited: number,
     player: Player | PlayerView,
+    sourceLevel: number = 1,
+    stationLevel: number = 1,
   ): Gold {
     // No penalty for the first 10 cities.
     citiesVisited = Math.max(0, citiesVisited - 9);
@@ -429,7 +449,8 @@ export class Config {
         break;
     }
     const distPenalty = citiesVisited * 5_000;
-    const gold = Math.max(5000, baseGold - distPenalty);
+    let gold = Math.max(5000, baseGold - distPenalty);
+    gold *= this.factoryStackMultiplier(sourceLevel) * this.stationStackMultiplier(stationLevel);
     return toInt(gold * this.goldMultiplierFor(player));
   }
 

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -450,7 +450,9 @@ export class Config {
     }
     const distPenalty = citiesVisited * 5_000;
     let gold = Math.max(5000, baseGold - distPenalty);
-    gold *= this.factoryStackMultiplier(sourceLevel) * this.stationStackMultiplier(stationLevel);
+    gold *=
+      this.factoryStackMultiplier(sourceLevel) *
+      this.stationStackMultiplier(stationLevel);
     return toInt(gold * this.goldMultiplierFor(player));
   }
 

--- a/src/core/execution/TrainExecution.ts
+++ b/src/core/execution/TrainExecution.ts
@@ -44,6 +44,10 @@ export class TrainExecution implements Execution {
     return this._tradeStopsVisited;
   }
 
+  public sourceLevel(): number {
+    return this.source.unit.level();
+  }
+
   init(mg: Game, ticks: number): void {
     this.mg = mg;
     const stations = this.railNetwork.findStationsPath(

--- a/src/core/execution/nation/NationStructureBehavior.ts
+++ b/src/core/execution/nation/NationStructureBehavior.ts
@@ -1120,7 +1120,7 @@ export class NationStructureBehavior {
         result.push({
           tile: unit.tile(),
           cluster: unitToCluster.get(unit)!,
-          weight: selfWeight,
+          weight: selfWeight * game.config().stationStackMultiplier(unit.level()),
         });
       }
     }
@@ -1135,7 +1135,7 @@ export class NationStructureBehavior {
         : player.isAlliedWith(neighbor)
           ? "ally"
           : "other";
-      const weight =
+      const baseWeight =
         Number(game.config().trainGold(relType, 0, player)) / maxTradeGold;
       for (const unit of neighbor.units(
         UnitType.City,
@@ -1146,7 +1146,7 @@ export class NationStructureBehavior {
           result.push({
             tile: unit.tile(),
             cluster: unitToCluster.get(unit)!,
-            weight,
+            weight: baseWeight * game.config().stationStackMultiplier(unit.level()),
           });
         }
       }

--- a/src/core/execution/nation/NationStructureBehavior.ts
+++ b/src/core/execution/nation/NationStructureBehavior.ts
@@ -1120,7 +1120,8 @@ export class NationStructureBehavior {
         result.push({
           tile: unit.tile(),
           cluster: unitToCluster.get(unit)!,
-          weight: selfWeight * game.config().stationStackMultiplier(unit.level()),
+          weight:
+            selfWeight * game.config().stationStackMultiplier(unit.level()),
         });
       }
     }
@@ -1146,7 +1147,8 @@ export class NationStructureBehavior {
           result.push({
             tile: unit.tile(),
             cluster: unitToCluster.get(unit)!,
-            weight: baseWeight * game.config().stationStackMultiplier(unit.level()),
+            weight:
+              baseWeight * game.config().stationStackMultiplier(unit.level()),
           });
         }
       }

--- a/src/core/game/TrainStation.ts
+++ b/src/core/game/TrainStation.ts
@@ -26,6 +26,8 @@ class TradeStationStopHandler implements TrainStopHandler {
         rel(trainOwner, stationOwner),
         trainExecution.tradeStopsVisited(),
         trainOwner,
+        trainExecution.sourceLevel(),
+        station.unit.level(),
       );
     // Share revenue with the station owner if it's not the current player
     if (trainOwner !== stationOwner) {

--- a/tests/NationStructureBehavior.test.ts
+++ b/tests/NationStructureBehavior.test.ts
@@ -30,7 +30,7 @@ function makeGame(stations: any[] = []): any {
   return {
     config: () => ({
       trainGold: (rel: string, _citiesVisited: number) => TRAIN_GOLD[rel] ?? 0n,
-      stationStackMultiplier: (level: number) => level,
+      stationStackMultiplier: (level: number) => 5 * level,
       factoryStackMultiplier: (level: number) => level,
     }),
     railNetwork: () => ({
@@ -158,14 +158,17 @@ describe("NationStructureBehavior.buildReachableStations", () => {
     const unit = makeUnit(10);
     const station = makeStation(unit, cluster);
     const player = makePlayer([unit], []);
-    const behavior = makeBehavior(makeGame([station]), player);
+    const game = makeGame([station]);
+    const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
     expect(result).toHaveLength(1);
     expect(result[0].tile).toBe(10);
     expect(result[0].cluster).toBe(cluster);
-    expect(result[0].weight).toBeCloseTo(selfWeight);
+    expect(result[0].weight).toBeCloseTo(
+      selfWeight * game.config().stationStackMultiplier(unit.level()),
+    );
   });
 
   it("applies the station stack multiplier to the base connectivity weight based on unit level", () => {
@@ -173,25 +176,31 @@ describe("NationStructureBehavior.buildReachableStations", () => {
     const unit = makeUnit(20, 2); // Level 2
     const station = makeStation(unit, cluster);
     const player = makePlayer([unit], []);
-    const behavior = makeBehavior(makeGame([station]), player);
+    const game = makeGame([station]);
+    const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
     expect(result).toHaveLength(1);
-    expect(result[0].weight).toBeCloseTo(selfWeight * 2);
+    expect(result[0].weight).toBeCloseTo(
+      selfWeight * game.config().stationStackMultiplier(unit.level()),
+    );
   });
 
   it("assigns null cluster when own unit is a station with no cluster", () => {
     const unit = makeUnit(11);
     const station = makeStation(unit, null);
     const player = makePlayer([unit], []);
-    const behavior = makeBehavior(makeGame([station]), player);
+    const game = makeGame([station]);
+    const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
     expect(result).toHaveLength(1);
     expect(result[0].cluster).toBeNull();
-    expect(result[0].weight).toBeCloseTo(selfWeight);
+    expect(result[0].weight).toBeCloseTo(
+      selfWeight * game.config().stationStackMultiplier(unit.level()),
+    );
   });
 
   it("excludes own units not registered in the station manager", () => {
@@ -251,14 +260,17 @@ describe("NationStructureBehavior.buildReachableStations", () => {
       isOnSameTeam: () => false,
       isAlliedWith: () => false,
     });
-    const behavior = makeBehavior(makeGame([station]), player);
+    const game = makeGame([station]);
+    const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
     expect(result).toHaveLength(1);
     expect(result[0].tile).toBe(60);
     expect(result[0].cluster).toBe(cluster);
-    expect(result[0].weight).toBeCloseTo(otherWeight);
+    expect(result[0].weight).toBeCloseTo(
+      otherWeight * game.config().stationStackMultiplier(unit.level()),
+    );
   });
 
   it("uses 'ally' weight for allied neighbor", () => {
@@ -270,12 +282,15 @@ describe("NationStructureBehavior.buildReachableStations", () => {
       isOnSameTeam: () => false,
       isAlliedWith: (n) => n === neighbor,
     });
-    const behavior = makeBehavior(makeGame([station]), player);
+    const game = makeGame([station]);
+    const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
     expect(result).toHaveLength(1);
-    expect(result[0].weight).toBeCloseTo(allyWeight);
+    expect(result[0].weight).toBeCloseTo(
+      allyWeight * game.config().stationStackMultiplier(unit.level()),
+    );
   });
 
   it("uses 'team' weight for team neighbor (team check precedes ally)", () => {
@@ -287,12 +302,15 @@ describe("NationStructureBehavior.buildReachableStations", () => {
       isOnSameTeam: (n) => n === neighbor,
       isAlliedWith: () => false,
     });
-    const behavior = makeBehavior(makeGame([station]), player);
+    const game = makeGame([station]);
+    const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
     expect(result).toHaveLength(1);
-    expect(result[0].weight).toBeCloseTo(teamWeight);
+    expect(result[0].weight).toBeCloseTo(
+      teamWeight * game.config().stationStackMultiplier(unit.level()),
+    );
   });
 
   it("excludes neighbor units not registered in the station manager", () => {

--- a/tests/NationStructureBehavior.test.ts
+++ b/tests/NationStructureBehavior.test.ts
@@ -30,8 +30,8 @@ function makeGame(stations: any[] = []): any {
   return {
     config: () => ({
       trainGold: (rel: string, _citiesVisited: number) => TRAIN_GOLD[rel] ?? 0n,
-      stationStackMultiplier: () => 1,
-      factoryStackMultiplier: () => 1,
+      stationStackMultiplier: (level: number) => level,
+      factoryStackMultiplier: (level: number) => level,
     }),
     railNetwork: () => ({
       stationManager: () => ({ getAll: () => new Set(stations) }),
@@ -166,6 +166,19 @@ describe("NationStructureBehavior.buildReachableStations", () => {
     expect(result[0].tile).toBe(10);
     expect(result[0].cluster).toBe(cluster);
     expect(result[0].weight).toBeCloseTo(selfWeight);
+  });
+
+  it("applies the station stack multiplier to the base connectivity weight based on unit level", () => {
+    const cluster = new Cluster();
+    const unit = makeUnit(20, 2); // Level 2
+    const station = makeStation(unit, cluster);
+    const player = makePlayer([unit], []);
+    const behavior = makeBehavior(makeGame([station]), player);
+
+    const result = (behavior as any).buildReachableStations();
+
+    expect(result).toHaveLength(1);
+    expect(result[0].weight).toBeCloseTo(selfWeight * 2);
   });
 
   it("assigns null cluster when own unit is a station with no cluster", () => {

--- a/tests/NationStructureBehavior.test.ts
+++ b/tests/NationStructureBehavior.test.ts
@@ -18,8 +18,8 @@ const MAX_TRADE_GOLD = Number(TRAIN_GOLD.ally); // denominator
 
 // ── Factory helpers ──────────────────────────────────────────────────────────
 
-function makeUnit(tile: number): any {
-  return { tile: () => tile };
+function makeUnit(tile: number, level: number = 1): any {
+  return { tile: () => tile, level: () => level };
 }
 
 function makeStation(unit: any, cluster: Cluster | null = null): any {
@@ -30,6 +30,8 @@ function makeGame(stations: any[] = []): any {
   return {
     config: () => ({
       trainGold: (rel: string, _citiesVisited: number) => TRAIN_GOLD[rel] ?? 0n,
+      stationStackMultiplier: () => 1,
+      factoryStackMultiplier: () => 1,
     }),
     railNetwork: () => ({
       stationManager: () => ({ getAll: () => new Set(stations) }),

--- a/tests/NationStructureBehavior.test.ts
+++ b/tests/NationStructureBehavior.test.ts
@@ -171,19 +171,32 @@ describe("NationStructureBehavior.buildReachableStations", () => {
     );
   });
 
-  it("applies the station stack multiplier to the base connectivity weight based on unit level", () => {
+  it("applies the station stack multiplier to both own and neighbor units based on level", () => {
     const cluster = new Cluster();
-    const unit = makeUnit(20, 2); // Level 2
-    const station = makeStation(unit, cluster);
-    const player = makePlayer([unit], []);
-    const game = makeGame([station]);
+    const ownUnit = makeUnit(20, 2);
+    const ownStation = makeStation(ownUnit, cluster);
+
+    const neighborUnit = makeUnit(30, 2);
+    const neighborStation = makeStation(neighborUnit, cluster);
+    const neighbor = makeNeighbor({ units: [neighborUnit], isPlayer: true });
+    const player = makePlayer([ownUnit], [neighbor], {
+      isAlliedWith: () => true,
+    });
+
+    const game = makeGame([ownStation, neighborStation]);
     const behavior = makeBehavior(game, player);
 
     const result = (behavior as any).buildReachableStations();
 
-    expect(result).toHaveLength(1);
-    expect(result[0].weight).toBeCloseTo(
-      selfWeight * game.config().stationStackMultiplier(unit.level()),
+    expect(result).toHaveLength(2);
+    const ownRes = result.find((r: any) => r.tile === 20);
+    const neighborRes = result.find((r: any) => r.tile === 30);
+
+    expect(ownRes.weight).toBeCloseTo(
+      selfWeight * game.config().stationStackMultiplier(ownUnit.level()),
+    );
+    expect(neighborRes.weight).toBeCloseTo(
+      allyWeight * game.config().stationStackMultiplier(neighborUnit.level()),
     );
   });
 

--- a/tests/core/game/TrainStation.test.ts
+++ b/tests/core/game/TrainStation.test.ts
@@ -1,5 +1,5 @@
 import { GameUpdateType } from "src/core/game/GameUpdates";
-import { vi, type Mocked } from "vitest";
+import { vi } from "vitest";
 import { Config } from "../../../src/core/configuration/Config";
 import { TrainExecution } from "../../../src/core/execution/TrainExecution";
 import {
@@ -10,157 +10,154 @@ import {
   GameMode,
   GameType,
   Player,
+  PlayerType,
   Unit,
   UnitType,
 } from "../../../src/core/game/Game";
 import { Cluster, TrainStation } from "../../../src/core/game/TrainStation";
 import { UserSettings } from "../../../src/core/game/UserSettings";
 import { GameConfig } from "../../../src/core/Schemas";
+import { playerInfo, setup } from "../../util/Setup";
+import { TestConfig } from "../../util/TestConfig";
 
-vi.mock("../../../src/core/game/Game");
-vi.mock("../../../src/core/execution/TrainExecution");
-vi.mock("../../../src/core/PseudoRandom");
+class WiringTestConfig extends TestConfig {
+  factoryStackMultiplier(level: number) {
+    return level;
+  }
+  stationStackMultiplier(level: number) {
+    return level;
+  }
+}
 
 describe("TrainStation", () => {
-  let game: Mocked<Game>;
-  let gameStats: {
-    trainExternalTrade: ReturnType<typeof vi.fn>;
-    trainSelfTrade: ReturnType<typeof vi.fn>;
-  };
-  let unit: Mocked<Unit>;
-  let player: Mocked<Player>;
-  let trainExecution: Mocked<TrainExecution>;
+  let game: Game;
+  let unit: Unit;
+  let player: Player;
+  let trainExecution: TrainExecution;
 
-  beforeEach(() => {
-    gameStats = {
-      trainExternalTrade: vi.fn(),
-      trainSelfTrade: vi.fn(),
-    };
-    game = {
-      ticks: vi.fn().mockReturnValue(123),
-      config: vi.fn().mockReturnValue({
-        trainGold: (rel: string, _tradeStopsVisited: number) =>
-          rel !== "other" ? BigInt(1000) : BigInt(500),
-      }),
-      addUpdate: vi.fn(),
-      addExecution: vi.fn(),
-      stats: vi.fn().mockReturnValue(gameStats),
-    } as any;
+  beforeEach(async () => {
+    game = await setup(
+      "plains",
+      {},
+      [
+        playerInfo("one", PlayerType.Human),
+        playerInfo("two", PlayerType.Human),
+      ],
+      undefined,
+      WiringTestConfig,
+    );
 
-    player = {
-      addGold: vi.fn(),
-      addTrainGold: vi.fn(),
-      id: 1,
-      canTrade: vi.fn().mockReturnValue(true),
-      isAlliedWith: vi.fn().mockReturnValue(false),
-      isOnSameTeam: vi.fn().mockReturnValue(false),
-      isFriendly: vi.fn().mockReturnValue(false),
-    } as any;
+    player = game.player("one")!;
+    const tile = game.ref(5, 5);
+    unit = player.buildUnit(UnitType.City, tile, {});
 
-    unit = {
-      owner: vi.fn().mockReturnValue(player),
-      level: vi.fn().mockReturnValue(1),
-      tile: vi.fn().mockReturnValue({ x: 0, y: 0 }),
-      type: vi.fn(),
-      isActive: vi.fn().mockReturnValue(true),
-    } as any;
+    const destTile = game.ref(10, 10);
+    const destUnit = player.buildUnit(UnitType.City, destTile, {});
 
-    trainExecution = {
-      loadCargo: vi.fn(),
-      owner: vi.fn().mockReturnValue(player),
-      level: vi.fn(),
-      sourceLevel: vi.fn().mockReturnValue(1),
-      tradeStopsVisited: vi.fn().mockReturnValue(0),
-    } as any;
+    const sourceStation = new TrainStation(game, unit);
+    const destStation = new TrainStation(game, destUnit);
+    trainExecution = new TrainExecution(
+      game.railNetwork(),
+      player,
+      sourceStation,
+      destStation,
+      1,
+    );
   });
 
   it("handles City stop", () => {
-    unit.type.mockReturnValue(UnitType.City);
     const station = new TrainStation(game, unit);
+    const goldBefore = player.gold();
 
     station.onTrainStop(trainExecution);
 
-    expect(unit.owner().addGold).toHaveBeenCalledWith(1000n, unit.tile());
+    // baseGold for self is 10_000n. Stack multiplier is 1 * 1 = 1.
+    expect(player.gold() - goldBefore).toBe(10_000n);
   });
 
   it("handles allied trade", () => {
-    unit.type.mockReturnValue(UnitType.City);
-    player.isFriendly.mockReturnValue(true);
+    const ally = game.player("two")!;
+    vi.spyOn(player, "isFriendly").mockReturnValue(true);
+    vi.spyOn(player, "isAlliedWith").mockReturnValue(true);
+
+    vi.spyOn(unit, "owner").mockReturnValue(ally);
+
     const station = new TrainStation(game, unit);
+    const allyGoldBefore = ally.gold();
+    const playerGoldBefore = player.gold();
 
     station.onTrainStop(trainExecution);
 
-    expect(unit.owner().addGold).toHaveBeenCalledWith(1000n, unit.tile());
-    expect(trainExecution.owner().addGold).toHaveBeenCalledWith(
-      1000n,
-      unit.tile(),
-    );
+    // baseGold for ally is 35_000n.
+    expect(ally.gold() - allyGoldBefore).toBe(35_000n);
+    expect(player.gold() - playerGoldBefore).toBe(35_000n);
   });
 
   it("records external trade on the station owner", () => {
-    const stationOwner = {
-      addGold: vi.fn(),
-      addTrainGold: vi.fn(),
-      id: 1,
-      canTrade: vi.fn().mockReturnValue(true),
-      isAlliedWith: vi.fn().mockReturnValue(false),
-      isOnSameTeam: vi.fn().mockReturnValue(false),
-    } as any;
-    const trainOwner = {
-      addGold: vi.fn(),
-      addTrainGold: vi.fn(),
-      id: 2,
-      canTrade: vi.fn().mockReturnValue(true),
-      isAlliedWith: vi.fn().mockReturnValue(false),
-      isOnSameTeam: vi.fn().mockReturnValue(false),
-    } as any;
+    const stationOwner = game.player("two")!;
+    vi.spyOn(unit, "owner").mockReturnValue(stationOwner);
 
-    unit.type.mockReturnValue(UnitType.City);
-    unit.owner.mockReturnValue(stationOwner);
-    trainExecution.owner.mockReturnValue(trainOwner);
+    const trainExternalTradeSpy = vi.spyOn(game.stats(), "trainExternalTrade");
+    const trainSelfTradeSpy = vi.spyOn(game.stats(), "trainSelfTrade");
+
     const station = new TrainStation(game, unit);
-
     station.onTrainStop(trainExecution);
 
-    expect(stationOwner.addGold).toHaveBeenCalledWith(500n, unit.tile());
-    expect(trainOwner.addGold).toHaveBeenCalledWith(500n, unit.tile());
-    expect(stationOwner.addTrainGold).toHaveBeenCalledWith(500n);
-    expect(trainOwner.addTrainGold).toHaveBeenCalledWith(500n);
-    expect(gameStats.trainExternalTrade).toHaveBeenCalledWith(
-      stationOwner,
-      500n,
-    );
-    expect(gameStats.trainSelfTrade).toHaveBeenCalledWith(trainOwner, 500n);
+    // baseGold for other/team is 25_000n.
+    expect(trainExternalTradeSpy).toHaveBeenCalledWith(stationOwner, 25_000n);
+    expect(trainSelfTradeSpy).toHaveBeenCalledWith(player, 25_000n);
   });
 
-  it("passes tradeStopsVisited to trainGold", () => {
-    unit.type.mockReturnValue(UnitType.City);
-    const trainGoldSpy = vi.fn().mockReturnValue(500n);
-    (game.config as any).mockReturnValue({
-      trainGold: trainGoldSpy,
-    });
-    (trainExecution as any).tradeStopsVisited = vi.fn().mockReturnValue(3);
+  it("passes exact source and station levels through the simulation to trainGold", () => {
+    // 1. Create a Level 2 Factory (Source)
+    const factoryTile = game.ref(15, 15);
+    const factory = player.buildUnit(UnitType.Factory, factoryTile, {});
+    factory.increaseLevel();
+    expect(factory.level()).toBe(2);
+
+    // 2. Create a Level 3 City (Destination)
+    const cityTile = game.ref(25, 25);
+    const city = player.buildUnit(UnitType.City, cityTile, {});
+    city.increaseLevel();
+    city.increaseLevel();
+    expect(city.level()).toBe(3);
+
+    // 3. Instantiate true TrainStations and TrainExecution
+    const factoryStation = new TrainStation(game, factory);
+    const cityStation = new TrainStation(game, city);
+
+    const trainExec = new TrainExecution(
+      game.railNetwork(),
+      player,
+      factoryStation,
+      cityStation,
+      1,
+    );
+
+    // 4. Trigger the stop and measure exact gold output
+    const goldBefore = player.gold();
+    cityStation.onTrainStop(trainExec);
+    const goldEarned = player.gold() - goldBefore;
+
+    // Wiring Verification: base 10k * factoryLevel(2) * cityLevel(3)
+    expect(goldEarned).toBe(60_000n);
+  });
+
+  it("passes tradeStopsVisited to trainGold through distance penalty", () => {
+    vi.spyOn(trainExecution, "tradeStopsVisited").mockReturnValue(10); // 10 cities visited = penalty of 5k (1 stop over free window)
+
     const station = new TrainStation(game, unit);
+    const goldBefore = player.gold();
 
     station.onTrainStop(trainExecution);
 
-    expect(trainGoldSpy).toHaveBeenCalledWith(
-      expect.any(String),
-      3,
-      expect.anything(),
-      expect.any(Number),
-      expect.any(Number),
-    );
+    // baseGold 10k - 5k penalty = 5k.
+    expect(player.gold() - goldBefore).toBe(5_000n);
   });
 
   it("checks trade availability (same owner)", () => {
-    const otherUnit = {
-      owner: vi.fn().mockReturnValue(unit.owner()),
-    } as any;
-
     const station = new TrainStation(game, unit);
-    const otherStation = new TrainStation(game, otherUnit);
-
+    const otherStation = new TrainStation(game, unit);
     expect(station.tradeAvailable(otherStation.unit.owner())).toBe(true);
   });
 
@@ -171,14 +168,12 @@ describe("TrainStation", () => {
 
     stationA.addRailroad(railRoad);
 
-    const neighbors = stationA.neighbors();
-    expect(neighbors).toContain(stationB);
+    expect(stationA.neighbors()).toContain(stationB);
   });
 
   it("removes neighboring rail", () => {
     const stationA = new TrainStation(game, unit);
     const stationB = new TrainStation(game, unit);
-
     const railRoad = {
       from: stationA,
       to: stationB,
@@ -188,9 +183,10 @@ describe("TrainStation", () => {
     stationA.addRailroad(railRoad);
     expect(stationA.getRailroads().size).toBe(1);
 
+    const addUpdateSpy = vi.spyOn(game, "addUpdate");
     stationA.removeNeighboringRails(stationB);
 
-    expect(game.addUpdate).toHaveBeenCalledWith(
+    expect(addUpdateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         type: GameUpdateType.RailroadDestructionEvent,
       }),
@@ -199,7 +195,7 @@ describe("TrainStation", () => {
   });
 
   it("assigns and retrieves cluster", () => {
-    const cluster: Cluster = {} as Cluster;
+    const cluster = {} as Cluster;
     const station = new TrainStation(game, unit);
 
     station.setCluster(cluster);
@@ -208,7 +204,7 @@ describe("TrainStation", () => {
 
   it("returns tile and active status", () => {
     const station = new TrainStation(game, unit);
-    expect(station.tile()).toEqual({ x: 0, y: 0 });
+    expect(station.tile()).toEqual(unit.tile());
     expect(station.isActive()).toBe(true);
   });
 });
@@ -239,33 +235,27 @@ describe("Config.trainGold trade stop penalty", () => {
   });
 
   it("returns full base gold within free window (stops 0-9)", () => {
-    // first 10 stops (0-9) are free — no penalty
     expect(config.trainGold("self", 0, mockPlayer)).toBe(10_000n);
     expect(config.trainGold("self", 9, mockPlayer)).toBe(10_000n);
   });
 
   it("reduces gold by 5k per stop after the free window", () => {
-    // stop 10: effective = 10-9 = 1 -> 10k - 5k = 5k
     expect(config.trainGold("self", 10, mockPlayer)).toBe(5_000n);
   });
 
   it("floors at 5k when penalty exceeds base gold", () => {
-    // stop 12: effective = 3 -> 10k - 15k -> floor at 5k
     expect(config.trainGold("self", 12, mockPlayer)).toBe(5_000n);
   });
 
   it("floors at 5k for ally base even with heavy penalty", () => {
-    // ally base 35k, stop 20: effective = 11 -> penalty 55k -> floor at 5k
     expect(config.trainGold("ally", 20, mockPlayer)).toBe(5_000n);
   });
 
   it("ally base gold reduces correctly after free window", () => {
-    // ally base 35k, stop 11: effective = 2 -> 35k - 10k = 25k
     expect(config.trainGold("ally", 11, mockPlayer)).toBe(25_000n);
   });
 
   it("other/team base gold reduces correctly after free window", () => {
-    // other base 25k, stop 10: effective = 1 -> 25k - 5k = 20k
     expect(config.trainGold("other", 10, mockPlayer)).toBe(20_000n);
     expect(config.trainGold("team", 10, mockPlayer)).toBe(20_000n);
   });

--- a/tests/core/game/TrainStation.test.ts
+++ b/tests/core/game/TrainStation.test.ts
@@ -69,6 +69,7 @@ describe("TrainStation", () => {
       loadCargo: vi.fn(),
       owner: vi.fn().mockReturnValue(player),
       level: vi.fn(),
+      sourceLevel: vi.fn().mockReturnValue(1),
       tradeStopsVisited: vi.fn().mockReturnValue(0),
     } as any;
   });
@@ -147,6 +148,8 @@ describe("TrainStation", () => {
       expect.any(String),
       3,
       expect.anything(),
+      expect.any(Number),
+      expect.any(Number),
     );
   });
 


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #1949

## Description:

Adds functionality to trainStation destinations to scale money based on structure level. Applies a similar thing to trainStation source (IE factories).

Table below shows the math with different lvl factories and different city tracks.
These numbers can be tweaked in the future. 

### This is a *low starting point*. 
Even in these setups, almost always the port generates more money.
This table assumed the visited cities are allied cities, so already max bonus.
In a real game, on avg a train only goes to the middle-most city. (random destinations means the avg is in the middle)
In a real game these values are halved. Self-traded would again be a division by 3.5.
*ports are much better*
*level 1 city lines are still much better*

**Goal/hope**: this does make tiny city stacks potentially more viable, especially under low level SAMs, which in turn makes atom bomb micro a viable counter strat late game.

| Factory Stack | City Route | Live Gold/Min (max potential) | New Gold/Min (max potential) | Multiplier | Eqv. Port Level | Port Gold/Min |
|---|---|---|---|---|---|---|
| L1 | L1 | 120,000 | 120,000 | **1.00x** | L2 | 761,523 |
| L1 | 5x L1 | 600,000 | 600,000 | **1.00x** | L6 | 1,955,186 |
| L1 | 10x L1 | 1,200,000 | 1,200,000 | **1.00x** | L11 | 3,044,123 |
| L1 | L5 | 120,000 | 231,453 | **1.93x** | L6 | 1,955,186 |
| L1 | L10 | 120,000 | 279,453 | **2.33x** | L11 | 3,044,123 |
| L1 | L50 | 120,000 | 390,905 | **3.26x** | L51 | 5,127,595 |
| L1 | L100 | 120,000 | 438,905 | **3.66x** | L101 | 9,855,595 |
| L1 | L5 → L5 → L5 | 360,000 | 694,358 | **1.93x** | L16 | 3,855,999 |
| L1 | L10 → L10 → L10 | 360,000 | 838,358 | **2.33x** | L31 | 4,718,623 |
| L1 | L100 → L1 | 240,000 | 558,905 | **2.33x** | L102 | 10,217,523 |
| L5 | L1 | 379,049 | 424,345 | **1.12x** | L6 | 1,955,186 |
| L5 | L5 | 379,049 | 818,464 | **2.16x** | L10 | 2,863,356 |
| L5 | L10 | 379,049 | 988,202 | **2.61x** | L15 | 3,729,368 |
| L5 | L50 | 379,049 | 1,382,322 | **3.65x** | L55 | 6,407,543 |
| L5 | 5x L1 | 1,895,246 | 2,121,725 | **1.12x** | L10 | 2,863,356 |
| L5 | 5x L5 | 1,895,246 | 4,092,322 | **2.16x** | L30 | 4,714,446 |
| L5 | 5x L10 | 1,895,246 | 4,941,012 | **2.61x** | L55 | 6,407,543 |
| L10 | L1 | 519,124 | 618,846 | **1.19x** | L11 | 3,044,123 |
| L10 | L5 | 519,124 | 1,193,612 | **2.30x** | L15 | 3,729,368 |
| L10 | L10 | 519,124 | 1,441,150 | **2.78x** | L20 | 4,337,546 |
| L10 | L50 | 519,124 | 2,015,916 | **3.88x** | L60 | 7,591,356 |
| L10 | L100 | 519,124 | 2,263,454 | **4.36x** | L110 | 12,319,356 |
| L10 | 10x L1 | 5,191,241 | 6,188,456 | **1.19x** | L20 | 4,337,546 |
| L10 | 10x L5 | 5,191,241 | 11,936,117 | **2.30x** | L60 | 7,591,356 |
| L10 | 10x L10 | 5,191,241 | 14,411,499 | **2.78x** | L110 | 12,319,356 |
| L20 | L1 | 636,775 | 788,709 | **1.24x** | L21 | 4,429,427 |
| L20 | L5 | 636,775 | 1,521,240 | **2.39x** | L25 | 4,627,766 |
| L20 | L10 | 636,775 | 1,836,723 | **2.88x** | L30 | 4,714,446 |
| L20 | L20 | 636,775 | 2,152,207 | **3.38x** | L40 | 4,728,000 |
| L20 | L50 | 636,775 | 2,569,254 | **4.03x** | L70 | 9,065,546 |
| L20 | L20 → L20 → L20 | 1,910,324 | 6,456,621 | **3.38x** | L80 | 9,442,446 |
| L50 | L1 | 736,981 | 921,162 | **1.25x** | L51 | 5,127,595 |
| L50 | L5 | 736,981 | 1,776,711 | **2.41x** | L55 | 6,407,543 |
| L50 | L10 | 736,981 | 2,145,176 | **2.91x** | L60 | 7,591,356 |
| L50 | L50 | 736,981 | 3,000,725 | **4.07x** | L100 | 9,456,000 |
| L50 | L100 | 736,981 | 3,369,189 | **4.57x** | L150 | 14,184,000 |
| L50 | 5x L50 | 3,684,905 | 15,003,623 | **4.07x** | L300 | 28,368,000 |
| L50 | 20x L1 | 10,001,885 | 12,501,486 | **1.25x** | L70 | 9,065,546 |
| L100 | L1 | 777,776 | 972,220 | **1.25x** | L101 | 9,855,595 |
| L100 | L100 | 777,776 | 3,555,937 | **4.57x** | L200 | 18,912,000 |
| L100 | L10 → L20 → L30 → L40 → L50 | 3,888,882 | 14,006,402 | **3.60x** | L250 | 23,640,000 |
| L1 | L10 → L20 → L30 → L40 → L50 | 600,000 | 1,728,793 | **2.88x** | L151 | 14,583,595 |
| L5 | L1 → L2 → L3 → L4 → L5 → L6 → L7 → L8 → L9 → L10 | 3,790,492 | 7,942,220 | **2.10x** | L60 | 7,591,356 |
| L10 | 15x L1 | 6,674,453 | 7,956,587 | **1.19x** | L25 | 4,627,766 |
| L10 | 15x L5 | 6,674,453 | 15,346,436 | **2.30x** | L85 | 9,455,054 |
| L10 | 15x L10 | 6,674,453 | 18,529,071 | **2.78x** | L160 | 17,047,356 |
| L50 | 20x L50 | 10,001,885 | 40,724,120 | **4.07x** | L1050 | 99,288,000 |
| L20 | L50 → L10 → L5 → L1 → L1 → L1 | 3,820,648 | 8,293,344 | **2.17x** | L88 | 9,455,921 |
| L20 | L1 → L1 → L1 → L5 → L10 → L50 | 3,820,648 | 8,293,344 | **2.17x** | L88 | 9,455,921 |

1. City Stacks
Live upgrading a city provided zero benefit to train networks. The new code introduces logarithmic scaling (1.0 + 0.4 * log2(L)).

Level 1: 1.00x (Live: 1.00x)
Level 5: 1.93x (Live: 1.00x)
Level 10: 2.33x (Live: 1.00x)
Level 15: 2.56x (Live: 1.00x)
Level 50: 3.26x (Live: 1.00x)
Level 100: 3.66x (Live: 1.00x)
new code gives cities an early-game power spike (lvl 5 ~2x), reducing the negative of lower level stacks. The math falls off to prevent hyper-scaling. 

2. Factory Stacking
Factory efficiency was purely tied to the diminishing returns of the train spawn cooldown. new code introduces an asymptotic gold mult 1.0 + 0.25 * (1 - pow(0.85, level - 1)) cap at 1.25x

Gold Multiplier:
Level 1: 1.00x (Live: 1.00x)
Level 5: 1.12x (Live: 1.00x)
Level 10: 1.19x (Live: 1.00x)
Level 15: 1.22x (Live: 1.00x)
Level 50: 1.25x (Live: 1.00x)
Level 100: 1.25x (Live: 1.00x)
Total Factory Efficiency:
Level 1: 100.0% (Live: 100.0%)
Level 5: 94.9% (Live: 84.8%)
Level 10: 91.3% (Live: 76.6%)
Level 15: 88.6% (Live: 72.3%)
Level 50: 79.8% (Live: 63.9%)
Level 100: 76.8% (Live: 61.5%)

live factory stacking fell off a cliff, losing nearly 25% efficiency by Level 10. The new math cushions this, keeping factories above 90% efficiency all the way to Level 10. However, because the gold multiplier hard-caps at 1.25x,  high levels are forced to bleed efficiency down into the 70s, making them still less optimal than spreading out, and making them worse than ports at every stage.


<img width="1285" height="628" alt="firefox_vyp4QOXAhY" src="https://github.com/user-attachments/assets/01dfb7da-2f44-4574-b3c1-93e3e9f7ba67" />
<img width="1345" height="560" alt="firefox_SHIkzuPRQm" src="https://github.com/user-attachments/assets/df7e3109-0b67-45fa-967a-c3bf81231376" />

## Please put your Discord username so you can be contacted if a bug or regression is found:

JB940
