### PR TITLE
fix(client): report the debt on single-cosmetic purchase (OPE-373)

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -806,12 +806,27 @@ export async function fetchTribeStats(
   }
 }
 
+export type PurchaseWithCurrencyResult =
+  | { ok: true }
+  // 400 "Insufficient balance": the balance moved since the client's
+  // pre-check. Nothing charged.
+  | { ok: false; code: "insufficient_balance" }
+  // 400 insufficient_balance_debt: a refund/chargeback left the wallet
+  // negative; `debt` (bigint string) must be settled before anything is
+  // spendable. Nothing charged. Distinct from the above because buying more
+  // currency is not the remedy.
+  | { ok: false; code: "debt"; debt: string }
+  | { ok: false; code: "failed" };
+
+// POST /shop/purchase — buy a single cosmetic for hard or soft currency. The
+// only spend path that takes soft currency. Any error means no debit and no
+// grant. Callers invalidate the cached /users/@me on success.
 export async function purchaseWithCurrency(
   cosmeticType: "pattern" | "skin" | "flag" | "crown" | "effect",
   cosmeticName: string,
   currencyType: "hard" | "soft",
   colorPaletteName?: string,
-): Promise<boolean> {
+): Promise<PurchaseWithCurrencyResult> {
   try {
     const response = await fetch(`${getApiBase()}/shop/purchase`, {
       method: "POST",
@@ -828,7 +843,21 @@ export async function purchaseWithCurrency(
     });
     if (response.status === 401) {
       await logOut();
-      return false;
+      return { ok: false, code: "failed" };
+    }
+    if (response.status === 400) {
+      const body = await response.json().catch(() => null);
+      const reason = typeof body?.reason === "string" ? body.reason : "";
+      if (reason === "insufficient_balance_debt") {
+        return { ok: false, code: "debt", debt: String(body.debt ?? "") };
+      }
+      if (reason === "Insufficient balance") {
+        return { ok: false, code: "insufficient_balance" };
+      }
+      // Not logging the body: an unrecognised reason is exactly the case
+      // where we don't know what it contains.
+      console.warn("purchaseWithCurrency: unrecognised 400 reason");
+      return { ok: false, code: "failed" };
     }
     if (!response.ok) {
       console.error(
@@ -836,12 +865,12 @@ export async function purchaseWithCurrency(
         response.status,
         response.statusText,
       );
-      return false;
+      return { ok: false, code: "failed" };
     }
-    return true;
+    return { ok: true };
   } catch (e) {
     console.error("purchaseWithCurrency: request failed", e);
-    return false;
+    return { ok: false, code: "failed" };
   }
 }
 

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -849,7 +849,18 @@ export async function purchaseWithCurrency(
       const body = await response.json().catch(() => null);
       const reason = typeof body?.reason === "string" ? body.reason : "";
       if (reason === "insufficient_balance_debt") {
-        return { ok: false, code: "debt", debt: String(body.debt ?? "") };
+        // The amount is the whole message ("your balance is X in debt"), so a
+        // debt we can't state is worse than a generic failure: it would render
+        // a blank or "[object Object]" at the player. Digits only — the API
+        // sends a stringified positive bigint.
+        const debt = String(body?.debt ?? "");
+        if (!/^\d+$/.test(debt)) {
+          console.warn(
+            "purchaseWithCurrency: debt refusal with no usable amount",
+          );
+          return { ok: false, code: "failed" };
+        }
+        return { ok: false, code: "debt", debt };
       }
       if (reason === "Insufficient balance") {
         return { ok: false, code: "insufficient_balance" };

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -424,7 +424,9 @@ export async function purchaseCosmetic(
     method === "hard"
       ? (userMe.player.currency?.hard ?? 0)
       : (userMe.player.currency?.soft ?? 0);
-  if (balance < price) {
+  // Built for the pre-check below and reused when the server refuses for the
+  // same reason, so both routes describe the same item the same way.
+  const insufficient = (available: number): InsufficientCurrency => {
     const currencyName = translateText(
       method === "hard" ? "cosmetics.hard" : "cosmetics.soft",
     );
@@ -448,11 +450,17 @@ export async function purchaseCosmetic(
     }
     return {
       currency: currencyName,
-      shortfall: price - balance,
+      // Clamped: the server can refuse on a balance the client still reads as
+      // sufficient, and a zero or negative shortfall reads as "you have
+      // enough", which is the one thing we know is untrue.
+      shortfall: Math.max(1, price - available),
       item: itemName,
       // Only plutonium can be topped up; caps are dismiss-only.
       canTopUp: method === "hard",
     };
+  };
+  if (balance < price) {
+    return insufficient(balance);
   }
 
   const cosmeticType = resolved.type as
@@ -461,15 +469,40 @@ export async function purchaseCosmetic(
     | "flag"
     | "crown"
     | "effect";
-  const success = await purchaseWithCurrency(
+  const result = await purchaseWithCurrency(
     cosmeticType,
     c.name,
     method,
     colorPaletteName,
   );
-  if (!success) {
-    await showInGameAlert(translateText("store.purchase_failed"));
-    return;
+  if (!result.ok) {
+    switch (result.code) {
+      case "insufficient_balance": {
+        // The balance moved since the pre-check: re-read it for the shortfall,
+        // the same way the pack path does.
+        invalidateUserMe();
+        const fresh = await getUserMe();
+        const available =
+          fresh === false
+            ? 0
+            : method === "hard"
+              ? (fresh.player.currency?.hard ?? 0)
+              : (fresh.player.currency?.soft ?? 0);
+        return insufficient(available);
+      }
+      case "debt":
+        // A refund or chargeback left the wallet negative. Topping up does not
+        // unblock it, so this gets a plain explanation rather than the
+        // insufficient-currency dialog — the debt settles out of the next
+        // credit.
+        await showInGameAlert(
+          translateText("store.pack_debt", { debt: result.debt }),
+        );
+        return;
+      default:
+        await showInGameAlert(translateText("store.purchase_failed"));
+        return;
+    }
   }
   await showInGameAlert(
     translateText("store.purchase_success", { name: c.name }),

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -424,6 +424,18 @@ export async function purchaseCosmetic(
     method === "hard"
       ? (userMe.player.currency?.hard ?? 0)
       : (userMe.player.currency?.soft ?? 0);
+  // A charged-back wallet is served as a NEGATIVE balance (the API derives its
+  // own `debt` field as exactly `-hard`), so this — not the server refusal
+  // below — is how a player in debt normally gets here. Without this branch
+  // the negative balance just fails the shortfall check underneath and they
+  // are told "you need 400 more" with a top-up button that cannot clear a
+  // debt. Soft currency can never go negative, so this only fires for hard.
+  if (balance < 0) {
+    await showInGameAlert(
+      translateText("store.pack_debt", { debt: String(-balance) }),
+    );
+    return;
+  }
   // Built for the pre-check below and reused when the server refuses for the
   // same reason, so both routes describe the same item the same way.
   const insufficient = (available: number): InsufficientCurrency => {
@@ -488,13 +500,30 @@ export async function purchaseCosmetic(
             : method === "hard"
               ? (fresh.player.currency?.hard ?? 0)
               : (fresh.player.currency?.soft ?? 0);
+        // The chargeback landed mid-session, so the pre-check above ran on a
+        // cache that still showed a positive balance.
+        if (available < 0) {
+          await showInGameAlert(
+            translateText("store.pack_debt", { debt: String(-available) }),
+          );
+          return;
+        }
+        // The re-read says they can afford it. We have no shortfall to quote,
+        // and inventing one would tell them to buy currency they already have
+        // for a purchase that would now succeed.
+        if (price - available <= 0) {
+          await showInGameAlert(translateText("store.purchase_failed"));
+          return;
+        }
         return insufficient(available);
       }
       case "debt":
         // A refund or chargeback left the wallet negative. Topping up does not
         // unblock it, so this gets a plain explanation rather than the
         // insufficient-currency dialog — the debt settles out of the next
-        // credit.
+        // credit. Drop the cached profile: it still shows the pre-chargeback
+        // balance, which the store would otherwise keep rendering.
+        invalidateUserMe();
         await showInGameAlert(
           translateText("store.pack_debt", { debt: result.debt }),
         );
@@ -536,6 +565,15 @@ async function purchasePack(
     canTopUp: true,
   });
   const balance = userMe.player.currency?.hard ?? 0;
+  // Same as the single-cosmetic path: a charged-back wallet arrives here as a
+  // negative balance, and without this it reads as a very large shortfall
+  // with a top-up button that cannot clear a debt.
+  if (balance < 0) {
+    await showInGameAlert(
+      translateText("store.pack_debt", { debt: String(-balance) }),
+    );
+    return;
+  }
   if (balance < pack.priceHard) {
     return insufficient(balance);
   }
@@ -559,6 +597,9 @@ async function purchasePack(
       );
     }
     case "debt":
+      // The cached profile still shows the pre-chargeback balance; drop it so
+      // the store stops rendering a balance the player does not have.
+      invalidateUserMe();
       await showInGameAlert(
         translateText("store.pack_debt", { debt: result.debt }),
       );

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -216,10 +216,10 @@ export function handlePurchaseReturn(
  * whole app to its logged-out UI immediately after a successful purchase. A
  * stale balance is much the better failure.
  */
-async function broadcastFreshUserMe(): Promise<void> {
+async function broadcastFreshUserMe(): Promise<UserMeResponse | false> {
   invalidateUserMe();
   const fresh = await getUserMe();
-  if (fresh === false) return;
+  if (fresh === false) return false;
   document.dispatchEvent(
     new CustomEvent("userMeResponse", {
       detail: fresh,
@@ -227,6 +227,28 @@ async function broadcastFreshUserMe(): Promise<void> {
       cancelable: true,
     }),
   );
+  // Returned so a caller that also needs the new balance reads the same
+  // profile it just broadcast, rather than re-fetching it separately.
+  return fresh;
+}
+
+// "Insufficient balance" means three different things once the real balance is
+// known, and each needs a different message. Shared by the single-cosmetic and
+// pack paths so they cannot drift apart.
+function balanceOutcome(
+  balance: number,
+  price: number,
+): "debt" | "shortfall" | "unexplained" {
+  // A chargeback landed since the pre-check; topping up cannot clear it.
+  if (balance < 0) return "debt";
+  // The re-read says they can afford it, so there is no shortfall to quote and
+  // inventing one sends them to buy currency they already have.
+  if (price - balance <= 0) return "unexplained";
+  return "shortfall";
+}
+
+function debtMessage(debt: number): string {
+  return translateText("store.pack_debt", { debt: String(debt) });
 }
 
 export async function purchaseCosmetic(
@@ -431,9 +453,7 @@ export async function purchaseCosmetic(
   // are told "you need 400 more" with a top-up button that cannot clear a
   // debt. Soft currency can never go negative, so this only fires for hard.
   if (balance < 0) {
-    await showInGameAlert(
-      translateText("store.pack_debt", { debt: String(-balance) }),
-    );
+    await showInGameAlert(debtMessage(-balance));
     return;
   }
   // Built for the pre-check below and reused when the server refuses for the
@@ -491,27 +511,27 @@ export async function purchaseCosmetic(
     switch (result.code) {
       case "insufficient_balance": {
         // The balance moved since the pre-check: re-read it for the shortfall,
-        // the same way the pack path does.
-        invalidateUserMe();
-        const fresh = await getUserMe();
-        const available =
-          fresh === false
-            ? 0
-            : method === "hard"
-              ? (fresh.player.currency?.hard ?? 0)
-              : (fresh.player.currency?.soft ?? 0);
-        // The chargeback landed mid-session, so the pre-check above ran on a
-        // cache that still showed a positive balance.
-        if (available < 0) {
-          await showInGameAlert(
-            translateText("store.pack_debt", { debt: String(-available) }),
-          );
+        // the same way the pack path does. Broadcast as well as re-read —
+        // dropping the cache alone leaves the open Store rendering the old
+        // balance, since it renders from the userMeResponse event.
+        const fresh = await broadcastFreshUserMe();
+        // A failed re-read leaves the real balance unknown. Treating it as
+        // zero would quote the full price as the shortfall — a guess wearing
+        // a number, with a top-up button sized to it.
+        if (fresh === false) {
+          await showInGameAlert(translateText("store.purchase_failed"));
           return;
         }
-        // The re-read says they can afford it. We have no shortfall to quote,
-        // and inventing one would tell them to buy currency they already have
-        // for a purchase that would now succeed.
-        if (price - available <= 0) {
+        const available =
+          method === "hard"
+            ? (fresh.player.currency?.hard ?? 0)
+            : (fresh.player.currency?.soft ?? 0);
+        const outcome = balanceOutcome(available, price);
+        if (outcome === "debt") {
+          await showInGameAlert(debtMessage(-available));
+          return;
+        }
+        if (outcome === "unexplained") {
           await showInGameAlert(translateText("store.purchase_failed"));
           return;
         }
@@ -521,9 +541,10 @@ export async function purchaseCosmetic(
         // A refund or chargeback left the wallet negative. Topping up does not
         // unblock it, so this gets a plain explanation rather than the
         // insufficient-currency dialog — the debt settles out of the next
-        // credit. Drop the cached profile: it still shows the pre-chargeback
-        // balance, which the store would otherwise keep rendering.
-        invalidateUserMe();
+        // credit. Re-read and re-broadcast so the store stops showing the
+        // pre-chargeback balance: dropping the cache alone would not do it,
+        // since the Store renders from the userMeResponse broadcast.
+        await broadcastFreshUserMe();
         await showInGameAlert(
           translateText("store.pack_debt", { debt: result.debt }),
         );
@@ -569,9 +590,7 @@ async function purchasePack(
   // negative balance, and without this it reads as a very large shortfall
   // with a top-up button that cannot clear a debt.
   if (balance < 0) {
-    await showInGameAlert(
-      translateText("store.pack_debt", { debt: String(-balance) }),
-    );
+    await showInGameAlert(debtMessage(-balance));
     return;
   }
   if (balance < pack.priceHard) {
@@ -589,17 +608,31 @@ async function purchasePack(
   }
   switch (result.code) {
     case "insufficient_balance": {
-      // The balance moved since the pre-check: re-read it for the shortfall.
-      invalidateUserMe();
-      const fresh = await getUserMe();
-      return insufficient(
-        fresh === false ? 0 : (fresh.player.currency?.hard ?? 0),
-      );
+      // The balance moved since the pre-check: re-read it for the shortfall,
+      // and re-broadcast so the open Store stops showing the old balance.
+      const fresh = await broadcastFreshUserMe();
+      // Unknown balance — no honest number to quote.
+      if (fresh === false) {
+        await showInGameAlert(translateText("store.purchase_failed"));
+        return;
+      }
+      const available = fresh.player.currency?.hard ?? 0;
+      const outcome = balanceOutcome(available, pack.priceHard);
+      if (outcome === "debt") {
+        await showInGameAlert(debtMessage(-available));
+        return;
+      }
+      if (outcome === "unexplained") {
+        await showInGameAlert(translateText("store.purchase_failed"));
+        return;
+      }
+      return insufficient(available);
     }
     case "debt":
-      // The cached profile still shows the pre-chargeback balance; drop it so
-      // the store stops rendering a balance the player does not have.
-      invalidateUserMe();
+      // Re-read and re-broadcast, not just invalidate: the Store renders from
+      // the userMeResponse broadcast, so dropping the cache alone would leave
+      // it showing the pre-chargeback balance.
+      await broadcastFreshUserMe();
       await showInGameAlert(
         translateText("store.pack_debt", { debt: result.debt }),
       );

--- a/tests/client/CosmeticPackPurchase.test.ts
+++ b/tests/client/CosmeticPackPurchase.test.ts
@@ -157,6 +157,35 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
     expect(reloadMock).toHaveBeenCalled();
   });
 
+  // The API serves a charged-back wallet as a negative balance, so the
+  // pre-check is where a player in debt normally meets this — the server
+  // refusal below only fires when the chargeback lands mid-session. Without
+  // it, -50 against a 250 pack reads as "you need 300 more" with a top-up
+  // button that cannot clear a debt.
+  it("explains the debt from a negative cached balance, before any request", async () => {
+    vi.mocked(getUserMe).mockResolvedValue(userWithHard(-50));
+
+    const result = await purchaseCosmetic(starter, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("debt 50");
+    expect(purchaseCosmeticPack).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
+  });
+
+  it("drops the cached profile after a debt refusal", async () => {
+    vi.mocked(getUserMe).mockResolvedValue(userWithHard(300));
+    vi.mocked(purchaseCosmeticPack).mockResolvedValueOnce({
+      ok: false,
+      code: "debt",
+      debt: "300",
+    });
+
+    await purchaseCosmetic(starter, "hard");
+
+    // Otherwise the store keeps rendering the pre-chargeback balance.
+    expect(invalidateUserMe).toHaveBeenCalled();
+  });
+
   it("explains debt and stale listings without reloading", async () => {
     vi.mocked(getUserMe).mockResolvedValue(userWithHard(300));
 

--- a/tests/client/CosmeticPackPurchase.test.ts
+++ b/tests/client/CosmeticPackPurchase.test.ts
@@ -172,18 +172,64 @@ describe("purchaseCosmetic for a cosmetic pack", () => {
     expect(result).toBeUndefined();
   });
 
-  it("drops the cached profile after a debt refusal", async () => {
+  // An empty wallet is not a debt; a `<= 0` slip would tell every broke
+  // player they are "0 in debt" instead of offering the top-up they need.
+  it("offers the shortfall, not a debt message, on an empty wallet", async () => {
+    vi.mocked(getUserMe).mockResolvedValue(userWithHard(0));
+
+    const result = await purchaseCosmetic(starter, "hard");
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ shortfall: 250, canTopUp: true });
+  });
+
+  it("explains the debt when the re-read comes back negative", async () => {
+    vi.mocked(getUserMe)
+      .mockResolvedValueOnce(userWithHard(300))
+      .mockResolvedValueOnce(userWithHard(-100));
+    vi.mocked(purchaseCosmeticPack).mockResolvedValueOnce({
+      ok: false,
+      code: "insufficient_balance",
+    });
+
+    const result = await purchaseCosmetic(starter, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("debt 100");
+    // Not a shortfall with a top-up button: it cannot clear a debt.
+    expect(result).toBeUndefined();
+  });
+
+  it("does not invent a shortfall when the re-read covers the price", async () => {
+    vi.mocked(getUserMe).mockResolvedValue(userWithHard(300));
+    vi.mocked(purchaseCosmeticPack).mockResolvedValueOnce({
+      ok: false,
+      code: "insufficient_balance",
+    });
+
+    const result = await purchaseCosmetic(starter, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("failed");
+    expect(result).toBeUndefined();
+  });
+
+  // Dropping the cache is not enough on its own: the Store renders from the
+  // userMeResponse broadcast, so without a re-read and re-dispatch it keeps
+  // showing the pre-chargeback balance.
+  it("re-broadcasts the profile after a debt refusal", async () => {
     vi.mocked(getUserMe).mockResolvedValue(userWithHard(300));
     vi.mocked(purchaseCosmeticPack).mockResolvedValueOnce({
       ok: false,
       code: "debt",
       debt: "300",
     });
+    const broadcast = vi.fn();
+    document.addEventListener("userMeResponse", broadcast);
 
     await purchaseCosmetic(starter, "hard");
 
-    // Otherwise the store keeps rendering the pre-chargeback balance.
     expect(invalidateUserMe).toHaveBeenCalled();
+    expect(broadcast).toHaveBeenCalled();
+    document.removeEventListener("userMeResponse", broadcast);
   });
 
   it("explains debt and stale listings without reloading", async () => {

--- a/tests/client/CosmeticPurchaseDebt.test.ts
+++ b/tests/client/CosmeticPurchaseDebt.test.ts
@@ -1,0 +1,205 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  purchaseCosmetic,
+  type ResolvedCosmetic,
+} from "../../src/client/Cosmetics";
+
+// POST /shop/purchase is the highest-traffic spend path (every single-cosmetic
+// buy) and the only one that takes soft currency. It used to return a bare
+// boolean and never read the response body, so the shared spend helper's
+// `{reason: "insufficient_balance_debt", debt}` — a wallet left negative by a
+// refund or chargeback — was indistinguishable from any other failure.
+//
+// Mirrors CosmeticPackPurchase.test.ts, which covers the same branches on the
+// pack path.
+
+vi.mock("../../src/client/Api", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Api")>()),
+  getUserMe: vi.fn(),
+  invalidateUserMe: vi.fn(),
+  purchaseWithCurrency: vi.fn(),
+}));
+
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: vi.fn().mockResolvedValue(true),
+  showInGameConfirm: vi.fn().mockResolvedValue(true),
+}));
+
+const { getUserMe, invalidateUserMe, purchaseWithCurrency } =
+  await import("../../src/client/Api");
+const { showInGameAlert } = await import("../../src/client/InGameModal");
+
+const translations = {
+  "cosmetics.hard": "plutonium",
+  "cosmetics.soft": "caps",
+  "flags.pirate": "Jolly Roger",
+  "store.login_required": "log in",
+  "store.pack_debt": "debt {debt}",
+  "store.purchase_failed": "failed",
+  "store.purchase_success": "bought {name}",
+};
+
+const pirateFlag: ResolvedCosmetic = {
+  type: "flag",
+  cosmetic: {
+    name: "pirate",
+    priceHard: 100,
+    priceSoft: 400,
+  },
+  colorPalette: null,
+  relationship: "purchasable",
+  key: "flag:pirate",
+} as unknown as ResolvedCosmetic;
+
+function userWith(hard: number, soft: number) {
+  return { player: { currency: { hard, soft }, flares: [] } } as never;
+}
+
+describe("purchaseCosmetic when the wallet is in debt", () => {
+  let languageFixture: HTMLElement;
+  let reloadMock: ReturnType<typeof vi.fn>;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    languageFixture = document.createElement("lang-selector");
+    Object.assign(languageFixture, {
+      translations,
+      defaultTranslations: translations,
+      currentLang: "en",
+    });
+    document.body.appendChild(languageFixture);
+    reloadMock = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...originalLocation, reload: reloadMock },
+    });
+    vi.mocked(getUserMe).mockResolvedValue(userWith(500, 5000));
+  });
+
+  afterEach(() => {
+    languageFixture.remove();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: originalLocation,
+    });
+    vi.mocked(getUserMe).mockReset();
+    vi.mocked(invalidateUserMe).mockReset();
+    vi.mocked(purchaseWithCurrency).mockReset();
+    vi.mocked(showInGameAlert).mockClear();
+  });
+
+  it("names the debt and its amount instead of a generic failure", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "debt",
+      debt: "150",
+    });
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("debt 150");
+    // Not the insufficient-currency dialog: topping up cannot clear a debt.
+    expect(result).toBeUndefined();
+    // Nothing was granted, so the page must not reload as if it had been.
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("never leaks the machine reason into the message", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "debt",
+      debt: "150",
+    });
+
+    await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(vi.mocked(showInGameAlert).mock.calls[0][0]).not.toContain(
+      "insufficient_balance_debt",
+    );
+  });
+
+  // The other half of the same 400. Being short IS fixed by topping up, so it
+  // keeps the shortfall dialog — re-read after the refusal, since the balance
+  // moved under a pre-check that passed.
+  it("reports a shortfall when the balance moved after the pre-check", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "insufficient_balance",
+    });
+    vi.mocked(getUserMe)
+      .mockResolvedValueOnce(userWith(500, 5000))
+      .mockResolvedValueOnce(userWith(40, 5000));
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(result).toEqual({
+      currency: "plutonium",
+      shortfall: 60,
+      item: "Jolly Roger",
+      canTopUp: true,
+    });
+    expect(invalidateUserMe).toHaveBeenCalled();
+    expect(showInGameAlert).not.toHaveBeenCalled();
+  });
+
+  // Caps cannot be bought, so the dialog must not offer a top-up for them.
+  it("does not offer a top-up for a soft-currency shortfall", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "insufficient_balance",
+    });
+    vi.mocked(getUserMe)
+      .mockResolvedValueOnce(userWith(500, 5000))
+      .mockResolvedValueOnce(userWith(500, 10));
+
+    const result = await purchaseCosmetic(pirateFlag, "soft");
+
+    expect(result).toMatchObject({
+      currency: "caps",
+      shortfall: 390,
+      canTopUp: false,
+    });
+  });
+
+  // The server can refuse on a balance this client still reads as sufficient.
+  // A zero or negative shortfall would render as "you have enough", which is
+  // the one thing we know is false.
+  it("never reports a non-positive shortfall", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "insufficient_balance",
+    });
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(result).toMatchObject({ shortfall: 1 });
+  });
+
+  it("still reports an unexplained failure generically", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "failed",
+    });
+
+    await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("failed");
+    expect(reloadMock).not.toHaveBeenCalled();
+  });
+
+  it("still grants and reloads on success", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({ ok: true });
+
+    await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(purchaseWithCurrency).toHaveBeenCalledWith(
+      "flag",
+      "pirate",
+      "hard",
+      undefined,
+    );
+    expect(showInGameAlert).toHaveBeenCalledWith("bought pirate");
+    expect(invalidateUserMe).toHaveBeenCalled();
+    expect(reloadMock).toHaveBeenCalled();
+  });
+});

