### PR TITLE
feat(server): authenticated admin-bot game-record endpoint

### DIFF
--- a/src/server/AdminBotRoutes.ts
+++ b/src/server/AdminBotRoutes.ts
@@ -17,6 +17,7 @@ import {
   LobbyAccentSchema,
   LobbyLabelSchema,
 } from "../core/Schemas";
+import { readGameRecord } from "./Archive";
 import type { GameManager } from "./GameManager";
 import { ServerEnv } from "./ServerEnv";
 
@@ -272,6 +273,28 @@ export function registerAdminBotRoutes(opts: {
       liveStats: game.liveStats(),
     });
   });
+
+  // The FINAL archived game record (placements, tiles, kills, winner) — the
+  // authoritative post-game scoring input. Unlike /roster and /stats, which read
+  // the live in-memory game and 404 once it ends, this reads the archive, so it
+  // resolves after the game is over (which is exactly when a scoring caller needs
+  // it). Key-gated like every route here: it is the authenticated equivalent of
+  // the unauthenticated public /public/game/:id record, for callers that cannot
+  // take the public path.
+  app.get(
+    "/api/adminbot/game/:id/record",
+    requireAdminBotKey,
+    async (req, res) => {
+      const id = req.params.id as string;
+      if (!ownsGame(id, res)) return;
+
+      const record = await readGameRecord(id);
+      if (record === null) {
+        return res.status(404).json({ error: "Game record not found" });
+      }
+      res.json(record);
+    },
+  );
 
   // Send an intent. Honors the lobby-management intents; everything else 400.
   // Returns the resulting team list so the caller can assert what landed: a


### PR DESCRIPTION
## What

Adds a key-gated `GET /api/adminbot/game/:id/record` that returns the final archived game record via `readGameRecord(id)` — the authenticated equivalent of the public `GET /public/game/:id`.

## Why

The public game-record API (`/public/*`) now sits behind a Cloudflare managed challenge. That's great against scrapers, but it also blocks legitimate **server-to-server** consumers: a backend has no browser to solve the JS challenge, so it gets the "Just a moment…" interstitial (HTTP 403) instead of the JSON. Any integration that reads the authoritative post-game record for **scoring / standings / analytics** is now broken.

The admin-bot API already exposes live game data over a key-gated surface (`/api/adminbot/game/:id/roster`, `/stats`), but those read the in-memory game and 404 once it ends — which is exactly when a scoring caller needs the result. This adds the **archived** record on that same authenticated surface, so a trusted integration can fetch results after the game is over without depending on the public, challenge-guarded path.

## Details

- Same auth as the rest of the admin-bot API (`requireAdminBotKey`); no new trust surface.
- Reuses the existing `readGameRecord` archive read — no new data path.
- `ownsGame` id-format + worker-routing validation, consistent with `/roster` and `/stats`.
- Returns the same PII-stripped record shape `/public/game/:id` returns, so callers can switch paths without reshaping.
- 404 when the record isn't archived (yet); 401/404 on auth per the existing gate.
