### PR TITLE
fix(version): show the build's commit when it has no tagged version (OPE-358)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,15 @@ jobs:
           Changelog:
           ${RELEASE_BODY}
           EOF
-          ./build.sh prod "${RELEASE_TAG_NAME}" "${RELEASE_NAME}" "${RELEASE_BODY}" /tmp/build-metadata.json
+          # Third argument is VERSION_TXT, which build.sh writes to
+          # resources/version.txt and the client bakes into the bundle as the
+          # version the footer and nav bar show. It used to be RELEASE_NAME --
+          # free text typed into the GitHub Release UI, so the shipped version
+          # label was whatever someone happened to title the release. The TAG
+          # is the build's actual identity and is already validated as the
+          # image tag on the line's second argument, so use it. RELEASE_NAME
+          # stays in the job summary above, where free text belongs.
+          ./build.sh prod "${RELEASE_TAG_NAME}" "${RELEASE_TAG_NAME}" "${RELEASE_BODY}" /tmp/build-metadata.json
           IMAGE_ID=$(jq -r '."containerimage.digest"' /tmp/build-metadata.json)
           echo "IMAGE_ID=${IMAGE_ID}" >> $GITHUB_OUTPUT
           echo "Image ID: \`${IMAGE_ID}\`" >> $GITHUB_STEP_SUMMARY

--- a/src/client/DesktopShell.ts
+++ b/src/client/DesktopShell.ts
@@ -52,7 +52,13 @@ export function composeVersionDisplay(
   if (!shellVersion) return gameVersion;
   const trimmed = shellVersion.trim();
   if (trimmed === "") return gameVersion;
-  const withV = trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+  // Prefixed only when the value looks like a bare version. The shell reports
+  // its 7-char commit on an untagged build (OPE-358), and "va1b2c3d" reads as
+  // a version that does not exist. Conditional rather than dropped outright
+  // so an older shell -- which always answers "0.2.0" -- still renders
+  // "v0.2.0": the two repositories update on separate schedules, so both
+  // shapes are live at once.
+  const withV = /^\d+\.\d+\.\d+/.test(trimmed) ? `v${trimmed}` : trimmed;
   return `${gameVersion} (Steam ${withV})`;
 }
 

