### PR TITLE
fix(client): stop logging raw 400 bodies (OPE-376)

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -746,7 +746,9 @@ export async function boostTribeName(
       if (typeof body?.reason === "string") {
         return { ok: false, code: "insufficient_balance" };
       }
-      console.error("boostTribeName: bad request", body);
+      // Body-free on purpose: an unrecognised 400 is exactly the case where we
+      // do not know what the body contains, so it must not reach a log line.
+      console.warn("boostTribeName: unrecognised 400 response");
       return { ok: false, code: "failed" };
     }
     if (response.status === 404) {
@@ -903,7 +905,9 @@ export async function purchaseCosmeticPack(
       if (PACK_UNAVAILABLE_REASONS.includes(reason)) {
         return { ok: false, code: "unavailable" };
       }
-      console.error("purchaseCosmeticPack: bad request", body);
+      // Body-free on purpose: an unrecognised 400 is exactly the case where we
+      // do not know what the body contains, so it must not reach a log line.
+      console.warn("purchaseCosmeticPack: unrecognised 400 response");
       return { ok: false, code: "failed" };
     }
     if (response.status === 409) {

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -1250,7 +1250,12 @@ export async function createPaymentsCheckout(
 
       if (response.status === 400) {
         if (CHECKOUT_CLIENT_BUG_REASONS.includes(reason)) {
-          console.error("createPaymentsCheckout: bad request", body);
+          // Body-free, like the other refusal logs. Kept at error (rather
+          // than the warn the two unrecognised-400 paths use) because the
+          // reason here is one we recognise and it means this client sent
+          // something it never should have -- a real bug, not a refusal we
+          // simply cannot classify.
+          console.error("createPaymentsCheckout: client-bug 400 response");
           return { ok: false, code: "client_bug" };
         }
         if (CHECKOUT_STALE_LISTING_REASONS.includes(reason)) {

--- a/tests/client/BoostTribeNameBadRequest.test.ts
+++ b/tests/client/BoostTribeNameBadRequest.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../src/client/Auth", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Auth")>()),
+  getAuthHeader: vi.fn(async () => "Bearer test"),
+  logOut: vi.fn(async () => true),
+}));
+
+import { boostTribeName } from "../../src/client/Api";
+import { ClientEnv } from "../../src/client/ClientEnv";
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+// Planted in the server body so the assertions test the actual rule — that no
+// part of a server body reaches a log line — rather than the current wording
+// of any one warning.
+const CANARY = "CANARY-7f3a";
+
+function respond(status: number, body: unknown) {
+  fetchMock.mockResolvedValueOnce(
+    new Response(JSON.stringify(body), {
+      status,
+      headers: { "content-type": "application/json" },
+    }),
+  );
+}
+
+function expectNoConsoleCallContains(needle: string) {
+  for (const spy of [console.error, console.warn]) {
+    for (const call of vi.mocked(spy).mock.calls) {
+      for (const arg of call) {
+        expect(String(arg)).not.toContain(needle);
+        expect(String(JSON.stringify(arg))).not.toContain(needle);
+      }
+    }
+  }
+}
+
+beforeEach(() => {
+  (window as any).BOOTSTRAP_CONFIG = {
+    gameEnv: "prod",
+    numWorkers: 1,
+    turnstileSiteKey: "x",
+    jwtAudience: "openfront.io",
+    instanceId: "test",
+    gitCommit: "test",
+    serverHost: "main.openfront.dev",
+  };
+  ClientEnv.reset();
+  fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  delete (window as any).BOOTSTRAP_CONFIG;
+  ClientEnv.reset();
+});
+
+describe("boostTribeName 400 handling", () => {
+  // Guards the warn against becoming over-broad: a recognised player-facing
+  // refusal is an expected outcome, not something to log about.
+  it("maps a player-facing reason without logging anything", async () => {
+    respond(400, { reason: "Insufficient balance", canary: CANARY });
+    expect(await boostTribeName("7", "key")).toEqual({
+      ok: false,
+      code: "insufficient_balance",
+    });
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  it("warns without the body on an unrecognised 400", async () => {
+    respond(400, { resource: "id", canary: CANARY });
+    expect(await boostTribeName("nope", "key")).toEqual({
+      ok: false,
+      code: "failed",
+    });
+    expectNoConsoleCallContains(CANARY);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(console.warn).mock.calls[0]).toHaveLength(1);
+  });
+
+  it("warns without the body when the 400 body is not JSON", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response(`not json ${CANARY}`, {
+        status: 400,
+        headers: { "content-type": "text/plain" },
+      }),
+    );
+    expect(await boostTribeName("7", "key")).toEqual({
+      ok: false,
+      code: "failed",
+    });
+    expectNoConsoleCallContains(CANARY);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(console.warn).mock.calls[0]).toHaveLength(1);
+  });
+});

