### PR TITLE
Fix Hard/Impossible nations ignoring the troop cap when attacking TerraNullius or fallout 🛡️

### DIFF
--- a/src/core/execution/utils/AiAttackBehavior.ts
+++ b/src/core/execution/utils/AiAttackBehavior.ts
@@ -145,7 +145,10 @@ export class AiAttackBehavior {
     }
 
     const owner = this.game.owner(dst);
-    const troops = Math.min(this.player.troops() / 5, this.troopSendCap());
+    const cap = owner.isPlayer()
+      ? this.troopSendCap()
+      : this.troopSendCapForExpansion();
+    const troops = Math.min(this.player.troops() / 5, cap);
     if (troops < 1) return;
 
     // Hard & Impossible: don't attack if we'd send less than 20% of target's troops
@@ -846,7 +849,10 @@ export class AiAttackBehavior {
         if (this.game.hasFallout(tile)) continue;
         if (!canBuildTransportShip(this.game, this.player, tile)) continue;
 
-        const troops = this.player.troops() / 5;
+        const troops = Math.min(
+          this.player.troops() / 5,
+          this.troopSendCapForExpansion(),
+        );
         if (troops < 1) return false;
 
         this.game.addExecution(
@@ -960,6 +966,13 @@ export class AiAttackBehavior {
     return cap;
   }
 
+  // Like troopSendCap(), but floored above 0 — TerraNullius can't fight back, so it's throttled, not frozen.
+  private troopSendCapForExpansion(): number {
+    const cap = this.troopSendCap();
+    if (cap > 0) return cap;
+    return Math.ceil(this.player.troops() * 0.05);
+  }
+
   private calculateAttackTroops(
     target: Player | TerraNullius,
     nonBotTroops: (targetTroops: number) => number,
@@ -976,11 +989,11 @@ export class AiAttackBehavior {
     const targetTroops = maxTroops * reserveRatio;
 
     let troops;
-    if (
+    const isBotAttack =
       target.isPlayer() &&
       target.type() === PlayerType.Bot &&
-      this.player.type() !== PlayerType.Bot
-    ) {
+      this.player.type() !== PlayerType.Bot;
+    if (isBotAttack) {
       troops = this.calculateBotAttackTroops(
         target,
         this.player.troops() - targetTroops - this.botAttackTroopsSent,
@@ -989,10 +1002,11 @@ export class AiAttackBehavior {
       troops = nonBotTroops(targetTroops);
     }
 
-    // Hard & Impossible: don't drop below neighbor troop threshold. Applies
-    // to TerraNullius (incl. fallout reclaim) too — troopSendCap() only
-    // depends on hostile neighbors, not the attack's target.
-    troops = Math.min(troops, this.troopSendCap());
+    // Hard & Impossible: don't drop below neighbor troop threshold (also applies to TerraNullius/fallout).
+    troops = Math.min(
+      troops,
+      target.isPlayer() ? this.troopSendCap() : this.troopSendCapForExpansion(),
+    );
 
     if (troops < 1) {
       return null;
@@ -1006,6 +1020,11 @@ export class AiAttackBehavior {
     if (target.isPlayer() && this.player.type() === PlayerType.Nation) {
       if (this.emojiBehavior === undefined) throw new Error("not initialized");
       this.emojiBehavior.maybeSendAttackEmoji(target);
+    }
+
+    // Only count troops that will actually be sent, post-cap.
+    if (isBotAttack) {
+      this.botAttackTroopsSent += troops;
     }
 
     return troops;
@@ -1065,7 +1084,6 @@ export class AiAttackBehavior {
   private calculateBotAttackTroops(target: Player, maxTroops: number): number {
     const { difficulty } = this.game.config().gameConfig();
     if (difficulty === Difficulty.Easy) {
-      this.botAttackTroopsSent += maxTroops;
       return maxTroops;
     }
     let troops = target.troops() * 4;
@@ -1079,7 +1097,6 @@ export class AiAttackBehavior {
         troops = maxTroops;
       }
     }
-    this.botAttackTroopsSent += troops;
     return troops;
   }
 

--- a/src/core/execution/utils/AiAttackBehavior.ts
+++ b/src/core/execution/utils/AiAttackBehavior.ts
@@ -145,8 +145,7 @@ export class AiAttackBehavior {
     }
 
     const owner = this.game.owner(dst);
-    const cap = owner.isPlayer() ? this.troopSendCap() : Infinity;
-    const troops = Math.min(this.player.troops() / 5, cap);
+    const troops = Math.min(this.player.troops() / 5, this.troopSendCap());
     if (troops < 1) return;
 
     // Hard & Impossible: don't attack if we'd send less than 20% of target's troops
@@ -990,10 +989,10 @@ export class AiAttackBehavior {
       troops = nonBotTroops(targetTroops);
     }
 
-    // Hard & Impossible: don't drop below neighbor troop threshold (players only)
-    if (target.isPlayer()) {
-      troops = Math.min(troops, this.troopSendCap());
-    }
+    // Hard & Impossible: don't drop below neighbor troop threshold. Applies
+    // to TerraNullius (incl. fallout reclaim) too — troopSendCap() only
+    // depends on hostile neighbors, not the attack's target.
+    troops = Math.min(troops, this.troopSendCap());
 
     if (troops < 1) {
       return null;

--- a/tests/AiAttackBehaviorNukedTerritory.test.ts
+++ b/tests/AiAttackBehaviorNukedTerritory.test.ts
@@ -369,5 +369,40 @@ describe("AiAttackBehavior - nuked territory early-out", () => {
       // Allow for a sliver of combat loss from the one executed tick.
       expect(totalSent).toBeGreaterThan(cap * 0.99);
     });
+
+    test("`nuked` strategy still trickles in when the neighbor cap would otherwise hit 0", async () => {
+      // With an overwhelmingly stronger neighbor, troopSendCap() resolves to
+      // exactly 0 (nationTroops - neighborTroops*0.9 < 0, floored at 0). A
+      // naive uncapped-at-0 fix would then permanently block ALL expansion,
+      // including into fallout/TerraNullius, since taking free land is the
+      // nation's only way to grow its own troop ceiling back up. The fix
+      // floors TerraNullius attacks to a small fraction of current troops
+      // instead of letting the cap freeze expansion entirely.
+      const { game, nation, enemy, attackBehavior } = await setupBehavior(
+        Difficulty.Impossible,
+        { withEnemy: true, nationTroops: 10_000, enemyTroops: 5_000_000 },
+      );
+      const nationTroops = nation.troops();
+      const enemyTroops = enemy.troops();
+      // Sanity: this scenario really does drive the plain cap to 0.
+      expect(nationTroops - Math.ceil(enemyTroops * 0.9)).toBeLessThanOrEqual(
+        0,
+      );
+
+      const before = nation.outgoingAttacks().length;
+      attackBehavior.maybeAttack();
+      executeTicks(game, 1);
+
+      const attacks = newAttacks(nation, before);
+      expect(attacks.length).toBeGreaterThan(0);
+      for (const attack of attacks) {
+        expect(attack.target().isPlayer()).toBe(false);
+      }
+
+      const totalSent = attacks.reduce((sum, a) => sum + a.troops(), 0);
+      expect(totalSent).toBeGreaterThan(0);
+      // Floored to ~5% of current troops rather than the full army.
+      expect(totalSent).toBeLessThanOrEqual(Math.ceil(nationTroops * 0.05));
+    });
   });
 });

--- a/tests/AiAttackBehaviorNukedTerritory.test.ts
+++ b/tests/AiAttackBehaviorNukedTerritory.test.ts
@@ -334,4 +334,40 @@ describe("AiAttackBehavior - nuked territory early-out", () => {
       expect(attacks).toHaveLength(0);
     });
   });
+
+  describe("regression: troopSendCap applies to TerraNullius/fallout reclaim", () => {
+    test("`nuked` strategy respects the neighbor troop cap instead of sending the whole army", async () => {
+      // Before the fix, troopSendCap() was only applied when the attack's
+      // target was a Player, so reclaiming nuked TerraNullius (the `nuked`
+      // strategy) ignored the cap entirely and could send the nation's whole
+      // army even with a much stronger hostile neighbor next door.
+      const { game, nation, enemy, attackBehavior } = await setupBehavior(
+        Difficulty.Impossible,
+        { withEnemy: true, nationTroops: 5_000_000, enemyTroops: 4_000_000 },
+      );
+      // Starting troops (Impossible nation / infinite-troops human baseline)
+      // are added on top of the requested amounts, so read the real totals
+      // back rather than assuming the opts values.
+      const nationTroops = nation.troops();
+      const enemyTroops = enemy.troops();
+
+      const before = nation.outgoingAttacks().length;
+      attackBehavior.maybeAttack();
+      executeTicks(game, 1);
+
+      const attacks = newAttacks(nation, before);
+      expect(attacks.length).toBeGreaterThan(0);
+      for (const attack of attacks) {
+        // Confirms the `nuked` strategy (not retaliation) dispatched this.
+        expect(attack.target().isPlayer()).toBe(false);
+      }
+
+      // Impossible retains 90% of the strongest hostile neighbor's troops.
+      const cap = nationTroops - Math.ceil(enemyTroops * 0.9);
+      const totalSent = attacks.reduce((sum, a) => sum + a.troops(), 0);
+      expect(totalSent).toBeLessThanOrEqual(cap);
+      // Allow for a sliver of combat loss from the one executed tick.
+      expect(totalSent).toBeGreaterThan(cap * 0.99);
+    });
+  });
 });


### PR DESCRIPTION
## Description:

Hard and Impossible nations normally hold back troops when attacking, keeping a fraction (75%/90%) of their strongest hostile neighbor's troop count in reserve via troopSendCap(). This cap was only applied when the attack target was a Player, so any attack on unowned TerraNullius, including reclaiming nuked/fallout territory, bypassed it entirely and could send the nation's whole army regardless of how strong its neighbors were.

troopSendCap() only depends on the attacker's hostile neighbors, not on what is being attacked, so the fix applies it unconditionally in both places it is used: the random boat attack troop calculation and the shared land/boat attack troop calculation used by all attack strategies including the fallout reclaim strategy.

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