--- a/src/client/GameVersion.ts
+++ b/src/client/GameVersion.ts
@@ -1,0 +1,93 @@
+import version from "resources/version.txt?raw";
+import { ClientEnv } from "./ClientEnv";
+
+// A build HAS a version only if it was tagged. resources/version.txt ships as
+// the placeholder "x.xx.xx" and only a tagged deploy overwrites it:
+// .github/workflows/release.yml hands build.sh a third argument, which
+// build.sh writes to the file, while every untagged deploy goes through
+// build-deploy.sh, which passes two arguments and leaves the placeholder in
+// the tree. So the nav bar and footer read "vx.xx.xx" on every nightly, every
+// staging deploy and every Steam depot build -- a label naming no build at
+// all, and the one thing a player is asked to quote in a bug report.
+const VERSION_RE = /^v?\d+\.\d+\.\d+/;
+const SHA_RE = /^[0-9a-f]{7,40}$/i;
+const SHORT_COMMIT_LENGTH = 7;
+
+/**
+ * The label identifying this client build.
+ *
+ * Show the version when the build has one, and the 7-char commit when it does
+ * not -- the same rule the Electron shell applies to its own half of the
+ * footer line (OPE-358), so "v0.33.18 (Steam v0.1.0)" and
+ * "bf739f8 (Steam a1b2c3d)" are both self-consistent rather than one half
+ * naming a build and the other a placeholder.
+ *
+ * Pure, and takes both inputs, so the nav bar and the footer cannot drift:
+ * they are two renderings of one answer, not two derivations of it.
+ */
+export function composeGameVersion(
+  rawVersion: string,
+  gitCommit: string,
+): string {
+  const trimmed = rawVersion.trim();
+  const withV = trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+  if (VERSION_RE.test(trimmed)) return withV;
+
+  // Untagged, so the commit is the only thing identifying this build.
+  const commit = gitCommit.trim();
+  if (SHA_RE.test(commit)) {
+    return commit.slice(0, SHORT_COMMIT_LENGTH).toLowerCase();
+  }
+  // Not a sha, but not nothing either: "DEV" from the local dev server, or
+  // the "desktop" placeholder an Electron shell predating OPE-358 injects.
+  // Both say strictly more than the version placeholder does.
+  if (commit !== "") return commit;
+  // Unreachable in a live client -- ClientEnv.get() throws long before this
+  // if BOOTSTRAP_CONFIG is absent -- but the label must never come back
+  // blank, so fall back to whatever the file held.
+  return withV;
+}
+
+/**
+ * composeGameVersion applied to this page.
+ *
+ * Called at render time rather than evaluated at module scope: the commit
+ * comes from BOOTSTRAP_CONFIG, which the server injects into the page, and
+ * which is not guaranteed to exist when this module is first imported.
+ */
+export function currentGameVersion(): string {
+  return composeGameVersion(version, currentGitCommit());
+}
+
+/** The nav bar's version elements, in both the mobile and desktop nav bars. */
+const NAV_VERSION_SELECTOR = "#game-version, .game-version-display";
+
+/**
+ * Stamps the build label onto the nav bar, and reports how many elements it
+ * found so the caller can warn when the markup has moved out from under it.
+ *
+ * Lives here rather than inline in Main.ts so it goes through the same helper
+ * the footer does and can be tested without importing Main.ts, which is a
+ * module of side effects. The nav bar showing "vx.xx.xx" beside a footer
+ * showing "bf739f8" would be worse than either label alone.
+ */
+export function renderNavVersion(root: ParentNode = document): number {
+  const elements = root.querySelectorAll(NAV_VERSION_SELECTOR);
+  const label = currentGameVersion();
+  elements.forEach((el) => {
+    (el as HTMLElement).style.fontFamily = '"OpenFront", Inter, sans-serif';
+    el.textContent = label;
+  });
+  return elements.length;
+}
+
+// ClientEnv.get() throws when BOOTSTRAP_CONFIG is missing. A cosmetic version
+// label must never be the thing that takes the page down, so read it
+// defensively and let composeGameVersion treat "" as "no commit known".
+function currentGitCommit(): string {
+  try {
+    return ClientEnv.gitCommit();
+  } catch {
+    return "";
+  }
+}

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1,5 +1,5 @@
-import version from "resources/version.txt?raw";
 import { ClientEnv } from "src/client/ClientEnv";
+import { renderNavVersion } from "src/client/GameVersion";
 import { isTemporaryUsername, UserMeResponse } from "../core/ApiSchemas";
 import { assetUrl } from "../core/AssetUrls";
 import { EventBus } from "../core/EventBus";
