### PR TITLE
fix(client): tolerate unknown bareClaim values (OPE-271)

### DIFF
--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -349,7 +349,17 @@ export const PutUsernameResponseSchema = z.object({
   // response is parsed with safeParse, so requiring the field would make every
   // rename against the current API fail validation and surface as a generic
   // "failed". Treat `undefined` as "the API predates this" and say nothing.
-  bareClaim: BareClaimSchema.optional(),
+  //
+  // `.catch(undefined)` for the mirror image of the same skew: the client also
+  // ships BEHIND the API, on every API change, not just this one. A fourth
+  // value added server-side would otherwise fail safeParse on every
+  // un-updated client — and this is a 200, so the rename has already
+  // committed. Rejecting would report failure for a rename that succeeded,
+  // spend the player's 30-day cooldown and reopen the modal on a name they
+  // never chose. Degrading an unknown value to `undefined` degrades to "say
+  // nothing", which is the intended behaviour for a client that predates the
+  // value (warnBareClaimUnavailable only acts on "unavailable").
+  bareClaim: BareClaimSchema.optional().catch(undefined),
 });
 export type PutUsernameResponse = z.infer<typeof PutUsernameResponseSchema>;
 

--- a/src/core/ApiSchemas.ts
+++ b/src/core/ApiSchemas.ts
@@ -356,9 +356,15 @@ export const PutUsernameResponseSchema = z.object({
   // un-updated client — and this is a 200, so the rename has already
   // committed. Rejecting would report failure for a rename that succeeded,
   // spend the player's 30-day cooldown and reopen the modal on a name they
-  // never chose. Degrading an unknown value to `undefined` degrades to "say
-  // nothing", which is the intended behaviour for a client that predates the
-  // value (warnBareClaimUnavailable only acts on "unavailable").
+  // never chose. An unknown value is therefore treated as absent, which means
+  // "say nothing".
+  //
+  // The contract that keeps this safe: "unavailable" is the only value that
+  // obliges a client to say anything, so it must remain the value sent
+  // whenever a premium player is given a suffixed name. New values may be
+  // added only for outcomes where saying nothing is correct — splitting
+  // "unavailable" into narrower values would silence this message on clients
+  // that predate the split.
   bareClaim: BareClaimSchema.optional().catch(undefined),
 });
 export type PutUsernameResponse = z.infer<typeof PutUsernameResponseSchema>;

--- a/tests/ApiSchemas.test.ts
+++ b/tests/ApiSchemas.test.ts
@@ -878,6 +878,19 @@ describe("PutUsernameResponseSchema", () => {
     delete rest.base;
     expect(PutUsernameResponseSchema.safeParse(rest).success).toBe(false);
   });