--- a/tests/client/CosmeticPurchaseDebt.test.ts
+++ b/tests/client/CosmeticPurchaseDebt.test.ts
@@ -102,20 +102,24 @@ describe("purchaseCosmetic when the wallet is in debt", () => {
     expect(result).toBeUndefined();
     // Nothing was granted, so the page must not reload as if it had been.
     expect(reloadMock).not.toHaveBeenCalled();
+    // The cached profile still holds the pre-chargeback balance, which the
+    // store would otherwise keep rendering.
+    expect(invalidateUserMe).toHaveBeenCalled();
   });
 
-  it("never leaks the machine reason into the message", async () => {
-    vi.mocked(purchaseWithCurrency).mockResolvedValue({
-      ok: false,
-      code: "debt",
-      debt: "150",
-    });
+  // Finding 1: this is the COMMON way a player in debt arrives. The API
+  // serves a charged-back wallet as a negative balance, so the pre-check sees
+  // it before any request is made — the server refusal above only happens
+  // when the chargeback lands mid-session against a stale cache.
+  it("explains the debt from a negative cached balance, before any request", async () => {
+    vi.mocked(getUserMe).mockResolvedValue(userWith(-150, 5000));
 
-    await purchaseCosmetic(pirateFlag, "hard");
+    const result = await purchaseCosmetic(pirateFlag, "hard");
 
-    expect(vi.mocked(showInGameAlert).mock.calls[0][0]).not.toContain(
-      "insufficient_balance_debt",
-    );
+    expect(showInGameAlert).toHaveBeenCalledWith("debt 150");
+    // Never reaches the network, and never offers a top-up that cannot help.
+    expect(purchaseWithCurrency).not.toHaveBeenCalled();
+    expect(result).toBeUndefined();
   });
 
   // The other half of the same 400. Being short IS fixed by topping up, so it
@@ -161,10 +165,10 @@ describe("purchaseCosmetic when the wallet is in debt", () => {
     });
   });
 
