### PR TITLE
Expand ghost structure multiplier controls (mostly atom bomb)

### DIFF
--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -462,6 +462,7 @@ export class InputHandler {
       (e) => {
         this.onScroll(e);
         this.onShiftScroll(e);
+        this.onAltScroll(e);
         e.preventDefault();
       },
       { passive: false },
@@ -586,6 +587,10 @@ export class InputHandler {
         return;
       }
 
+      if (e.altKey || e.code === this.keybinds.altKey) {
+        e.preventDefault();
+      }
+
       if (this.keybindMatchesEvent(e, this.keybinds.toggleView)) {
         e.preventDefault();
         if (!this.alternateView) {
@@ -701,6 +706,10 @@ export class InputHandler {
       const isTextInput = this.isTextInputTarget(e.target);
       if (isTextInput && !this.activeKeys.has(e.code)) {
         return;
+      }
+
+      if (e.altKey || e.code === this.keybinds.altKey) {
+        e.preventDefault();
       }
 
       // When the meta (cmd) or ctrl key is released, any keys that were held
@@ -865,7 +874,9 @@ export class InputHandler {
     }
     if (this.activeKeys.has(this.keybinds.emojiMenuModifier)) {
       this.suppressNextTap = false;
+      if (this.uiState.ghostStructure === null) {
       this.eventBus.emit(new ShowEmojiMenuEvent(event.clientX, event.clientY));
+      }
       return;
     }
 
@@ -901,31 +912,31 @@ export class InputHandler {
     if (event.shiftKey || event.altKey){
       return; // Shift/Alt scroll is handled separately
     }
-      const realCtrl =
-        this.activeKeys.has("ControlLeft") ||
-        this.activeKeys.has("ControlRight");
-      if (event.ctrlKey) {
-        if (!realCtrl) {
-          // Pinch-to-zoom gesture (trackpad): small deltas, amplify.
-          // Ignore large deltas — those are browser zoom shortcuts (cmd+/cmd-)
-          // which fire synthetic wheel events we don't want to handle.
-          if (Math.abs(event.deltaY) <= 10) {
-            this.eventBus.emit(
-              new ZoomEvent(event.x, event.y, event.deltaY * 10),
-            );
-          }
+    const realCtrl =
+      this.activeKeys.has("ControlLeft") ||
+      this.activeKeys.has("ControlRight");
+    if (event.ctrlKey) {
+      if (!realCtrl) {
+        // Pinch-to-zoom gesture (trackpad): small deltas, amplify.
+        // Ignore large deltas — those are browser zoom shortcuts (cmd+/cmd-)
+        // which fire synthetic wheel events we don't want to handle.
+        if (Math.abs(event.deltaY) <= 10) {
+          this.eventBus.emit(
+            new ZoomEvent(event.x, event.y, event.deltaY * 10),
+          );
         }
-        // Always return when ctrlKey is set — whether it's a real ctrl scroll,
-        // a pinch gesture, or a browser zoom event, none should reach the
-        // regular scroll path below.
-        return;
       }
-      // Regular scroll wheel: ignore tiny residual momentum events that macOS
-      // keeps sending after a gesture ends (especially after browser zoom changes
-      // devicePixelRatio, which can cause these to accumulate into runaway zoom).
-      if (Math.abs(event.deltaY) < 2) return;
-      this.eventBus.emit(new ZoomEvent(event.x, event.y, event.deltaY));
+      // Always return when ctrlKey is set — whether it's a real ctrl scroll,
+      // a pinch gesture, or a browser zoom event, none should reach the
+      // regular scroll path below.
+      return;
     }
+    // Regular scroll wheel: ignore tiny residual momentum events that macOS
+    // keeps sending after a gesture ends (especially after browser zoom changes
+    // devicePixelRatio, which can cause these to accumulate into runaway zoom).
+    if (Math.abs(event.deltaY) < 2) return;
+    this.eventBus.emit(new ZoomEvent(event.x, event.y, event.deltaY));
+  }
 
   /**
    * `scale` is cumulative since gesturestart, so the per-event ratio is
@@ -958,6 +969,15 @@ export class InputHandler {
       this.eventBus.emit(new AttackRatioEvent(ratio));
     }
   }
+
+  private onAltScroll(event: WheelEvent) {
+    if (event.altKey) {
+      const scrollValue = event.deltaY === 0 ? event.deltaX : event.deltaY;
+      this.setGhostStructure(this.uiState.ghostStructure,
+      scrollValue > 0 ? "decrease" : "increase");
+    }
+  }
+
 
   private onPointerMove(event: PointerEvent) {
     if (event.button === 1) {
@@ -1087,15 +1107,27 @@ export class InputHandler {
     }
   }
 
-  private setGhostStructure(ghostStructure: PlayerBuildableUnitType | null) {
+  private setGhostStructure(ghostStructure: PlayerBuildableUnitType | null, source: "increase" | "decrease" | "hotkey" = "hotkey") {
     this.stopNukeHoldDeployment();
     if (
       this.uiState.ghostStructure === ghostStructure &&
       ghostStructure !== null
     ) {
       const currentMultiplier = this.uiState.upgradeMultiplier ?? 1;
-      this.uiState.upgradeMultiplier =
+      if (source === "hotkey") {
+        this.uiState.upgradeMultiplier =
         currentMultiplier === 1 ? 5 : currentMultiplier + 5;
+        return;
+      }
+      if (source === "increase"){
+        this.uiState.upgradeMultiplier =
+        currentMultiplier + 1;
+      }
+      if (source === "decrease"){
+        this.uiState.upgradeMultiplier =
+        currentMultiplier > 1 ? currentMultiplier - 1 : 1;
+      }
+
     } else {
       this.uiState.upgradeMultiplier = 1;
       this.uiState.ghostStructure = ghostStructure;

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -840,6 +840,14 @@ export class InputHandler {
       pointerDist < this.DRAG_THRESHOLD_PX &&
       this.isNukeGhostActive()
     ) {
+      // Ensure any pending touch long-press is cleared before returning
+      if (this.longPressTimer !== null) {
+        clearTimeout(this.longPressTimer);
+        this.longPressTimer = null;
+      }
+      this.longPressActive = false;
+      this.canvas.style.cursor = "";
+
       this.stopNukeHoldDeployment();
       this.eventBus.emit(new MouseUpEvent(event.x, event.y));
       return;
@@ -849,6 +857,15 @@ export class InputHandler {
       this.nukeHoldTimer !== null ||
       this.nukeHoldInitialDelayTimer !== null
     ) {
+      // Clear long-press state as above so touch devices don't fire the
+      // long-press after we've stopped nuke deployment and returned early.
+      if (this.longPressTimer !== null) {
+        clearTimeout(this.longPressTimer);
+        this.longPressTimer = null;
+      }
+      this.longPressActive = false;
+      this.canvas.style.cursor = "";
+
       this.stopNukeHoldDeployment();
       return;
     }

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -1399,6 +1399,8 @@ export class InputHandler {
     }
     this.activeKeys.clear();
     this.lastGestureScale = null;
+    // destroy nuke hold timers if they are active, to prevent them from firing after the InputHandler is destroyed
+    this.stopNukeHoldDeployment();
     this.keybindAndEvent = [];
   }
 }

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -247,6 +247,12 @@ export class InputHandler {
   private suppressNextTap: boolean = false;
   private readonly LONG_PRESS_MS = 800;
 
+  // Nuke hold-to-deploy parameters
+  private readonly NUKE_INITIAL_DELAY_MS = 150;  // Delay before hold-to-deploy
+  private readonly NUKE_LAUNCH_DELAY_MS = 90;  // hold-to-deploy firerate (multiplier affects this)
+  private nukeHoldTimer: ReturnType<typeof setInterval> | null = null;
+  private nukeHoldInitialDelayTimer: ReturnType<typeof setTimeout> | null = null;
+
   private moveInterval: NodeJS.Timeout | null = null;
   private activeKeys = new Set<string>();
   private keybinds: Record<string, string> = {};
@@ -511,6 +517,7 @@ export class InputHandler {
       }
       this.longPressActive = false;
       this.suppressNextTap = false;
+      this.stopNukeHoldDeployment();
       if (this.selectionBoxActive || this.multiSelectionActive) {
         this.selectionBoxActive = false;
         this.multiSelectionActive = false;
@@ -760,6 +767,9 @@ export class InputHandler {
       this.lastPointerDownY = event.clientY;
 
       this.eventBus.emit(new MouseDownEvent(event.clientX, event.clientY));
+      if (this.isNukeGhostActive()) {
+        this.startNukeHoldDeployment();
+      }
 
       // Start long-press timer for touch devices
       if (event.pointerType === "touch") {
@@ -806,6 +816,11 @@ export class InputHandler {
     }
     this.pointerDown = false;
     this.pointers.clear();
+
+    if (this.nukeHoldTimer !== null || this.nukeHoldInitialDelayTimer !== null) {
+      this.stopNukeHoldDeployment();
+      return;
+    }
 
     // Clean up long-press state
     if (this.longPressTimer !== null) {
@@ -1029,7 +1044,50 @@ export class InputHandler {
     this.eventBus.emit(new ContextMenuEvent(event.clientX, event.clientY));
   }
 
+  private isNukeGhostActive(): boolean {
+    return (
+      this.uiState.ghostStructure === UnitType.AtomBomb);
+  }
+
+  private startNukeHoldDeployment() {
+    if (!this.isNukeGhostActive()) return;
+    if (this.nukeHoldTimer !== null || this.nukeHoldInitialDelayTimer !== null) {
+      return;
+    }
+
+    const emit = () => {
+      if (!this.pointerDown || !this.isNukeGhostActive()) {
+        this.stopNukeHoldDeployment();
+        return;
+      }
+      this.eventBus.emit(new MouseUpEvent(this.lastPointerX, this.lastPointerY));
+    };
+
+    emit();
+
+    this.nukeHoldInitialDelayTimer = setTimeout(() => {
+      this.nukeHoldInitialDelayTimer = null;
+      if (!this.pointerDown || !this.isNukeGhostActive()) {
+        this.stopNukeHoldDeployment();
+        return;
+      }
+      this.nukeHoldTimer = setInterval(emit, this.NUKE_LAUNCH_DELAY_MS);
+    }, this.NUKE_INITIAL_DELAY_MS);
+  }
+
+  private stopNukeHoldDeployment() {
+    if (this.nukeHoldInitialDelayTimer !== null) {
+      clearTimeout(this.nukeHoldInitialDelayTimer);
+      this.nukeHoldInitialDelayTimer = null;
+    }
+    if (this.nukeHoldTimer !== null) {
+      clearInterval(this.nukeHoldTimer);
+      this.nukeHoldTimer = null;
+    }
+  }
+
   private setGhostStructure(ghostStructure: PlayerBuildableUnitType | null) {
+    this.stopNukeHoldDeployment();
     if (
       this.uiState.ghostStructure === ghostStructure &&
       ghostStructure !== null

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -248,10 +248,11 @@ export class InputHandler {
   private readonly LONG_PRESS_MS = 800;
 
   // Nuke hold-to-deploy parameters
-  private readonly NUKE_INITIAL_DELAY_MS = 150;  // Delay before hold-to-deploy
-  private readonly NUKE_LAUNCH_DELAY_MS = 90;  // hold-to-deploy firerate (multiplier affects this)
+  private readonly NUKE_INITIAL_DELAY_MS = 150; // Delay before hold-to-deploy
+  private readonly NUKE_LAUNCH_DELAY_MS = 90; // hold-to-deploy firerate (multiplier affects this)
   private nukeHoldTimer: ReturnType<typeof setInterval> | null = null;
-  private nukeHoldInitialDelayTimer: ReturnType<typeof setTimeout> | null = null;
+  private nukeHoldInitialDelayTimer: ReturnType<typeof setTimeout> | null =
+    null;
 
   private moveInterval: NodeJS.Timeout | null = null;
   private activeKeys = new Set<string>();
@@ -826,7 +827,10 @@ export class InputHandler {
     this.pointerDown = false;
     this.pointers.clear();
 
-    if (this.nukeHoldTimer !== null || this.nukeHoldInitialDelayTimer !== null) {
+    if (
+      this.nukeHoldTimer !== null ||
+      this.nukeHoldInitialDelayTimer !== null
+    ) {
       this.stopNukeHoldDeployment();
       return;
     }
@@ -875,7 +879,9 @@ export class InputHandler {
     if (this.activeKeys.has(this.keybinds.emojiMenuModifier)) {
       this.suppressNextTap = false;
       if (this.uiState.ghostStructure === null) {
-      this.eventBus.emit(new ShowEmojiMenuEvent(event.clientX, event.clientY));
+        this.eventBus.emit(
+          new ShowEmojiMenuEvent(event.clientX, event.clientY),
+        );
       }
       return;
     }
@@ -909,12 +915,11 @@ export class InputHandler {
   }
 
   private onScroll(event: WheelEvent) {
-    if (event.shiftKey || event.altKey){
+    if (event.shiftKey || event.altKey) {
       return; // Shift/Alt scroll is handled separately
     }
     const realCtrl =
-      this.activeKeys.has("ControlLeft") ||
-      this.activeKeys.has("ControlRight");
+      this.activeKeys.has("ControlLeft") || this.activeKeys.has("ControlRight");
     if (event.ctrlKey) {
       if (!realCtrl) {
         // Pinch-to-zoom gesture (trackpad): small deltas, amplify.
@@ -973,11 +978,12 @@ export class InputHandler {
   private onAltScroll(event: WheelEvent) {
     if (event.altKey) {
       const scrollValue = event.deltaY === 0 ? event.deltaX : event.deltaY;
-      this.setGhostStructure(this.uiState.ghostStructure,
-      scrollValue > 0 ? "decrease" : "increase");
+      this.setGhostStructure(
+        this.uiState.ghostStructure,
+        scrollValue > 0 ? "decrease" : "increase",
+      );
     }
   }
-
 
   private onPointerMove(event: PointerEvent) {
     if (event.button === 1) {
@@ -1066,13 +1072,15 @@ export class InputHandler {
   }
 
   private isNukeGhostActive(): boolean {
-    return (
-      this.uiState.ghostStructure === UnitType.AtomBomb);
+    return this.uiState.ghostStructure === UnitType.AtomBomb;
   }
 
   private startNukeHoldDeployment() {
     if (!this.isNukeGhostActive()) return;
-    if (this.nukeHoldTimer !== null || this.nukeHoldInitialDelayTimer !== null) {
+    if (
+      this.nukeHoldTimer !== null ||
+      this.nukeHoldInitialDelayTimer !== null
+    ) {
       return;
     }
 
@@ -1081,7 +1089,9 @@ export class InputHandler {
         this.stopNukeHoldDeployment();
         return;
       }
-      this.eventBus.emit(new MouseUpEvent(this.lastPointerX, this.lastPointerY));
+      this.eventBus.emit(
+        new MouseUpEvent(this.lastPointerX, this.lastPointerY),
+      );
     };
 
     emit();
@@ -1107,7 +1117,10 @@ export class InputHandler {
     }
   }
 
-  private setGhostStructure(ghostStructure: PlayerBuildableUnitType | null, source: "increase" | "decrease" | "hotkey" = "hotkey") {
+  private setGhostStructure(
+    ghostStructure: PlayerBuildableUnitType | null,
+    source: "increase" | "decrease" | "hotkey" = "hotkey",
+  ) {
     this.stopNukeHoldDeployment();
     if (
       this.uiState.ghostStructure === ghostStructure &&
@@ -1116,18 +1129,16 @@ export class InputHandler {
       const currentMultiplier = this.uiState.upgradeMultiplier ?? 1;
       if (source === "hotkey") {
         this.uiState.upgradeMultiplier =
-        currentMultiplier === 1 ? 5 : currentMultiplier + 5;
+          currentMultiplier === 1 ? 5 : currentMultiplier + 5;
         return;
       }
-      if (source === "increase"){
-        this.uiState.upgradeMultiplier =
-        currentMultiplier + 1;
+      if (source === "increase") {
+        this.uiState.upgradeMultiplier = currentMultiplier + 1;
       }
-      if (source === "decrease"){
+      if (source === "decrease") {
         this.uiState.upgradeMultiplier =
-        currentMultiplier > 1 ? currentMultiplier - 1 : 1;
+          currentMultiplier > 1 ? currentMultiplier - 1 : 1;
       }
-
     } else {
       this.uiState.upgradeMultiplier = 1;
       this.uiState.ghostStructure = ghostStructure;

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -1034,8 +1034,9 @@ export class InputHandler {
       this.uiState.ghostStructure === ghostStructure &&
       ghostStructure !== null
     ) {
+      const currentMultiplier = this.uiState.upgradeMultiplier ?? 1;
       this.uiState.upgradeMultiplier =
-        this.uiState.upgradeMultiplier === 1 ? 5 : 1;
+        currentMultiplier === 1 ? 5 : currentMultiplier + 5;
     } else {
       this.uiState.upgradeMultiplier = 1;
       this.uiState.ghostStructure = ghostStructure;

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -1,5 +1,9 @@
 import { EventBus, GameEvent } from "../core/EventBus";
-import { PlayerBuildableUnitType, UnitType } from "../core/game/Game";
+import {
+  MAX_UPGRADE_AMOUNT,
+  PlayerBuildableUnitType,
+  UnitType,
+} from "../core/game/Game";
 import { UserSettings } from "../core/game/UserSettings";
 import { Platform } from "./Platform";
 import { UIState } from "./UIState";
@@ -1216,17 +1220,26 @@ export class InputHandler {
       ghostStructure !== null
     ) {
       const currentMultiplier = this.uiState.upgradeMultiplier ?? 1;
-      if (source === "hotkey") {
-        this.uiState.upgradeMultiplier =
-          currentMultiplier === 1 ? 5 : currentMultiplier + 5;
-        return;
+      switch (source) {
+        case "hotkey":
+          this.uiState.upgradeMultiplier =
+            currentMultiplier === 1 ? 5 : currentMultiplier + 5;
+          break;
+        case "increase":
+          this.uiState.upgradeMultiplier = currentMultiplier + 1;
+          break;
+        case "decrease":
+          this.uiState.upgradeMultiplier =
+            currentMultiplier > 1 ? currentMultiplier - 1 : 1;
+          break;
       }
-      if (source === "increase") {
-        this.uiState.upgradeMultiplier = currentMultiplier + 1;
-      }
-      if (source === "decrease") {
-        this.uiState.upgradeMultiplier =
-          currentMultiplier > 1 ? currentMultiplier - 1 : 1;
+      if (this.uiState.upgradeMultiplier > MAX_UPGRADE_AMOUNT) {
+        if (source === "hotkey") {
+          // Reset to 1 if hotkey was used to exceed max, otherwise clamp to max
+          this.uiState.upgradeMultiplier = 1;
+        } else {
+          this.uiState.upgradeMultiplier = MAX_UPGRADE_AMOUNT;
+        }
       }
     } else {
       this.uiState.upgradeMultiplier = 1;

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -248,11 +248,14 @@ export class InputHandler {
   private readonly LONG_PRESS_MS = 800;
 
   // Nuke hold-to-deploy parameters
-  private readonly NUKE_INITIAL_DELAY_MS = 150; // Delay before hold-to-deploy
-  private readonly NUKE_LAUNCH_DELAY_MS = 90; // hold-to-deploy firerate (multiplier affects this)
+  private readonly NUKE_POINTER_WAIT_MS = 100; // First shot stays near-instant when stationary.
+  private readonly NUKE_SECOND_LAUNCH_DELAY_MS = 150; // Delay before continuous repeats after the first shot.
+  private readonly NUKE_HOLD_FIRE_RATE = 90; // hold-to-deploy firerate (multiplier affects this)
   private nukeHoldTimer: ReturnType<typeof setInterval> | null = null;
   private nukeHoldInitialDelayTimer: ReturnType<typeof setTimeout> | null =
     null;
+  private nukeHoldWasDragged: boolean = false;
+  private nukeHoldHasFired: boolean = false;
 
   private moveInterval: NodeJS.Timeout | null = null;
   private activeKeys = new Set<string>();
@@ -827,6 +830,21 @@ export class InputHandler {
     this.pointerDown = false;
     this.pointers.clear();
 
+    const pointerDist =
+      Math.abs(event.x - this.lastPointerDownX) +
+      Math.abs(event.y - this.lastPointerDownY);
+
+    if (
+      this.nukeHoldInitialDelayTimer !== null &&
+      !this.nukeHoldHasFired &&
+      pointerDist < this.DRAG_THRESHOLD_PX &&
+      this.isNukeGhostActive()
+    ) {
+      this.stopNukeHoldDeployment();
+      this.eventBus.emit(new MouseUpEvent(event.x, event.y));
+      return;
+    }
+
     if (
       this.nukeHoldTimer !== null ||
       this.nukeHoldInitialDelayTimer !== null
@@ -1017,6 +1035,19 @@ export class InputHandler {
         }
       }
 
+      if (
+        this.nukeHoldTimer !== null ||
+        this.nukeHoldInitialDelayTimer !== null
+      ) {
+        const dragDistance =
+          Math.abs(event.clientX - this.lastPointerDownX) +
+          Math.abs(event.clientY - this.lastPointerDownY);
+        if (dragDistance >= this.DRAG_THRESHOLD_PX) {
+          this.nukeHoldWasDragged = true;
+          this.stopNukeHoldDeployment();
+        }
+      }
+
       // If shift is held OR touch long-press is active OR selection box already
       // started, continue emitting selection box updates
       if (
@@ -1084,26 +1115,63 @@ export class InputHandler {
       return;
     }
 
+    this.nukeHoldWasDragged = false;
+    this.nukeHoldHasFired = false;
+
     const emit = () => {
-      if (!this.pointerDown || !this.isNukeGhostActive()) {
+      if (
+        !this.pointerDown ||
+        this.nukeHoldWasDragged ||
+        !this.isNukeGhostActive()
+      ) {
         this.stopNukeHoldDeployment();
         return;
       }
+      this.nukeHoldHasFired = true;
       this.eventBus.emit(
         new MouseUpEvent(this.lastPointerX, this.lastPointerY),
       );
     };
 
-    emit();
+    const startRepeatLoop = () => {
+      this.nukeHoldInitialDelayTimer = setTimeout(() => {
+        this.nukeHoldInitialDelayTimer = null;
+        if (
+          !this.pointerDown ||
+          !this.isNukeGhostActive() ||
+          this.nukeHoldWasDragged
+        ) {
+          this.stopNukeHoldDeployment();
+          return;
+        }
+        emit();
+        this.nukeHoldTimer = setInterval(() => {
+          if (
+            !this.pointerDown ||
+            !this.isNukeGhostActive() ||
+            this.nukeHoldWasDragged
+          ) {
+            this.stopNukeHoldDeployment();
+            return;
+          }
+          emit();
+        }, this.NUKE_HOLD_FIRE_RATE);
+      }, this.NUKE_SECOND_LAUNCH_DELAY_MS);
+    };
 
     this.nukeHoldInitialDelayTimer = setTimeout(() => {
       this.nukeHoldInitialDelayTimer = null;
-      if (!this.pointerDown || !this.isNukeGhostActive()) {
+      if (
+        !this.pointerDown ||
+        !this.isNukeGhostActive() ||
+        this.nukeHoldWasDragged
+      ) {
         this.stopNukeHoldDeployment();
         return;
       }
-      this.nukeHoldTimer = setInterval(emit, this.NUKE_LAUNCH_DELAY_MS);
-    }, this.NUKE_INITIAL_DELAY_MS);
+      emit();
+      startRepeatLoop();
+    }, this.NUKE_POINTER_WAIT_MS);
   }
 
   private stopNukeHoldDeployment() {
@@ -1115,6 +1183,8 @@ export class InputHandler {
       clearInterval(this.nukeHoldTimer);
       this.nukeHoldTimer = null;
     }
+    this.nukeHoldWasDragged = false;
+    this.nukeHoldHasFired = false;
   }
 
   private setGhostStructure(

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -913,12 +913,14 @@ export class InputHandler {
     }
     if (this.activeKeys.has(this.keybinds.emojiMenuModifier)) {
       this.suppressNextTap = false;
+      // If no ghost structure is active, show the emoji menu and return.
+      // else, fall through to normal build/launch handling
       if (this.uiState.ghostStructure === null) {
         this.eventBus.emit(
           new ShowEmojiMenuEvent(event.clientX, event.clientY),
         );
+        return;
       }
-      return;
     }
 
     const dist =

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -898,7 +898,9 @@ export class InputHandler {
   }
 
   private onScroll(event: WheelEvent) {
-    if (!event.shiftKey) {
+    if (event.shiftKey || event.altKey){
+      return; // Shift/Alt scroll is handled separately
+    }
       const realCtrl =
         this.activeKeys.has("ControlLeft") ||
         this.activeKeys.has("ControlRight");
@@ -924,7 +926,6 @@ export class InputHandler {
       if (Math.abs(event.deltaY) < 2) return;
       this.eventBus.emit(new ZoomEvent(event.x, event.y, event.deltaY));
     }
-  }
 
   /**
    * `scale` is cumulative since gesturestart, so the per-event ratio is

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -661,8 +661,22 @@ describe("InputHandler AutoUpgrade", () => {
     });
   });
 
+  describe("Alt key default prevention", () => {
+    test("prevents the browser's default action when Alt is pressed", () => {
+      const preventDefaultSpy = vi.spyOn(
+        KeyboardEvent.prototype,
+        "preventDefault",
+      );
+
+      window.dispatchEvent(new KeyboardEvent("keydown", { code: "AltLeft" }));
+
+      expect(preventDefaultSpy).toHaveBeenCalled();
+      preventDefaultSpy.mockRestore();
+    });
+  });
+
   describe("Nuke click-and-hold deployment", () => {
-    test("fires an immediate launch, then waits 125 ms before repeating every 90 ms while held", () => {
+    test("fires repeated MouseUpEvents while a nuke ghost is held and suppresses the release repeat", () => {
       vi.useFakeTimers();
       try {
         const mockEmit = vi.spyOn(eventBus, "emit");
@@ -685,46 +699,12 @@ describe("InputHandler AutoUpgrade", () => {
           }),
         );
 
-        let mouseUpCalls = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(mouseUpCalls).toHaveLength(1);
+        vi.advanceTimersByTime(250);
 
-        vi.advanceTimersByTime(124);
-        mouseUpCalls = mockEmit.mock.calls.filter(
+        const mouseUpCalls = mockEmit.mock.calls.filter(
           ([event]) => event instanceof MouseUpEvent,
         );
-        expect(mouseUpCalls).toHaveLength(1);
-
-        vi.advanceTimersByTime(1);
-        mouseUpCalls = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(mouseUpCalls).toHaveLength(1);
-
-        vi.advanceTimersByTime(89);
-        mouseUpCalls = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(mouseUpCalls).toHaveLength(1);
-
-        vi.advanceTimersByTime(1);
-        mouseUpCalls = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(mouseUpCalls).toHaveLength(2);
-
-        vi.advanceTimersByTime(89);
-        mouseUpCalls = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(mouseUpCalls).toHaveLength(2);
-
-        vi.advanceTimersByTime(1);
-        mouseUpCalls = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(mouseUpCalls).toHaveLength(3);
+        expect(mouseUpCalls.length).toBeGreaterThanOrEqual(2);
 
         inputHandler["onPointerUp"](
           new PointerEvent("pointerup", {
@@ -735,7 +715,6 @@ describe("InputHandler AutoUpgrade", () => {
           }),
         );
 
-        vi.advanceTimersByTime(500);
         const afterRelease = mockEmit.mock.calls.filter(
           ([event]) => event instanceof MouseUpEvent,
         );

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -676,7 +676,160 @@ describe("InputHandler AutoUpgrade", () => {
   });
 
   describe("Nuke click-and-hold deployment", () => {
-    test("fires repeated MouseUpEvents while a nuke ghost is held and suppresses the release repeat", () => {
+    test("waits for the initial hold delay before firing the first launch", () => {
+      vi.useFakeTimers();
+      try {
+        const mockEmit = vi.spyOn(eventBus, "emit");
+        const pointerWaitMs = inputHandler["NUKE_POINTER_WAIT_MS"] as number;
+        const secondLaunchDelayMs = inputHandler[
+          "NUKE_SECOND_LAUNCH_DELAY_MS"
+        ] as number;
+
+        inputHandler["uiState"].ghostStructure = UnitType.AtomBomb;
+
+        inputHandler["onPointerDown"](
+          new PointerEvent("pointerdown", {
+            button: 0,
+            clientX: 100,
+            clientY: 200,
+            pointerId: 1,
+          }),
+        );
+
+        expect(
+          mockEmit.mock.calls.filter(
+            ([event]) => event instanceof MouseUpEvent,
+          ),
+        ).toHaveLength(0);
+
+        vi.advanceTimersByTime(pointerWaitMs - 1);
+        expect(
+          mockEmit.mock.calls.filter(
+            ([event]) => event instanceof MouseUpEvent,
+          ),
+        ).toHaveLength(0);
+
+        vi.advanceTimersByTime(1);
+        expect(
+          mockEmit.mock.calls.filter(
+            ([event]) => event instanceof MouseUpEvent,
+          ),
+        ).toHaveLength(1);
+
+        vi.advanceTimersByTime(secondLaunchDelayMs - 1);
+        expect(
+          mockEmit.mock.calls.filter(([event]) => event instanceof MouseUpEvent)
+            .length,
+        ).toBe(1);
+
+        vi.advanceTimersByTime(1);
+        expect(
+          mockEmit.mock.calls.filter(([event]) => event instanceof MouseUpEvent)
+            .length,
+        ).toBeGreaterThanOrEqual(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("fires repeated MouseUpEvents while a stationary nuke ghost is held and suppresses the release repeat", () => {
+      vi.useFakeTimers();
+      try {
+        const mockEmit = vi.spyOn(eventBus, "emit");
+        const pointerWaitMs = inputHandler["NUKE_POINTER_WAIT_MS"] as number;
+        const secondLaunchDelayMs = inputHandler[
+          "NUKE_SECOND_LAUNCH_DELAY_MS"
+        ] as number;
+
+        inputHandler["uiState"].ghostStructure = UnitType.AtomBomb;
+
+        inputHandler["onPointerDown"](
+          new PointerEvent("pointerdown", {
+            button: 0,
+            clientX: 100,
+            clientY: 200,
+            pointerId: 1,
+          }),
+        );
+        inputHandler["onPointerMove"](
+          new PointerEvent("pointermove", {
+            button: 0,
+            clientX: 102,
+            clientY: 202,
+            pointerId: 1,
+          }),
+        );
+
+        vi.advanceTimersByTime(pointerWaitMs);
+        expect(
+          mockEmit.mock.calls.filter(
+            ([event]) => event instanceof MouseUpEvent,
+          ),
+        ).toHaveLength(1);
+
+        vi.advanceTimersByTime(secondLaunchDelayMs);
+
+        const mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls.length).toBeGreaterThanOrEqual(2);
+
+        inputHandler["onPointerUp"](
+          new PointerEvent("pointerup", {
+            button: 0,
+            clientX: 102,
+            clientY: 202,
+            pointerId: 1,
+          }),
+        );
+
+        const afterRelease = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(afterRelease).toHaveLength(mouseUpCalls.length);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("launches on release when a stationary nuke click has not fired yet", () => {
+      vi.useFakeTimers();
+      try {
+        const mockEmit = vi.spyOn(eventBus, "emit");
+        const pointerWaitMs = inputHandler["NUKE_POINTER_WAIT_MS"] as number;
+
+        inputHandler["uiState"].ghostStructure = UnitType.AtomBomb;
+
+        inputHandler["onPointerDown"](
+          new PointerEvent("pointerdown", {
+            button: 0,
+            clientX: 100,
+            clientY: 200,
+            pointerId: 1,
+          }),
+        );
+
+        vi.advanceTimersByTime(pointerWaitMs - 1);
+        inputHandler["onPointerUp"](
+          new PointerEvent("pointerup", {
+            button: 0,
+            clientX: 100,
+            clientY: 200,
+            pointerId: 1,
+          }),
+        );
+
+        expect(
+          mockEmit.mock.calls.filter(
+            ([event]) => event instanceof MouseUpEvent,
+          ),
+        ).toHaveLength(1);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    test("cancels hold-to-deploy when the pointer drifts beyond the drag threshold", () => {
       vi.useFakeTimers();
       try {
         const mockEmit = vi.spyOn(eventBus, "emit");
@@ -693,8 +846,8 @@ describe("InputHandler AutoUpgrade", () => {
         inputHandler["onPointerMove"](
           new PointerEvent("pointermove", {
             button: 0,
-            clientX: 150,
-            clientY: 250,
+            clientX: 220,
+            clientY: 320,
             pointerId: 1,
           }),
         );
@@ -704,21 +857,7 @@ describe("InputHandler AutoUpgrade", () => {
         const mouseUpCalls = mockEmit.mock.calls.filter(
           ([event]) => event instanceof MouseUpEvent,
         );
-        expect(mouseUpCalls.length).toBeGreaterThanOrEqual(2);
-
-        inputHandler["onPointerUp"](
-          new PointerEvent("pointerup", {
-            button: 0,
-            clientX: 150,
-            clientY: 250,
-            pointerId: 1,
-          }),
-        );
-
-        const afterRelease = mockEmit.mock.calls.filter(
-          ([event]) => event instanceof MouseUpEvent,
-        );
-        expect(afterRelease).toHaveLength(mouseUpCalls.length);
+        expect(mouseUpCalls).toHaveLength(0);
       } finally {
         vi.useRealTimers();
       }

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -3,6 +3,7 @@ import {
   ConfirmGhostStructureEvent,
   ContextMenuEvent,
   InputHandler,
+  MouseUpEvent,
   UnitSelectionEvent,
   WarshipSelectionBoxCancelEvent,
   WarshipSelectionBoxCompleteEvent,
@@ -657,6 +658,91 @@ describe("InputHandler AutoUpgrade", () => {
         (call) => call[0] instanceof ConfirmGhostStructureEvent,
       );
       expect(confirmCalls).toHaveLength(0);
+    });
+  });
+
+  describe("Nuke click-and-hold deployment", () => {
+    test("fires an immediate launch, then waits 125 ms before repeating every 90 ms while held", () => {
+      vi.useFakeTimers();
+      try {
+        const mockEmit = vi.spyOn(eventBus, "emit");
+        inputHandler["uiState"].ghostStructure = UnitType.AtomBomb;
+
+        inputHandler["onPointerDown"](
+          new PointerEvent("pointerdown", {
+            button: 0,
+            clientX: 100,
+            clientY: 200,
+            pointerId: 1,
+          }),
+        );
+        inputHandler["onPointerMove"](
+          new PointerEvent("pointermove", {
+            button: 0,
+            clientX: 150,
+            clientY: 250,
+            pointerId: 1,
+          }),
+        );
+
+        let mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(1);
+
+        vi.advanceTimersByTime(124);
+        mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(1);
+
+        vi.advanceTimersByTime(89);
+        mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(1);
+
+        vi.advanceTimersByTime(1);
+        mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(2);
+
+        vi.advanceTimersByTime(89);
+        mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(2);
+
+        vi.advanceTimersByTime(1);
+        mouseUpCalls = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(mouseUpCalls).toHaveLength(3);
+
+        inputHandler["onPointerUp"](
+          new PointerEvent("pointerup", {
+            button: 0,
+            clientX: 150,
+            clientY: 250,
+            pointerId: 1,
+          }),
+        );
+
+        vi.advanceTimersByTime(500);
+        const afterRelease = mockEmit.mock.calls.filter(
+          ([event]) => event instanceof MouseUpEvent,
+        );
+        expect(afterRelease).toHaveLength(mouseUpCalls.length);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/tests/InputHandler.test.ts
+++ b/tests/InputHandler.test.ts
@@ -708,6 +708,20 @@ describe("InputHandler AutoUpgrade", () => {
 
       expect(inputHandler["uiState"].ghostStructure).toBeNull();
     });
+
+    test("repeated taps increase the build multiplier by 5 each time", () => {
+      const uiState = inputHandler["uiState"];
+
+      inputHandler["setGhostStructure"](UnitType.AtomBomb);
+      expect(uiState.ghostStructure).toBe(UnitType.AtomBomb);
+      expect(uiState.upgradeMultiplier).toBe(1);
+
+      inputHandler["setGhostStructure"](UnitType.AtomBomb);
+      expect(uiState.upgradeMultiplier).toBe(5);
+
+      inputHandler["setGhostStructure"](UnitType.AtomBomb);
+      expect(uiState.upgradeMultiplier).toBe(10);
+    });
   });
 
   describe("Digit keys still set ghost structure when bound to Numpad", () => {


### PR DESCRIPTION
Resolves #5265

## Purpose
Expands nuke deployment controls with additional input methods, giving players finer and faster control over build/deploy multipliers — from precise single adjustments to rapid mass launches.

## Objectives
- Change the hotkey multiplier progression from a fixed 1x/5x toggle to a stacking sequence (1 → 5 → 10 → 15...).
- Add Alt+scroll for fine-grained ±1 adjustment of the multiplier, applying to any valid ghost structure target (e.g. hovering a city and scrolling adjusts city upgrade size by 1 at a time).
- Add click-and-hold to repeatedly deploy Atom Bombs while a nuke ghost structure is active, without needing repeated clicks. This is Atom Bomb-specific and does not apply to other buildable units.
- Prevent default on Alt keydown/keyup globally — needed because Firefox opens its menu bar on Alt otherwise.


## Description
- **Hotkey**: pressing a build hotkey while already hovering a matching ghost structure now steps the multiplier 1 → 5 → 10 → 15, etc., instead of toggling only between 1x and 5x. Applies to all existing ghost-structure targets (cities, silos, etc.), same as before.
- **Alt+scroll**: scrolling up/down while holding Alt adjusts the current multiplier by ±1. Applies to the same valid targets as the hotkey (not limited to nukes) — e.g. tapping the city hotkey then fine-tuning with Alt+scroll.
- **Click-and-hold (Atom Bomb only)**: holding the pointer down while an Atom Bomb ghost structure is selected repeatedly fires launches (150ms initial delay, then every 90ms) until release. This respects whatever multiplier is currently set via the hotkey and/or Alt+scroll — e.g. stacking the multiplier to 15 first, then holding, launches 15 nukes per repeated tick rather than 1.
- Alt keydown/keyup now call `preventDefault()` specifically to stop Firefox's native menu-bar focus behavior, which previously interfered with using Alt as a modifier. (Other browsers weren't affected by this issue, but the fix is harmless there.)

Implementation is contained to `src/client/InputHandler.ts`, with new tests covering the multiplier progression, hold-to-deploy start/stop behavior, and Alt default-prevention.

## Testing
- Ran `npm test` locally — full suite passes.
- Manually tested all three input methods in-game via `npm run dev`: hotkey stacking, Alt+scroll fine adjustment, and click-and-hold repeated launches (including the multiplier interaction with hold).
- Noticed an unrelated flaky timeout in `tests/client/InventoryModal.test.ts` when running the full suite (passes standalone) — appears pre-existing and unrelated to this change.
- Timing values (150ms initial delay, 90ms repeat interval) were chosen based on what felt comfortable in testing, not any hard requirement — open to adjustment if others feel they're off (e.g. too short/long before the repeat starts).


Discord: Pesinario