### PR TITLE
feat(lobby): show a friend marker in the lobby player list

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -695,6 +695,7 @@
     "incoming": "Incoming",
     "load_failed": "Failed to load friends",
     "load_more": "Load More",
+    "lobby_marker": "On your friends list",
     "no_friends": "You haven't added any friends yet.",
     "outgoing": "Outgoing",
     "pending_requests": "Pending Requests",

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -224,6 +224,8 @@ export class JoinLobbyModal extends BaseModal {
                         .clients=${this.players}
                         .lobbyCreatorClientID=${hostClientID}
                         .currentClientID=${this.currentClientID}
+                        .anonymizeNames=${this.gameConfig?.anonymizeNames ??
+                        false}
                         .teamCount=${this.gameConfig?.playerTeams ?? 2}
                         .isPublicGame=${this.gameConfig?.gameType ===
                         GameType.Public}

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -14,7 +14,7 @@ import {
 } from "../../core/game/Game";
 import { assignTeamsLobbyPreview } from "../../core/game/TeamAssignment";
 import { UserSettings } from "../../core/game/UserSettings";
-import { ClientInfo, TeamCountConfig } from "../../core/Schemas";
+import { ClientID, ClientInfo, TeamCountConfig } from "../../core/Schemas";
 import { createRandomName, formatPlayerDisplayName } from "../../core/Util";
 import { Theme, themeProvider } from "../theme/ThemeProvider";
 import {
@@ -51,6 +51,7 @@ export class LobbyTeamView extends LitElement {
   @state() private showTeamColors: boolean = false;
   private _clanUpdateTimeout: number | null = null;
   private _teamClanTags: Map<Team, string | null> = new Map();
+  private _viewerFriends: ReadonlySet<ClientID> = new Set();
 
   // Spectators are in the lobby roster (flagged) but hold no seat and never
   // reach the simulation — so the count header, the team preview and both
@@ -76,6 +77,15 @@ export class LobbyTeamView extends LitElement {
   }
 
   willUpdate(changedProperties: Map<string, any>) {
+    if (
+      changedProperties.has("clients") ||
+      changedProperties.has("currentClientID")
+    ) {
+      const self = this.currentClientID
+        ? this.clients.find((c) => c.clientID === this.currentClientID)
+        : undefined;
+      this._viewerFriends = new Set(self?.friends ?? []);
+    }
     // Recompute team preview when relevant properties change
     // clients is updated from WebSocket lobby_info events
     if (
@@ -202,6 +212,7 @@ export class LobbyTeamView extends LitElement {
                 : "bg-gray-700/70 border-transparent"}"
             >
               ${displayName} ${this.renderVerifiedBadge(client)}
+              ${this.renderFriendBadge(client)}
             </div>`;
           },
         )}
@@ -264,7 +275,8 @@ export class LobbyTeamView extends LitElement {
             : ""}"
         >
           <span class="text-white"
-            >${displayName} ${this.renderVerifiedBadge(client)}</span
+            >${displayName} ${this.renderVerifiedBadge(client)}
+            ${this.renderFriendBadge(client)}</span
           >
           ${this.renderRevealToggle(client.clientID)}
           ${client.clientID === this.lobbyCreatorClientID
@@ -341,7 +353,8 @@ export class LobbyTeamView extends LitElement {
                       : "bg-gray-700/70 border-transparent"}"
                   >
                     <span class="truncate text-white"
-                      >${displayName} ${this.renderVerifiedBadge(p)}</span
+                      >${displayName} ${this.renderVerifiedBadge(p)}
+                      ${this.renderFriendBadge(p)}</span
                     >
                     ${this.renderRevealToggle(p.clientID)}
                     ${p.clientID === this.lobbyCreatorClientID
@@ -555,6 +568,29 @@ export class LobbyTeamView extends LitElement {
         fill="none"
         stroke-linecap="round"
         stroke-linejoin="round"
+      ></path>
+    </svg>`;
+  }
+
+  // A mark for players on the viewer's friends list
+  private renderFriendBadge(client: ClientInfo) {
+    if (!this._viewerFriends.has(client.clientID)) return html``;
+    if (this.isCurrentPlayer(client)) return html``;
+    if (this.userSettings.anonymousNames()) return html``;
+    return html`<svg
+      viewBox="0 0 24 24"
+      class="lobby-friend-badge inline-block w-4 h-4 align-[-3px] text-emerald-400 shrink-0"
+      fill="currentColor"
+      aria-label=${translateText("friends.lobby_marker")}
+    >
+      <title>${translateText("friends.lobby_marker")}</title>
+      <circle cx="9" cy="8" r="3.6"></circle>
+      <path
+        d="M9 13.2c-3.4 0-6.3 1.7-6.3 3.9V20h12.6v-2.9c0-2.2-2.9-3.9-6.3-3.9z"
+      ></path>
+      <circle cx="17.4" cy="8.6" r="2.9"></circle>
+      <path
+        d="M17.4 13.4c-.7 0-1.3.06-1.9.18 1.2 1 1.9 2.24 1.9 3.52V20h5.4v-2.6c0-1.9-2.4-4-5.4-4z"
       ></path>
     </svg>`;
   }

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -206,7 +206,7 @@ export class LobbyTeamView extends LitElement {
           (client) => {
             const displayName = this.getClientDisplayName(client);
             return html`<div
-              class="px-2 py-1 rounded-sm mb-1 text-xs text-white border
+              class="px-2 py-1 rounded-sm mb-1 text-xs text-white border break-words
                 ${this.isCurrentPlayer(client)
                 ? "bg-malibu-blue/20 border-sky-500/40"
                 : "bg-gray-700/70 border-transparent"}"
@@ -352,10 +352,11 @@ export class LobbyTeamView extends LitElement {
                       ? "bg-malibu-blue/20 border-sky-500/40"
                       : "bg-gray-700/70 border-transparent"}"
                   >
-                    <span class="truncate text-white"
-                      >${displayName} ${this.renderVerifiedBadge(p)}
-                      ${this.renderFriendBadge(p)}</span
-                    >
+                    <span class="flex items-center gap-1 min-w-0">
+                      <span class="truncate text-white">${displayName}</span>
+                      ${this.renderVerifiedBadge(p)}
+                      ${this.renderFriendBadge(p)}
+                    </span>
                     ${this.renderRevealToggle(p.clientID)}
                     ${p.clientID === this.lobbyCreatorClientID
                       ? html`<span class="ml-2 text-[11px] text-green-300"

--- a/src/client/components/LobbyPlayerView.ts
+++ b/src/client/components/LobbyPlayerView.ts
@@ -576,7 +576,8 @@ export class LobbyTeamView extends LitElement {
   private renderFriendBadge(client: ClientInfo) {
     if (!this._viewerFriends.has(client.clientID)) return html``;
     if (this.isCurrentPlayer(client)) return html``;
-    if (this.userSettings.anonymousNames()) return html``;
+    if (this.anonymizeNames || this.userSettings.anonymousNames())
+      return html``;
     return html`<svg
       viewBox="0 0 24 24"
       class="lobby-friend-badge inline-block w-4 h-4 align-[-3px] text-emerald-400 shrink-0"

--- a/tests/client/components/LobbyPlayerView.friendMarker.test.ts
+++ b/tests/client/components/LobbyPlayerView.friendMarker.test.ts
@@ -109,6 +109,16 @@ describe("lobby friend marker", () => {
     expect(markedPlayers(view)).toEqual([]);
   });
 
+  it("withholds the marker when the lobby anonymizes names", async () => {
+    const view = await mount({
+      currentClientID: "me",
+      anonymizeNames: true,
+      clients: [client("me", { friends: ["pal"] }), client("pal")],
+    });
+
+    expect(markedPlayers(view)).toEqual([]);
+  });
+
   it("recomputes when the roster changes", async () => {
     const view = await mount({
       currentClientID: "me",

--- a/tests/client/components/LobbyPlayerView.friendMarker.test.ts
+++ b/tests/client/components/LobbyPlayerView.friendMarker.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import "../../../src/client/components/LobbyPlayerView";
+import type { LobbyTeamView } from "../../../src/client/components/LobbyPlayerView";
+import { GameMode } from "../../../src/core/game/Game";
+import { UserSettings } from "../../../src/core/game/UserSettings";
+import type { ClientInfo } from "../../../src/core/Schemas";
+
+function client(
+  clientID: string,
+  overrides: Partial<ClientInfo> = {},
+): ClientInfo {
+  return {
+    clientID,
+    username: clientID,
+    clanTag: null,
+    ...overrides,
+  };
+}
+
+async function mount(
+  props: Partial<LobbyTeamView> & { clients: ClientInfo[] },
+): Promise<LobbyTeamView> {
+  const view = document.createElement("lobby-player-view") as LobbyTeamView;
+  view.gameMode = GameMode.FFA;
+  Object.assign(view, props);
+  document.body.append(view);
+  await view.updateComplete;
+  return view;
+}
+
+function markedPlayers(view: LobbyTeamView): string[] {
+  return Array.from(view.querySelectorAll(".lobby-friend-badge")).map(
+    (badge) => {
+      const row = badge.closest(".player-tag, div");
+      if (row === null) return "";
+
+      const clone = row.cloneNode(true) as HTMLElement;
+      clone.querySelectorAll("svg").forEach((svg) => svg.remove());
+      return clone.textContent?.trim() ?? "";
+    },
+  );
+}
+
+describe("lobby friend marker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    (
+      UserSettings as unknown as { cache: Map<string, string | null> }
+    ).cache.clear();
+    document.body.replaceChildren();
+  });
+
+  it("marks the players on the viewer's friends list", async () => {
+    const view = await mount({
+      currentClientID: "me",
+      clients: [
+        client("me", { friends: ["pal"] }),
+        client("pal"),
+        client("stranger"),
+      ],
+    });
+
+    expect(markedPlayers(view)).toEqual(["pal"]);
+  });
+
+  it("does not mark the viewer themselves", async () => {
+    const view = await mount({
+      currentClientID: "me",
+      clients: [client("me", { friends: ["me", "pal"] }), client("pal")],
+    });
+
+    expect(markedPlayers(view)).toEqual(["pal"]);
+  });
+
+  it("marks friends in both team-mode lists", async () => {
+    const view = await mount({
+      gameMode: GameMode.Team,
+      teamCount: 2,
+      currentClientID: "me",
+      clients: [client("me", { friends: ["pal"] }), client("pal")],
+    });
+
+    expect(view.querySelectorAll(".lobby-friend-badge").length).toBe(2);
+    expect(markedPlayers(view)).toEqual(["pal", "pal"]);
+  });
+
+  it("never reads another client's friends list", async () => {
+    const view = await mount({
+      currentClientID: "me",
+      clients: [
+        client("me"),
+
+        client("teammate", { friends: ["me", "stranger"] }),
+        client("stranger"),
+      ],
+    });
+
+    expect(markedPlayers(view)).toEqual([]);
+  });
+
+  it("withholds the marker when the viewer anonymizes names", async () => {
+    new UserSettings().toggleRandomName();
+
+    const view = await mount({
+      currentClientID: "me",
+      clients: [client("me", { friends: ["pal"] }), client("pal")],
+    });
+
+    expect(markedPlayers(view)).toEqual([]);
+  });
+
+  it("recomputes when the roster changes", async () => {
+    const view = await mount({
+      currentClientID: "me",
+      clients: [client("me", { friends: ["pal"] }), client("pal")],
+    });
+    expect(markedPlayers(view)).toEqual(["pal"]);
+
+    view.clients = [
+      client("me", { friends: ["pal", "buddy"] }),
+      client("pal"),
+      client("buddy"),
+    ];
+    await view.updateComplete;
+
+    expect(markedPlayers(view)).toEqual(["pal", "buddy"]);
+  });
+});


### PR DESCRIPTION
Resolves #5272

## Description:

Adds a small marker next to players in the lobby list who are on the viewer's friends list, next to the existing verified check and clan tag

Suppressed when the row's name is locally anonymized (same rule as with the verified badge)

## Screenshots
<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/ba70ca60-7d2e-4df3-9ed0-7cae9af67fd6" />
<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/ba1c24c9-16cb-4c1f-b0aa-06a89b4b049c" />
<img width="2560" height="1800" alt="image" src="https://github.com/user-attachments/assets/d4ede2d6-2138-4f1f-ad6d-afc2dbefc232" />


## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory