### PR TITLE
Route each game to its own deployment by id letter

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,7 +124,7 @@
         instanceLetter: <%- instanceLetter %>,
         turnstileSiteKey: <%- turnstileSiteKey %>,
         jwtAudience: <%- jwtAudience %>,
-        instanceId: <%- instanceId %>,<%- typeof serverHost !== "undefined" && serverHost ? "\n        serverHost: " + serverHost + "," : "" %>
+        instanceId: <%- instanceId %>,<%- typeof serverHost !== "undefined" && serverHost ? "\n        serverHost: " + serverHost + "," : "" %><%- typeof siteHost !== "undefined" && siteHost ? "\n        siteHost: " + siteHost + "," : "" %>
       };
       document.documentElement.style.setProperty(
         "--background-image-url",

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -1521,7 +1521,7 @@ export async function openSubscriptionPortal(): Promise<string | false> {
 export async function fetchLobbyListed(gameID: string): Promise<boolean> {
   try {
     const res = await fetch(
-      `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(gameID)}/api/game/${gameID}`,
+      `${ClientEnv.gameHttpBase(gameID)}/${ClientEnv.gameWorkerPath(gameID)}/api/game/${gameID}`,
       { headers: { Accept: "application/json" } },
     );
     if (!res.ok) return false;
@@ -1545,7 +1545,7 @@ export async function setLobbyListed(
   try {
     const token = await getPlayToken();
     const response = await fetch(
-      `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(gameID)}/api/game/${gameID}/listing`,
+      `${ClientEnv.gameHttpBase(gameID)}/${ClientEnv.gameWorkerPath(gameID)}/api/game/${gameID}/listing`,
       {
         method: "POST",
         headers: {
@@ -1615,7 +1615,7 @@ export async function createNextLobby(
 ): Promise<GameInfo> {
   const token = await getPlayToken();
   const response = await fetch(
-    `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(previousGameID)}/api/create_game?previous=${previousGameID}`,
+    `${ClientEnv.gameHttpBase(previousGameID)}/${ClientEnv.gameWorkerPath(previousGameID)}/api/create_game?previous=${previousGameID}`,
     {
       method: "POST",
       headers: {

--- a/src/client/ClientEnv.ts
+++ b/src/client/ClientEnv.ts
@@ -143,6 +143,42 @@ export class ClientEnv {
   static workerPath(gameID: GameID): string {
     return `w${ClientEnv.workerIndex(gameID)}`;
   }
+  // Which deployment hosts this game (docs/MultiServer.md): a 10-char id's
+  // leading letter names its server in the cluster map.
+  static resolveGame(gameID: GameID): GameResolution {
+    const v = ClientEnv.get();
+    return resolveGameHost(gameID, v.cluster, v.instanceLetter);
+  }
+  // True when the id carries a letter this bundle's map doesn't know: the
+  // map predates the letter's deployment. Join flows answer by redirecting
+  // to the apex, whose shell carries the freshest map.
+  static gameLetterUnknown(gameID: GameID): boolean {
+    return ClientEnv.resolveGame(gameID).kind === "unknown-letter";
+  }
+  // Per-game WS/HTTP bases and worker path: same-origin (or the desktop
+  // serverHost) for own and legacy games, the owning deployment's host —
+  // always TLS, cross-host maps only exist deployed — for foreign letters.
+  // An unknown letter resolves like "own" so plain fetches 404 into the
+  // existing not-found paths; flows that can redirect check
+  // gameLetterUnknown first.
+  static gameWsBase(gameID: GameID): string {
+    const r = ClientEnv.resolveGame(gameID);
+    return r.kind === "cross" ? `wss://${r.host}` : ClientEnv.serverWsBase();
+  }
+  static gameHttpBase(gameID: GameID): string {
+    const r = ClientEnv.resolveGame(gameID);
+    return r.kind === "cross"
+      ? `https://${r.host}`
+      : ClientEnv.serverHttpBase();
+  }
+  // The worker path on the game's own server: a foreign deployment's worker
+  // count comes from its cluster entry, not this server's.
+  static gameWorkerPath(gameID: GameID): string {
+    const r = ClientEnv.resolveGame(gameID);
+    return r.kind === "cross"
+      ? `w${simpleHash(gameID) % r.numWorkers}`
+      : ClientEnv.workerPath(gameID);
+  }
   // Explicit game-server host, injected by the desktop app (absent on web).
   static serverHost(): string | undefined {
     return ClientEnv.get().serverHost;
@@ -204,6 +240,38 @@ function resolveServerOrigin(
     return { secure: true, host: serverHost };
   }
   return { secure: locationProtocol === "https:", host: locationHost };
+}
+
+export type GameResolution =
+  | { kind: "own" }
+  | { kind: "cross"; host: string; numWorkers: number }
+  | { kind: "unknown-letter" };
+
+/**
+ * Which deployment hosts a game. Pure and exported for tests.
+ *
+ * - Legacy 8-char ids (and the never-minted 9-char length) carry no letter:
+ *   they were minted by whichever server this page already talks to, so they
+ *   stay on the own server.
+ * - No cluster map means an old desktop shell that predates it: everything
+ *   keeps routing to its configured serverHost, as before.
+ * - A 10-char id's leading letter is looked up in the map. Own letter (or a
+ *   letter the map doesn't know) is not a cross-host target; unknown letters
+ *   get their own kind so join flows can redirect to the apex for a fresher
+ *   map instead of silently 404ing.
+ */
+export function resolveGameHost(
+  gameID: string,
+  cluster: ClusterConfig | undefined,
+  instanceLetter: string | undefined,
+): GameResolution {
+  if (gameID.length < 10) return { kind: "own" };
+  if (cluster === undefined) return { kind: "own" };
+  const letter = gameID[0];
+  const entry = cluster[letter];
+  if (entry === undefined) return { kind: "unknown-letter" };
+  if (letter === instanceLetter) return { kind: "own" };
+  return { kind: "cross", host: entry.host, numWorkers: entry.numWorkers };
 }
 
 /** Game-server WebSocket origin: see resolveServerOrigin. */

--- a/src/client/ClientEnv.ts
+++ b/src/client/ClientEnv.ts
@@ -57,6 +57,7 @@ export class ClientEnv {
       // Optional: only the desktop app injects an explicit game-server host.
       // Absent on the web build (falls back to same-origin window.location).
       serverHost: bc.serverHost,
+      siteHost: bc.siteHost,
     };
     return ClientEnv.values;
   }
@@ -182,6 +183,12 @@ export class ClientEnv {
   // Explicit game-server host, injected by the desktop app (absent on web).
   static serverHost(): string | undefined {
     return ClientEnv.get().serverHost;
+  }
+  // The load-balancer apex this deployment sits behind — the unknown-letter
+  // redirect target, whose shell always carries the freshest cluster map.
+  // Absent for standalone deployments and desktop: no apex to bounce to.
+  static siteHost(): string | undefined {
+    return ClientEnv.get().siteHost;
   }
   // Origin (scheme + host, no trailing slash) of the game server that hosts the
   // public-lobby and in-game WebSockets. The lobby-list and game sockets append
@@ -319,4 +326,5 @@ export interface ClientEnvValues {
   instanceId: string;
   gitCommit: string;
   serverHost?: string;
+  siteHost?: string;
 }

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -358,7 +358,7 @@ export function joinLobby(
         } else {
           const r = ClientEnv.resolveGame(lobbyConfig.gameID);
           if (r.kind === "cross") {
-            window.location.href = `https://${r.host}/game/${lobbyConfig.gameID}`;
+            window.location.href = `https://${r.host}/game/${lobbyConfig.gameID}${window.location.search}`;
           } else {
             showInGameAlert(translateText("update_available.message")).then(
               () => {

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -345,19 +345,27 @@ export function joinLobby(
         console.info(
           `version mismatch: bundle ${ClientEnv.gitCommit()}, server ${message.gitCommit}`,
         );
-        // The server runs a newer build than this bundle (tab left open
-        // across a deploy). On the web a reload picks up the new version. The
-        // desktop shell updates its local overlay itself and reloading would
-        // only re-run the old bundle, so there we just say what's happening
-        // and let the shell's update bar take it from here.
+        // The game's server runs a different build than this bundle. On the
+        // desktop the shell updates its local overlay itself, so just say
+        // what's happening and let its update bar take it from there. On the
+        // web, fork on where the game lives: a cross-host game means OUR
+        // shell is simply a different deployment's — reloading would fetch
+        // the same wrong build, so navigate to the game's own host, whose
+        // shell serves the matching bundle (and map). An own-host game means
+        // this tab is stale (left open across a deploy): reload.
         if (isDesktopShell()) {
           void showInGameAlert(translateText("update_available.desktop"));
         } else {
-          showInGameAlert(translateText("update_available.message")).then(
-            () => {
-              reloadForUpdate();
-            },
-          );
+          const r = ClientEnv.resolveGame(lobbyConfig.gameID);
+          if (r.kind === "cross") {
+            window.location.href = `https://${r.host}/game/${lobbyConfig.gameID}`;
+          } else {
+            showInGameAlert(translateText("update_available.message")).then(
+              () => {
+                reloadForUpdate();
+              },
+            );
+          }
         }
       } else {
         showErrorModal(

--- a/src/client/JoinLobbyModal.ts
+++ b/src/client/JoinLobbyModal.ts
@@ -1193,7 +1193,7 @@ export class JoinLobbyModal extends BaseModal {
     lobbyId: string,
     spectator = false,
   ): Promise<boolean> {
-    const url = `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(lobbyId)}/api/game/${lobbyId}/exists`;
+    const url = `${ClientEnv.gameHttpBase(lobbyId)}/${ClientEnv.gameWorkerPath(lobbyId)}/api/game/${lobbyId}/exists`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -969,6 +969,12 @@ class Client {
     const lobbyId =
       pathMatch && GAME_ID_REGEX.test(pathMatch[1]) ? pathMatch[1] : null;
     if (lobbyId) {
+      // A letter this shell's cluster map doesn't know means the map
+      // predates the game's deployment (stale CDN shell, or a link into a
+      // newer fleet). The apex always serves the freshest map, so re-enter
+      // through it; on the apex itself (and dev/desktop) fall through to
+      // the join flow's normal not-found handling.
+      if (this.redirectUnknownLetterToApex(lobbyId)) return;
       // ?host means the lobby creator is returning to a successor lobby they
       // reused from the win screen: reopen the host view bound to the existing
       // lobby instead of the join flow. Non-creators who hit this URL still get
@@ -1053,6 +1059,16 @@ class Client {
    * Draws attention to the status bar rather than failing silently, matching
    * what the dimmed buttons do.
    */
+  // See the call site in handleUrl. True when a navigation was issued.
+  private redirectUnknownLetterToApex(gameID: string): boolean {
+    if (!ClientEnv.gameLetterUnknown(gameID)) return false;
+    if (isDesktopShell()) return false;
+    const apex = ClientEnv.jwtAudience();
+    if (apex === "localhost" || window.location.host === apex) return false;
+    window.location.href = `https://${apex}${window.location.pathname.replace(/^\/w\d+\//, "/")}${window.location.search}`;
+    return true;
+  }
+
   private blockedDesktopJoin(lobby: JoinLobbyEvent): boolean {
     if (!isDesktopShell()) return false;
     if (

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -94,7 +94,12 @@ import {
 import { UserSettingModal } from "./UserSettingModal";
 import "./UsernameInput";
 import { UsernameInput } from "./UsernameInput";
-import { incrementGamesPlayed, presenceMapKey, translateText } from "./Utils";
+import {
+  homeHref,
+  incrementGamesPlayed,
+  presenceMapKey,
+  translateText,
+} from "./Utils";
 import { isReplayShellHost } from "./VersionedReplay";
 import "./components/BannedModal";
 import "./components/DesktopStatusBar";
@@ -783,7 +788,7 @@ class Client {
     const leaveGame = () => {
       crazyGamesSDK.gameplayStop().then(() => {
         // redirect to the home page
-        window.location.href = "/";
+        window.location.href = homeHref();
       });
     };
 
@@ -1011,7 +1016,7 @@ class Client {
       }
     }
     if (decodedHash.startsWith("#refresh")) {
-      window.location.href = "/";
+      window.location.href = homeHref();
     }
 
     const requeueMode = this.consumeRequeueUrl();

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -1063,8 +1063,12 @@ class Client {
   private redirectUnknownLetterToApex(gameID: string): boolean {
     if (!ClientEnv.gameLetterUnknown(gameID)) return false;
     if (isDesktopShell()) return false;
-    const apex = ClientEnv.jwtAudience();
-    if (apex === "localhost" || window.location.host === apex) return false;
+    // Only load-balanced deployments have an apex to bounce to; standalone
+    // ones (beta, branch previews, dev) have no siteHost injected and fall
+    // through to the normal not-found flow, as does the apex shell itself
+    // (its map is already the freshest; CDN staleness ages out in minutes).
+    const apex = ClientEnv.siteHost();
+    if (apex === undefined || window.location.host === apex) return false;
     window.location.href = `https://${apex}${window.location.pathname.replace(/^\/w\d+\//, "/")}${window.location.search}`;
     return true;
   }

--- a/src/client/Matchmaking.ts
+++ b/src/client/Matchmaking.ts
@@ -457,7 +457,7 @@ export class MatchmakingModal extends BaseModal {
     if (this.gameID === null) {
       return;
     }
-    const url = `${ClientEnv.serverHttpBase()}/${ClientEnv.workerPath(this.gameID)}/api/game/${this.gameID}/exists`;
+    const url = `${ClientEnv.gameHttpBase(this.gameID)}/${ClientEnv.gameWorkerPath(this.gameID)}/api/game/${this.gameID}/exists`;
 
     const response = await fetch(url, {
       method: "GET",

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -43,6 +43,7 @@ import {
 } from "../core/ZbinWire";
 import { getPlayToken } from "./Auth";
 import { LobbyConfig } from "./ClientGameRunner";
+import { isDesktopShell } from "./DesktopShell";
 import { showInGameConfirm } from "./InGameModal";
 import { LocalServer } from "./LocalServer";
 import { translateText } from "./Utils";
@@ -419,10 +420,14 @@ export class Transport {
     this.isSessionReady = false;
     this.startPing();
     this.killExistingSocket();
-    // WS origin comes from ClientEnv (same-origin on web, audience-derived on
-    // the desktop app://openfront origin), not window.location.host.
-    const workerPath = ClientEnv.workerPath(this.lobbyConfig.gameID);
-    this.socket = new WebSocket(`${ClientEnv.serverWsBase()}/${workerPath}`);
+    // WS origin comes from ClientEnv, resolved per game: the id's letter
+    // names the hosting deployment, so a shared lobby link or rejoin works
+    // from any shell in the fleet. Own/legacy ids keep the historical
+    // behavior (same-origin on web, serverHost on the desktop app).
+    const workerPath = ClientEnv.gameWorkerPath(this.lobbyConfig.gameID);
+    this.socket = new WebSocket(
+      `${ClientEnv.gameWsBase(this.lobbyConfig.gameID)}/${workerPath}`,
+    );
     // Every frame is a zbin payload; without this they would arrive as Blobs.
     this.socket.binaryType = "arraybuffer";
     this.onconnect = onconnect;
@@ -494,6 +499,21 @@ export class Transport {
     }
     this.connectionRefused = true;
     this.stopPing();
+    // WrongWorker: the worker says it doesn't own this game, which means
+    // this bundle routed with a stale worker count. One full navigation to
+    // the game's own host re-fetches shell + cluster map and re-resolves;
+    // the sessionStorage latch stops a loop if the fresh map still
+    // misroutes (a real bug), falling through to the dialog instead. Not on
+    // desktop: its shell owns navigation and updates its map at boot.
+    if (reason === CloseReason.WrongWorker && !isDesktopShell()) {
+      const gameID = this.lobbyConfig.gameID;
+      const latch = `wrong-worker-redirect:${gameID}`;
+      if (sessionStorage.getItem(latch) === null) {
+        sessionStorage.setItem(latch, "1");
+        window.location.href = `${ClientEnv.gameHttpBase(gameID)}/game/${gameID}`;
+        return;
+      }
+    }
     // The reason is a close_reason.* key the server chose. Anything else (a
     // proxy closing on its own, an empty reason) gets the generic text
     // rather than a bare key.

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -510,7 +510,7 @@ export class Transport {
       const latch = `wrong-worker-redirect:${gameID}`;
       if (sessionStorage.getItem(latch) === null) {
         sessionStorage.setItem(latch, "1");
-        window.location.href = `${ClientEnv.gameHttpBase(gameID)}/game/${gameID}`;
+        window.location.href = `${ClientEnv.gameHttpBase(gameID)}/game/${gameID}${window.location.search}`;
         return;
       }
     }

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -46,7 +46,7 @@ import { LobbyConfig } from "./ClientGameRunner";
 import { isDesktopShell } from "./DesktopShell";
 import { showInGameConfirm } from "./InGameModal";
 import { LocalServer } from "./LocalServer";
-import { translateText } from "./Utils";
+import { homeHref, translateText } from "./Utils";
 import { PlayerView } from "./view";
 
 export class PauseGameIntentEvent implements GameEvent {
@@ -534,7 +534,7 @@ export class Transport {
       cancelText: translateText("common.close"),
     }).then((goHome) => {
       if (goHome) {
-        window.location.href = "/";
+        window.location.href = homeHref();
       }
     });
   }

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -12,6 +12,7 @@ import {
   Trios,
 } from "../core/game/Game";
 import { GameConfig } from "../core/Schemas";
+import { ClientEnv } from "./ClientEnv";
 import type { LangSelector } from "./LangSelector";
 import { Platform } from "./Platform";
 
@@ -842,9 +843,37 @@ export function getSecondsUntilServerTimestamp(
  * stale HTML — with the old gitCommit baked in — for minutes after a deploy,
  * and a version check that reloads on mismatch would loop. A unique query
  * string misses the shared cache, so the origin renders the current shell.
+ *
+ * On a deployment host (the document landed there for a cross-host game, or
+ * via a stale bookmark) a same-origin reload re-fetches that SAME
+ * deployment's shell — for a drained or outdated deployment that can never
+ * help, and the drain prompt would loop forever. The apex serves the active
+ * deployment's shell, so go there instead, keeping the path (letter routing
+ * re-resolves a /game/<id>) minus the origin-specific worker prefix.
  */
 export function reloadForUpdate(): void {
   const url = new URL(window.location.href);
+  const siteHost = ClientEnv.siteHost();
+  if (siteHost !== undefined && url.host !== siteHost) {
+    url.protocol = "https:";
+    url.host = siteHost;
+    url.pathname = url.pathname.replace(/^\/w\d+\//, "/");
+  }
   url.searchParams.set("v", Date.now().toString(36));
   window.location.replace(url.toString());
+}
+
+/**
+ * Where "leave to the menu" navigations should land. On a deployment host
+ * the local homepage may belong to a drained deployment whose public lobby
+ * list is empty; the apex always fronts the active one. Same-host,
+ * standalone deployments (no siteHost injected), dev, and desktop keep the
+ * plain root.
+ */
+export function homeHref(): string {
+  const siteHost = ClientEnv.siteHost();
+  if (siteHost !== undefined && window.location.host !== siteHost) {
+    return `https://${siteHost}/`;
+  }
+  return "/";
 }

--- a/src/client/hud/layers/GameRightSidebar.ts
+++ b/src/client/hud/layers/GameRightSidebar.ts
@@ -12,7 +12,7 @@ import { crazyGamesSDK } from "../../CrazyGamesSDK";
 import { showInGameAlert, showInGameConfirm } from "../../InGameModal";
 import { TogglePauseIntentEvent } from "../../InputHandler";
 import { PauseGameIntentEvent, SendWinnerEvent } from "../../Transport";
-import { showToast, translateText } from "../../Utils";
+import { homeHref, showToast, translateText } from "../../Utils";
 import { GameView } from "../../view";
 import { ImmunityBarVisibleEvent } from "./ImmunityTimer";
 import { ShowReplayPanelEvent } from "./ReplayPanel";
@@ -274,7 +274,7 @@ export class GameRightSidebar extends LitElement implements Controller {
     await crazyGamesSDK.requestMidgameAd();
     await crazyGamesSDK.gameplayStop();
     // redirect to the home page
-    window.location.href = "/";
+    window.location.href = homeHref();
   }
 
   private onSettingsButtonClick() {

--- a/src/client/hud/layers/SettingsModal.ts
+++ b/src/client/hud/layers/SettingsModal.ts
@@ -10,7 +10,7 @@ import {
   AlternateViewEvent,
   ToggleRenderDebugGuiEvent,
 } from "../../InputHandler";
-import { translateText } from "../../Utils";
+import { homeHref, translateText } from "../../Utils";
 import {
   SetBackgroundMusicVolumeEvent,
   SetSoundEffectsVolumeEvent,
@@ -196,7 +196,7 @@ export class SettingsModal extends LitElement implements Controller {
 
   private onExitButtonClick() {
     // redirect to the home page
-    window.location.href = "/";
+    window.location.href = homeHref();
   }
 
   private onVolumeChange(event: Event) {

--- a/src/client/hud/layers/WinModal.ts
+++ b/src/client/hud/layers/WinModal.ts
@@ -2,6 +2,7 @@ import { html, LitElement, TemplateResult } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import {
   getGamesPlayed,
+  homeHref,
   isInIframe,
   translateText,
   TUTORIAL_VIDEO_URL,
@@ -273,7 +274,7 @@ export class WinModal extends LitElement implements Controller {
 
   private _handleExit() {
     this.hide();
-    window.location.href = "/";
+    window.location.href = homeHref();
   }
 
   private _handleRequeue() {

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -43,6 +43,9 @@ declare global {
       // Desktop-only: explicit game-server host for the WebSocket origin.
       // Absent on the web build (client falls back to same-origin location).
       serverHost?: string;
+      // The load-balancer apex this deployment sits behind; absent for
+      // standalone deployments (beta, branch previews, dev) and desktop.
+      siteHost?: string;
     };
   }
 }

--- a/src/server/GameApiCors.ts
+++ b/src/server/GameApiCors.ts
@@ -11,7 +11,15 @@ export const DESKTOP_APP_ORIGIN = "app://openfront";
 function isAllowedOrigin(origin: string): boolean {
   if (origin === DESKTOP_APP_ORIGIN) return true;
   const siteHost = ServerEnv.siteHost();
-  return siteHost !== undefined && origin === `https://${siteHost}`;
+  if (siteHost !== undefined && origin === `https://${siteHost}`) return true;
+  // Every deployment host in the fleet: a tab pinned to one deployment
+  // reaches a game on another cross-origin (per-game routing by id letter,
+  // docs/MultiServer.md), so each sibling's origin must be allowed. Own host
+  // included — harmless (same-origin requests skip CORS) and keeps the rule
+  // uniform.
+  return Object.values(ServerEnv.cluster()).some(
+    (entry) => origin === `https://${entry.host}`,
+  );
 }
 
 /**

--- a/src/server/RenderHtml.ts
+++ b/src/server/RenderHtml.ts
@@ -38,6 +38,15 @@ export async function renderHtmlContent(htmlPath: string): Promise<string> {
       ServerEnv.publicHost() === undefined
         ? undefined
         : JSON.stringify(ServerEnv.publicHost()),
+    // The load-balancer apex, when this deployment sits behind one. The
+    // client uses it as the unknown-letter redirect target — the apex shell
+    // always carries the freshest cluster map. Absent for standalone
+    // deployments (beta, branch previews, dev), which have no apex to
+    // bounce to and fall through to their normal not-found flow.
+    siteHost:
+      ServerEnv.siteHost() === undefined
+        ? undefined
+        : JSON.stringify(ServerEnv.siteHost()),
     manifestHref: buildAssetUrl("manifest.json", assetManifest, cdnBase),
     faviconHref: buildAssetUrl("images/Favicon.svg", assetManifest, cdnBase),
     gameplayScreenshotUrl: buildAssetUrl(

--- a/tests/client/ApexNavigation.test.ts
+++ b/tests/client/ApexNavigation.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ClientEnv } from "../../src/client/ClientEnv";
+import { homeHref, reloadForUpdate } from "../../src/client/Utils";
+
+// A document can sit on a deployment host (cross-host game visit, stale
+// bookmark). There, a same-origin reload or a "/" exit re-enters the SAME
+// deployment — possibly drained, with an empty lobby list and an outdated
+// shell the drain prompt would reload in a loop. Both helpers answer with
+// the apex instead, which always fronts the active deployment.
+describe("apex-aware navigation", () => {
+  const replace = vi.fn<(url: string) => void>();
+
+  function stubPage(host: string, path: string, siteHost?: string) {
+    ClientEnv.reset();
+    window.BOOTSTRAP_CONFIG = {
+      gameEnv: "prod",
+      cluster: {
+        c: { host: "blue.openfront.io", color: "blue", numWorkers: 2 },
+        d: { host: "green.openfront.io", color: "green", numWorkers: 2 },
+      },
+      instanceLetter: "d",
+      turnstileSiteKey: "k",
+      jwtAudience: "openfront.io",
+      instanceId: "i",
+      gitCommit: "abc",
+      ...(siteHost === undefined ? {} : { siteHost }),
+    };
+    Object.defineProperty(window, "location", {
+      value: {
+        href: `https://${host}${path}`,
+        host,
+        search: "",
+        replace,
+      },
+      writable: true,
+      configurable: true,
+    });
+  }
+
+  beforeEach(() => {
+    replace.mockClear();
+  });
+
+  afterEach(() => {
+    ClientEnv.reset();
+    delete window.BOOTSTRAP_CONFIG;
+  });
+
+  it("homeHref leaves a deployment host for the apex", () => {
+    stubPage("green.openfront.io", "/", "openfront.io");
+    expect(homeHref()).toBe("https://openfront.io/");
+  });
+
+  it("homeHref stays local on the apex and on standalone deployments", () => {
+    stubPage("openfront.io", "/", "openfront.io");
+    expect(homeHref()).toBe("/");
+    stubPage("beta.openfront.io", "/");
+    expect(homeHref()).toBe("/");
+  });
+
+  it("reloadForUpdate re-enters through the apex, keeping the game path", () => {
+    stubPage("green.openfront.io", "/w1/game/dAbCd12345", "openfront.io");
+    reloadForUpdate();
+    expect(replace).toHaveBeenCalledTimes(1);
+    const url = new URL(replace.mock.calls[0][0]);
+    expect(url.host).toBe("openfront.io");
+    // Worker prefixes are origin-specific; letter routing re-resolves.
+    expect(url.pathname).toBe("/game/dAbCd12345");
+    expect(url.searchParams.has("v")).toBe(true);
+  });
+
+  it("reloadForUpdate stays same-origin on the apex and standalone hosts", () => {
+    stubPage("openfront.io", "/", "openfront.io");
+    reloadForUpdate();
+    stubPage("beta.openfront.io", "/");
+    reloadForUpdate();
+    for (const call of replace.mock.calls) {
+      const url = new URL(call[0]);
+      expect(["openfront.io", "beta.openfront.io"]).toContain(url.host);
+      expect(url.searchParams.has("v")).toBe(true);
+    }
+  });
+});

--- a/tests/client/ResolveGameHost.test.ts
+++ b/tests/client/ResolveGameHost.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { resolveGameHost } from "../../src/client/ClientEnv";
+import { ClusterConfig } from "../../src/core/ClusterConfig";
+
+// The per-game routing decision (docs/MultiServer.md, PR 5): a 10-char id's
+// leading letter names its deployment in the cluster map; everything older
+// or unmapped stays on the server the page already talks to.
+const CLUSTER: ClusterConfig = {
+  c: { host: "blue.openfront.io", color: "blue", numWorkers: 20 },
+  d: { host: "green.openfront.io", color: "green", numWorkers: 20 },
+};
+
+describe("resolveGameHost", () => {
+  it("routes a foreign letter to its deployment with its worker count", () => {
+    expect(resolveGameHost("dAbCd12345", CLUSTER, "c")).toEqual({
+      kind: "cross",
+      host: "green.openfront.io",
+      numWorkers: 20,
+    });
+  });
+
+  it("keeps the own letter on the own server", () => {
+    expect(resolveGameHost("cAbCd12345", CLUSTER, "c")).toEqual({
+      kind: "own",
+    });
+  });
+
+  it.each(["AbCd1234", "AbCd12345"])(
+    "keeps legacy short id %s on the own server",
+    (id) => {
+      expect(resolveGameHost(id, CLUSTER, "c")).toEqual({ kind: "own" });
+    },
+  );
+
+  it("keeps everything on the own server without a map (old desktop shell)", () => {
+    expect(resolveGameHost("dAbCd12345", undefined, undefined)).toEqual({
+      kind: "own",
+    });
+  });
+
+  it("flags a letter the map does not know", () => {
+    expect(resolveGameHost("zAbCd12345", CLUSTER, "c")).toEqual({
+      kind: "unknown-letter",
+    });
+  });
+});

--- a/tests/client/TransportConnectionRefused.test.ts
+++ b/tests/client/TransportConnectionRefused.test.ts
@@ -26,6 +26,9 @@ vi.mock("src/client/ClientEnv", () => ({
   ClientEnv: {
     workerPath: vi.fn(() => "w0"),
     serverWsBase: vi.fn(() => "ws://game.test"),
+    gameWorkerPath: vi.fn(() => "w0"),
+    gameWsBase: vi.fn(() => "ws://game.test"),
+    gameHttpBase: vi.fn(() => "http://game.test"),
   },
 }));
 
@@ -203,5 +206,31 @@ describe("Transport terminal connection refused", () => {
 
     expect(sockets).toHaveLength(2);
     expect(modalMocks.showInGameConfirm).not.toHaveBeenCalled();
+  });
+
+  // WrongWorker means this bundle routed with a stale worker count: one full
+  // navigation to the game's own host re-fetches shell + cluster map. The
+  // sessionStorage latch keeps a still-wrong fresh map from looping — the
+  // second refusal falls through to the regular dialog.
+  it("navigates to the game's host on a wrong-worker close, once", () => {
+    sessionStorage.clear();
+    connectTransport();
+    sockets[0].serverClose(CloseCode.WrongWorker, CloseReason.WrongWorker);
+
+    expect(window.location.href).toBe("http://game.test/game/abcd1234");
+    expect(modalMocks.showInGameConfirm).not.toHaveBeenCalled();
+  });
+
+  it("shows the dialog instead of looping on a second wrong-worker close", () => {
+    sessionStorage.clear();
+    sessionStorage.setItem("wrong-worker-redirect:abcd1234", "1");
+    connectTransport();
+    sockets[0].serverClose(CloseCode.WrongWorker, CloseReason.WrongWorker);
+
+    expect(window.location.href).toBe("http://localhost:9000/w1/game/abcd1234");
+    expect(modalMocks.showInGameConfirm).toHaveBeenCalledTimes(1);
+    expect(modalMocks.showInGameConfirm.mock.calls[0][0]).toContain(
+      CloseReason.WrongWorker,
+    );
   });
 });

--- a/tests/client/TransportConnectionRefused.test.ts
+++ b/tests/client/TransportConnectionRefused.test.ts
@@ -20,6 +20,7 @@ vi.mock("../../src/client/Utils", () => ({
   translateText: vi.fn((key: string, vars?: { reason?: string }) =>
     vars?.reason !== undefined ? `${key}:${vars.reason}` : key,
   ),
+  homeHref: vi.fn(() => "/"),
 }));
 
 vi.mock("src/client/ClientEnv", () => ({

--- a/tests/client/TransportConnectionRefused.test.ts
+++ b/tests/client/TransportConnectionRefused.test.ts
@@ -104,6 +104,8 @@ describe("Transport terminal connection refused", () => {
         set href(value: string) {
           mockLocationHref = value;
         },
+        // Cross-host redirects carry the query string along (?spectate).
+        search: "",
       },
       writable: true,
       configurable: true,

--- a/tests/client/TransportReconnect.test.ts
+++ b/tests/client/TransportReconnect.test.ts
@@ -39,6 +39,7 @@ vi.mock("../../src/client/InGameModal", () => ({
 vi.mock("../../src/client/Utils", () => ({
   translateText: (key: string, params?: Record<string, unknown>) =>
     params === undefined ? key : `${key} ${JSON.stringify(params)}`,
+  homeHref: () => "/",
 }));
 
 import type { LobbyConfig } from "../../src/client/ClientGameRunner";

--- a/tests/client/TransportReconnect.test.ts
+++ b/tests/client/TransportReconnect.test.ts
@@ -16,6 +16,9 @@ vi.mock("../../src/client/ClientEnv", () => ({
   ClientEnv: {
     workerPath: () => "w0",
     serverWsBase: () => "ws://game.test",
+    gameWorkerPath: () => "w0",
+    gameWsBase: () => "ws://game.test",
+    gameHttpBase: () => "http://game.test",
     gitCommit: () => "test-commit",
   },
 }));

--- a/tests/server/GameApiCors.test.ts
+++ b/tests/server/GameApiCors.test.ts
@@ -266,3 +266,42 @@ describe("applyGameApiCorsHeaders with a load balancer site host", () => {
     expect(headers.has("Access-Control-Allow-Origin")).toBe(false);
   });
 });
+
+describe("applyGameApiCorsHeaders across the cluster", () => {
+  // Per-game routing (docs/MultiServer.md): a tab pinned to one deployment
+  // reaches a game on a sibling deployment cross-origin, so every host in
+  // the fleet map must be allowed — and nothing else.
+  const CLUSTER = JSON.stringify({
+    a: { host: "blue.openfront.io", color: "blue", numWorkers: 2 },
+    b: { host: "green.openfront.io", color: "green", numWorkers: 2 },
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  test("allows a sibling deployment's origin", () => {
+    vi.stubEnv("CLUSTER_JSON", CLUSTER);
+    vi.stubEnv("SITE_HOST", "openfront.io");
+    const { headers, setHeader } = collect();
+    applyGameApiCorsHeaders("https://blue.openfront.io", setHeader);
+    expect(headers.get("Access-Control-Allow-Origin")).toBe(
+      "https://blue.openfront.io",
+    );
+  });
+
+  test("only allows cluster hosts over https", () => {
+    vi.stubEnv("CLUSTER_JSON", CLUSTER);
+    const { headers, setHeader } = collect();
+    applyGameApiCorsHeaders("http://green.openfront.io", setHeader);
+    expect(headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+
+  test("rejects a host outside the map", () => {
+    vi.stubEnv("CLUSTER_JSON", CLUSTER);
+    vi.stubEnv("SITE_HOST", "openfront.io");
+    const { headers, setHeader } = collect();
+    applyGameApiCorsHeaders("https://evil.openfront.io", setHeader);
+    expect(headers.has("Access-Control-Allow-Origin")).toBe(false);
+  });
+});

--- a/tests/server/RenderHtml.test.ts
+++ b/tests/server/RenderHtml.test.ts
@@ -132,3 +132,45 @@ describe("RenderHtml serverHost pinning", () => {
     expect(await render()).toBe("");
   });
 });
+
+describe("RenderHtml siteHost injection", () => {
+  let tempDir: string | null = null;
+
+  beforeEach(() => {
+    vi.stubEnv("CLUSTER_JSON", TEST_CLUSTER);
+    vi.stubEnv("TURNSTILE_SITE_KEY", "test-key");
+    vi.stubEnv("GIT_COMMIT", "abc");
+    vi.stubEnv("DOMAIN", "openfront.io");
+    vi.stubEnv("SUBDOMAIN", "blue");
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    clearAppShellContentCache();
+    if (tempDir) {
+      await fs.rm(tempDir, { recursive: true, force: true });
+      tempDir = null;
+    }
+  });
+
+  // Same expression index.html uses to emit the optional siteHost line.
+  const TEMPLATE =
+    '<%- typeof siteHost !== "undefined" && siteHost ? "siteHost: " + siteHost + "," : "" %>';
+
+  async function render(): Promise<string> {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "render-html-"));
+    const htmlPath = path.join(tempDir, "index.html");
+    await fs.writeFile(htmlPath, TEMPLATE, "utf8");
+    return getAppShellContent(htmlPath);
+  }
+
+  test("advertises the apex behind a load balancer (unknown-letter redirect target)", async () => {
+    vi.stubEnv("SITE_HOST", "openfront.io");
+    expect(await render()).toBe('siteHost: "openfront.io",');
+  });
+
+  test("omits siteHost for a standalone deployment", async () => {
+    vi.stubEnv("SITE_HOST", "");
+    expect(await render()).toBe("");
+  });
+});


### PR DESCRIPTION
## Summary

PR 5 of the multi-server plan ([docs/MultiServer.md](https://github.com/openfrontio/OpenFrontIO/blob/main/docs/MultiServer.md)) — the client seam that makes shared lobby links and mid-game rejoins work across servers. Builds on #5310's cluster map in `BOOTSTRAP_CONFIG`.

- **`resolveGameHost`** (pure, exported, tested): a 10-char game id's leading letter names its deployment in the cluster map. Own letter, legacy 8-char ids, and mapless old desktop shells resolve to the own server (today's behavior, unchanged); foreign letters resolve to their entry's host + worker count, always over TLS.
- **Per-game bases**: the game WebSocket and every game-scoped API call (`exists` checks in the join modal and matchmaking, game info/listing, successor `create_game?previous`) now use `gameWsBase`/`gameHttpBase`/`gameWorkerPath`. The lobby feed and fresh `create_game` deliberately stay own-server. Same-origin page URLs (`/wN/game/<id>`) are untouched — any shell can serve the page; only the sockets/API follow the letter.
- **`version_mismatch` forks by host**: own-host mismatch = stale tab → reload (as today); cross-host mismatch = our shell is another deployment's build → full navigation to the game's host, whose shell serves the matching bundle *and* map. Desktop keeps its shell-driven update path.
- **`WrongWorker` close** (from #5299): one full navigation to the game's host re-fetches shell + map and re-resolves; a sessionStorage latch prevents loops, falling through to the normal refusal dialog on a second rejection.
- **Unknown letter** on a `/game/<id>` link: redirect to the apex (freshest map); on the apex itself, or dev/desktop, fall through to the normal not-found flow.

On today's single-deployment-per-fleet maps every resolution is "own", so this is a production no-op until a second letter exists.

Desktop note: the shell-side `/cluster.json` discovery (replacing its injected `numWorkers`) lives in the Electron repo; until it ships, mapless desktop shells keep routing everything to their `serverHost` exactly as before.

## Test plan
- New `tests/client/ResolveGameHost.test.ts`: cross/own/legacy/mapless/unknown-letter resolution.
- `TransportConnectionRefused` gains the two WrongWorker cases: navigates once to the game's host; latched second refusal shows the dialog.
- Transport test mocks extended for the per-game methods.
- Full suite 384 + 62 files, 5527 tests green; `tsc --noEmit`, Prettier, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)