### PR TITLE
Accept 8-10 char game ids ahead of the multi-server format

### DIFF
--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -557,7 +557,11 @@ const TokenSchema = z
 
 const EmojiSchema = zb.uint({ max: flattenedEmojiTable.length - 1 });
 
-export const GAME_ID_REGEX = /^[A-Za-z0-9]{8}$/;
+// 8–10: today's ids are 8 chars; multi-server ids (docs/MultiServer.md) will
+// be 10 (instance letter + 9 random). The range ships ahead of the new format
+// so every deployed client/server validates the longer ids before any are
+// minted — old bundles reject unknown id lengths at the Zod layer.
+export const GAME_ID_REGEX = /^[A-Za-z0-9]{8,10}$/;
 
 export const isValidGameID = (value: string): boolean =>
   GAME_ID_REGEX.test(value);

--- a/tests/core/GameIdRegex.test.ts
+++ b/tests/core/GameIdRegex.test.ts
@@ -21,7 +21,7 @@ describe("GAME_ID_REGEX", () => {
     "", // empty
     "AbCd 234", // space
     "AbCd-234", // punctuation
-    "AbCd123\n", // trailing newline (regex must be anchored)
+    "AbCd1234\n", // valid 8-char body + newline (regex must be anchored)
   ])("rejects %j", (id) => {
     expect(GAME_ID_REGEX.test(id)).toBe(false);
     expect(isValidGameID(id)).toBe(false);

--- a/tests/core/GameIdRegex.test.ts
+++ b/tests/core/GameIdRegex.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import { GAME_ID_REGEX, ID, isValidGameID } from "../../src/core/Schemas";
+import { generateID } from "../../src/core/Util";
+
+// Game ids are permanent archive keys, so the accepted range must cover every
+// id ever minted: the historical 8-char format and the upcoming 10-char
+// multi-server format (instance letter + 9 random, docs/MultiServer.md).
+describe("GAME_ID_REGEX", () => {
+  it.each(["AbCd1234", "AbCd12345", "AbCd123456"])(
+    "accepts %s (8–10 alphanumeric chars)",
+    (id) => {
+      expect(GAME_ID_REGEX.test(id)).toBe(true);
+      expect(isValidGameID(id)).toBe(true);
+      expect(ID.safeParse(id).success).toBe(true);
+    },
+  );
+
+  it.each([
+    "AbCd123", // 7 chars: too short
+    "AbCd1234567", // 11 chars: too long
+    "", // empty
+    "AbCd 234", // space
+    "AbCd-234", // punctuation
+    "AbCd123\n", // trailing newline (regex must be anchored)
+  ])("rejects %j", (id) => {
+    expect(GAME_ID_REGEX.test(id)).toBe(false);
+    expect(isValidGameID(id)).toBe(false);
+    expect(ID.safeParse(id).success).toBe(false);
+  });
+
+  // Minting is unchanged in this PR: the widened range only ships validation
+  // ahead of the 10-char format, so old bundles have soaked before any longer
+  // id exists.
+  it("generateID still mints 8-char ids that match the regex", () => {
+    for (let i = 0; i < 100; i++) {
+      const id = generateID();
+      expect(id).toHaveLength(8);
+      expect(GAME_ID_REGEX.test(id)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Widen `GAME_ID_REGEX` from exactly 8 to 8–10 alphanumeric chars. Multi-server game ids ([docs/MultiServer.md](https://github.com/openfrontio/OpenFrontIO/pull/5295), PR 1 of that plan) will be 10 chars: an instance letter plus 9 random.
- Minting is unchanged — `generateID()` still produces 8-char ids, pinned by test. This PR only ships validation ahead of the format change.
- Why it must land (and soak) first: game ids are Zod-validated by every deployed bundle — web clients, the desktop/Steam build, and servers. The zbin wire format (varint length + UTF-8) carries longer ids fine, but old bundles reject unknown lengths at the validation layer. The wider regex needs to be in every bundle in the field before the first 10-char id is minted.
- Client ids share the regex via `MappedID`; they also stay 8 chars at mint, and the widened validation range is harmless for them.

## Test plan
- New `tests/core/GameIdRegex.test.ts`: accepts 8/9/10-char ids, rejects 7/11/empty/punctuation/unanchored input, pins `generateID()` at 8 chars.
- Full suite: `npm test` — 378 + 59 files, 5428 tests, all passing.
- `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)