### PR TITLE
ci: run the Claude code review on a Blacksmith runner

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
   review:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: blacksmith-4vcpu-ubuntu-2404
     # A real review of a ~1.8k-line PR took 15.7 min; 20 was too close to the
     # ceiling for anything larger.
     timeout-minutes: 30


### PR DESCRIPTION
## Why

Since 14:44Z on 8 Sept 2026 every Claude Code Review run in the org fails at dispatch with zero steps. The check annotation reads: "The job was not started because recent account payments have failed or your spending limit needs to be increased." The review job is on GitHub-hosted runners (`ubuntu-latest`); the checks that kept passing are on Blacksmith. Josh's decision: move the review job to Blacksmith rather than depend on GitHub-hosted minutes.

## What

One line: `runs-on: ubuntu-latest` → `runs-on: blacksmith-4vcpu-ubuntu-2404` in `.github/workflows/claude-code-review.yml`. Nothing else in the workflow changes.

Existing open PRs do not need a rebase to pick this up: `pull_request` runs use the workflow file from the PR's merge commit, so once this is on main, toggling a PR to draft and back (`ready_for_review` is a trigger) starts a fresh run on the new runner.

Note for OpenFrontIO: its `ci.yml` and the rest of its workflows are also on `ubuntu-latest`, so that repo's CI stays blocked until billing is fixed or those move too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfTQZps1QwQHmBMoV3gq3U