+
+  // Deliberately lenient, unlike every other field here: this is a 200, so
+  // the rename has already committed server-side. Rejecting an unknown
+  // bareClaim would report failure for a rename that succeeded and burn the
+  // player's 30-day cooldown. Dropping it degrades to "say nothing".
+  it("drops an unknown bareClaim instead of failing the parse", () => {
+    const result = PutUsernameResponseSchema.safeParse({
+      ...base,
+      bareClaim: "nope",
+    });
+    expect(result.success).toBe(true);
+    expect(result.success && result.data.bareClaim).toBeUndefined();
+  });
 });
 
 describe("UserMeResponseSchema creator", () => {

--- a/tests/client/UsernameBareClaim.test.ts
+++ b/tests/client/UsernameBareClaim.test.ts
@@ -66,10 +66,27 @@ describe("PutUsernameResponseSchema bareClaim", () => {
     }
   });
 
-  it("rejects a value outside the enum rather than passing it through", () => {
+  // The same skew in the other direction: the client ships BEHIND the API
+  // too, on every API change. This is a 200 — the rename has committed — so
+  // failing the parse would report failure for a rename that succeeded and
+  // burn the 30-day cooldown. Dropping the value degrades to "say nothing",
+  // which is exactly how a client that predates the value should behave.
+  it("drops a value outside the enum rather than failing the parse", () => {
+    const parsed = PutUsernameResponseSchema.safeParse(
+      okBody({ bareClaim: "nope" }),
+    );
+    expect(parsed.success).toBe(true);
+    // Specifically `undefined`, not the raw string and not some substituted
+    // enum member: `.catch("claimed")` would silently make a future
+    // "unavailable"-like value say nothing AND claim it succeeded outright.
+    expect(parsed.success && parsed.data.bareClaim).toBeUndefined();
+  });
+
+  // The rest of the body still has to be right — tolerating an unknown
+  // bareClaim must not turn into tolerating a malformed response.
+  it("still rejects a response whose other fields are wrong", () => {
     expect(
-      PutUsernameResponseSchema.safeParse(okBody({ bareClaim: "nope" }))
-        .success,
+      PutUsernameResponseSchema.safeParse(okBody({ username: 42 })).success,
     ).toBe(false);
   });
 });
@@ -164,6 +181,42 @@ describe("UsernamePanel bare-claim fallback", () => {
     expect(reload).toHaveBeenCalled();
   });
 
+  // The `await` on the dialog is load-bearing: without it the reload races
+  // the dialog away and the player never reads why their name changed.
+  //
+  // Note what does NOT hold it: `showInGameAlert` is *invoked* synchronously
+  // either way (an async function runs to its first await), so
+  // invocationCallOrder alone still passes when the `await` is replaced with
+  // `void`. What distinguishes them is whether the reload waits for the
+  // dialog to be dismissed, so the alert is left pending here.
+  it("does not reload until the player has dismissed the dialog", async () => {
+    let dismiss!: () => void;
+    showInGameAlert.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          dismiss = () => resolve(true);
+        }),
+    );
+    updateUsername.mockResolvedValue({
+      ok: true,
+      data: okBody({ bareClaim: "unavailable" }),
+    });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
+    expect(reload).not.toHaveBeenCalled();
+
+    dismiss();
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(showInGameAlert.mock.invocationCallOrder[0]).toBeLessThan(
+      reload.mock.invocationCallOrder[0],
+    );
+  });
+
   it("names the date they can change again when the API supplies one", async () => {
     updateUsername.mockResolvedValue({
       ok: true,
@@ -220,6 +273,28 @@ describe("UsernamePanel bare-claim fallback", () => {
     await submit(el, "Ninja");
 
     expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(reload).toHaveBeenCalled();
+  });
+
+  // The tests above hand the panel a hand-built body, so they never reach
+  // safeParse and would not notice the schema rejecting a value. This one
+  // runs the real schema over a value no client knows yet — what a client
+  // sees the day infra adds a fourth one. The rename is a 200 and has
+  // already committed, so the only correct outcome is "success, say
+  // nothing": no dialog, no inline error, and a reload onto the new name.
+  it("treats an unknown bareClaim as a success with nothing to say", async () => {
+    updateUsername.mockResolvedValue({
+      ok: true,
+      data: PutUsernameResponseSchema.parse(
+        okBody({ bareClaim: "some_future_value" }),
+      ),
+    });
+    const el = await mount();
+
+    await submit(el, "Ninja");
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(el.textContent).not.toContain("username_error");
     expect(reload).toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What

`PutUsernameResponseSchema.bareClaim` becomes `.optional().catch(undefined)`, so an unknown value is treated as absent rather than failing the parse.

## Why

The field was made optional in #5213 because this client ships *ahead* of the API. But the skew runs both ways and recurs on **every** API change, not just the one that introduced the field.

`bareClaim` was optional but still strict: it accepted the field being absent and rejected any value outside the enum (a test pinned that rejection deliberately). So adding a fourth value server-side would fail `safeParse` on every un-updated client. `updateUsername` is parsing a **200** — the rename has already committed — so the client would:

- report failure for a rename that succeeded,
- spend the player's 30-day cooldown, and
- reopen the modal on a name they never chose,

on 100% of renames until clients caught up. That is the same failure mode #5213 was written to prevent, arriving one release later by a different route.

The asymmetry is what makes it clear-cut. `warnBareClaimUnavailable` only acts on `=== "unavailable"`, so an unknown value treated as `undefined` degrades to *"say nothing"* — the documented intended behaviour for an older client. Rejecting degrades to breaking renames for everyone.

Zod is `^4.4.2` (verified installed: exactly 4.4.2), so `.catch()` is available.

### Contract this relies on

Tolerating unknown values means an older client says nothing when it sees one. That is only safe while `"unavailable"` remains the sole value that obliges a client to speak. So: **any API outcome where a premium player receives a suffixed name instead of the bare name must keep sending `bareClaim: "unavailable"`.** New values may be added for outcomes where saying nothing is correct, but splitting `"unavailable"` into narrower values (e.g. `unavailable_reserved`) would silence the message on every client that predates the split. This is recorded in a comment on the schema.

## Tests

- The case that pinned the rejection now pins the drop, and asserts `undefined` **specifically** — so a later `.catch("claimed")` cannot pass.
- A new case in `tests/ApiSchemas.test.ts`, where the rest of the schema is pinned, so a future "tighten core schemas" pass meets the intent where schema maintainers look.
- The existing behavioural tests mock `updateUsername` wholesale and never reach `safeParse`, so a new panel test runs the **real** schema over an unknown value and asserts the rename is treated as a success with no dialog and no inline error.
- A test that the awaited notice is not torn down by the reload.

**On that last one:** the ticket proposed an `invocationCallOrder` assertion, but that does not hold the `await`. `showInGameAlert` is *invoked* synchronously either way (an async function runs to its first `await`), so the order assertion still passes when the `await` is replaced with `void`. I ran that experiment to confirm it. What distinguishes the two is whether the reload waits for the dialog to be **dismissed**, so the test leaves the alert promise pending and asserts `reload` has not fired. The order assertion is kept alongside it.

Mutation-verified, both directions:

| Mutation | Result |
| --- | --- |
| revert to `.optional()` | 3 fail (2 in `UsernameBareClaim`, 1 in `ApiSchemas`), rest pass |
| `await` → `void` in `UsernamePanel.handleSave` | 1 fails (the pending-dialog test), rest pass |

Commands run in the worktree:

```
npx vitest tests/client/UsernameBareClaim.test.ts --run          # 13 passed
npx vitest tests/ApiSchemas.test.ts tests/client/UsernameBareClaim.test.ts --run   # 158 passed
npx vitest tests/client/UsernameBareClaim.test.ts tests/client/UsernameVerifiedRoute.test.ts \
  tests/client/UsernameInput.steam.test.ts tests/client/AccountIdentity.test.ts \
  tests/client/CreatorCodePanel.test.ts tests/Api.test.ts --run   # 102 passed
npx tsc --noEmit                                                  # clean
npm run lint                                                      # clean
```

Resolves OPE-271 — https://linear.app/openfront/issue/OPE-271

🤖 Generated with [Claude Code](https://claude.com/claude-code)
