### PR TITLE
fix(deploy): give nightly the same restart policy as main (OPE-361)

### DIFF
--- a/tests/UpdateRestartPolicy.test.ts
+++ b/tests/UpdateRestartPolicy.test.ts
@@ -1,0 +1,83 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, "../update.sh");
+
+const BEGIN = "# --- BEGIN restart policy (tested) ---";
+const END = "# --- END restart policy (tested) ---";
+
+// update.sh as a whole runs docker pull/run against a real host, so it cannot
+// be executed here. The restart-policy decision inside it is pure, though --
+// two strings in, one string out -- so lift exactly that block out of the
+// shipped file and run it. Reading the real script rather than restating its
+// logic is the point: a copy of the condition in this file would keep passing
+// after someone edited update.sh, which is the only failure this test exists
+// to catch.
+function extractPolicyBlock(): string {
+  const source = fs.readFileSync(SCRIPT, "utf8");
+  const start = source.indexOf(BEGIN);
+  const end = source.indexOf(END);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(
+      `Could not find the restart-policy markers in ${SCRIPT}. If the block ` +
+        `moved or was renamed, update the markers here and there together.`,
+    );
+  }
+  return source.slice(start + BEGIN.length, end);
+}
+
+function restartPolicyFor(subdomain: string, domain: string): string {
+  const script = `SUBDOMAIN='${subdomain}'\nDOMAIN='${domain}'\n${extractPolicyBlock()}\nprintf '%s' "$RESTART"\n`;
+  return execFileSync("bash", ["-c", script], { encoding: "utf8" });
+}
+
+describe("update.sh restart policy", () => {
+  // A crash here means a deployment somebody depends on stays down until the
+  // next deploy touches it. For nightly that is the 07:00 UTC scheduled run,
+  // so up to ~24 hours (OPE-361).
+  it.each([
+    ["main", "openfront.dev"],
+    ["nightly", "openfront.dev"],
+  ])("restarts the long-lived %s.%s deployment after a crash", (sub, dom) => {
+    expect(restartPolicyFor(sub, dom)).toBe("always");
+  });
+
+  it.each([["main"], ["nightly"], ["blue"], ["green"]])(
+    "restarts production (%s.openfront.io) whatever its subdomain is",
+    (sub) => {
+      expect(restartPolicyFor(sub, "openfront.io")).toBe("always");
+    },
+  );
+
+  // deploy.yml deploys every push on every branch to <branch>.openfront.dev,
+  // so these accumulate one container per branch anyone has ever pushed.
+  // `always` would resurrect every abandoned one on a host reboot.
+  it.each([["fix-some-bug"], ["t3code-mirv-cooldown-timer"], ["experiment"]])(
+    "leaves the per-branch preview %s.openfront.dev down after a crash",
+    (sub) => {
+      expect(restartPolicyFor(sub, "openfront.dev")).toBe("no");
+    },
+  );
+
+  // The membership test is space-delimited rather than a substring match, and
+  // these are the names that would wrongly match if that ever regressed to a
+  // plain `*main*` / `*nightly*` glob. A branch called `main-feature` is an
+  // ordinary preview and must not outlive its deploy.
+  it.each([
+    ["main-feature"],
+    ["nightly-test"],
+    ["remain"],
+    ["overnightly"],
+    ["premain"],
+  ])("does not treat %s as a long-lived subdomain", (sub) => {
+    expect(restartPolicyFor(sub, "openfront.dev")).toBe("no");
+  });
+
+  it("does not restart a deployment whose subdomain somehow arrived empty", () => {
+    expect(restartPolicyFor("", "openfront.dev")).toBe("no");
+  });
+});

--- a/update.sh
+++ b/update.sh
@@ -204,11 +204,44 @@ if [ -n "$STOPPED_CONTAINER" ]; then
     echo "Container $STOPPED_CONTAINER removed."
 fi
 
-if [ "${SUBDOMAIN}" = main ] || [ "${DOMAIN}" = openfront.io ]; then
+# Docker restart policy. `always` means the daemon brings this container back
+# after a crash, and again after a host reboot; `no` means it stays down until
+# somebody deploys again.
+#
+# Which one is right depends entirely on whether the deployment is long-lived,
+# and that is what SUBDOMAIN tells us:
+#
+#   Long-lived, listed below. Something depends on these being reachable at a
+#   fixed hostname without anyone watching. `main` and `nightly` are both
+#   staging deployments people test against; `nightly` is here because a
+#   scheduled deploy is the only thing that would otherwise restart it, so a
+#   crash at 07:05 UTC is a ~24-hour outage rather than a blip (OPE-361). Any
+#   deployment on the production domain qualifies for the same reason and is
+#   matched separately, since its subdomain is not fixed.
+#
+#   Everything else: a per-branch preview. deploy.yml deploys EVERY push on
+#   EVERY branch to <branch>.openfront.dev, so these accumulate one container
+#   per branch anyone has ever pushed. `no` is what lets them die quietly --
+#   with `always` a host reboot would resurrect months of abandoned branch
+#   containers, each holding its memory and its worker processes, and nothing
+#   would ever clean them up. Their owner is present when they are deployed and
+#   can redeploy, which is exactly the case `no` is for.
+#
+# To make another fixed hostname survive a crash, add its subdomain here.
+#
+# The markers below delimit the block that tests/UpdateRestartPolicy.test.ts
+# extracts and runs against a table of subdomains -- the rest of this script
+# talks to docker and ssh and cannot be executed in a test, but this decision
+# can. Keep them in place.
+# --- BEGIN restart policy (tested) ---
+LONG_LIVED_SUBDOMAINS=" main nightly "
+
+if [[ "${LONG_LIVED_SUBDOMAINS}" == *" ${SUBDOMAIN} "* ]] || [ "${DOMAIN}" = openfront.io ]; then
     RESTART=always
 else
     RESTART=no
 fi