-  // The server can refuse on a balance this client still reads as sufficient.
-  // A zero or negative shortfall would render as "you have enough", which is
-  // the one thing we know is false.
-  it("never reports a non-positive shortfall", async () => {
+  // The server refused on a balance the re-read still says covers the price.
+  // There is no shortfall to quote, and "you need 1 more" would send them to
+  // buy currency they already have for a purchase that would now succeed.
+  it("does not invent a shortfall when the re-read covers the price", async () => {
     vi.mocked(purchaseWithCurrency).mockResolvedValue({
       ok: false,
       code: "insufficient_balance",
@@ -172,7 +176,25 @@ describe("purchaseCosmetic when the wallet is in debt", () => {
 
     const result = await purchaseCosmetic(pirateFlag, "hard");
 
-    expect(result).toMatchObject({ shortfall: 1 });
+    expect(result).toBeUndefined();
+    expect(showInGameAlert).toHaveBeenCalledWith("failed");
+  });
+
+  // Finding 1's other half: the chargeback landed mid-session, so the
+  // pre-check ran on a cache that still showed a positive balance.
+  it("explains the debt when the re-read comes back negative", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "insufficient_balance",
+    });
+    vi.mocked(getUserMe)
+      .mockResolvedValueOnce(userWith(500, 5000))
+      .mockResolvedValueOnce(userWith(-150, 5000));
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("debt 150");
+    expect(result).toBeUndefined();
   });
 
   it("still reports an unexplained failure generically", async () => {

--- a/tests/client/CosmeticPurchaseDebt.test.ts
+++ b/tests/client/CosmeticPurchaseDebt.test.ts
@@ -122,6 +122,41 @@ describe("purchaseCosmetic when the wallet is in debt", () => {
     expect(result).toBeUndefined();
   });
 
+  // Dropping the cache is not enough: the Store renders from the
+  // userMeResponse broadcast, so without a re-dispatch it keeps showing the
+  // balance the purchase was refused on.
+  it("re-broadcasts the profile after a shortfall refusal", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "insufficient_balance",
+    });
+    vi.mocked(getUserMe)
+      .mockResolvedValueOnce(userWith(500, 5000))
+      .mockResolvedValueOnce(userWith(40, 5000));
+    const broadcast = vi.fn();
+    document.addEventListener("userMeResponse", broadcast);
+
+    await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(broadcast).toHaveBeenCalled();
+    document.removeEventListener("userMeResponse", broadcast);
+  });
+
+  it("re-broadcasts the profile after a debt refusal", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "debt",
+      debt: "150",
+    });
+    const broadcast = vi.fn();
+    document.addEventListener("userMeResponse", broadcast);
+
+    await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(broadcast).toHaveBeenCalled();
+    document.removeEventListener("userMeResponse", broadcast);
+  });
+
   // The other half of the same 400. Being short IS fixed by topping up, so it
   // keeps the shortfall dialog — re-read after the refusal, since the balance
   // moved under a pre-check that passed.
