### PR TITLE
fix(ci): install Claude Code from npm to dodge broken native installer

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,10 +47,26 @@ jobs:
           submodules: false
           persist-credentials: false
 
+      # The action's native installer intermittently exits 0 while never
+      # placing a working launcher at ~/.local/bin/claude; the action trusts
+      # the exit code and then dies spawning the missing binary at the
+      # plugin-marketplace step (anthropics/claude-code-action#1290; every
+      # review run here since 2026-09-08 22:31 UTC failed this way). Install
+      # the same version from npm instead and hand the action the path, which
+      # skips the native installer entirely. The pin matches the version the
+      # action itself installs (its bundled agent SDK 0.3.x maps to CLI 2.1.x);
+      # bump it when bumping the action.
+      - name: Install Claude Code from npm
+        id: install-claude
+        run: |
+          npm install -g @anthropic-ai/claude-code@2.1.265
+          echo "path=$(command -v claude)" >> "$GITHUB_OUTPUT"
+
       - name: Claude multi-agent review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          path_to_claude_code_executable: ${{ steps.install-claude.outputs.path }}
 
           # The action refuses to run for an actor without write access to the
           # repo (src/github/validation/permissions.ts), and on a fork PR the


### PR DESCRIPTION
## Problem

Every 🤖 Claude Code Review run since **2026-09-08 22:31 UTC** fails during action setup (e.g. [this run on #5296](https://github.com/openfrontio/OpenFrontIO/actions/runs/34286389321)):

```
⚠ Setup notes:
  ● claude command at /home/runner/.local/bin/claude missing or broken
✔ Claude Code successfully installed!
...
##[error]Action failed with error: Failed to add marketplace 'https://github.com/anthropics/claude-code.git': ENOENT: no such file or directory, posix_spawn '/home/runner/.local/bin/claude'
```

The native installer exits 0 without actually placing a working launcher, and the action trusts the exit code and dies spawning the missing binary at the plugin-marketplace step. A run at 21:44 UTC succeeded with the **same** action SHA (`0d0e087`), same runner image (ubuntu-24.04 `20260831.293.1`), and same CLI version (2.1.265) — the regression is in the runtime-fetched install artifacts. Known upstream: anthropics/claude-code-action#1290 (fix pending in anthropics/claude-code-action#1754). A re-run reproduced the failure, so it's not a flake.

## Fix

Install the same CLI version (2.1.265, matching the action's bundled agent SDK 0.3.265) from npm in a prior step and pass it via the action's `path_to_claude_code_executable` input, which skips the native installer entirely. Verified in the action source at the pinned SHA that the custom path flows through to both the marketplace-add spawn and the SDK invocation.

Note: this workflow runs on `pull_request_target`, so the fix only takes effect after merge — it can't be exercised by this PR's own checks (and this PR touches no paths that trigger the review anyway).

🤖 Generated with [Claude Code](https://claude.com/claude-code)