+# --- END restart policy (tested) ---
 
 echo "Starting new container for ${HOST} environment..."
 


### PR DESCRIPTION
## Why

`update.sh` gave a deployed container `--restart=always` only when the subdomain was `main` or the domain was `openfront.io`. `nightly` fell through to `--restart=no`, so a crashed nightly game server stayed down until something deployed over it — and the only thing that deploys nightly is the 07:00 UTC scheduled run in `deploy.yml`. A crash just after that run is close to a 24-hour outage.

That was survivable while nightly was a spare staging deploy nobody relied on. It stops being survivable now that staging desktop builds pull both their client and their game server from it ([OPE-359](https://linear.app/openfront/issue/OPE-359)): a crash would take out Steam staging testers for a day.

Found while doing OPE-359. Closes [OPE-361](https://linear.app/openfront/issue/OPE-361).

## What

One decision in `update.sh`, now driven by an explicit list of long-lived subdomains instead of a single hardcoded name.

**Gets `restart=always`:**

- `main` — unchanged.
- `nightly` — the fix.
- Anything on `openfront.io` — unchanged, and still matched on the domain rather than the subdomain, because production's subdomain is not fixed.

**Stays on `restart=no`, deliberately: per-branch previews.** `deploy.yml` deploys every push on every branch to `<branch>.openfront.dev`, so the staging host accumulates one container per branch anyone has ever pushed. With `always` a host reboot or Docker daemon restart would resurrect every abandoned branch container, each holding its memory and its worker processes, and nothing would ever reap them. `no` is what lets them die quietly. Their owner is present when they deploy and can redeploy; that is exactly the case `no` is for.

To make another fixed hostname survive a crash, add its subdomain to `LONG_LIVED_SUBDOMAINS`.

The membership test is space-delimited (`*" ${SUBDOMAIN} "*` against `" main nightly "`) rather than a plain substring glob, so a branch named `main-feature`, `nightly-test` or `remain` is still treated as an ordinary preview. `deploy.sh` already validates the subdomain as a hostname label, so it cannot contain a space and cannot smuggle its way into that match.

## Tests

New: `tests/UpdateRestartPolicy.test.ts`, 15 cases. It follows the pattern `tests/GenerateNginxUpstream.test.ts` set — execute the real shell, do not restate its logic in TypeScript.

`update.sh` as a whole talks to docker and ssh and cannot run in a test, so the test extracts the policy block from the shipped file between two marker comments and runs that under `bash`. Reading the real script matters: a copy of the condition living in the test file would keep passing after somebody edited `update.sh`, which is the only failure this test exists to catch.

Covered: both long-lived subdomains, production on four different subdomains, three realistic branch previews, five near-miss names, and an empty subdomain.

I confirmed the test can actually fail, by breaking the shipped logic three ways and checking which cases caught it:

| Mutation to `update.sh` | Result |
| --- | --- |
| Drop `nightly` from the list | 1 failed — the nightly case |
| Substring match on `${SUBDOMAIN}` in either direction | 1 failed — the empty-subdomain case |
| Naive `*main*` / `*nightly*` glob | 5 failed — every near-miss name |

`update.sh` was restored after each; the diff here is the intended change only.

| Check | Result |
| --- | --- |
| `npx vitest run tests/UpdateRestartPolicy.test.ts` | 15 passed |
| `npm run lint` | clean |
| `npx prettier --check .` | clean |
| `npx tsc --noEmit` | clean |
| `npm test` | 4694 passed, 3 failed — see below |

The three failures were all `Test timed out in 5000ms`, in `tests/MapConsistency.test.ts` and `tests/client/InventoryModal.test.ts`. Both files re-run clean on their own (43 passed), and neither imports anything this PR touches — the suite was competing with other work on the machine. Reporting them rather than quietly rounding to green.

## Verifying after merge

Per the ticket's acceptance: after the next nightly deploy, `docker inspect` the nightly container and check `.HostConfig.RestartPolicy.Name` reads `always`. `main` and prod should be unchanged. Nothing in this PR changes an already-running container — Docker applies the policy at `docker run`, so nightly picks it up on its next scheduled deploy, not on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfTQZps1QwQHmBMoV3gq3U
