### PR TITLE
Update CLA for OpenFront Inc

### DIFF
--- a/CLA.md
+++ b/CLA.md
@@ -1,0 +1,65 @@
+# Contributor License Agreement (CLA)
+
+**OpenFront Inc.**
+
+Thank you for your interest in contributing to projects owned or managed by OpenFront Inc., a Delaware corporation with its registered address at 2140 South DuPont Hwy, Camden, DE 19934 ("OpenFront"). This Contributor License Agreement ("Agreement") documents the rights granted by the contributor identified below ("You") to OpenFront. By signing this Agreement, or by submitting a Contribution to OpenFront, You accept and agree to the following terms and conditions for Your present, past, and future Contributions. Except for the licenses granted herein to OpenFront and recipients of software distributed by OpenFront, You reserve all right, title, and interest in and to Your Contributions.
+
+## 1. Definitions
+
+**1.1** "You" (or "Your") means the copyright owner or legal entity authorized by the copyright owner that is entering into this Agreement with OpenFront. For legal entities, the entity making a Contribution and all other entities that control, are controlled by, or are under common control with that entity are considered a single Contributor.
+
+**1.2** "Contribution" means any original work of authorship, including but not limited to source code, object code, scripts, patches, documentation, artwork, music, sound, images, or any other material, that You Submit to OpenFront for inclusion in, or use with, any Project. **"Contribution" includes all such works You Submitted to OpenFront or its predecessor, OpenFront LLC, at any time prior to the date of this Agreement, as well as all works You Submit on or after that date.**
+
+**1.3** "Submit" (or "Submitted") means any form of electronic, verbal, or written communication sent to OpenFront or its representatives, including but not limited to communication via pull requests, source code repositories, issue trackers, and mailing lists managed by or on behalf of OpenFront, excluding communication that is conspicuously marked or otherwise designated in writing by You as "Not a Contribution."
+
+**1.4** "Project" means any software, game, digital product, or content platform owned, managed, maintained, or distributed by OpenFront.
+
+## 2. Grant of Copyright License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to OpenFront and to recipients of software distributed by OpenFront a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute Your Contributions and such derivative works.
+
+## 3. Grant of Patent License
+
+Subject to the terms and conditions of this Agreement, You hereby grant to OpenFront and to recipients of software distributed by OpenFront a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer Your Contributions, where such license applies only to those patent claims licensable by You that are necessarily infringed by Your Contributions alone or by combination of Your Contributions with the Project to which such Contributions were Submitted. If any entity institutes patent litigation against You or any other entity alleging that Your Contribution, or the Project to which You contributed, constitutes direct or contributory patent infringement, then any patent licenses granted to that entity under this Agreement for that Contribution or Project shall terminate as of the date such litigation is filed.
+
+## 4. Outbound Licensing
+
+OpenFront may license Contributions, and derivative works thereof, under license terms of its choosing, including:
+
+**(a)** for source code Contributions, the GNU General Public License (GPL) version 2 or later, or the GNU Affero General Public License (AGPL) version 3 or later, at OpenFront's discretion; and
+
+**(b)** for non-code Contributions (assets, documentation, artwork, music, sound, and similar materials), such license terms as OpenFront deems appropriate, which may differ from the terms applied to source code.
+
+## 5. Your Representations
+
+You represent that:
+
+**(a)** You are legally entitled to grant the above licenses. If Your employer(s) has rights to intellectual property that You create that includes Your Contributions, You represent that You have received permission to make Contributions on behalf of that employer, that Your employer has waived such rights for Your Contributions, or that Your employer has entered into a separate agreement with OpenFront covering Your Contributions.
+
+**(b)** Each of Your Contributions is Your original creation (see Section 6 for submissions on behalf of others).
+
+**(c)** To Your knowledge, Your Contributions do not infringe the intellectual property rights of any third party, and no Contribution includes confidential or proprietary information of any third party.
+
+You agree to notify OpenFront of any facts or circumstances of which You become aware that would make these representations inaccurate in any respect.
+
+## 6. Third-Party Works
+
+Should You wish to Submit work that is not Your original creation, You may Submit it separately from any Contribution, identifying the complete details of its source and of any license or other restriction (including, but not limited to, related patents, trademarks, and license agreements) of which You are personally aware, and conspicuously marking the work as "Submitted on behalf of a third-party: [named here]".
+
+## 7. No Obligation; No Compensation
+
+You understand that the decision to include Your Contribution in any Project is entirely at the discretion of OpenFront, and that OpenFront is under no obligation to use, include, or retain any Contribution. All Contributions are made without expectation of compensation, unless otherwise agreed in writing. You are not expected to provide support for Your Contributions, except to the extent You desire to provide support.
+
+## 8. Disclaimer
+
+Unless required by applicable law or agreed to in writing, You provide Your Contributions on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE.
+
+## 9. Miscellaneous
+
+**(a)** This Agreement shall be governed by the laws of the State of Delaware, without regard to its conflict of law rules.
+
+**(b)** This Agreement is for the benefit of OpenFront and its successors and assigns, and supersedes any prior contributor license agreement between You and OpenFront or OpenFront LLC with respect to its subject matter, including any such agreement entered into with OpenFront LLC, to which OpenFront Inc. is the successor in interest. Licenses granted to OpenFront LLC under any prior agreement are hereby confirmed as granted to OpenFront Inc.
+
+**(c)** This Agreement constitutes the entire agreement between the parties regarding its subject matter. Any amendment must be made in writing and signed by both parties.
+
+**(d)** If any provision of this Agreement is found to be unenforceable, the remaining provisions shall remain in full force and effect.


### PR DESCRIPTION
## Summary

Adds an updated Contributor License Agreement (`CLA.md`) reflecting the company's conversion to **OpenFront Inc.** (Delaware), rewritten on the Apache ICLA template — the de-facto standard used by most corporate-backed open source projects.

### Changes from the previous CLA

- **Entity updated** to OpenFront Inc., a Delaware corporation, 2140 South DuPont Hwy, Camden, DE 19934
- **All past contributions covered**: the "Contribution" definition explicitly includes works submitted to OpenFront LLC before this agreement's date, and §9(b) confirms licenses granted to OpenFront LLC now run to OpenFront Inc. as successor in interest
- **Patent license grant added** (§3) with the standard litigation-termination clause
- **Standard ICLA machinery added**: "Submit" definition, employer-rights representation, third-party works procedure
- **Indemnity clause dropped** in favor of the standard "AS IS" disclaimer plus a duty to notify of inaccurate representations
- **Code vs. assets outbound licensing split preserved** (GPL v2+/AGPL v3+ for code; separate terms for assets)
- **Governing law** changed from California to Delaware to match the state of incorporation

### Notes for reviewers

- The authoritative copy for the CLA Assistant signing flow is the linked GitHub Gist — that needs to be updated separately to match this file; this `CLA.md` is the in-repo human-readable copy.
- The retroactivity clause binds a contributor's past contributions once they sign the new version, so re-signing should be required in CLA Assistant after the gist is updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)