@@ -195,6 +230,34 @@ describe("purchaseCosmetic when the wallet is in debt", () => {
 
     expect(showInGameAlert).toHaveBeenCalledWith("debt 150");
     expect(result).toBeUndefined();
+  });
+
+  // The boundary the debt pre-check must not swallow: an empty wallet is not
+  // a debt. A `<= 0` slip would tell every broke player they are "0 in debt".
+  it("offers the shortfall, not a debt message, on an empty wallet", async () => {
+    vi.mocked(getUserMe).mockResolvedValue(userWith(0, 0));
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ shortfall: 100, canTopUp: true });
+  });
+
+  // A failed re-read leaves the real balance unknown; quoting the full price
+  // would be a guess with a top-up button sized to it.
+  it("reports a generic failure when the re-read fails", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "insufficient_balance",
+    });
+    vi.mocked(getUserMe)
+      .mockResolvedValueOnce(userWith(500, 5000))
+      .mockResolvedValueOnce(false as never);
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(result).toBeUndefined();
+    expect(showInGameAlert).toHaveBeenCalledWith("failed");
   });
 
   it("still reports an unexplained failure generically", async () => {

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -191,6 +191,7 @@ describe("purchaseWithCurrency", () => {
   ])(
     "falls back to a generic failure when the amount is %s",
     async (_l, extra) => {
+      vi.spyOn(console, "warn").mockImplementation(() => {});
       respond(400, { reason: "insufficient_balance_debt", ...extra });
       expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
         ok: false,

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -6,7 +6,10 @@ vi.mock("../../src/client/Auth", async (importOriginal) => ({
   logOut: vi.fn(async () => true),
 }));
 
-import { purchaseCosmeticPack } from "../../src/client/Api";
+import {
+  purchaseCosmeticPack,
+  purchaseWithCurrency,
+} from "../../src/client/Api";
 import { ClientEnv } from "../../src/client/ClientEnv";
 
 let fetchMock: ReturnType<typeof vi.fn>;
@@ -136,6 +139,88 @@ describe("purchaseCosmeticPack", () => {
 
     fetchMock.mockRejectedValueOnce(new Error("offline"));
     expect(await purchaseCosmeticPack("starter")).toEqual({
+      ok: false,
+      code: "failed",
+    });
+  });
+});
+
+// POST /shop/purchase — the single-cosmetic sibling of the pack endpoint
+// above, routed through the same spend helper, so it surfaces the same two
+// balance reasons. It used to ignore the body entirely and answer with a bare
+// boolean.
+describe("purchaseWithCurrency", () => {
+  it("posts the cosmetic and reports success", async () => {
+    respond(200, {
+      flareName: "flag:pirate",
+      currencyType: "hard",
+      amount: "100",
+    });
+
+    const result = await purchaseWithCurrency("flag", "pirate", "hard");
+
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toMatch(/\/shop\/purchase$/);
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      cosmeticType: "flag",
+      cosmeticName: "pirate",
+      currencyType: "hard",
+    });
+    expect(result).toEqual({ ok: true });
+  });
+
+  it("reports the debt and its amount", async () => {
+    respond(400, { reason: "insufficient_balance_debt", debt: "150" });
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+      ok: false,
+      code: "debt",
+      debt: "150",
+    });
+  });
+
+  // The reason is the branch key; the amount is only quoted back. A body
+  // missing it must still take the debt branch.
+  it("still reports a debt whose amount is missing", async () => {
+    respond(400, { reason: "insufficient_balance_debt" });
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+      ok: false,
+      code: "debt",
+      debt: "",
+    });
+  });
+
+  it("distinguishes being short from being in debt", async () => {
+    respond(400, { reason: "Insufficient balance" });
+    expect(await purchaseWithCurrency("flag", "pirate", "soft")).toEqual({
+      ok: false,
+      code: "insufficient_balance",
+    });
+  });
+
+  it("fails closed on an unrecognised 400, a 500 and a network error", async () => {
+    respond(400, { reason: "Invalid request body" });
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+      ok: false,
+      code: "failed",
+    });
+
+    fetchMock.mockResolvedValueOnce(
+      new Response("<html>gateway</html>", { status: 400 }),
+    );
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+      ok: false,
+      code: "failed",
+    });
+
+    respond(500, {});
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+      ok: false,
+      code: "failed",
+    });
+
+    fetchMock.mockRejectedValueOnce(new Error("offline"));
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
       ok: false,
       code: "failed",
     });

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -179,16 +179,25 @@ describe("purchaseWithCurrency", () => {
     });
   });
 
