### PR TITLE
MIRV: flat 25M price, global 60s launch cooldown with build-menu timer

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -152,6 +152,7 @@
       "warship": "Captures trade ships, destroys ships and boats"
     },
     "not_enough_money": "Not enough money",
+    "on_cooldown": "On cooldown",
     "upgrade_amount": "x{amount}",
     "warship_shift_hint": "Hold Shift and drag to select multiple warships at once"
   },

--- a/src/client/hud/layers/BuildMenu.ts
+++ b/src/client/hud/layers/BuildMenu.ts
@@ -24,7 +24,7 @@ import {
   SendUpgradeStructureIntentEvent,
 } from "../../Transport";
 import { UIState } from "../../UIState";
-import { renderNumber } from "../../Utils";
+import { renderDuration, renderNumber } from "../../Utils";
 import { GameView } from "../../view";
 const warshipIcon = assetUrl("images/BattleshipIconWhite.svg");
 const cityIcon = assetUrl("images/CityIconWhite.svg");
@@ -473,7 +473,7 @@ export class BuildMenu extends LitElement implements Controller {
                     ${cooldownSeconds > 0
                       ? html`<div class="build-count-chip" translate="no">
                           <span class="build-count build-cooldown"
-                            >🕐 ${cooldownSeconds}s</span
+                            >🕐 ${renderDuration(cooldownSeconds)}</span
                           >
                         </div>`
                       : ""}

--- a/src/client/hud/layers/BuildMenu.ts
+++ b/src/client/hud/layers/BuildMenu.ts
@@ -280,6 +280,9 @@ export class BuildMenu extends LitElement implements Controller {
       font-weight: bold;
       font-size: 14px;
     }
+    .build-cooldown {
+      color: #ffd700;
+    }
 
     @media (max-width: 768px) {
       .build-menu {
@@ -422,6 +425,9 @@ export class BuildMenu extends LitElement implements Controller {
                 const enabled =
                   buildableUnit.canBuild !== false ||
                   buildableUnit.canUpgrade !== false;
+                const cooldownSeconds = buildableUnit.cooldown
+                  ? Math.ceil(buildableUnit.cooldown / 10)
+                  : 0;
                 return html`
                   <button
                     class="build-button"
@@ -429,7 +435,9 @@ export class BuildMenu extends LitElement implements Controller {
                       this.sendBuildOrUpgrade(buildableUnit, this.clickedTile)}
                     ?disabled=${!enabled}
                     title=${!enabled
-                      ? translateText("build_menu.not_enough_money")
+                      ? cooldownSeconds > 0
+                        ? translateText("build_menu.on_cooldown")
+                        : translateText("build_menu.not_enough_money")
                       : ""}
                   >
                     <img
@@ -460,6 +468,13 @@ export class BuildMenu extends LitElement implements Controller {
                     ${item.countable
                       ? html`<div class="build-count-chip">
                           <span class="build-count">${this.count(item)}</span>
+                        </div>`
+                      : ""}
+                    ${cooldownSeconds > 0
+                      ? html`<div class="build-count-chip" translate="no">
+                          <span class="build-count build-cooldown"
+                            >🕐 ${cooldownSeconds}s</span
+                          >
                         </div>`
                       : ""}
                   </button>

--- a/src/client/hud/layers/UnitDisplay.ts
+++ b/src/client/hud/layers/UnitDisplay.ts
@@ -12,7 +12,7 @@ import { UserSettings } from "../../../core/game/UserSettings";
 import { Controller } from "../../Controller";
 import { ToggleStructureEvent } from "../../InputHandler";
 import { UIState } from "../../UIState";
-import { renderNumber, translateText } from "../../Utils";
+import { renderDuration, renderNumber, translateText } from "../../Utils";
 import { GameView } from "../../view";
 import {
   atomBombIcon,
@@ -323,7 +323,7 @@ export class UnitDisplay extends LitElement implements Controller {
                 style="background: conic-gradient(rgba(15, 23, 42, 0.8) ${cooldownPercent}%, rgba(15, 23, 42, 0.2) 0)"
                 translate="no"
               >
-                ${Math.ceil(cooldown / 10)}s
+                ${renderDuration(Math.ceil(cooldown / 10))}
               </div>`
             : null}
         </div>

--- a/src/client/hud/layers/UnitDisplay.ts
+++ b/src/client/hud/layers/UnitDisplay.ts
@@ -68,13 +68,27 @@ export class UnitDisplay extends LitElement implements Controller {
     return 0n;
   }
 
+  private mirvCooldown(): number {
+    for (const bu of this.playerBuildables ?? []) {
+      if (bu.type === UnitType.MIRV) {
+        return bu.cooldown ?? 0;
+      }
+    }
+    return 0;
+  }
+
   private canBuild(item: UnitType): boolean {
     if (this.game?.config().isUnitDisabled(item)) return false;
     const player = this.game?.myPlayer();
     switch (item) {
+      case UnitType.MIRV:
+        return (
+          this.mirvCooldown() === 0 &&
+          this.cost(item) <= (player?.gold() ?? 0n) &&
+          (player?.units(UnitType.MissileSilo).length ?? 0) > 0
+        );
       case UnitType.AtomBomb:
       case UnitType.HydrogenBomb:
-      case UnitType.MIRV:
         return (
           this.cost(item) <= (player?.gold() ?? 0n) &&
           (player?.units(UnitType.MissileSilo).length ?? 0) > 0
@@ -209,6 +223,10 @@ export class UnitDisplay extends LitElement implements Controller {
     }
     const selected = this.uiState.ghostStructure === unitType;
     const hovered = this._hoveredUnit === unitType;
+    const cooldown = unitType === UnitType.MIRV ? this.mirvCooldown() : 0;
+    // Radial sweep that empties clockwise as the cooldown runs out.
+    const cooldownPercent =
+      (cooldown / (this.game.config().mirvLaunchCooldown() || 1)) * 100;
     const displayHotkey = hotkey
       .replace("Digit", "")
       .replace("Key", "")
@@ -258,7 +276,7 @@ export class UnitDisplay extends LitElement implements Controller {
         <div
           class="${this.canBuild(unitType)
             ? ""
-            : "opacity-40"} border border-slate-500 rounded-sm px-0.5 pb-0.5 flex items-center gap-0.5 cursor-pointer
+            : "opacity-40"} relative border border-slate-500 rounded-sm px-0.5 pb-0.5 flex items-center gap-0.5 cursor-pointer
              ${selected ? "hover:bg-gray-400/10" : "hover:bg-gray-800"}
              rounded-sm text-white ${selected ? "bg-slate-400/20" : ""}"
           @click=${() => {
@@ -299,6 +317,15 @@ export class UnitDisplay extends LitElement implements Controller {
               ? html`<span class="text-xs">${renderNumber(number)}</span>`
               : null}
           </div>
+          ${cooldown > 0
+            ? html`<div
+                class="absolute inset-0 rounded-sm flex items-center justify-center text-[10px] font-bold text-white pointer-events-none"
+                style="background: conic-gradient(rgba(15, 23, 42, 0.8) ${cooldownPercent}%, rgba(15, 23, 42, 0.2) 0)"
+                translate="no"
+              >
+                ${Math.ceil(cooldown / 10)}s
+              </div>`
+            : null}
         </div>
       </div>
     `;

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -333,6 +333,11 @@ export class Config {
   SiloCooldown(): number {
     return 90;
   }
+  // Global cooldown after any MIRV launch during which no player can launch
+  // another MIRV.
+  mirvLaunchCooldown(): Tick {
+    return 60 * 10;
+  }
 
   defensePostRange(): number {
     return 30;
@@ -522,15 +527,7 @@ export class Config {
         break;
       case UnitType.MIRV:
         info = {
-          cost: (game: Game, player: Player) => {
-            if (
-              player.type() === PlayerType.Human &&
-              this.hasInfiniteGoldFor(player)
-            ) {
-              return 0n;
-            }
-            return 25_000_000n + game.stats().numMirvsLaunched() * 15_000_000n;
-          },
+          cost: this.costWrapper(() => 25_000_000, UnitType.MIRV),
         };
         break;
       case UnitType.MIRVWarhead:

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -96,6 +96,7 @@ export class MirvExecution implements Execution {
         targetPlayer: this.targetPlayer,
       });
       this.mg.stats().bombLaunch(this.player, this.targetPlayer, UnitType.MIRV);
+      this.mg.recordMirvLaunch();
       const x = Math.floor((this.baseX + this.mg.x(this.nuke.tile())) / 2);
       const y = Math.max(0, this.baseY - 500) + 50;
       this.separateDst = this.mg.ref(x, y);

--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -59,6 +59,9 @@ export class MirvExecution implements Execution {
   constructor(
     private player: Player,
     private dst: TileRef,
+    // Invoked once the launch actually spawns a missile — side effects that
+    // must not fire for a launch blocked by the global MIRV cooldown.
+    private onLaunch?: () => void,
   ) {}
 
   init(mg: Game, ticks: number): void {
@@ -68,18 +71,6 @@ export class MirvExecution implements Execution {
     this.baseX = this.mg.x(this.dst);
     this.baseY = this.mg.y(this.dst);
     this.stagedTargets = [this.dst];
-
-    // Betrayal on launch
-    if (this.targetPlayer.isPlayer()) {
-      const alliance = this.player.allianceWith(this.targetPlayer);
-      if (alliance !== null) {
-        this.player.breakAlliance(alliance);
-      }
-      if (this.targetPlayer !== this.player) {
-        this.targetPlayer.updateRelation(this.player, -100);
-        this.player.updateRelation(this.targetPlayer, -100);
-      }
-    }
   }
 
   tick(ticks: number): void {
@@ -96,7 +87,21 @@ export class MirvExecution implements Execution {
         targetPlayer: this.targetPlayer,
       });
       this.mg.stats().bombLaunch(this.player, this.targetPlayer, UnitType.MIRV);
-      this.mg.recordMirvLaunch();
+      this.mg.recordMirvLaunch(this.player);
+
+      // Betrayal on launch. Applied only once the missile actually spawns, so
+      // a launch blocked by the global cooldown pays no diplomatic cost.
+      if (this.targetPlayer.isPlayer()) {
+        const alliance = this.player.allianceWith(this.targetPlayer);
+        if (alliance !== null) {
+          this.player.breakAlliance(alliance);
+        }
+        if (this.targetPlayer !== this.player) {
+          this.targetPlayer.updateRelation(this.player, -100);
+          this.player.updateRelation(this.targetPlayer, -100);
+        }
+      }
+      this.onLaunch?.();
       const x = Math.floor((this.baseX + this.mg.x(this.nuke.tile())) / 2);
       const y = Math.max(0, this.baseY - 500) + 50;
       this.separateDst = this.mg.ref(x, y);

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -108,6 +108,9 @@ export class NationMIRVBehavior {
     if (this.game.config().isUnitDisabled(UnitType.MIRV)) {
       return false;
     }
+    if (this.game.mirvCooldownRemaining() > 0) {
+      return false;
+    }
     if (this.player.units(UnitType.MissileSilo).length === 0) {
       return false;
     }

--- a/src/core/execution/nation/NationMIRVBehavior.ts
+++ b/src/core/execution/nation/NationMIRVBehavior.ts
@@ -108,7 +108,7 @@ export class NationMIRVBehavior {
     if (this.game.config().isUnitDisabled(UnitType.MIRV)) {
       return false;
     }
-    if (this.game.mirvCooldownRemaining() > 0) {
+    if (this.game.mirvCooldownRemaining(this.player) > 0) {
       return false;
     }
     if (this.player.units(UnitType.MissileSilo).length === 0) {
@@ -277,10 +277,16 @@ export class NationMIRVBehavior {
 
     const centerTile = this.calculateTerritoryCenter(enemy);
     if (centerTile && this.player.canBuild(UnitType.MIRV, centerTile)) {
-      this.game.addExecution(new MirvExecution(this.player, centerTile));
-      this.recordMirvHit(enemy);
-      this.emojiBehavior.sendEmoji(AllPlayers, EMOJI_NUKE);
-      respondToMIRV(this.game, this.random, enemy);
+      // Defer the hit-record/emoji/response until the missile actually
+      // spawns — a same-tick launch elsewhere can start the global cooldown
+      // and fizzle this one.
+      this.game.addExecution(
+        new MirvExecution(this.player, centerTile, () => {
+          this.recordMirvHit(enemy);
+          this.emojiBehavior.sendEmoji(AllPlayers, EMOJI_NUKE);
+          respondToMIRV(this.game, this.random, enemy);
+        }),
+      );
     }
   }
 

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -895,6 +895,11 @@ export interface Game extends GameMap {
   numTilesWithFallout(): number;
   stats(): Stats;
 
+  // MIRV launches share a global cooldown: after any player launches one, no
+  // player can launch another until it expires.
+  recordMirvLaunch(): void;
+  mirvCooldownRemaining(): Tick;
+
   addUpdate(update: GameUpdate): void;
   railNetwork(): RailNetwork;
   conquerPlayer(conqueror: Player, conquered: Player): void;
@@ -945,6 +950,9 @@ export interface BuildableUnit {
   // escalate per level, so a bulk total is NOT cost * amount). Only set when
   // canUpgrade is not false.
   upgradeCosts?: Gold[];
+  // Remaining ticks of the global MIRV launch cooldown. Only set for MIRV
+  // while the cooldown is active.
+  cooldown?: Tick;
   overlappingRailroads: TileRef[];
   ghostRailPaths: TileRef[][];
 }

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -895,10 +895,11 @@ export interface Game extends GameMap {
   numTilesWithFallout(): number;
   stats(): Stats;
 
-  // MIRV launches share a global cooldown: after any player launches one, no
-  // player can launch another until it expires.
-  recordMirvLaunch(): void;
-  mirvCooldownRemaining(): Tick;
+  // MIRV launches share a global cooldown: after a player launches one, no
+  // OTHER player can launch until it expires. The last launcher is exempt
+  // and each of their launches restarts the timer for everyone else.
+  recordMirvLaunch(launcher: Player): void;
+  mirvCooldownRemaining(player: Player): Tick;
 
   addUpdate(update: GameUpdate): void;
   railNetwork(): RailNetwork;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -34,6 +34,7 @@ import {
   TeamGameSpawnAreas,
   TerrainType,
   TerraNullius,
+  Tick,
   Trios,
   Unit,
   UnitInfo,
@@ -118,6 +119,7 @@ export class GameImpl implements Game {
   private _teamGameSpawnAreas: TeamGameSpawnAreas | undefined;
   /** Tiles from nuke blast radii this tick, drained by the renderer. */
   private _nukeImpactQueue: TileRef[] = [];
+  private _lastMirvLaunchTick: Tick | null = null;
 
   constructor(
     private _humans: PlayerInfo[],
@@ -1307,6 +1309,19 @@ export class GameImpl implements Game {
   }
   stats(): Stats {
     return this._stats;
+  }
+  recordMirvLaunch(): void {
+    this._lastMirvLaunchTick = this._ticks;
+  }
+  mirvCooldownRemaining(): Tick {
+    if (this._lastMirvLaunchTick === null) {
+      return 0;
+    }
+    return Math.max(
+      0,
+      this._config.mirvLaunchCooldown() -
+        (this._ticks - this._lastMirvLaunchTick),
+    );
   }
   railNetwork(): RailNetwork {
     return this._railNetwork;

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -120,6 +120,7 @@ export class GameImpl implements Game {
   /** Tiles from nuke blast radii this tick, drained by the renderer. */
   private _nukeImpactQueue: TileRef[] = [];
   private _lastMirvLaunchTick: Tick | null = null;
+  private _lastMirvLauncher: Player | null = null;
 
   constructor(
     private _humans: PlayerInfo[],
@@ -1310,11 +1311,15 @@ export class GameImpl implements Game {
   stats(): Stats {
     return this._stats;
   }
-  recordMirvLaunch(): void {
+  recordMirvLaunch(launcher: Player): void {
     this._lastMirvLaunchTick = this._ticks;
+    this._lastMirvLauncher = launcher;
   }
-  mirvCooldownRemaining(): Tick {
-    if (this._lastMirvLaunchTick === null) {
+  mirvCooldownRemaining(player: Player): Tick {
+    if (
+      this._lastMirvLaunchTick === null ||
+      this._lastMirvLauncher === player
+    ) {
       return 0;
     }
     return Math.max(

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -1426,7 +1426,7 @@ export class PlayerImpl implements Player {
     if (this.mg.config().isUnitDisabled(unitType)) {
       return false;
     }
-    if (unitType === UnitType.MIRV && this.mg.mirvCooldownRemaining() > 0) {
+    if (unitType === UnitType.MIRV && this.mg.mirvCooldownRemaining(this) > 0) {
       return false;
     }
     const cost = knownCost ?? this.mg.unitInfo(unitType).cost(this.mg, this);
@@ -1528,7 +1528,8 @@ export class PlayerImpl implements Player {
         }
       }
 
-      const mirvCooldown = u === UnitType.MIRV ? mg.mirvCooldownRemaining() : 0;
+      const mirvCooldown =
+        u === UnitType.MIRV ? mg.mirvCooldownRemaining(this) : 0;
 
       result[i] = {
         type: u,

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -1426,6 +1426,9 @@ export class PlayerImpl implements Player {
     if (this.mg.config().isUnitDisabled(unitType)) {
       return false;
     }
+    if (unitType === UnitType.MIRV && this.mg.mirvCooldownRemaining() > 0) {
+      return false;
+    }
     const cost = knownCost ?? this.mg.unitInfo(unitType).cost(this.mg, this);
     if (this._gold < cost) {
       return false;
@@ -1525,12 +1528,15 @@ export class PlayerImpl implements Player {
         }
       }
 
+      const mirvCooldown = u === UnitType.MIRV ? mg.mirvCooldownRemaining() : 0;
+
       result[i] = {
         type: u,
         canBuild,
         canUpgrade,
         cost,
         upgradeCosts,
+        cooldown: mirvCooldown > 0 ? mirvCooldown : undefined,
         overlappingRailroads: buildNew
           ? rail.overlappingRailroads(u, canBuild as TileRef)
           : [],

--- a/tests/MirvCooldown.test.ts
+++ b/tests/MirvCooldown.test.ts
@@ -1,3 +1,4 @@
+import { AllianceRequestExecution } from "../src/core/execution/alliance/AllianceRequestExecution";
 import { MirvExecution } from "../src/core/execution/MIRVExecution";
 import {
   Game,
@@ -13,19 +14,23 @@ import { executeTicks } from "./util/utils";
 let game: Game;
 let player1: Player;
 let player2: Player;
+let player3: Player;
 
 describe("MIRV global launch cooldown", () => {
   beforeEach(async () => {
     game = await setup("plains", { instantBuild: true }, [
       new PlayerInfo("player1", PlayerType.Human, "c1", "p1"),
       new PlayerInfo("player2", PlayerType.Human, "c2", "p2"),
+      new PlayerInfo("player3", PlayerType.Human, "c3", "p3"),
     ]);
 
     player1 = game.player("p1");
     player2 = game.player("p2");
+    player3 = game.player("p3");
 
     player1.conquer(game.ref(0, 0));
     player2.conquer(game.ref(10, 10));
+    player3.conquer(game.ref(20, 20));
 
     player1.buildUnit(UnitType.MissileSilo, game.ref(0, 0), {});
     player2.buildUnit(UnitType.MissileSilo, game.ref(10, 10), {});
@@ -51,33 +56,44 @@ describe("MIRV global launch cooldown", () => {
     expect(game.unitInfo(UnitType.MIRV).cost(game, player2)).toBe(25_000_000n);
   });
 
-  test("no player can launch another MIRV until the cooldown expires", () => {
+  test("blocks other players but not the launcher; relaunch restarts the timer", () => {
     (game.config() as TestConfig).setMirvLaunchCooldown(50);
 
-    expect(game.mirvCooldownRemaining()).toBe(0);
+    expect(game.mirvCooldownRemaining(player2)).toBe(0);
     expect(player2.canBuild(UnitType.MIRV, game.ref(10, 10))).not.toBe(false);
 
     game.addExecution(new MirvExecution(player1, game.ref(0, 0)));
     executeTicks(game, 2); // init + spawn
     expect(player1.units(UnitType.MIRV)).toHaveLength(1);
-    expect(game.mirvCooldownRemaining()).toBeGreaterThan(0);
 
-    // Neither the launcher nor anyone else can build a MIRV.
-    expect(player1.canBuild(UnitType.MIRV, game.ref(10, 10))).toBe(false);
+    // Everyone else is blocked; the launcher is exempt (they still need a
+    // ready silo — the one that just fired is reloading).
+    expect(game.mirvCooldownRemaining(player2)).toBeGreaterThan(0);
+    expect(game.mirvCooldownRemaining(player1)).toBe(0);
     expect(player2.canBuild(UnitType.MIRV, game.ref(10, 10))).toBe(false);
+    player1.conquer(game.ref(1, 1));
+    player1.buildUnit(UnitType.MissileSilo, game.ref(1, 1), {});
+    expect(player1.canBuild(UnitType.MIRV, game.ref(10, 10))).not.toBe(false);
 
-    // A MIRV execution added during the cooldown fizzles.
+    // A blocked player's MIRV execution fizzles.
     game.addExecution(new MirvExecution(player2, game.ref(0, 0)));
     executeTicks(game, 2);
     expect(player2.units(UnitType.MIRV)).toHaveLength(0);
 
-    // Once the cooldown expires, launching is possible again.
+    // The launcher firing again mid-cooldown restarts the timer for others.
+    executeTicks(game, 20);
+    const before = game.mirvCooldownRemaining(player2);
+    game.addExecution(new MirvExecution(player1, game.ref(0, 0)));
+    executeTicks(game, 2);
+    expect(game.mirvCooldownRemaining(player2)).toBeGreaterThan(before);
+
+    // Once the cooldown expires, others can launch again.
     executeTicks(game, 50);
-    expect(game.mirvCooldownRemaining()).toBe(0);
+    expect(game.mirvCooldownRemaining(player2)).toBe(0);
     expect(player2.canBuild(UnitType.MIRV, game.ref(10, 10))).not.toBe(false);
   });
 
-  test("buildableUnits reports the remaining MIRV cooldown", () => {
+  test("buildableUnits reports the remaining MIRV cooldown to blocked players only", () => {
     (game.config() as TestConfig).setMirvLaunchCooldown(50);
 
     const before = player2
@@ -88,11 +104,39 @@ describe("MIRV global launch cooldown", () => {
     game.addExecution(new MirvExecution(player1, game.ref(0, 0)));
     executeTicks(game, 2); // init + spawn
 
-    const during = player2
+    const blocked = player2
       .buildableUnits(game.ref(10, 10))
       .find((u) => u.type === UnitType.MIRV);
-    expect(during?.canBuild).toBe(false);
-    expect(during?.cooldown).toBeGreaterThan(0);
-    expect(during?.cooldown).toBeLessThanOrEqual(50);
+    expect(blocked?.canBuild).toBe(false);
+    expect(blocked?.cooldown).toBeGreaterThan(0);
+    expect(blocked?.cooldown).toBeLessThanOrEqual(50);
+
+    // The launcher sees no cooldown.
+    const launcher = player1
+      .buildableUnits(game.ref(0, 0))
+      .find((u) => u.type === UnitType.MIRV);
+    expect(launcher?.cooldown).toBeUndefined();
+  });
+
+  test("a launch fizzled by the cooldown applies no betrayal side effects", () => {
+    (game.config() as TestConfig).setMirvLaunchCooldown(50);
+
+    game.addExecution(new AllianceRequestExecution(player2, player3.id()));
+    game.executeNextTick();
+    game.addExecution(new AllianceRequestExecution(player3, player2.id()));
+    game.executeNextTick();
+    expect(player2.isAlliedWith(player3)).toBe(true);
+
+    // Both launch at player3 in the same tick. player1's execution runs
+    // first and starts the cooldown; player2's fizzles and must not break
+    // the alliance or mark player2 a traitor.
+    game.addExecution(new MirvExecution(player1, game.ref(20, 20)));
+    game.addExecution(new MirvExecution(player2, game.ref(20, 20)));
+    executeTicks(game, 2);
+
+    expect(player1.units(UnitType.MIRV)).toHaveLength(1);
+    expect(player2.units(UnitType.MIRV)).toHaveLength(0);
+    expect(player2.isAlliedWith(player3)).toBe(true);
+    expect(player2.isTraitor()).toBe(false);
   });
 });

--- a/tests/MirvCooldown.test.ts
+++ b/tests/MirvCooldown.test.ts
@@ -1,0 +1,98 @@
+import { MirvExecution } from "../src/core/execution/MIRVExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+import { TestConfig } from "./util/TestConfig";
+import { executeTicks } from "./util/utils";
+
+let game: Game;
+let player1: Player;
+let player2: Player;
+
+describe("MIRV global launch cooldown", () => {
+  beforeEach(async () => {
+    game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("player1", PlayerType.Human, "c1", "p1"),
+      new PlayerInfo("player2", PlayerType.Human, "c2", "p2"),
+    ]);
+
+    player1 = game.player("p1");
+    player2 = game.player("p2");
+
+    player1.conquer(game.ref(0, 0));
+    player2.conquer(game.ref(10, 10));
+
+    player1.buildUnit(UnitType.MissileSilo, game.ref(0, 0), {});
+    player2.buildUnit(UnitType.MissileSilo, game.ref(10, 10), {});
+
+    player1.addGold(1_000_000_000n);
+    player2.addGold(1_000_000_000n);
+  });
+
+  test("cooldown defaults to 60 seconds", () => {
+    expect(game.config().mirvLaunchCooldown()).toBe(600);
+  });
+
+  test("MIRV cost stays flat at 25M after a launch", () => {
+    expect(game.unitInfo(UnitType.MIRV).cost(game, player1)).toBe(25_000_000n);
+
+    // MIRV targets must be owned tiles; player1 self-targets so player2's
+    // territory and silo stay intact for later assertions.
+    game.addExecution(new MirvExecution(player1, game.ref(0, 0)));
+    executeTicks(game, 2); // init + spawn
+    expect(game.units(UnitType.MIRV)).toHaveLength(1);
+
+    expect(game.unitInfo(UnitType.MIRV).cost(game, player1)).toBe(25_000_000n);
+    expect(game.unitInfo(UnitType.MIRV).cost(game, player2)).toBe(25_000_000n);
+  });
+
+  test("no player can launch another MIRV until the cooldown expires", () => {
+    (game.config() as TestConfig).setMirvLaunchCooldown(50);
+
+    expect(game.mirvCooldownRemaining()).toBe(0);
+    expect(player2.canBuild(UnitType.MIRV, game.ref(10, 10))).not.toBe(false);
+
+    game.addExecution(new MirvExecution(player1, game.ref(0, 0)));
+    executeTicks(game, 2); // init + spawn
+    expect(player1.units(UnitType.MIRV)).toHaveLength(1);
+    expect(game.mirvCooldownRemaining()).toBeGreaterThan(0);
+
+    // Neither the launcher nor anyone else can build a MIRV.
+    expect(player1.canBuild(UnitType.MIRV, game.ref(10, 10))).toBe(false);
+    expect(player2.canBuild(UnitType.MIRV, game.ref(10, 10))).toBe(false);
+
+    // A MIRV execution added during the cooldown fizzles.
+    game.addExecution(new MirvExecution(player2, game.ref(0, 0)));
+    executeTicks(game, 2);
+    expect(player2.units(UnitType.MIRV)).toHaveLength(0);
+
+    // Once the cooldown expires, launching is possible again.
+    executeTicks(game, 50);
+    expect(game.mirvCooldownRemaining()).toBe(0);
+    expect(player2.canBuild(UnitType.MIRV, game.ref(10, 10))).not.toBe(false);
+  });
+
+  test("buildableUnits reports the remaining MIRV cooldown", () => {
+    (game.config() as TestConfig).setMirvLaunchCooldown(50);
+
+    const before = player2
+      .buildableUnits(game.ref(10, 10))
+      .find((u) => u.type === UnitType.MIRV);
+    expect(before?.cooldown).toBeUndefined();
+
+    game.addExecution(new MirvExecution(player1, game.ref(0, 0)));
+    executeTicks(game, 2); // init + spawn
+
+    const during = player2
+      .buildableUnits(game.ref(10, 10))
+      .find((u) => u.type === UnitType.MIRV);
+    expect(during?.canBuild).toBe(false);
+    expect(during?.cooldown).toBeGreaterThan(0);
+    expect(during?.cooldown).toBeLessThanOrEqual(50);
+  });
+});

--- a/tests/NationMIRV.test.ts
+++ b/tests/NationMIRV.test.ts
@@ -10,6 +10,7 @@ import {
   UnitType,
 } from "../src/core/game/Game";
 import { setup } from "./util/Setup";
+import { TestConfig } from "./util/TestConfig";
 import { executeTicks } from "./util/utils";
 
 describe("Nation MIRV Retaliation", () => {
@@ -18,6 +19,10 @@ describe("Nation MIRV Retaliation", () => {
       infiniteGold: true,
       instantBuild: true,
     });
+    // The global MIRV launch cooldown would block a counter-launch while the
+    // attacker's MIRV is in flight; disable it here since this test exercises
+    // the nation's counter-MIRV targeting logic.
+    (game.config() as TestConfig).setMirvLaunchCooldown(0);
 
     // Create two players
     const attackerInfo = new PlayerInfo(

--- a/tests/economy/ConstructionGold.test.ts
+++ b/tests/economy/ConstructionGold.test.ts
@@ -72,7 +72,7 @@ describe("Construction economy", () => {
     ).toBe(false);
   });
 
-  test("MIRV gets more expensive with each launch", () => {
+  test("MIRV price stays flat at 25M after a launch", () => {
     expect(game.config().unitInfo(UnitType.MIRV).cost(game, other)).toBe(
       25_000_000n,
     );
@@ -92,9 +92,10 @@ describe("Construction economy", () => {
 
     expect(player.units(UnitType.MIRV)).toHaveLength(1);
 
-    // Price of the MIRV increases for everyone with each launch.
+    // The MIRV price no longer escalates with launches; instead launches
+    // trigger a global cooldown (see MirvCooldown.test.ts).
     expect(game.config().unitInfo(UnitType.MIRV).cost(game, other)).toBe(
-      40_000_000n,
+      25_000_000n,
     );
   });
 });

--- a/tests/nukes/HydrogenAndMirv.test.ts
+++ b/tests/nukes/HydrogenAndMirv.test.ts
@@ -379,6 +379,9 @@ describe("Hydrogen Bomb and MIRV flows", () => {
       { infiniteGold: true, instantBuild: true },
       [info],
     );
+    // Disable the global MIRV launch cooldown — this test launches two MIRVs
+    // back-to-back to compare their flight paths.
+    (edgeGame.config() as TestConfig).setMirvLaunchCooldown(0);
     const edgePlayer = edgeGame.player(info.id);
 
     edgePlayer.conquer(edgeGame.ref(10, 1));

--- a/tests/nukes/HydrogenAndMirv.test.ts
+++ b/tests/nukes/HydrogenAndMirv.test.ts
@@ -379,9 +379,6 @@ describe("Hydrogen Bomb and MIRV flows", () => {
       { infiniteGold: true, instantBuild: true },
       [info],
     );
-    // Disable the global MIRV launch cooldown — this test launches two MIRVs
-    // back-to-back to compare their flight paths.
-    (edgeGame.config() as TestConfig).setMirvLaunchCooldown(0);
     const edgePlayer = edgeGame.player(info.id);
 
     edgePlayer.conquer(edgeGame.ref(10, 1));

--- a/tests/util/TestConfig.ts
+++ b/tests/util/TestConfig.ts
@@ -11,6 +11,7 @@ export class TestConfig extends Config {
   private _defaultNukeSpeed: number = 4;
   private _spawnImmunityDuration: number = 0;
   private _nationSpawnImmunityDuration: number = 0;
+  private _mirvLaunchCooldown: Tick | null = null;
 
   disableNavMesh(): boolean {
     return this.gameConfig().disableNavMesh ?? true;
@@ -68,6 +69,14 @@ export class TestConfig extends Config {
 
   setNationSpawnImmunityDuration(duration: Tick) {
     this._nationSpawnImmunityDuration = duration;
+  }
+
+  setMirvLaunchCooldown(cooldown: Tick) {
+    this._mirvLaunchCooldown = cooldown;
+  }
+
+  mirvLaunchCooldown(): Tick {
+    return this._mirvLaunchCooldown ?? super.mirvLaunchCooldown();
   }
 
   nationSpawnImmunityDuration(): Tick {


### PR DESCRIPTION
## Summary

- The MIRV price no longer escalates by +15M per launch — it stays flat at 25M (`costWrapper` in `Config.ts`, same as the other bombs).
- Instead, every MIRV launch starts a **global cooldown** (`Config.mirvLaunchCooldown()`, 600 ticks = 60s, configurable like the other cooldown knobs) during which no *other* player can launch a MIRV. **The last launcher is exempt**: they can keep firing (still gated by silo reload), and each of their launches restarts the 60s lockout for everyone else. If someone else launches after the window expires, the exemption transfers to them. Enforced in the deterministic core (`PlayerImpl.canBuildUnitType`), recorded by `MirvExecution` when the missile spawns, so it applies to humans, nations, and any raw intent alike.
- **Deliberate design note**: combined with the flat price, a wealthy player can chain MIRVs and keep everyone else locked out — first-mover advantage is the intent of this change. Betrayal/relations side effects only apply when a missile actually spawns, so a launch fizzled by the cooldown pays no diplomatic cost (nation hit-recording/emoji/response deferred via an `onLaunch` callback).
- The build menu's MIRV card shows a live countdown chip (🕐 + `renderDuration`) and the quick-build hotbar's MIRV slot shows a radial cooldown sweep with the remaining time, both only for players actually blocked. Blocked-state tooltip says "On cooldown" instead of "Not enough money".
- Nations skip MIRV consideration while blocked. With the 60s lockout, in-flight counter-MIRV retaliation can no longer fire at the default cooldown; tests that exercise that targeting logic zero the cooldown via `TestConfig.setMirvLaunchCooldown`.

## Test plan

- New `tests/MirvCooldown.test.ts`: default is 600 ticks; price stays 25M after a launch; other players are blocked during the window (a mid-cooldown `MirvExecution` fizzles) while the launcher stays exempt; a launcher relaunch restarts the timer for others; blocked players see the remaining ticks in `buildableUnits` while the launcher sees none; a fizzled same-tick launch applies no betrayal side effects.
- Full suite passes: 4687 tests, plus `tsc --noEmit`, oxlint/eslint, prettier.
- Verified live in a headless-browser singleplayer game: built a silo, launched a MIRV at a bot, confirmed the build-menu chip and the hotbar radial sweep counting down (60s → 57s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)