### PR TITLE
Drain by color, not instanceId

### DIFF
--- a/src/server/ActiveDeployment.ts
+++ b/src/server/ActiveDeployment.ts
@@ -1,28 +1,34 @@
 import { z } from "zod";
+import { ClusterColorSchema, type ClusterColor } from "../core/ClusterConfig";
 
-const HealthSchema = z.object({ instanceId: z.string() });
+const HealthSchema = z.object({ color: ClusterColorSchema });
 
 /**
  * Ask the site host (the load balancer, e.g. `openfront.io`) which deployment
- * it currently routes to, by reading the instanceId its /api/health reports.
+ * COLOR it currently routes to, by reading the color its /api/health reports.
+ *
+ * Color, not instanceId: with several machines per color behind the apex, an
+ * active server polling it usually reaches a SIBLING — same color, different
+ * instanceId — and an identity compare would wrongly drain the whole active
+ * fleet. Color is deployment-wide; instanceId is per-machine.
  *
  * Returns null when the answer is unusable (network error, non-JSON, a build
- * that doesn't report an instanceId yet). Callers must treat null as "no
- * change", never as "inactive": a Cloudflare hiccup or bot challenge must not
- * stop the live deployment from scheduling lobbies. The failure mode of
- * staying active is the pre-feature status quo.
+ * that doesn't report a color yet). Callers must treat null as "no change",
+ * never as "inactive": a Cloudflare hiccup or bot challenge must not stop the
+ * live deployment from scheduling lobbies. The failure mode of staying active
+ * is the pre-feature status quo.
  */
