### PR TITLE
fix: show wilderness as boat target

### DIFF
--- a/src/client/hud/layers/AttacksDisplay.ts
+++ b/src/client/hud/layers/AttacksDisplay.ts
@@ -336,7 +336,7 @@ export class AttacksDisplay extends LitElement implements Controller {
     const target = boat.targetTile();
     if (target === undefined) return "";
     const ownerID = this.game.ownerID(target);
-    if (ownerID === 0) return "";
+    if (ownerID === 0) return translateText("help_modal.ui_wilderness");
     const player = this.game.playerBySmallID(ownerID) as PlayerView;
     return player?.displayName() ?? "";
   }

--- a/tests/GUI.test.ts
+++ b/tests/GUI.test.ts
@@ -1,11 +1,13 @@
-import { describe, it, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { AttacksDisplay } from "../src/client/hud/layers/AttacksDisplay";
 import { translateText } from "../src/client/Utils";
 
 // Simple mock game view that can return a configurable owner ID and a mock player.
 class MockGameView {
   constructor(private readonly ownerId: number = 0) {}
-  ownerID() { return this.ownerId; }
+  ownerID() {
+    return this.ownerId;
+  }
   playerBySmallID(id: number) {
     return id === this.ownerId && this.ownerId !== 0
       ? { displayName: () => `MockPlayer${id}` }

--- a/tests/GUI.test.ts
+++ b/tests/GUI.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { AttacksDisplay } from "../src/client/hud/layers/AttacksDisplay";
+import { translateText } from "../src/client/Utils";
+
+// Simple mock game view that can return a configurable owner ID and a mock player.
+class MockGameView {
+  constructor(private readonly ownerId: number = 0) {}
+  ownerID() { return this.ownerId; }
+  playerBySmallID(id: number) {
+    return id === this.ownerId && this.ownerId !== 0
+      ? { displayName: () => `MockPlayer${id}` }
+      : null;
+  }
+}
+
+// Minimal mock for a unit view; targetTile can be overridden per case.
+const mockUnit = (tile: any) => ({
+  targetTile: () => tile,
+  owner: () => ({ id: () => 1 }),
+});
+
+describe("AttacksDisplay.getBoatTargetName", () => {
+  it("returns wilderness text when ownerID is 0", () => {
+    const d = new AttacksDisplay();
+    (d as any).game = new MockGameView();
+    const r = (d as any).getBoatTargetName(mockUnit(42));
+    expect(r).toBe(translateText("help_modal.ui_wilderness"));
+  });
+
+  it("returns player name when ownerID is non-zero", () => {
+    const d = new AttacksDisplay();
+    (d as any).game = new MockGameView(7);
+    const r = (d as any).getBoatTargetName(mockUnit(42));
+    expect(r).toBe("MockPlayer7");
+  });
+
+  it("returns empty string when targetTile is undefined", () => {
+    const d = new AttacksDisplay();
+    (d as any).game = new MockGameView(3);
+    const r = (d as any).getBoatTargetName(mockUnit(undefined));
+    expect(r).toBe("");
+  });
+});


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #5260

## Description:

Single line modification in AttacksDisplay.ts, implements existing translation logic.

## Proof:
English:
<img width="1263" height="705" alt="english_boat_wilderness" src="https://github.com/user-attachments/assets/a2b2c64c-fb01-4c84-b472-f0fe4bc5cc00" />
French:
<img width="783" height="466" alt="french_boat_wilderness" src="https://github.com/user-attachments/assets/7999ef09-d928-49bf-8b5a-d742236d8f47" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
  - Reused existing `translateText("help_modal.ui_wilderness")` for consistency with land attacks
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

Pesinario
