### PR TITLE
fix(client): bound and back off WebSocket reconnects (OPE-175)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -621,6 +621,7 @@
   },
   "error_modal": {
     "connection_error": "Connection error!",
+    "connection_lost": "Lost connection to the game server and could not reconnect. Please refresh to try rejoining.",
     "connection_refused": "Connection refused: {reason}",
     "copy_clipboard": "Copy to clipboard",
     "crashed": "Game crashed!",

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -432,8 +432,11 @@ export class Transport {
     };
     this.socket.onmessage = (event: MessageEvent) => {
       // A frame from the server is the proof the connection is real; onopen
-      // is not (a proxy can accept and drop us in a loop).
+      // is not (a proxy can accept and drop us in a loop). It also settles
+      // any retry the watchdog scheduled while this socket was silent —
+      // left armed, it would tear down the socket that just recovered.
       this.reconnectAttempts = 0;
+      this.cancelReconnect();
       try {
         const msg = decodeServerMessage(
           new Uint8Array(event.data as ArrayBuffer),

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -217,6 +217,16 @@ export class SendSpectateEvent implements GameEvent {
 }
 
 export class Transport {
+  // Retry budget for a dropped game socket. Exponential from the base to the
+  // cap, +/-25% jitter, ten attempts: about 65s nominal (50-80s with jitter)
+  // — long enough to ride out a router reboot or a worker restart, short
+  // enough that a player is not left staring at a frozen map. Every
+  // requester (onclose, the silence watchdog, a send on a closed socket)
+  // goes through scheduleReconnect, so this is the only budget there is.
+  static readonly RECONNECT_MAX_ATTEMPTS = 10;
+  static readonly RECONNECT_BASE_DELAY_MS = 500;
+  static readonly RECONNECT_MAX_DELAY_MS = 10_000;
+
   private socket: WebSocket | null = null;
 
   private localServer: LocalServer;
@@ -227,6 +237,12 @@ export class Transport {
   private onmessage: (msg: ServerMessage) => void;
 
   private pingInterval: number | null = null;
+  private reconnectTimer: number | null = null;
+  // Consecutive attempts that have not yet produced a server message.
+  private reconnectAttempts = 0;
+  // Set once the budget is spent or the server refused us (1002): no more
+  // sockets get opened for this game, whoever asks.
+  private reconnectTerminal = false;
   public readonly isLocal: boolean;
 
   // clientID dictionary for the binary wire (see ZbinWire.ts), seeded from
@@ -415,6 +431,9 @@ export class Transport {
       onconnect();
     };
     this.socket.onmessage = (event: MessageEvent) => {
+      // A frame from the server is the proof the connection is real; onopen
+      // is not (a proxy can accept and drop us in a loop).
+      this.reconnectAttempts = 0;
       try {
         const msg = decodeServerMessage(
           new Uint8Array(event.data as ArrayBuffer),
@@ -441,6 +460,9 @@ export class Transport {
         `WebSocket closed. Code: ${event.code}, Reason: ${event.reason}`,
       );
       if (event.code === 1002) {
+        // Refused (banned, game gone, bad token): retrying would only get
+        // refused again, and the watchdog used to re-show this every 5s.
+        this.enterTerminalState();
         showInGameAlert(
           translateText("error_modal.connection_refused", {
             reason: event.reason,
@@ -453,8 +475,66 @@ export class Transport {
     };
   }
 
+  // Ask for a reconnect. Callers do not decide when (or whether) it happens:
+  // one attempt is scheduled at a time, on the backoff schedule, until the
+  // budget runs out.
   public reconnect() {
-    this.connect(this.onconnect, this.onmessage);
+    if (this.isLocal) {
+      this.connect(this.onconnect, this.onmessage);
+      return;
+    }
+    this.scheduleReconnect();
+  }
+
+  private scheduleReconnect() {
+    if (this.reconnectTerminal || this.reconnectTimer !== null) {
+      return;
+    }
+    // An attempt is already in flight; let it succeed or fail on its own.
+    if (this.socket?.readyState === WebSocket.CONNECTING) {
+      return;
+    }
+    if (this.reconnectAttempts >= Transport.RECONNECT_MAX_ATTEMPTS) {
+      console.error(
+        `giving up after ${this.reconnectAttempts} reconnect attempts`,
+      );
+      this.enterTerminalState();
+      showInGameAlert(translateText("error_modal.connection_lost"));
+      return;
+    }
+    this.reconnectAttempts++;
+    const delay = Transport.reconnectDelay(this.reconnectAttempts);
+    console.log(
+      `reconnect attempt ${this.reconnectAttempts}/${Transport.RECONNECT_MAX_ATTEMPTS} in ${delay} ms`,
+    );
+    this.reconnectTimer = window.setTimeout(() => {
+      this.reconnectTimer = null;
+      this.connectRemote(this.onconnect, this.onmessage);
+    }, delay);
+  }
+
+  // Delay before the n-th consecutive attempt (1-based).
+  static reconnectDelay(attempt: number): number {
+    const nominal = Math.min(
+      Transport.RECONNECT_MAX_DELAY_MS,
+      Transport.RECONNECT_BASE_DELAY_MS * 2 ** (attempt - 1),
+    );
+    // Jitter so a fleet of clients dropped by one worker restart does not
+    // come back in lockstep.
+    return Math.round(nominal * (0.75 + Math.random() * 0.5));
+  }
+
+  private cancelReconnect() {
+    if (this.reconnectTimer !== null) {
+      window.clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+  }
+
+  private enterTerminalState() {
+    this.reconnectTerminal = true;
+    this.cancelReconnect();
+    this.stopPing();
   }
 
   public turnComplete() {
@@ -492,19 +572,19 @@ export class Transport {
       this.localServer.endGame();
       return;
     }
-    this.stopPing();
+    // A left game is never rejoined through this transport, whatever still
+    // asks (the watchdog, a late send).
+    this.enterTerminalState();
     if (this.socket === null) return;
     if (this.socket.readyState === WebSocket.OPEN) {
       console.log("on stop: leaving game");
-      this.killExistingSocket();
     } else {
       console.log(
         "WebSocket is not open. Current state:",
         this.socket.readyState,
       );
-      console.error("attempting reconnect");
-      this.killExistingSocket();
     }
+    this.killExistingSocket();
   }
 
   private onSendAllianceRequest(event: SendAllianceRequestIntentEvent) {
@@ -775,12 +855,10 @@ export class Transport {
       return;
     }
     if (this.socket.readyState === WebSocket.CLOSED) {
-      // Buffer message
-      console.warn("socket not ready, closing and trying later");
-      this.socket.close();
-      this.socket = null;
-      this.connectRemote(this.onconnect, this.onmessage);
+      // Buffer the message for the next successful open.
+      console.warn("socket not ready, buffering and reconnecting");
       this.buffer.push(msg);
+      this.scheduleReconnect();
     } else {
       // Send the message directly
       this.socket.send(encodeClientMessage(msg, this.zbinCtx ?? undefined));

--- a/tests/client/TransportReconnect.test.ts
+++ b/tests/client/TransportReconnect.test.ts
@@ -315,6 +315,25 @@ describe("Transport reconnect policy", () => {
 
       expect(FakeWebSocket.instances.length).toBe(2);
     });
+
+    it("drops a scheduled retry when the silent socket speaks before it fires", () => {
+      // The server accepts, goes quiet long enough for the watchdog to
+      // schedule a retry, then recovers before the delay expires. The retry
+      // must not tear down the socket that just came back.
+      FakeWebSocket.script = acceptAfter(10);
+      connect();
+      vi.advanceTimersByTime(6_000);
+      expect(watchdog.fired.length).toBe(1);
+      const socket = FakeWebSocket.instances[0];
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+
+      socket.serverTalk();
+      vi.advanceTimersByTime(60_000);
+
+      expect(FakeWebSocket.instances.length).toBe(1);
+      expect(socket.readyState).toBe(FakeWebSocket.OPEN);
+      expect(showInGameAlert).not.toHaveBeenCalled();
+    });
   });
 
   describe("recovery", () => {

--- a/tests/client/TransportReconnect.test.ts
+++ b/tests/client/TransportReconnect.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, it, Mock, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import { ServerMessage } from "../../src/core/Schemas";
+import {
+  decodeClientMessage,
+  encodeServerMessage,
+} from "../../src/core/ZbinWire";
+
+// Transport's reconnect policy against a scripted WebSocket. The real
+// symptom (OPE-175: "loses the game on a blip and never gets back in") needs
+// a packaged build on real hardware; what can be pinned down headless is the
+// schedule — how many sockets get opened, how far apart, and when the player
+// is told it is over.
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: {
+    workerPath: () => "w0",
+    serverWsBase: () => "ws://game.test",
+  },
+}));
+vi.mock("../../src/client/Auth", () => ({
+  // The rejoin frame is schema-validated on decode: token must be a UUID.
+  getPlayToken: async () => "8f1d2c3e-4b5a-4c6d-8e7f-90a1b2c3d4e5",
+}));
+vi.mock("../../src/client/LocalServer", () => ({
+  LocalServer: class {},
+}));
+const showInGameAlert = vi.fn<(message: string) => Promise<boolean>>(
+  async () => true,
+);
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: (message: string) => showInGameAlert(message),
+}));
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string, params?: Record<string, unknown>) =>
+    params === undefined ? key : `${key} ${JSON.stringify(params)}`,
+}));
+
+import type { LobbyConfig } from "../../src/client/ClientGameRunner";
+import { Transport } from "../../src/client/Transport";
+
+type Script = (ws: FakeWebSocket) => void;
+
+// Mirrors the browser socket closely enough for Transport: readyState
+// constants, handler properties, async close. The per-connection `script`
+// plays the server's side of the handshake.
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+  static script: Script = () => {};
+
+  readonly url: string;
+  readonly openedAt = Date.now();
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = "blob";
+  sent: Uint8Array[] = [];
+  clientClosed = false;
+  private talk: ReturnType<typeof setInterval> | null = null;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: ArrayBuffer }) => void) | null = null;
+  onerror: ((err: unknown) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+    FakeWebSocket.script(this);
+  }
+
+  send(data: Uint8Array) {
+    this.sent.push(data);
+  }
+
+  // Client-initiated close. Browsers fire onclose asynchronously; Transport
+  // nulls the handlers before closing, so this must not be observable.
+  close() {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.clientClosed = true;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.stopTalking();
+    setTimeout(() => this.onclose?.({ code: 1006, reason: "" }), 0);
+  }
+
+  serverOpen() {
+    if (this.readyState !== FakeWebSocket.CONNECTING) return;
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  serverClose(code: number, reason = "") {
+    if (this.readyState === FakeWebSocket.CLOSED) return;
+    this.readyState = FakeWebSocket.CLOSED;
+    this.stopTalking();
+    this.onclose?.({ code, reason });
+  }
+
+  serverSend(msg: ServerMessage) {
+    if (this.readyState !== FakeWebSocket.OPEN) return;
+    this.onmessage?.({ data: encodeServerMessage(msg, undefined).buffer });
+  }
+
+  // A healthy game server never goes quiet: a frame every second.
+  serverTalk() {
+    this.serverSend({ type: "ping" });
+    this.talk ??= setInterval(() => this.serverSend({ type: "ping" }), 1000);
+  }
+
+  private stopTalking() {
+    if (this.talk !== null) {
+      clearInterval(this.talk);
+      this.talk = null;
+    }
+  }
+
+  static reset() {
+    for (const ws of FakeWebSocket.instances) ws.stopTalking();
+    FakeWebSocket.instances = [];
+    FakeWebSocket.script = () => {};
+  }
+}
+
+// Scripts.
+const rejectAfter =
+  (ms: number, code: number, reason = ""): Script =>
+  (ws) => {
+    setTimeout(() => ws.serverClose(code, reason), ms);
+  };
+const acceptAfter =
+  (ms: number): Script =>
+  (ws) => {
+    setTimeout(() => ws.serverOpen(), ms);
+  };
+// Accept and keep sending, the way a live game does.
+const acceptAndTalk =
+  (ms: number): Script =>
+  (ws) => {
+    setTimeout(() => {
+      ws.serverOpen();
+      ws.serverTalk();
+    }, ms);
+  };
+// The first `failures` connections are refused, then the server is back.
+function flakyThenHealthy(failures: number, code = 1006): Script {
+  let n = 0;
+  return (ws) => {
+    n++;
+    if (n <= failures) rejectAfter(50, code)(ws);
+    else acceptAndTalk(10)(ws);
+  };
+}
+
+// ClientGameRunner.onConnectionCheck, without the runner: every second, if
+// the server has been silent for 5s, ask the transport to reconnect.
+class Watchdog {
+  private lastMessageTime = Date.now();
+  readonly fired: number[] = [];
+  private readonly interval: ReturnType<typeof setInterval>;
+
+  constructor(private readonly transport: Transport) {
+    this.interval = setInterval(() => {
+      const now = Date.now();
+      if (now - this.lastMessageTime > 5000) {
+        this.lastMessageTime = now;
+        this.fired.push(now);
+        this.transport.reconnect();
+      }
+    }, 1000);
+  }
+  heard() {
+    this.lastMessageTime = Date.now();
+  }
+  stop() {
+    clearInterval(this.interval);
+  }
+}
+
+function makeTransport() {
+  const lobbyConfig = {
+    gameID: "game1234",
+    playerName: "tester",
+    spectator: false,
+  } as unknown as LobbyConfig;
+  return new Transport(lobbyConfig, new EventBus());
+}
+
+// Offsets (ms) of every socket after the first, relative to the first.
+function attemptOffsets(): number[] {
+  const first = FakeWebSocket.instances[0].openedAt;
+  return FakeWebSocket.instances.slice(1).map((ws) => ws.openedAt - first);
+}
+
+describe("Transport reconnect policy", () => {
+  let transport: Transport;
+  let onconnect: Mock<() => void>;
+  let watchdog: Watchdog;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    FakeWebSocket.reset();
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    showInGameAlert.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    // Jitter factor of exactly 1.0 so the nominal schedule is asserted.
+    vi.spyOn(Math, "random").mockReturnValue(0.5);
+    transport = makeTransport();
+    onconnect = vi.fn<() => void>();
+  });
+
+  afterEach(() => {
+    watchdog?.stop();
+    transport.leaveGame();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  function connect() {
+    transport.connect(onconnect, (msg) => {
+      watchdog?.heard();
+      void msg;
+    });
+    watchdog = new Watchdog(transport);
+  }
+
+  describe("bounded, backed-off retries", () => {
+    it("does not storm a server that refuses every connection", () => {
+      // The pre-fix loop: onclose -> reconnect -> onclose ..., with the
+      // 5s watchdog stacking attempts on top. Every refused connection
+      // cost the server a handshake and the client a 50ms round trip, so
+      // an outage produced a new socket every 50ms, indefinitely.
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      connect();
+      vi.advanceTimersByTime(120_000);
+
+      // 1 initial + the retry budget, and not one more.
+      expect(FakeWebSocket.instances.length).toBe(
+        1 + Transport.RECONNECT_MAX_ATTEMPTS,
+      );
+    });
+
+    it("spaces attempts out exponentially up to the cap", () => {
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      connect();
+      vi.advanceTimersByTime(120_000);
+
+      // Each retry is scheduled from the moment the previous socket closed
+      // (50ms after it opened) with delay min(cap, base * 2^(n-1)).
+      const expected: number[] = [];
+      let t = 0;
+      for (let n = 1; n <= Transport.RECONNECT_MAX_ATTEMPTS; n++) {
+        const delay = Math.min(
+          Transport.RECONNECT_MAX_DELAY_MS,
+          Transport.RECONNECT_BASE_DELAY_MS * 2 ** (n - 1),
+        );
+        t += 50 + delay;
+        expected.push(t);
+      }
+      expect(attemptOffsets()).toEqual(expected);
+    });
+
+    it("applies +/-25% jitter to each delay", () => {
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      (Math.random as ReturnType<typeof vi.fn>).mockReturnValue(0);
+      connect();
+      vi.advanceTimersByTime(2_000);
+      const low = attemptOffsets()[0];
+
+      FakeWebSocket.reset();
+      transport.leaveGame();
+      transport = makeTransport();
+      watchdog.stop();
+      (Math.random as ReturnType<typeof vi.fn>).mockReturnValue(1);
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      connect();
+      vi.advanceTimersByTime(2_000);
+      const high = attemptOffsets()[0];
+
+      const base = Transport.RECONNECT_BASE_DELAY_MS;
+      expect(low).toBe(50 + base * 0.75);
+      expect(high).toBe(50 + base * 1.25);
+    });
+
+    it("bounds the watchdog too when the socket opens but stays silent", () => {
+      // A half-open connection: the server accepts and never speaks. onclose
+      // never fires, so the only thing that notices is the watchdog. Before
+      // the fix it opened a fresh socket every 5s forever.
+      FakeWebSocket.script = acceptAfter(10);
+      connect();
+      vi.advanceTimersByTime(300_000);
+
+      expect(watchdog.fired.length).toBeGreaterThan(
+        Transport.RECONNECT_MAX_ATTEMPTS,
+      );
+      expect(FakeWebSocket.instances.length).toBe(
+        1 + Transport.RECONNECT_MAX_ATTEMPTS,
+      );
+    });
+
+    it("lets one owner schedule: onclose and the watchdog in the same window make one socket", () => {
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      connect();
+      vi.advanceTimersByTime(60);
+      // Socket 1 closed at t=50; retry 1 is pending. The watchdog asks too.
+      transport.reconnect();
+      transport.reconnect();
+      vi.advanceTimersByTime(Transport.RECONNECT_BASE_DELAY_MS + 10);
+
+      expect(FakeWebSocket.instances.length).toBe(2);
+    });
+  });
+
+  describe("recovery", () => {
+    it("resumes through onconnect (the rejoin path) and resets the budget", async () => {
+      FakeWebSocket.script = flakyThenHealthy(3);
+      onconnect.mockImplementation(() => {
+        void transport.rejoinGame(42);
+      });
+      connect();
+      vi.advanceTimersByTime(10_000);
+      await vi.runAllTicks();
+
+      const healthy = FakeWebSocket.instances[3];
+      expect(healthy.readyState).toBe(FakeWebSocket.OPEN);
+      expect(onconnect).toHaveBeenCalledTimes(1);
+      // rejoinGame awaits the play token before sending, and the 5s ping
+      // may land first.
+      await Promise.resolve();
+      await Promise.resolve();
+      const frames = healthy.sent.map((f) => decodeClientMessage(f, undefined));
+      expect(frames).toContainEqual(
+        expect.objectContaining({
+          type: "rejoin",
+          gameID: "game1234",
+          lastTurn: 42,
+        }),
+      );
+      expect(showInGameAlert).not.toHaveBeenCalled();
+
+      // The next outage starts a fresh budget: first retry is back at the
+      // base delay, not where the last run left off.
+      const before = FakeWebSocket.instances.length;
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      const dropAt = Date.now();
+      healthy.serverClose(1006);
+      vi.advanceTimersByTime(Transport.RECONNECT_BASE_DELAY_MS + 10);
+      expect(FakeWebSocket.instances.length).toBe(before + 1);
+      expect(FakeWebSocket.instances[before].openedAt - dropAt).toBe(
+        Transport.RECONNECT_BASE_DELAY_MS,
+      );
+    });
+
+    it("never shows the terminal message on a single blip", () => {
+      FakeWebSocket.script = flakyThenHealthy(1);
+      connect();
+      vi.advanceTimersByTime(60_000);
+
+      expect(showInGameAlert).not.toHaveBeenCalled();
+      expect(FakeWebSocket.instances.length).toBe(2);
+    });
+  });
+
+  describe("terminal state", () => {
+    it("tells the player once, only after the budget is spent, and stops", () => {
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      connect();
+
+      // Still trying: no message yet.
+      vi.advanceTimersByTime(5_000);
+      expect(showInGameAlert).not.toHaveBeenCalled();
+
+      vi.advanceTimersByTime(120_000);
+      expect(showInGameAlert).toHaveBeenCalledTimes(1);
+      expect(showInGameAlert).toHaveBeenCalledWith(
+        "error_modal.connection_lost",
+      );
+
+      // The watchdog keeps asking; nothing more happens.
+      const sockets = FakeWebSocket.instances.length;
+      vi.advanceTimersByTime(120_000);
+      expect(FakeWebSocket.instances.length).toBe(sockets);
+      expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    });
+
+    it("keeps the 1002 refusal modal and does not retry after it", () => {
+      FakeWebSocket.script = rejectAfter(50, 1002, "Game not found");
+      connect();
+      vi.advanceTimersByTime(120_000);
+
+      expect(FakeWebSocket.instances.length).toBe(1);
+      expect(showInGameAlert).toHaveBeenCalledTimes(1);
+      expect(showInGameAlert).toHaveBeenCalledWith(
+        'error_modal.connection_refused {"reason":"Game not found"}',
+      );
+    });
+
+    it("does not reconnect after leaveGame", () => {
+      FakeWebSocket.script = rejectAfter(50, 1006);
+      connect();
+      vi.advanceTimersByTime(60);
+      transport.leaveGame();
+      vi.advanceTimersByTime(120_000);
+
+      expect(FakeWebSocket.instances.length).toBe(1);
+      expect(showInGameAlert).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes [OPE-175](https://linear.app/openfront/issue/OPE-175) — players who lose a game to a connection blip do not get back in.

The reported symptom was "three retries, then it gives up". The client has no cap at all; the actual shape is the opposite: an unbounded, un-backed-off reconnect loop with three separate requesters.

### What the client did (on `main` @ 086270be7)

- `src/client/Transport.ts:456` `reconnect()` was `connect()` — no delay, counter or ceiling.
- `Transport.ts:439-454` `onclose` reconnected on every code except 1000/1002.
- `src/client/ClientGameRunner.ts:1482` `onConnectionCheck()` fires every second and calls `transport.reconnect()` after 5s of silence — on top of whatever `onclose` had already started.
- `Transport.ts:777-782` `sendMsg` on a CLOSED socket called `connectRemote()` directly — a third requester nobody had listed.

Headless reproduction against a scripted WebSocket (`tests/client/TransportReconnect.test.ts`, run before the fix):

- Server refuses every connection (1006 after 50ms): **2,401 sockets opened in 120s of simulated time** — one per round trip, no delay, no cap.
- Server closes with 1002 ("Game not found"): the watchdog reopened a socket every 5s and re-showed the *Connection refused* modal **21 times in 120s**.
- Server accepts but goes silent (half-open): a new socket every 5s, forever.

### The fix

`Transport` is now the single owner of reconnect scheduling. Every requester (`onclose`, the watchdog, `sendMsg`) goes through `scheduleReconnect()`, which:

- keeps at most one pending attempt (and does not preempt one that is still `CONNECTING`);
- backs off exponentially: base **500ms**, doubling, cap **10s**, **±25% jitter**, **10 attempts** — about 65s nominal (50–80s with jitter), enough to ride out a router reboot or a worker restart, short enough not to leave a frozen map on screen for minutes;
- resets the counter on the first **server frame**, not on `onopen`, so a proxy that accepts-then-drops cannot make it unbounded;
- on a spent budget enters a terminal state and tells the player once via `translateText("error_modal.connection_lost")` (new key in `resources/lang/en.json`);
- treats 1002 as terminal too (the existing *Connection refused* modal is kept, shown once), and `leaveGame()` enters the same state so nothing reopens a socket afterwards.

A successful reconnect is unchanged: `onconnect` → `rejoinGame(turnsSeen)` → server `rejoinClient` by persistentID → `start` message with `turns.slice(lastTurn)`, which the runner replays. The test asserts the rejoin frame carries the right `lastTurn`.

`ClientGameRunner` is untouched — the watchdog is still useful for half-open sockets; it just no longer decides when a socket is opened.

## Tests

`tests/client/TransportReconnect.test.ts` (10 tests, fake timers, fake WebSocket, `Math.random` pinned for the nominal schedule):

- bounded: refused-forever server → exactly 1 + 10 sockets, then nothing;
- schedule: attempt offsets equal `min(10s, 500ms·2^(n-1))` cumulatively;
- jitter: 0.75× and 1.25× at the extremes;
- half-open socket: watchdog keeps asking, budget still bounds it;
- single owner: `onclose` + two watchdog calls in one window → one socket;
- recovery: 3 failures then healthy → `onconnect` once, rejoin frame with `lastTurn: 42`, no alert, next outage starts back at 500ms;
- a single blip never shows the terminal message;
- terminal message appears once, only after the budget, and the watchdog can't restart anything;
- 1002 keeps its modal, shown once, no retry;
- `leaveGame` cancels a pending attempt.

```
npx vitest tests/client/TransportReconnect.test.ts tests/EnJsonSorted.test.ts tests/client/ServerWsBase.test.ts --run   # 19 passed
npx vitest tests/client/graphics/layers/PlayerPanelKick.test.ts tests/client/graphics/RadialMenuElements.test.ts tests/client/view/UnitView.test.ts tests/CosmeticPreviewRenderer.test.ts tests/TranslationSystem.test.ts --run   # 83 passed
npm run lint        # clean
npx tsc --noEmit    # clean
```

## Still needs a real-hardware repro

The ticket's step 1 (packaged Steam desktop build, capture close codes and whether the server sheds the client) is not something a headless run can do. What to look for once this is in a build: the new console lines `reconnect attempt N/10 in M ms` and `giving up after N reconnect attempts`, and whether the *Lost connection* dialog ever appears on a blip that a player would expect to survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfTQZps1QwQHmBMoV3gq3U