@@ -360,20 +360,12 @@ class Client {
     document.fonts.add(openFrontFont);
     openFrontFont.load().catch(() => {});
 
-    const versionElements = document.querySelectorAll(
-      "#game-version, .game-version-display",
-    );
-    if (versionElements.length === 0) {
+    // Game version only, so a player's version reads the same across web and
+    // Steam. The full string, shell version included, is in page-footer --
+    // and both go through the same helper, so the two cannot disagree. See
+    // renderNavVersion / composeGameVersion (OPE-358).
+    if (renderNavVersion() === 0) {
       console.warn("Game version element not found");
-    } else {
-      // Game version only, so a player's version reads the same across web and
-      // Steam. The full string, shell version included, is in page-footer.
-      const trimmed = version.trim();
-      const displayVersion = trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
-      versionElements.forEach((el) => {
-        (el as HTMLElement).style.fontFamily = '"OpenFront", Inter, sans-serif';
-        el.textContent = displayVersion;
-      });
     }
 
     const langSelector = document.querySelector(

--- a/src/client/components/Footer.ts
+++ b/src/client/components/Footer.ts
@@ -1,20 +1,20 @@
 import { LitElement, html } from "lit";
 import { customElement, state } from "lit/decorators.js";
-import version from "resources/version.txt?raw";
 import { assetUrl } from "../../core/AssetUrls";
 import { composeVersionDisplay, desktopVersion } from "../DesktopShell";
+import { currentGameVersion } from "../GameVersion";
 import "./SteamWishlistButton";
-
-const gameVersion = (() => {
-  const trimmed = version.trim();
-  return trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
-})();
 
 @customElement("page-footer")
 export class Footer extends LitElement {
+  // Per instance, not at module scope: currentGameVersion reads
+  // BOOTSTRAP_CONFIG, which the server injects into the page and which is not
+  // guaranteed to exist at the moment this module is first imported.
+  private readonly gameVersion = currentGameVersion();
+
   // Starts as the game version alone and gains the shell version once the
   // bridge answers, so the line is never blank while that call is in flight.
-  @state() private versionLabel = gameVersion;
+  @state() private versionLabel = this.gameVersion;
 
   createRenderRoot() {
     return this;
@@ -25,7 +25,7 @@ export class Footer extends LitElement {
     // desktopVersion() resolves null off the desktop shell and on its own
     // timeout, so this can only ever leave the label as-is or extend it.
     void desktopVersion().then((shellVersion) => {
-      this.versionLabel = composeVersionDisplay(gameVersion, shellVersion);
+      this.versionLabel = composeVersionDisplay(this.gameVersion, shellVersion);
     });
   }
 

--- a/tests/DesktopShell.test.ts
+++ b/tests/DesktopShell.test.ts
@@ -26,6 +26,15 @@ describe("composeVersionDisplay", () => {
   it("returns the game version unchanged for a blank shell version", () => {
     expect(composeVersionDisplay("v0.33.1", "")).toBe("v0.33.1");
   });
+
+  // An untagged shell build reports its 7-char commit rather than a version
+  // (OPE-358). Prefixing that would render "va1b2c3d", a version that does
+  // not exist.
+  it("does not prefix a shell commit with a v", () => {
+    expect(composeVersionDisplay("bf739f8", "a1b2c3d")).toBe(
+      "bf739f8 (Steam a1b2c3d)",
+    );
+  });
 });
 
 describe("desktopVersion", () => {

--- a/tests/client/GameVersion.test.ts
+++ b/tests/client/GameVersion.test.ts
@@ -1,0 +1,138 @@
+import version from "resources/version.txt?raw";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { ClientEnv } from "../../src/client/ClientEnv";
+import {
+  composeGameVersion,
+  currentGameVersion,
+  renderNavVersion,
+} from "../../src/client/GameVersion";
+
+const SHA = "bf739f86c4e1d2a3b5c6d7e8f90123456789abcd";
+
+// The rule this exists for: only a TAGGED deploy overwrites version.txt, so on
+// every nightly, staging deploy and Steam depot build the version label read
+// "vx.xx.xx" -- naming no build at all, and it is the one string a player is
+// asked to quote in a bug report. See OPE-358.
+describe("composeGameVersion", () => {
+  it("shows the version when the build was tagged", () => {
+    expect(composeGameVersion("v0.33.18", SHA)).toBe("v0.33.18");
+  });
+
+  it("adds the v when the tag was written without one", () => {
+    expect(composeGameVersion("0.33.18", SHA)).toBe("v0.33.18");
+  });
+
+  it("tolerates surrounding whitespace, as the raw file import carries", () => {
+    expect(composeGameVersion("  v0.33.18\n", SHA)).toBe("v0.33.18");
+  });
+
+  it("accepts a version carrying a suffix", () => {
+    expect(composeGameVersion("v0.33.18-rc1", SHA)).toBe("v0.33.18-rc1");
+  });
+
+  // The placeholder an untagged deploy leaves in the tree. This is the case
+  // the whole change exists for.
+  it("shows the 7-char commit instead of the placeholder", () => {
+    expect(composeGameVersion("x.xx.xx", SHA)).toBe("bf739f8");
+  });
+
+  it("lowercases an upper-cased commit", () => {
+    expect(composeGameVersion("x.xx.xx", SHA.toUpperCase())).toBe("bf739f8");
+  });
+
+  it("accepts a commit already abbreviated by the deploy pipeline", () => {
+    expect(composeGameVersion("x.xx.xx", "bf739f86c4e1")).toBe("bf739f8");
+  });
+
+  // "DEV" is what the local dev server injects, and "desktop" is what an
+  // Electron shell predating OPE-358 injects. Neither is a sha, and both say
+  // strictly more than the placeholder.
+  it.each(["DEV", "desktop"])("passes through a non-sha commit (%s)", (c) => {
+    expect(composeGameVersion("x.xx.xx", c)).toBe(c);
+  });
+
+  // Unreachable in a live client, but the label must never come back blank.
+  it("falls back to the file when there is no commit at all", () => {
+    expect(composeGameVersion("x.xx.xx", "")).toBe("vx.xx.xx");
+  });
+});
+
+describe("currentGameVersion", () => {
+  beforeEach(() => {
+    ClientEnv.reset();
+  });
+
+  afterEach(() => {
+    delete (window as { BOOTSTRAP_CONFIG?: unknown }).BOOTSTRAP_CONFIG;
+    ClientEnv.reset();
+  });
+
+  it("reads the commit out of BOOTSTRAP_CONFIG", () => {
+    (window as { BOOTSTRAP_CONFIG?: unknown }).BOOTSTRAP_CONFIG = {
+      gameEnv: "prod",
+      numWorkers: 1,
+      turnstileSiteKey: "1x00000000000000000000AA",
+      jwtAudience: "openfront.io",
+      instanceId: "test",
+      gitCommit: SHA,
+    };
+
+    expect(currentGameVersion()).toBe(composeGameVersion(version, SHA));
+  });
+
+  // A cosmetic label must never be what takes the page down: ClientEnv.get()
+  // throws outright when BOOTSTRAP_CONFIG is absent.
+  it("does not throw when BOOTSTRAP_CONFIG is absent", () => {
+    expect(() => currentGameVersion()).not.toThrow();
+    expect(currentGameVersion()).toBe(composeGameVersion(version, ""));
+  });
+});
+
+describe("renderNavVersion", () => {
+  beforeEach(() => {
+    ClientEnv.reset();
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    delete (window as { BOOTSTRAP_CONFIG?: unknown }).BOOTSTRAP_CONFIG;
+    ClientEnv.reset();
+    document.body.innerHTML = "";
+  });
+
+  const setBootstrap = () => {
+    (window as { BOOTSTRAP_CONFIG?: unknown }).BOOTSTRAP_CONFIG = {
+      gameEnv: "prod",
+      numWorkers: 1,
+      turnstileSiteKey: "1x00000000000000000000AA",
+      jwtAudience: "openfront.io",
+      instanceId: "test",
+      gitCommit: SHA,
+    };
+  };
+
+  // The nav bar must not read "vx.xx.xx" while the footer reads the commit.
+  it("stamps the same label the footer uses onto both nav bars", () => {
+    setBootstrap();
+    document.body.innerHTML = `
+      <span id="game-version"></span>
+      <span class="game-version-display"></span>
+    `;
+
+    expect(renderNavVersion()).toBe(2);
+    const expected = composeGameVersion(version, SHA);
+    for (const el of document.querySelectorAll(
+      "#game-version, .game-version-display",
+    )) {
+      expect(el.textContent).toBe(expected);
+      expect(el.textContent).not.toContain("x.xx.xx");
+    }
+  });
+
+  it("reports zero when the markup carries no version element", () => {
+    setBootstrap();
+    document.body.innerHTML = '<span id="something-else"></span>';
+
+    expect(renderNavVersion()).toBe(0);
+  });
+});

--- a/tests/client/components/Footer.test.ts
+++ b/tests/client/components/Footer.test.ts
@@ -1,9 +1,17 @@
 import version from "resources/version.txt?raw";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClientEnv } from "../../../src/client/ClientEnv";
+import { composeGameVersion } from "../../../src/client/GameVersion";
 import { Footer } from "../../../src/client/components/Footer";
+
+const SHA = "bf739f86c4e1d2a3b5c6d7e8f90123456789abcd";
 
 // version.txt is a build-time placeholder in the repo, so derive the expected
 // label from the same source the component reads rather than hardcoding it.
+// These mount tests set no BOOTSTRAP_CONFIG, so composeGameVersion has no
+// commit to fall back to and returns the file's value -- which keeps this
+// the right expectation for the mounted component below. The choice itself is
+// covered in tests/client/GameVersion.test.ts.
 const gameVersion = `v${version.trim().replace(/^v/, "")}`;
 
 describe("page-footer version line", () => {
@@ -13,11 +21,14 @@ describe("page-footer version line", () => {
     if (!customElements.get("page-footer")) {
       customElements.define("page-footer", Footer);
     }
+    ClientEnv.reset();
   });
 
   afterEach(() => {
     footer?.remove();
     window.openfrontDesktop = undefined;
+    delete (window as { BOOTSTRAP_CONFIG?: unknown }).BOOTSTRAP_CONFIG;
+    ClientEnv.reset();
   });
 
   async function mount(): Promise<Footer> {
@@ -46,6 +57,26 @@ describe("page-footer version line", () => {
       const line = footer.querySelector(".footer-version");
       expect(line?.textContent?.trim()).toBe(`${gameVersion} (Steam v0.2.0)`);
     });
+  });
+
+  // End to end through the component: with a real BOOTSTRAP_CONFIG in the
+  // page and the placeholder still in version.txt, the line must name the
+  // commit rather than "vx.xx.xx". Expectation derived from the same helper
+  // so committing a real version.txt does not turn this red.
+  it("shows the commit rather than the placeholder on an untagged build", async () => {
+    (window as { BOOTSTRAP_CONFIG?: unknown }).BOOTSTRAP_CONFIG = {
+      gameEnv: "prod",
+      numWorkers: 1,
+      turnstileSiteKey: "1x00000000000000000000AA",
+      jwtAudience: "openfront.io",
+      instanceId: "test",
+      gitCommit: SHA,
+    };
+    window.openfrontDesktop = undefined;
+    await mount();
+
+    const line = footer.querySelector(".footer-version");
+    expect(line?.textContent?.trim()).toBe(composeGameVersion(version, SHA));
   });
 
   // The bridge lives in a separate private repo, so the footer must degrade to


### PR DESCRIPTION
## Why

A build has a version only if it was tagged, but the UI showed one either way.

`resources/version.txt` ships as the placeholder `x.xx.xx`, and only a tagged deploy overwrites it. `.github/workflows/release.yml` hands `build.sh` a third argument, which `build.sh` writes to the file; every untagged deploy goes through `build-deploy.sh`, which passes two arguments and leaves the placeholder in the tree. So on every nightly, every staging deploy and every Steam depot build, the nav bar and footer read `vx.xx.xx` — the one string a player is asked to quote in a bug report, naming no build at all.

Tracked as [OPE-358](https://linear.app/openfront/issue/OPE-358), where the Electron shell is adopting the same rule for its own half of the footer line.

## What

**The rule.** Show the version when the build has one, and the 7-character commit when it does not. `composeGameVersion` in the new `src/client/GameVersion.ts`:

| `version.txt` | shown |
|---|---|
| `v0.33.18` | `v0.33.18` |
| `x.xx.xx`, commit `bf739f86c4e1…` | `bf739f8` |
| `x.xx.xx`, commit `DEV` | `DEV` |

The commit comes from `BOOTSTRAP_CONFIG` via `ClientEnv.gitCommit()`, read defensively — a cosmetic label must never be what takes the page down.

**Both places, one helper.** The footer and the nav bar now call the same function. They previously derived the label independently, and the nav bar reading `vx.xx.xx` beside a footer reading `bf739f8` would be worse than either alone. `renderNavVersion` lives beside the helper rather than inline in `Main.ts` so it can be tested without importing a module of side effects.

**The `v` prefix on the shell version is now conditional.** `composeVersionDisplay` force-prefixed `v` onto whatever the desktop shell reported. The shell is changing to report its 7-character commit on an untagged build, and `va1b2c3d` reads as a version that does not exist. Conditional rather than dropped outright, so an older shell — which always answers `0.2.0` — still renders `v0.2.0`. The two repositories update on separate schedules, so both shapes are live at once.

The footer line ends up self-consistent in both directions: `v0.33.18 (Steam v0.1.0)` on tagged builds, `bf739f8 (Steam a1b2c3d)` on untagged ones.

## Deliberate change to the release workflow

`release.yml` passed `RELEASE_NAME` as `build.sh`'s third argument, so the version baked into every shipped build was **free text typed into the GitHub Release UI**. It has looked like a version so far, but nothing enforces that: a release titled "Halloween Update" would have shipped exactly that as the version string, and under this PR's regex it would instead fall through to the commit.

It now passes `RELEASE_TAG_NAME`. The tag is the build's actual identity and is already used, unmodified, as the image tag on the same line's second argument. `RELEASE_NAME` stays in the job summary above, where free text belongs.

**This changes what a tagged release displays** if a release's name and tag ever differed. That is the intent — the tag is the correct answer — but it is a behaviour change worth a second opinion rather than something to wave through.

## Not changed

`NavNotificationsController`'s `normalizedVersion()` also reads `version.txt`, but it is a change-detection key for the "new version" dot, not a display string. Routing it through this helper would make the key move on every commit, so an untagged deploy would re-show the dot constantly. Left alone deliberately.

## Desktop timing

The desktop shell currently injects the literal `desktop` as `gitCommit`, so on Steam this renders `desktop` rather than a commit until openfront-desktop [#40](https://github.com/openfrontio/openfront-desktop/pull/40) merges and the submodule pin moves. That is handled: `desktop` is passed through rather than special-cased, and it still says more than `vx.xx.xx` did. The web side is correct from the moment this lands.

## Tests

`tests/client/GameVersion.test.ts`, new:

- `composeGameVersion` — tagged, tag written without a `v`, surrounding whitespace as the raw import carries, a version with a suffix, the placeholder falling through to the commit, upper-cased and already-abbreviated commits, `DEV` and `desktop` passed through, and the no-commit-at-all fallback that keeps the label from coming back blank.
- `currentGameVersion` — reads the commit out of `BOOTSTRAP_CONFIG`, and does not throw when it is absent.
- `renderNavVersion` — stamps the same label the footer uses onto both nav bars and asserts the placeholder is gone; reports zero when the markup carries no version element.

`tests/DesktopShell.test.ts` — a shell commit is not given a `v` prefix. The three existing cases still pass unchanged, which is what pins the older-shell direction.

`tests/client/components/Footer.test.ts` — the mount tests keep their existing expectations; the choice itself moved to the new file.

Run locally on Windows:

```
npx tsc --noEmit      # clean
npm run lint          # clean (oxlint + eslint)
npx prettier --check  # clean
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfTQZps1QwQHmBMoV3gq3U
