### PR TITLE
fix(store): stop rendering the logged-out state while auth is pending (OPE-338)

### DIFF
--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -1,6 +1,6 @@
 import type { PropertyValues, TemplateResult } from "lit";
 import { html } from "lit";
-import { customElement } from "lit/decorators.js";
+import { customElement, state } from "lit/decorators.js";
 import { UserMeResponse } from "../core/ApiSchemas";
 import { CosmeticPack, Cosmetics, Product } from "../core/CosmeticSchemas";
 import { BaseModal } from "./components/BaseModal";
@@ -64,7 +64,10 @@ export class StoreModal extends BaseModal {
   // logged-in player for the whole window before Main's first userMeResponse
   // broadcast (a Steam ticket exchange on desktop). This distinguishes the
   // two: nothing is asserted about the session until it has actually settled.
-  private authSettled = false;
+  // Reactive on its own, unlike `userMeResponse`: onUserMe() only calls
+  // refresh() after the catalog fetch, and a settled no-session result must
+  // not wait on a slow catalog before it may say so.
+  @state() private authSettled = false;
   private cosmeticsSubTab: CosmeticsSubTab = "patterns";
   private inspected: ResolvedCosmetic | null = null;
   private previewingCosmetic: ResolvedCosmetic | null = null;

--- a/src/client/Store.ts
+++ b/src/client/Store.ts
@@ -59,6 +59,12 @@ export class StoreModal extends BaseModal {
   private cosmetics: Cosmetics | null = null;
   private affiliateCode: string | null = null;
   private userMeResponse: UserMeResponse | false = false;
+  // `userMeResponse` starts at `false`, which is also what "no session" looks
+  // like, so a tab that renders a sign-in prompt on `false` would show it to a
+  // logged-in player for the whole window before Main's first userMeResponse
+  // broadcast (a Steam ticket exchange on desktop). This distinguishes the
+  // two: nothing is asserted about the session until it has actually settled.
+  private authSettled = false;
   private cosmeticsSubTab: CosmeticsSubTab = "patterns";
   private inspected: ResolvedCosmetic | null = null;
   private previewingCosmetic: ResolvedCosmetic | null = null;
@@ -135,6 +141,7 @@ export class StoreModal extends BaseModal {
 
   async onUserMe(userMeResponse: UserMeResponse | false) {
     this.userMeResponse = userMeResponse;
+    this.authSettled = true;
     this.cosmetics = await fetchCosmetics();
     this.selectVisible(this.groupsForTab(this.activeTab));
     await this.refresh();
@@ -622,6 +629,9 @@ export class StoreModal extends BaseModal {
   }
 
   private renderTribeGrid(): TemplateResult {
+    // The panel's `false` branch is a sign-in prompt, i.e. a logged-out
+    // state; hold it back until the session is known (see authSettled).
+    if (!this.authSettled) return html``;
     return html`<tribes-panel
       .userMeResponse=${this.userMeResponse}
     ></tribes-panel>`;

--- a/src/client/components/NotLoggedInWarning.ts
+++ b/src/client/components/NotLoggedInWarning.ts
@@ -5,7 +5,14 @@ import { responseHasLinkedIdentity } from "../AccountIdentity";
 
 @customElement("not-logged-in-warning")
 export class NotLoggedInWarning extends LitElement {
-  @state() private linked = false;
+  // Three states, not two. `null` is "auth has not settled yet": Main only
+  // broadcasts userMeResponse once userAuth() (a Steam ticket exchange on
+  // desktop) has resolved, and this element is on the page from mount. Until
+  // that first broadcast nothing is known, so nothing is shown. Starting at
+  // `false` instead rendered the "Not logged in" button to every logged-in
+  // player for the whole pending window -- most visibly on the post-purchase
+  // reload, right after they had spent money (OPE-338).
+  @state() private linked: boolean | null = null;
 
   private _onUserMe = (event: CustomEvent<UserMeResponse | false>) => {
     this.linked = responseHasLinkedIdentity(event.detail);
@@ -32,7 +39,9 @@ export class NotLoggedInWarning extends LitElement {
   }
 
   render() {
-    if (this.linked) return html``;
+    // Pending and linked both render nothing; only a SETTLED no-session
+    // result warns.
+    if (this.linked !== false) return html``;
 
     return html`<div class="no-crazygames flex items-center">
       <button

--- a/tests/client/StoreAuthPending.test.ts
+++ b/tests/client/StoreAuthPending.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { fetchCosmetics } from "../../src/client/Cosmetics";
 import "../../src/client/Store";
 import type { StoreModal } from "../../src/client/Store";
 import type { TribesPanel } from "../../src/client/components/TribesPanel";
@@ -45,6 +46,8 @@ describe("StoreModal while auth is pending", () => {
 
   afterEach(() => {
     store.remove();
+    vi.mocked(fetchCosmetics).mockReset();
+    vi.mocked(fetchCosmetics).mockResolvedValue(null);
   });
 
   async function openTribes() {
@@ -58,6 +61,19 @@ describe("StoreModal while auth is pending", () => {
 
   function tribesPanel() {
     return store.querySelector<TribesPanel>("tribes-panel");
+  }
+
+  // The prompt's sign-in button, by label (translateText returns the key
+  // without a lang-selector). Null both when the panel is absent and when it
+  // renders the logged-in view, whose purchase card has buttons of its own;
+  // `?.` alone would yield undefined for an absent panel, which
+  // `.not.toBeNull()` accepts.
+  function signInPrompt() {
+    return (
+      [...(tribesPanel()?.querySelectorAll("button") ?? [])].find(
+        (button) => button.textContent?.trim() === "main.sign_in",
+      ) ?? null
+    );
   }
 
   async function settle() {
@@ -78,8 +94,34 @@ describe("StoreModal while auth is pending", () => {
     await vi.waitFor(async () => {
       await settle();
       expect(warningButton()).not.toBeNull();
-      expect(tribesPanel()?.querySelector("button")).not.toBeNull();
+      expect(signInPrompt()).not.toBeNull();
     });
+  });
+
+  it("shows the tribes sign-in prompt as soon as auth settles, not after the catalog", async () => {
+    // onUserMe() awaits fetchCosmetics() before it calls refresh(); a settled
+    // no-session result must schedule its own render rather than sit behind
+    // a slow (here: never-resolving) catalog request.
+    vi.mocked(fetchCosmetics).mockReturnValue(new Promise(() => {}));
+    await openTribes();
+    fireUserMe(false);
+    await vi.waitFor(async () => {
+      await settle();
+      expect(signInPrompt()).not.toBeNull();
+    });
+    expect(warningButton()).not.toBeNull();
+  });
+
+  it("shows the logged-in tribes panel as soon as auth settles, not after the catalog", async () => {
+    vi.mocked(fetchCosmetics).mockReturnValue(new Promise(() => {}));
+    await openTribes();
+    fireUserMe(steamOnly);
+    await vi.waitFor(async () => {
+      await settle();
+      expect(tribesPanel()).not.toBeNull();
+    });
+    expect(warningButton()).toBeNull();
+    expect(signInPrompt()).toBeNull();
   });
 
   it("never shows a logged-out state to a logged-in player, before or after auth settles", async () => {
@@ -95,8 +137,9 @@ describe("StoreModal while auth is pending", () => {
     });
     expect(warningButton()).toBeNull();
     // The panel's logged-in view has a purchase card, not a sign-in prompt.
-    expect(tribesPanel()?.textContent).not.toContain(
+    expect(tribesPanel()!.textContent).not.toContain(
       "store.tribes_login_required",
     );
+    expect(signInPrompt()).toBeNull();
   });
 });

--- a/tests/client/StoreAuthPending.test.ts
+++ b/tests/client/StoreAuthPending.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "../../src/client/Store";
+import type { StoreModal } from "../../src/client/Store";
+import type { TribesPanel } from "../../src/client/components/TribesPanel";
+import type { UserMeResponse } from "../../src/core/ApiSchemas";
+
+// The store's own network is out of scope here: the tribes panel fetches the
+// player's tribe names as soon as it learns the player is logged in, and the
+// catalog is fetched on every userMeResponse.
+vi.mock("../../src/client/Api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Api")>()),
+  getMyTribeNames: vi.fn(async () => false as const),
+}));
+vi.mock("../../src/client/Cosmetics", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Cosmetics")>()),
+  fetchCosmetics: vi.fn(async () => null),
+}));
+
+const steamOnly = {
+  user: { steam: { id: "76561198000000000" } },
+  player: { publicId: "p", flares: [], currency: { hard: 0, soft: 0 } },
+} as unknown as UserMeResponse;
+
+function fireUserMe(detail: UserMeResponse | false) {
+  document.dispatchEvent(new CustomEvent("userMeResponse", { detail }));
+}
+
+/**
+ * OPE-338: the store must never show a logged-out state to a logged-in
+ * player. Its account state starts out indistinguishable from "no session"
+ * (`false`) until Main's first userMeResponse broadcast, which on desktop
+ * waits on a Steam ticket exchange -- so every logged-out rendering has to be
+ * held back until auth has actually settled, not merely defaulted off.
+ */
+describe("StoreModal while auth is pending", () => {
+  Element.prototype.animate ??= () => ({ cancel: () => {} }) as Animation;
+  let store: StoreModal;
+
+  beforeEach(async () => {
+    store = document.createElement("store-modal") as StoreModal;
+    store.inline = true;
+    document.body.appendChild(store);
+    await store.updateComplete;
+  });
+
+  afterEach(() => {
+    store.remove();
+  });
+
+  async function openTribes() {
+    store.open({ tab: "tribes" });
+    await store.updateComplete;
+  }
+
+  function warningButton() {
+    return store.querySelector("not-logged-in-warning button");
+  }
+
+  function tribesPanel() {
+    return store.querySelector<TribesPanel>("tribes-panel");
+  }
+
+  async function settle() {
+    await store.updateComplete;
+    await tribesPanel()?.updateComplete;
+  }
+
+  it("shows neither the warning nor the tribes sign-in prompt before auth settles", async () => {
+    await openTribes();
+    await settle();
+    expect(warningButton()).toBeNull();
+    expect(tribesPanel()).toBeNull();
+  });
+
+  it("shows both once auth settles with no session", async () => {
+    await openTribes();
+    fireUserMe(false);
+    await vi.waitFor(async () => {
+      await settle();
+      expect(warningButton()).not.toBeNull();
+      expect(tribesPanel()?.querySelector("button")).not.toBeNull();
+    });
+  });
+
+  it("never shows a logged-out state to a logged-in player, before or after auth settles", async () => {
+    await openTribes();
+    await settle();
+    expect(warningButton()).toBeNull();
+    expect(tribesPanel()).toBeNull();
+
+    fireUserMe(steamOnly);
+    await vi.waitFor(async () => {
+      await settle();
+      expect(tribesPanel()).not.toBeNull();
+    });
+    expect(warningButton()).toBeNull();
+    // The panel's logged-in view has a purchase card, not a sign-in prompt.
+    expect(tribesPanel()?.textContent).not.toContain(
+      "store.tribes_login_required",
+    );
+  });
+});

--- a/tests/client/components/NotLoggedInWarning.test.ts
+++ b/tests/client/components/NotLoggedInWarning.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { NotLoggedInWarning } from "../../../src/client/components/NotLoggedInWarning";
+import type { UserMeResponse } from "../../../src/core/ApiSchemas";
+
+function fireUserMe(detail: UserMeResponse | false) {
+  document.dispatchEvent(new CustomEvent("userMeResponse", { detail }));
+}
+
+const steamOnly = {
+  user: { steam: { id: "76561198000000000" } },
+  player: { publicId: "p" },
+} as unknown as UserMeResponse;
+
+// A session with no linked identity at all: /users/@me answered, but the
+// account is anonymous. This is the one case the warning exists for.
+const anonymous = {
+  user: {},
+  player: { publicId: "p" },
+} as unknown as UserMeResponse;
+
+describe("not-logged-in-warning", () => {
+  let el: NotLoggedInWarning;
+
+  beforeEach(async () => {
+    // The @customElement define() side-effect doesn't run under the test
+    // transform, so register explicitly (as other client component tests do).
+    if (!customElements.get("not-logged-in-warning")) {
+      customElements.define("not-logged-in-warning", NotLoggedInWarning);
+    }
+    el = document.createElement("not-logged-in-warning") as NotLoggedInWarning;
+    document.body.appendChild(el);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    el.remove();
+  });
+
+  async function button(): Promise<HTMLButtonElement | null> {
+    await el.updateComplete;
+    return el.querySelector("button");
+  }
+
+  it("renders nothing while auth is still pending (OPE-338)", async () => {
+    // No userMeResponse has been broadcast yet: Main is still waiting on
+    // userAuth(). Nothing is known, so nothing may be claimed.
+    expect(await button()).toBeNull();
+  });
+
+  it("warns once auth settles with no session", async () => {
+    fireUserMe(false);
+    expect(await button()).not.toBeNull();
+  });
+
+  it("warns once auth settles on an account with no linked identity", async () => {
+    fireUserMe(anonymous);
+    expect(await button()).not.toBeNull();
+  });
+
+  it("renders nothing once auth settles on a linked account", async () => {
+    fireUserMe(steamOnly);
+    expect(await button()).toBeNull();
+  });
+
+  it("never shows the warning at any point for a player who is logged in", async () => {
+    // The post-purchase reload sequence: mount (pending) -> auth resolves.
+    expect(await button()).toBeNull();
+    fireUserMe(steamOnly);
+    expect(await button()).toBeNull();
+  });
+
+  it("warns when a linked session is later cleared", async () => {
+    fireUserMe(steamOnly);
+    expect(await button()).toBeNull();
+    // session-cleared routes through Main's onUserMe(false).
+    fireUserMe(false);
+    expect(await button()).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Fixes OPE-338 — after buying a skin, the full-page refresh races auth and flashes "Not logged in" on the store.

## Which state was rendering

**Pending, not failed.** On the happy path Main broadcasts exactly one `userMeResponse` — after `await userAuth()` (a Steam ticket exchange on desktop) and then `getUserMe()` — and it never broadcasts `false` first. The store and its `<not-logged-in-warning>` are in `index.html` from page mount, so they exist for that whole window, and:

- `NotLoggedInWarning` initialised `linked = false` — the same value a settled no-session result produces — and rendered the red button whenever `linked` was false. "Not known yet" rendered as "not logged in".
- `StoreModal.userMeResponse` initialises to `false`, and the tribes panel renders a sign-in prompt on `false` — the same shape, one tab over.

This is option 1 from the ticket: the bug is that pending rendered as negative, so the fix is to tell the two states apart. No state store, no change to the reload.

## Change

- `NotLoggedInWarning.linked` is now `boolean | null`; `null` (nothing broadcast yet) renders nothing. A settled `false` — startup `onUserMe(false)`, `session-cleared`, an account with no linked identity — still shows the warning.
- `StoreModal` tracks `authSettled` and holds the tribes panel back until the first `userMeResponse`, so its sign-in prompt can't render pre-auth either.

Nothing here depends on timing, so a wider pending window (cold Steam session, slow machine) changes nothing.

## Tests

`tests/client/components/NotLoggedInWarning.test.ts` (6) and `tests/client/StoreAuthPending.test.ts` (3), both directions: pending renders nothing; settled no-session / anonymous renders the warning and the prompt; settled linked renders neither at any point; a cleared session brings the warning back. Confirmed the 4 pending-state cases fail against the unfixed source.

- `npx vitest tests/client/components/NotLoggedInWarning.test.ts tests/client/StoreAuthPending.test.ts tests/client/StoreModal.test.ts --run` — 35 passed
- `npx vitest tests/client/CosmeticPurchaseCompletion.test.ts tests/client/PurchaseReturn.test.ts tests/client/AccountIdentity.test.ts tests/client/NavAccountMenu.test.ts tests/client/CosmeticPackPurchase.test.ts tests/client/PurchaseCosmeticPack.test.ts --run` — 58 passed
- `npx tsc --noEmit`, `npm run lint` — clean

Not verifiable here: the frame-by-frame acceptance on the packaged desktop build (real Steam sandbox purchase → reload → store). The unit tests cover the state machine; the desktop run confirms the store surface has no other pre-auth logged-out rendering I missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfTQZps1QwQHmBMoV3gq3U
