### PR TITLE
fix(version): show the tagged version under the logo again (OPE-387)

### DIFF
--- a/src/client/GameVersion.ts
+++ b/src/client/GameVersion.ts
@@ -59,21 +59,38 @@ export function currentGameVersion(): string {
   return composeGameVersion(version, currentGitCommit());
 }
 
+/**
+ * The version alone, never a commit -- what the nav bar under the logo shows.
+ *
+ * The commit is deliberately not substituted here (OPE-387). A sha under the
+ * logo reads as a broken label to a player who is not debugging a build, and
+ * that spot is the front door of the game rather than a place anyone is asked
+ * to quote from. The footer is where the build's real identity belongs, and it
+ * still names the commit on an untagged build, so nothing is lost -- it just
+ * is not the first thing on the main menu.
+ */
+export function taggedGameVersion(rawVersion: string): string {
+  const trimmed = rawVersion.trim();
+  return trimmed.startsWith("v") ? trimmed : `v${trimmed}`;
+}
+
 /** The nav bar's version elements, in both the mobile and desktop nav bars. */
 const NAV_VERSION_SELECTOR = "#game-version, .game-version-display";
 
 /**
- * Stamps the build label onto the nav bar, and reports how many elements it
- * found so the caller can warn when the markup has moved out from under it.
+ * Stamps the version onto the nav bar, and reports how many elements it found
+ * so the caller can warn when the markup has moved out from under it.
  *
- * Lives here rather than inline in Main.ts so it goes through the same helper
- * the footer does and can be tested without importing Main.ts, which is a
- * module of side effects. The nav bar showing "vx.xx.xx" beside a footer
- * showing "bf739f8" would be worse than either label alone.
+ * Lives here rather than inline in Main.ts so it can be tested without
+ * importing Main.ts, which is a module of side effects.
+ *
+ * Uses taggedGameVersion, not currentGameVersion: the nav bar and the footer
+ * answer different questions on an untagged build, by decision rather than by
+ * drift (OPE-387).
  */
 export function renderNavVersion(root: ParentNode = document): number {
   const elements = root.querySelectorAll(NAV_VERSION_SELECTOR);
-  const label = currentGameVersion();
+  const label = taggedGameVersion(version);
   elements.forEach((el) => {
     (el as HTMLElement).style.fontFamily = '"OpenFront", Inter, sans-serif';
     el.textContent = label;

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -361,10 +361,11 @@ class Client {
     document.fonts.add(openFrontFont);
     openFrontFont.load().catch(() => {});
 
-    // Game version only, so a player's version reads the same across web and
-    // Steam. The full string, shell version included, is in page-footer --
-    // and both go through the same helper, so the two cannot disagree. See
-    // renderNavVersion / composeGameVersion (OPE-358).
+    // The tagged version only, so a player's version reads the same across web
+    // and Steam. The build's full identity -- the commit on an untagged build,
+    // and the shell version on Steam -- is in page-footer instead, where it
+    // can be quoted in a bug report without a sha sitting under the logo on
+    // the main menu. See renderNavVersion / taggedGameVersion (OPE-387).
     if (renderNavVersion() === 0) {
       console.warn("Game version element not found");
     }

--- a/tests/client/GameVersion.test.ts
+++ b/tests/client/GameVersion.test.ts
@@ -5,6 +5,7 @@ import {
   composeGameVersion,
   currentGameVersion,
   renderNavVersion,
+  taggedGameVersion,
 } from "../../src/client/GameVersion";
 
 const SHA = "bf739f86c4e1d2a3b5c6d7e8f90123456789abcd";
@@ -88,6 +89,34 @@ describe("currentGameVersion", () => {
   });
 });
 
+// The nav bar under the logo shows the version and never a commit (OPE-387).
+// This is the pre-OPE-358 rendering, restored: a sha under the logo reads as a
+// broken label on the main menu, which is the front door rather than somewhere
+// anyone is asked to quote a build from.
+describe("taggedGameVersion", () => {
+  it("shows the version when the build was tagged", () => {
+    expect(taggedGameVersion("v0.33.18")).toBe("v0.33.18");
+  });
+
+  it("adds the v when the tag was written without one", () => {
+    expect(taggedGameVersion("0.33.18")).toBe("v0.33.18");
+  });
+
+  it("tolerates surrounding whitespace, as the raw file import carries", () => {
+    expect(taggedGameVersion("  v0.33.18\n")).toBe("v0.33.18");
+  });
+
+  // The original untagged rendering, kept deliberately. The footer is the half
+  // that names the commit instead -- see composeGameVersion above, which turns
+  // this same input into "bf739f8".
+  it("renders the placeholder as-is on an untagged build", () => {
+    expect(taggedGameVersion("x.xx.xx")).toBe("vx.xx.xx");
+    expect(composeGameVersion("x.xx.xx", SHA)).not.toBe(
+      taggedGameVersion("x.xx.xx"),
+    );
+  });
+});
+
 describe("renderNavVersion", () => {
   beforeEach(() => {
     ClientEnv.reset();
@@ -111,8 +140,10 @@ describe("renderNavVersion", () => {
     };
   };
 
-  // The nav bar must not read "vx.xx.xx" while the footer reads the commit.
-  it("stamps the same label the footer uses onto both nav bars", () => {
+  // The regression this pins: with a real commit sitting in BOOTSTRAP_CONFIG
+  // and version.txt still the placeholder, the nav bar shows the version
+  // anyway. Swapping the helper back to currentGameVersion turns this red.
+  it("stamps the version, not the commit, onto both nav bars", () => {
     setBootstrap();
     document.body.innerHTML = `
       <span id="game-version"></span>
@@ -120,12 +151,13 @@ describe("renderNavVersion", () => {
     `;
 
     expect(renderNavVersion()).toBe(2);
-    const expected = composeGameVersion(version, SHA);
     for (const el of document.querySelectorAll(
       "#game-version, .game-version-display",
     )) {
-      expect(el.textContent).toBe(expected);
-      expect(el.textContent).not.toContain("x.xx.xx");
+      expect(el.textContent).toBe(taggedGameVersion(version));
+      // Always a version, whatever version.txt holds when this runs: the
+      // commit form has no leading v and this one always does.
+      expect(el.textContent).toMatch(/^v/);
     }
   });
 


### PR DESCRIPTION
## Why

[OPE-387](https://linear.app/openfront/issue/OPE-387). #5286 made the version label **under the logo on the main menu** fall back to the build's 7-character commit when the build has no tagged version. On a real build that reads as a broken label: the front door of the game says `bf739f8` where a version belongs, to a player who is not debugging anything.

The **footer** was always the right home for that, and it keeps the #5286 behaviour untouched. It is the line a player is actually asked to quote in a bug report, and the only place the build's real identity was ever needed.

## What

| label | tagged build | untagged build |
| --- | --- | --- |
| under the logo | `v0.33.18` (unchanged) | `vx.xx.xx` — **was** `bf739f8` |
| page footer | `v0.33.18 (Steam v0.1.0)` (unchanged) | `bf739f8 (Steam v0.1.0)` (unchanged) |

`renderNavVersion` reads a new `taggedGameVersion` helper instead of the footer's `currentGameVersion`. That helper is the pre-#5286 expression verbatim — trim, prefix `v` if absent — so the untagged rendering is the original one rather than a new third shape.

**Why a second helper rather than a flag on the first.** The two labels genuinely answer different questions now, and #5286's comments asserted the opposite ("both go through the same helper, so the two cannot disagree"). Leaving those in place would have left the file arguing against its own behaviour, so they are corrected in `GameVersion.ts` and `Main.ts`. Both helpers still live in one module, so the split reads as one visible decision instead of two derivations that drifted apart.

**Nothing else in #5286 is touched.** `composeGameVersion`, `currentGameVersion`, `Footer.ts`, `composeVersionDisplay`'s conditional `v` prefix, and the `release.yml` change that hands `build.sh` the tag all stay exactly as they are.

## The desktop shell needs no change

Checked openfront-desktop #40 and #41, as the ticket asks. #40 injects the bundled client's real commit as `gitCommit`, and #41 makes `app:version` report the shell's version or its commit. Both only *supply* values; which of them a given label renders has always been the client's choice, and the footer still consumes both exactly as before. No shell PR follows this one.

## Tests

`tests/client/GameVersion.test.ts`:

- New `taggedGameVersion` block — tagged, missing `v`, surrounding whitespace, and the placeholder rendering as `vx.xx.xx`. The last case asserts directly against `composeGameVersion("x.xx.xx", SHA)` so the two halves are pinned as *different* on literal inputs, which is the whole point of the change.
- The `renderNavVersion` DOM case is rewritten to pin the opposite of what it pinned before. It still puts a real 40-character SHA in `BOOTSTRAP_CONFIG` — now to prove the nav bar ignores it. **Mutation-checked**: restoring `currentGameVersion()` fails with `expected 'bf739f8' to be 'vx.xx.xx'`, and restoring the fix passes.
- The second assertion is `toMatch(/^v/)` rather than a hardcoded string, because `version.txt` is a build-time placeholder in the tree. It holds whatever a tagged checkout would hold, and the commit form is the one shape that can never start with a `v`.

`tests/client/components/Footer.test.ts` and `tests/DesktopShell.test.ts` are unchanged and still green — that is the evidence the footer half did not move.

Run locally on Windows:

```
npx tsc --noEmit                                   # clean
npm run lint                                       # clean (oxlint + eslint)
npx prettier --write <changed files>               # no diff
npx vitest run tests/client/GameVersion.test.ts \
  tests/client/components/Footer.test.ts \
  tests/DesktopShell.test.ts                       # 35 passed, 3 files
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GfTQZps1QwQHmBMoV3gq3U