--- a/tests/client/PaymentsCheckout.test.ts
+++ b/tests/client/PaymentsCheckout.test.ts
@@ -29,6 +29,21 @@ function respond(
   );
 }
 
+// Planted in the server body so the assertion tests the actual rule -- that no
+// part of the body is logged -- rather than the spelling of one log call.
+const CANARY = "CANARY-7f3a";
+
+function expectNoConsoleCallContains(needle: string) {
+  for (const spy of [console.error, console.warn]) {
+    for (const call of vi.mocked(spy).mock.calls) {
+      for (const arg of call) {
+        expect(String(arg)).not.toContain(needle);
+        expect(String(JSON.stringify(arg))).not.toContain(needle);
+      }
+    }
+  }
+}
+
 function lastBody(): any {
   const calls = fetchMock.mock.calls;
   const [, init] = calls[calls.length - 1] as [string, RequestInit];
@@ -50,6 +65,7 @@ beforeEach(() => {
   logOutMock.mockClear();
   vi.stubGlobal("fetch", fetchMock);
   vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -260,6 +276,21 @@ describe("createPaymentsCheckout errors", () => {
   it("maps 400 Bad request to client_bug", async () => {
     respond(400, { reason: "Bad request", errors: ["provider: required"] });
     expect(await checkout()).toEqual({ ok: false, code: "client_bug" });
+  });
+
+  it("logs the client-bug 400 without any part of the server body", async () => {
+    respond(400, {
+      reason: "Bad request",
+      errors: [`provider: required ${CANARY}`],
+      canary: CANARY,
+    });
+    expect(await checkout()).toEqual({ ok: false, code: "client_bug" });
+    expectNoConsoleCallContains(CANARY);
+    // Still an error: a recognised client-bug reason is a real bug, unlike
+    // the unrecognised-400 paths that only warn.
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(console.error).mock.calls[0]).toHaveLength(1);
+    expect(console.warn).not.toHaveBeenCalled();
   });
 
   it("maps 400 Invalid hostname to client_bug", async () => {

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -20,6 +20,21 @@ function respond(status: number, body: unknown) {
   );
 }
 
+// Planted in the server body so the assertion tests the actual rule — that no
+// part of the body is logged — rather than the spelling of one warn call.
+const CANARY = "CANARY-7f3a";
+
+function expectNoConsoleCallContains(needle: string) {
+  for (const spy of [console.error, console.warn]) {
+    for (const call of vi.mocked(spy).mock.calls) {
+      for (const arg of call) {
+        expect(String(arg)).not.toContain(needle);
+        expect(String(JSON.stringify(arg))).not.toContain(needle);
+      }
+    }
+  }
+}
+
 beforeEach(() => {
   (window as any).BOOTSTRAP_CONFIG = {
     gameEnv: "prod",
@@ -34,6 +49,7 @@ beforeEach(() => {
   fetchMock = vi.fn();
   vi.stubGlobal("fetch", fetchMock);
   vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(console, "warn").mockImplementation(() => {});
 });
 
 afterEach(() => {
@@ -101,11 +117,21 @@ describe("purchaseCosmeticPack", () => {
     }
 
     // A malformed body is a client bug, not a player error.
-    respond(400, { error: "Bad request", reason: "Invalid request body" });
+    respond(400, {
+      error: "Bad request",
+      reason: "Invalid request body",
+      canary: CANARY,
+    });
     expect(await purchaseCosmeticPack("starter")).toEqual({
       ok: false,
       code: "failed",
     });
+    // The rule is that no part of the server body reaches a log line, so the
+    // canary is what is asserted on, not the current wording of the warning.
+    expectNoConsoleCallContains(CANARY);
+    expect(console.error).not.toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(console.warn).mock.calls[0]).toHaveLength(1);
   });
 
   it("reports which items are already owned on 409", async () => {


### PR DESCRIPTION
## What

Three client paths logged the full server error body on a refused request:

| `src/client/Api.ts` | before | after |
| --- | --- | --- |
| `boostTribeName` | `console.error("boostTribeName: bad request", body)` | `console.warn("boostTribeName: unrecognised 400 response")` |
| `purchaseCosmeticPack` | `console.error("purchaseCosmeticPack: bad request", body)` | `console.warn("purchaseCosmeticPack: unrecognised 400 response")` |
| `createPaymentsCheckout` | `console.error("createPaymentsCheckout: bad request", body)` | `console.error("createPaymentsCheckout: client-bug 400 response")` |

Each is now a single string literal naming the function and the status, with no second argument.

## Why

The rule (root `CLAUDE.md`, and the Steam launch hard rules) is that no raw server body, identifier or token reaches a log line. Today these bodies carry only a `reason`, a `debt` amount and a validation `errors` array, so nothing sensitive leaks — but the pattern is one infra change away from logging something that does, and for the two `unrecognised 400` paths an unrecognised reason is *precisely* the case where the client does not know what the body holds. The newer debt-handling paths (OPE-239, OPE-373) already log body-free warnings; this brings the rest in line.

The ticket named two sites. The third (`createPaymentsCheckout`) is folded in deliberately: closing two of three would leave the rule half-applied. After this change `grep` finds no remaining `console.*(..., body)` in `src/client/`.

### Why the checkout site stays at `error`

The two `unrecognised 400` paths drop to `warn` because they fire on input the client cannot classify. `createPaymentsCheckout` fires on a *recognised* `CHECKOUT_CLIENT_BUG_REASONS` match, which means this client sent something it never should have — a genuine bug. Only the body is removed; the severity is deliberately preserved.

## Tests

Assertions pin the *rule*, not the current wording. Each test plants a canary in the 400 body, spies on both `console.error` and `console.warn`, and asserts that no argument of any console call contains it under either `String()` or `JSON.stringify` — then checks arity and that the other channel is untouched.

- `tests/client/BoostTribeNameBadRequest.test.ts` (new): recognised reason maps to `insufficient_balance` and logs *nothing* (guards against an over-broad warn); `{resource:"id"}` and a non-JSON 400 body each warn once with exactly one argument.
- `tests/client/PurchaseCosmeticPack.test.ts`: canary added to the existing "Invalid request body" case.
- `tests/client/PaymentsCheckout.test.ts`: new case with the canary at the top level *and* inside the nested `errors` array.

### Evidence

- `npx vitest run` on the 4 touched/related suites: **106 passed**.
- `npx tsc --noEmit`: clean. `npm run lint` (oxlint + eslint): clean. `npx prettier --check`: clean.
- **Revert-proof.** Reverting only `src/client/Api.ts` fails 3 tests, the canary reporting the real leak: `expected '{"error":"Bad request","reason":"Inva…' not to contain 'CANARY-7f3a'`. Reverting only the checkout hunk fails 1 test the same way.
- **Conflict check.** `git merge-tree --write-tree` is clean against `origin/main`, `josh/ope-239-tribe-name-debt` (#5306/#5307) and `josh/ope-373-shop-purchase-debt` (#5308/#5309). Going beyond textual cleanliness, the merged `Api.ts` from each merge tree was extracted and the tests run against it: 7/7 passed against both, and neither merged result contains a remaining body log.

Based on `main` @ `532bad49c`.

Resolves OPE-376 — https://linear.app/openfront/issue/OPE-376/client-logs-raw-400-bodies-from-the-pack-purchase-and-tribe-boost

🤖 Generated with [Claude Code](https://claude.com/claude-code)
