### PR TITLE
fix(store): handle "already owned" on single-cosmetic purchase (OPE-375)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1757,6 +1757,7 @@
     "title": "Wishlist OpenFront on Steam!"
   },
   "store": {
+    "already_owned": "You already own this item. Nothing was charged.",
     "already_subscribed": "Already subscribed.",
     "bundles": "Bundles",
     "change_tier_failed": "Couldn't update your subscription. Please try again.",
@@ -1795,7 +1796,6 @@
     "no_skins": "No skins available. Check back later for new items.",
     "no_subscriptions": "No subscriptions available. Check back later for new items.",
     "no_tribes": "You haven't bought any tribe names yet.",
-    "already_owned": "You already own this item. Nothing was charged.",
     "pack_already_owned": "You already own {items}. Nothing was charged.",
     "pack_debt": "Your Plutonium balance is {debt} in debt. Settle it before buying.",
     "pack_no_items": "None of this bundle's items are available right now.",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1795,6 +1795,7 @@
     "no_skins": "No skins available. Check back later for new items.",
     "no_subscriptions": "No subscriptions available. Check back later for new items.",
     "no_tribes": "You haven't bought any tribe names yet.",
+    "already_owned": "You already own this item. Nothing was charged.",
     "pack_already_owned": "You already own {items}. Nothing was charged.",
     "pack_debt": "Your Plutonium balance is {debt} in debt. Settle it before buying.",
     "pack_no_items": "None of this bundle's items are available right now.",

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -897,6 +897,11 @@ export type PurchaseWithCurrencyResult =
   // spendable. Nothing charged. Distinct from the above because buying more
   // currency is not the remedy.
   | { ok: false; code: "debt"; debt: string }
+  // 409 "Already owned": the player already holds this cosmetic. Also what a
+  // retry after a timed-out success returns — treat it as "already bought"
+  // and refetch. Nothing charged. No payload: unlike the pack's 409 the body
+  // carries no item list, only {error, message}.
+  | { ok: false; code: "already_owned" }
   | { ok: false; code: "failed" };
 
 // POST /shop/purchase — buy a single cosmetic for hard or soft currency. The
@@ -950,6 +955,12 @@ export async function purchaseWithCurrency(
       // where we don't know what it contains.
       console.warn("purchaseWithCurrency: unrecognised 400 reason");
       return { ok: false, code: "failed" };
+    }
+    if (response.status === 409) {
+      // The body is deliberately not read: it carries no item list, so there
+      // is nothing to extract, and not touching it is the cheapest way to
+      // keep a server body away from a log line.
+      return { ok: false, code: "already_owned" };
     }
     if (!response.ok) {
       console.error(

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -549,6 +549,16 @@ export async function purchaseCosmetic(
           translateText("store.pack_debt", { debt: result.debt }),
         );
         return;
+      case "already_owned":
+        // Either a genuine double-buy or a retry of a purchase that did go
+        // through (the success response was lost): both mean the local
+        // ownership state is stale, so refetch. Mirrors the pack path. No
+        // broadcastFreshUserMe() here — the reload below tears the page down,
+        // so re-dispatching the profile first would be dead work.
+        await showInGameAlert(translateText("store.already_owned"));
+        invalidateUserMe();
+        window.location.reload();
+        return;
       default:
         await showInGameAlert(translateText("store.purchase_failed"));
         return;

--- a/tests/client/CosmeticPurchaseDebt.test.ts
+++ b/tests/client/CosmeticPurchaseDebt.test.ts
@@ -35,6 +35,7 @@ const translations = {
   "flags.pirate": "Jolly Roger",
   "store.login_required": "log in",
   "store.pack_debt": "debt {debt}",
+  "store.already_owned": "already owned",
   "store.purchase_failed": "failed",
   "store.purchase_success": "bought {name}",
 };
@@ -105,6 +106,35 @@ describe("purchaseCosmetic when the wallet is in debt", () => {
     // The cached profile still holds the pre-chargeback balance, which the
     // store would otherwise keep rendering.
     expect(invalidateUserMe).toHaveBeenCalled();
+  });
+
+  // The debt case above asserts reload is NOT called, because nothing was
+  // granted. This is the deliberate contrast: the grant already happened
+  // server-side, so the stale ownership state must be reloaded.
+  it("reloads on an already-owned refusal, unlike the debt case", async () => {
+    vi.mocked(purchaseWithCurrency).mockResolvedValue({
+      ok: false,
+      code: "already_owned",
+    });
+
+    const result = await purchaseCosmetic(pirateFlag, "hard");
+
+    expect(showInGameAlert).toHaveBeenCalledWith("already owned");
+    // The bug: this refusal used to be told as "try again", which loops
+    // forever because the retry 409s again.
+    expect(showInGameAlert).not.toHaveBeenCalledWith("failed");
+    expect(result).toBeUndefined();
+    expect(invalidateUserMe).toHaveBeenCalled();
+    expect(reloadMock).toHaveBeenCalledTimes(1);
+    // The player must read the message before the page goes away, and the
+    // cache must be dropped before the reload refills it.
+    const alertOrder = vi.mocked(showInGameAlert).mock
+      .invocationCallOrder[0] as number;
+    const invalidateOrder = vi.mocked(invalidateUserMe).mock
+      .invocationCallOrder[0] as number;
+    const reloadOrder = reloadMock.mock.invocationCallOrder[0] as number;
+    expect(alertOrder).toBeLessThan(invalidateOrder);
+    expect(invalidateOrder).toBeLessThan(reloadOrder);
   });
 
   // Finding 1: this is the COMMON way a player in debt arrives. The API

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -200,6 +200,26 @@ describe("purchaseWithCurrency", () => {
     },
   );
 
+  // A retry after a success whose response was lost gets this. Folding it
+  // into the generic failure told the player to try again, forever, while the
+  // store still showed the item as purchasable.
+  it("reports a 409 as already owned, silently and without retrying", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    respond(409, { error: "Conflict", message: "CANARY-a1b2" });
+
+    expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
+      ok: false,
+      code: "already_owned",
+    });
+    // Not an error condition: on main this fell into the !response.ok branch
+    // and logged the status. Nothing is read from the body, so nothing from
+    // it can reach a log line.
+    expect(console.error).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    // One request: guards against a retry loop creeping back in.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
   it("distinguishes being short from being in debt", async () => {
     respond(400, { reason: "Insufficient balance" });
     expect(await purchaseWithCurrency("flag", "pirate", "soft")).toEqual({

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -205,12 +205,20 @@ describe("purchaseWithCurrency", () => {
   // store still showed the item as purchasable.
   it("reports a 409 as already owned, silently and without retrying", async () => {
     const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-    respond(409, { error: "Conflict", message: "CANARY-a1b2" });
+    const response = new Response(
+      JSON.stringify({ error: "Conflict", message: "CANARY-a1b2" }),
+      { status: 409, headers: { "content-type": "application/json" } },
+    );
+    fetchMock.mockResolvedValueOnce(response);
 
     expect(await purchaseWithCurrency("flag", "pirate", "hard")).toEqual({
       ok: false,
       code: "already_owned",
     });
+    // The body is never read: a regression that calls response.json() and
+    // discards the result would leave bodyUsed true and fail here, which no
+    // assertion on the returned value could catch.
+    expect(response.bodyUsed).toBe(false);
     // Not an error condition: on main this fell into the !response.ok branch
     // and logged the status. Nothing is read from the body, so nothing from
     // it can reach a log line.


### PR DESCRIPTION
## What

`purchaseWithCurrency` folded infra's 409 `"Already owned"` into the generic `store.purchase_failed` ("Purchase failed. Please try again."). 409 now maps to a new `already_owned` result, and `purchaseCosmetic` handles it by telling the player they already own the item and reloading, mirroring the pack path.

## Why

If the first request succeeded server-side but the response was lost — a timeout, a closed tab, a flaky connection — the player retries, the server answers 409 because the grant already happened, and the client says "try again". The retry 409s too. The store meanwhile still shows the item as purchasable, because nothing invalidated the cached profile. That is a loop with no exit, on the highest-traffic spend path in the game.

`purchaseCosmeticPack` already got this right; this brings the single-cosmetic path in line.

## The 409 has exactly one meaning here

`/shop/purchase` returns 409 from a single site: `conflict("Already owned")` at `src/api/endpoints/shop/purchase/POST.ts:142` in the infra repo. The shared helper (`src/api/lib/Handler.ts:90-99`) renders it as `{ error: "Conflict", message: "Already owned" }`.

Note what is *absent*: unlike the pack endpoint's 409, there is no `ownedFlareNames` array — the player is buying one known item, so there is nothing to enumerate back. The new variant is therefore payload-free:

```ts
| { ok: false; code: "already_owned" }
```

**The branch does not read the response body at all.** No `response.json()`, no `.catch(() => null)`. There is nothing in it worth extracting, and not touching it is the cheapest way to honour the rule that no raw server body reaches a log line or an error message.

## Deliberate: no profile re-broadcast

The sibling refusal paths call `broadcastFreshUserMe()` so the open Store stops rendering a stale balance. This case does not, because it ends in `window.location.reload()` — the page is torn down, so re-dispatching the profile first would be dead work. `invalidateUserMe()` still runs, so the reload refills from the server rather than the cache. This mirrors the pack path at `Cosmetics.ts:640-650`, and is called out in a comment on the case.

## Tests

- `tests/client/PurchaseCosmeticPack.test.ts` — in the existing `describe("purchaseWithCurrency")`: a 409 maps to `already_owned`; **neither** `console.error` nor `console.warn` fires (on `main` this fell into the `!response.ok` branch and logged status/statusText); and `fetch` is called exactly once, guarding against a retry loop creeping back in. A canary in the 409 body backstops the no-body-read claim.
- `tests/client/CosmeticPurchaseDebt.test.ts` — the `store.already_owned` alert is shown and `store.purchase_failed` is **not**; `invalidateUserMe` runs; `reload` runs exactly once; and `invocationCallOrder` pins alert &lt; invalidateUserMe &lt; reload, so the player can read the message before the page goes away and the cache is dropped before the reload refills it. Named as the explicit contrast to the debt case directly above it, which asserts reload is *not* called.

### Evidence

- 42 tests passing across the 5 cosmetic/purchase suites. `npx tsc --noEmit`, `npm run lint`, `npx prettier` all clean.
- **Revert-proof, per half.** Reverting only `Api.ts` fails with `expected { ok: false, code: 'failed' } to deeply equal { ok: false, code: 'already_owned' }`. Reverting only `Cosmetics.ts` fails with `expected "vi.fn()" to be called with arguments: [ 'already owned' ]`.
- **Independent of #5319.** That PR also edits `Api.ts` and `PurchaseCosmeticPack.test.ts`. `git merge-tree --write-tree` is clean against both `origin/main` and `josh/ope-376-no-body-logs`; going further, the merged tree was checked out and the combined suites run against it — 31 passing. Neither branch is stacked on the other.

Based on `main` @ `4cd8c4dcb`.

Resolves OPE-375 — https://linear.app/openfront/issue/OPE-375/single-cosmetic-purchase-folds-the-409-already-owned-refusal-into-try

🤖 Generated with [Claude Code](https://claude.com/claude-code)