-  // The reason is the branch key; the amount is only quoted back. A body
-  // missing it must still take the debt branch.
-  it("still reports a debt whose amount is missing", async () => {
-    respond(400, { reason: "insufficient_balance_debt" });
-    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
-      ok: false,
-      code: "debt",
-      debt: "",
-    });
-  });
+  // The amount IS the message ("your balance is X in debt"), so a debt we
+  // cannot state is worse than a generic failure — it would render a blank,
+  // or "[object Object]", at the player.
+  it.each([
+    ["missing", {}],
+    ["empty", { debt: "" }],
+    ["not a number", { debt: "lots" }],
+    ["an object", { debt: { amount: 150 } }],
+    ["negative", { debt: "-150" }],
+  ])(
+    "falls back to a generic failure when the amount is %s",
+    async (_l, extra) => {
+      respond(400, { reason: "insufficient_balance_debt", ...extra });
+      expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+        ok: false,
+        code: "failed",
+      });
+    },
+  );
 
   it("distinguishes being short from being in debt", async () => {
     respond(400, { reason: "Insufficient balance" });
@@ -198,7 +207,25 @@ describe("purchaseWithCurrency", () => {
     });
   });
 
+  // The result must not carry the server's reason onward: everything that
+  // reads this object is one step from rendering what it finds.
+  it("does not pass an unrecognised reason back to the caller", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    respond(400, { reason: "some_future_machine_key" });
+
+    const result = await purchaseWithCurrency("flag", "pirate", "hard");
+
+    expect(result).toEqual({ ok: false, code: "failed" });
+    expect(result).not.toHaveProperty("reason");
+    expect(Object.values(result)).not.toContain("some_future_machine_key");
+    // One argument: the body is deliberately not logged, because an
+    // unrecognised reason is exactly the case where we don't know what is in it.
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0]).toHaveLength(1);
+  });
+
   it("fails closed on an unrecognised 400, a 500 and a network error", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
     respond(400, { reason: "Invalid request body" });
     expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
       ok: false,


### PR DESCRIPTION
## What

`purchaseWithCurrency` (`POST /shop/purchase`, every single-cosmetic buy, and the only spend path that also takes soft currency) returned a bare boolean and never read the response body. It now returns a result union with `insufficient_balance` and `debt` variants, mirroring the pack path, and the caller explains a debt instead of showing a generic "Purchase failed".

## Why

`insufficientBalance()` in the API refuses with `{reason: "insufficient_balance_debt", debt}` when a refund or chargeback has left the wallet negative. This path discarded the body entirely, so that was indistinguishable from a timeout. Steam adds a second chargeback rail with a much shorter fraud window, so the population that can hit it grows on day one.

### The part that makes this actually reachable

`/users/@me` serves a charged-back wallet as a **negative** `currency.hard` — the API derives its own `debt` field as exactly `-hard`. So the ordinary way a debtor arrives here is not the server refusal at all: they fail the *client-side* balance pre-check and get the top-up dialog ("you need 400 more") with a button that cannot clear a debt, without a request ever being made. The result-code branch alone would only have fired when a chargeback landed mid-session against a stale cache.

Both pre-checks (single cosmetic and pack) now test for a negative balance first. Without this the ticket's goal is essentially unreachable in production.

Three smaller consequences, all on the same theme of not telling the player something untrue:

- If the post-refusal re-read still covers the price, there is no shortfall to quote — it reports a generic failure rather than inventing "you need 1 more" for a purchase that would now succeed.
- If the post-refusal re-read comes back negative, it explains the debt.
- Both paths now `invalidateUserMe()` on a debt refusal. The pack path had the same omission; the store was left rendering the pre-chargeback balance.

A debt amount that is not a run of digits falls back to a generic failure rather than rendering a blank, or `[object Object]`, where the amount belongs. The amount is the whole message, so a debt we cannot state is worse than no debt message.

Reasons are allowlisted, not denylisted: anything unrecognised is a generic failure, with a `console.warn` that deliberately omits the body.

## Tests

- `tests/client/CosmeticPurchaseDebt.test.ts` — the caller's branches, mirroring `CosmeticPackPurchase.test.ts`.
- New `purchaseWithCurrency` describe in `tests/client/PurchaseCosmeticPack.test.ts` — the reason mapping over a mocked fetch, including a table of unusable debt amounts.
- Negative-balance pre-check coverage on both the single-cosmetic and pack paths, asserting no request is made at all.

**19 of the 30 fail against `origin/main`.**

```
npx vitest tests/client/CosmeticPurchaseDebt.test.ts tests/client/PurchaseCosmeticPack.test.ts \
  tests/client/CosmeticPackPurchase.test.ts --run                       # 30 passed
npx vitest <those + CosmeticsPaymentsMigration, PurchaseReturn,
  CosmeticLockerIntegration, PurchaseButton, StoreModal, InventoryModal> # 124 passed
npx tsc --noEmit                                                        # clean
npm run lint                                                            # clean
```

## Notes

- One test was deleted rather than fixed: it asserted the machine reason never reached the message while the mock itself supplied `code: "debt"`, so the string existed nowhere in the fixture and it could not fail. Replaced by assertions that an unrecognised 400 carries no reason back to the caller and that the warn takes exactly one argument.
- The equivalent `debt`-validation tightening is **not** applied to the tribe-name path on #5307, which is left at parity with the pre-existing pack behaviour. If #5307 is re-pushed for another reason it should come along.
- Out of scope, filed separately: this path folds the API's 409 "Already owned" into a generic failure, so a retry after a timed-out success cannot converge (the pack path maps 409 to `already_owned` + reload).

Resolves OPE-373 — https://linear.app/openfront/issue/OPE-373

🤖 Generated with [Claude Code](https://claude.com/claude-code)