-export async function fetchSiteInstanceId(
+export async function fetchSiteColor(
   siteHost: string,
   fetchFn: typeof fetch = fetch,
-): Promise<string | null> {
+): Promise<ClusterColor | null> {
   try {
     const res = await fetchFn(`https://${siteHost}/api/health`, {
       cache: "no-store",
       signal: AbortSignal.timeout(10_000),
     });
     const parsed = HealthSchema.safeParse(await res.json());
-    return parsed.success ? parsed.data.instanceId : null;
+    return parsed.success ? parsed.data.color : null;
   } catch {
     return null;
   }

--- a/src/server/Master.ts
+++ b/src/server/Master.ts
@@ -6,7 +6,7 @@ import http from "http";
 import path from "path";
 import { fileURLToPath } from "url";
 import { GameEnv } from "../core/configuration/Config";
-import { fetchSiteInstanceId } from "./ActiveDeployment";
+import { fetchSiteColor } from "./ActiveDeployment";
 import { getDescriptor } from "./DesktopRelease";
 import { logger } from "./Logger";
 import { MapPlaylist } from "./MapPlaylist";
@@ -176,11 +176,13 @@ export async function startMaster() {
     log.info(`Master HTTP server listening on port ${PORT}`);
   });
 
-  // Behind a load balancer (blue/green), only the deployment the balancer
+  // Behind a load balancer (blue/green), only the color the balancer
   // currently routes to should schedule public lobbies. The balancer's
-  // /api/health reports the instanceId of whichever deployment answered, so
-  // comparing it to our own tells us if that's us. A standalone deployment
-  // (no SITE_HOST, or SITE_HOST is our own host) is always active.
+  // /api/health reports the COLOR of whichever deployment answered; colors
+  // are deployment-wide, so with several machines per color the poll
+  // reaching a sibling — same color, different instanceId — still counts as
+  // "the live color is mine". A standalone deployment (no SITE_HOST, or
+  // SITE_HOST is our own host) is always active.
   const siteHost = ServerEnv.siteHost();
   if (siteHost !== undefined && siteHost !== ServerEnv.publicHost()) {
     log.info(`Polling https://${siteHost}/api/health for active deployment`);
@@ -189,9 +191,9 @@ export async function startMaster() {
     // still is). startPolling serializes runs, so the fetch's 10s timeout
     // can't pile requests up.
     startPolling(async () => {
-      const siteInstanceId = await fetchSiteInstanceId(siteHost);
-      if (siteInstanceId === null) return;
-      lobbyService.setActive(siteInstanceId === INSTANCE_ID);
+      const siteColor = await fetchSiteColor(siteHost);
+      if (siteColor === null) return;
+      lobbyService.setActive(siteColor === ServerEnv.color());
     }, 5 * 1000);
   }
 }
@@ -208,10 +210,14 @@ app.get("/cluster.json", (_req, res) => {
 app.get("/api/health", (_req, res) => {
   const ready = lobbyService?.isHealthy() ?? false;
   const instanceId = ServerEnv.instanceId();
+  // The drain check (ActiveDeployment) compares colors: deployment-wide,
+  // where instanceId is per-machine and would false-drain siblings behind
+  // the same apex. instanceId stays for diagnostics.
+  const color = ServerEnv.color();
   if (ready) {
-    res.json({ status: "ok", instanceId });
+    res.json({ status: "ok", instanceId, color });
   } else {
-    res.status(503).json({ status: "unavailable", instanceId });
+    res.status(503).json({ status: "unavailable", instanceId, color });
   }
 });
 

--- a/tests/server/ActiveDeployment.test.ts
+++ b/tests/server/ActiveDeployment.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test, vi } from "vitest";
-import { fetchSiteInstanceId } from "../../src/server/ActiveDeployment";
+import { fetchSiteColor } from "../../src/server/ActiveDeployment";
 
 function fetchReturning(body: unknown, status = 200): typeof fetch {
   return vi.fn(
@@ -7,52 +7,58 @@ function fetchReturning(body: unknown, status = 200): typeof fetch {
   ) as unknown as typeof fetch;
 }
 
-describe("fetchSiteInstanceId", () => {
-  test("reads the instanceId the site's /api/health reports", async () => {
-    const fetchFn = fetchReturning({ status: "ok", instanceId: "abcd1234" });
-    await expect(fetchSiteInstanceId("openfront.io", fetchFn)).resolves.toBe(
-      "abcd1234",
-    );
+// The drain decision is `siteColor === own color` with null meaning "no
+// change" (Master.ts). Colors are deployment-wide, so a poll answered by a
+// SIBLING — same color, different instanceId — reads as "still active",
+// which is exactly the multi-machine case the old instanceId compare got
+// wrong.
+describe("fetchSiteColor", () => {
+  test("reads the color the site's /api/health reports, whoever answers", async () => {
+    const fetchFn = fetchReturning({
+      status: "ok",
+      instanceId: "some-sibling",
+      color: "blue",
+    });
+    await expect(fetchSiteColor("openfront.io", fetchFn)).resolves.toBe("blue");
     expect(fetchFn).toHaveBeenCalledWith(
       "https://openfront.io/api/health",
       expect.anything(),
     );
   });
 
-  test("still reads the instanceId from an unhealthy (503) answer", async () => {
-    // The other deployment being mid-restart is still an answer to "who is
-    // the balancer routing to?".
+  test("still reads the color from an unhealthy (503) answer", async () => {
+    // The other deployment being mid-restart is still an answer to "which
+    // color is the balancer routing to?".
     const fetchFn = fetchReturning(
-      { status: "unavailable", instanceId: "abcd1234" },
+      { status: "unavailable", instanceId: "x", color: "green" },
       503,
     );
-    await expect(fetchSiteInstanceId("openfront.io", fetchFn)).resolves.toBe(
-      "abcd1234",
+    await expect(fetchSiteColor("openfront.io", fetchFn)).resolves.toBe(
+      "green",
     );
   });
 
-  test("returns null when the site runs a build without instanceId", async () => {
-    const fetchFn = fetchReturning({ status: "ok" });
-    await expect(
-      fetchSiteInstanceId("openfront.io", fetchFn),
-    ).resolves.toBeNull();
+  test("returns null when the site runs a build without a color", async () => {
+    const fetchFn = fetchReturning({ status: "ok", instanceId: "abcd1234" });
+    await expect(fetchSiteColor("openfront.io", fetchFn)).resolves.toBeNull();
+  });
+
+  test("returns null on a color outside the enum", async () => {
+    const fetchFn = fetchReturning({ status: "ok", color: "purple" });
+    await expect(fetchSiteColor("openfront.io", fetchFn)).resolves.toBeNull();
   });
 
   test("returns null on a non-JSON body (bot challenge page)", async () => {
     const fetchFn = vi.fn(
       async () => new Response("<html>challenge</html>", { status: 403 }),
     ) as unknown as typeof fetch;
-    await expect(
-      fetchSiteInstanceId("openfront.io", fetchFn),
-    ).resolves.toBeNull();
+    await expect(fetchSiteColor("openfront.io", fetchFn)).resolves.toBeNull();
   });
 
   test("returns null on a network error", async () => {
     const fetchFn = vi.fn(async () => {
       throw new Error("ECONNRESET");
     }) as unknown as typeof fetch;
-    await expect(
-      fetchSiteInstanceId("openfront.io", fetchFn),
-    ).resolves.toBeNull();
+    await expect(fetchSiteColor("openfront.io", fetchFn)).resolves.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

PR 6 — the last item of the multi-server plan ([docs/MultiServer.md](https://github.com/openfrontio/OpenFrontIO/blob/main/docs/MultiServer.md)) in this repo.

- The instanceId-based drain check develops a false drain once a color has more than one machine behind the apex: an active server polling `/api/health` usually gets a **sibling's** answer — same color, different per-machine instanceId — and wrongly concludes the balancer moved on. It also matters today on the new openfront.dev LB whenever health answers race a flip.
- `/api/health` now reports the deployment's `color` from its own cluster entry (instanceId stays in the payload for diagnostics), and `ActiveDeployment.fetchSiteColor` + the master's poll compare colors: "is the live color mine?".
- Null-tolerance semantics unchanged: network errors, bot challenges, and old builds that don't report a color yet (the transition case) all mean "no change", never "inactive".

With this, draining colors keep their games, stop scheduling public lobbies, and stay addressable forever via the game-id letter — which is what makes shared lobby links and mid-match rejoins survive a cutover, on one machine or ten.

## Test plan
- `tests/server/ActiveDeployment.test.ts` rewritten: reads the color whoever answers (the sibling case), 503 still answers, null on missing color / out-of-enum color / non-JSON / network error.
- Full suite 383 + 62 files, 5521 tests green; `tsc --noEmit`, Prettier, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)