### PR TITLE
Bounty market: pooled gold bounties with killer-takes-all payout (+ offline desktop shell)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ tests/perf/output/
 # Locally built Go binary (gen-maps uses `go run .`)
 map-generator/map-generator
 map-generator/map-generator.exe
+
+# Desktop offline shell (Electron)
+desktop/dist/
+desktop/release/
+desktop/node_modules/
+desktop/.electron-cache/
+
+# Packaged offline game folder (1GB+ binaries live here, never commit)
+openfront game/

--- a/desktop/electron-builder.yml
+++ b/desktop/electron-builder.yml
@@ -1,0 +1,24 @@
+appId: io.openfront.desktopoffline
+productName: OpenFront Offline
+directories:
+  output: release
+files:
+  - dist/**
+  - package.json
+  - "!node_modules/**/electron/**"
+extraResources:
+  # The production client build the protocol handler serves.
+  - from: ../static
+    to: static
+win:
+  target:
+    - target: portable
+      arch:
+        - x64
+  artifactName: OpenFront-Offline-${version}.exe
+  # Unsigned personal build. CSC_IDENTITY_AUTO_DISCOVERY=false (set in
+  # package.json) prevents winCodeSign toolcache extraction, which needs
+  # symlink privileges on Windows and fails without Developer Mode.
+  signAndEditExecutable: false
+electronDownload:
+  cache: .electron-cache

--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -1,0 +1,5309 @@
+{
+  "name": "openfront-desktop",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "openfront-desktop",
+      "version": "0.1.0",
+      "dependencies": {
+        "ejs": "^3.1.10"
+      },
+      "devDependencies": {
+        "cross-env": "^10.1.0",
+        "electron": "^33.2.0",
+        "electron-builder": "^25.1.8",
+        "typescript": "^5.7.3"
+      }
+    },
+    "node_modules/@develar/schema-utils": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@develar/schema-utils/-/schema-utils-2.6.5.tgz",
+      "integrity": "sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^6.12.0",
+        "ajv-keywords": "^3.4.1"
+      },
+      "engines": {
+        "node": ">= 8.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/@electron/asar": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@electron/asar/-/asar-3.4.1.tgz",
+      "integrity": "sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^5.0.0",
+        "glob": "^7.1.6",
+        "minimatch": "^3.0.4"
+      },
+      "bin": {
+        "asar": "bin/asar.js"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/asar/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@electron/asar/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/@electron/get": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-2.0.3.tgz",
+      "integrity": "sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "env-paths": "^2.2.0",
+        "fs-extra": "^8.1.0",
+        "got": "^11.8.5",
+        "progress": "^2.0.3",
+        "semver": "^6.2.0",
+        "sumchecker": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "global-agent": "^3.0.0"
+      }
+    },
+    "node_modules/@electron/notarize": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@electron/notarize/-/notarize-2.5.0.tgz",
+      "integrity": "sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.1",
+        "promise-retry": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/notarize/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@electron/osx-sign/-/osx-sign-1.3.1.tgz",
+      "integrity": "sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "compare-version": "^0.1.2",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.0.0",
+        "isbinaryfile": "^4.0.8",
+        "minimist": "^1.2.6",
+        "plist": "^3.0.5"
+      },
+      "bin": {
+        "electron-osx-flat": "bin/electron-osx-flat.js",
+        "electron-osx-sign": "bin/electron-osx-sign.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/isbinaryfile": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.10.tgz",
+      "integrity": "sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/osx-sign/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/rebuild": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/@electron/rebuild/-/rebuild-3.6.1.tgz",
+      "integrity": "sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "chalk": "^4.0.0",
+        "debug": "^4.1.1",
+        "detect-libc": "^2.0.1",
+        "fs-extra": "^10.0.0",
+        "got": "^11.7.0",
+        "node-abi": "^3.45.0",
+        "node-api-version": "^0.2.0",
+        "node-gyp": "^9.0.0",
+        "ora": "^5.1.0",
+        "read-binary-file-arch": "^1.0.6",
+        "semver": "^7.3.5",
+        "tar": "^6.0.5",
+        "yargs": "^17.0.1"
+      },
+      "bin": {
+        "electron-rebuild": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=12.13.0"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@electron/rebuild/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@electron/universal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@electron/universal/-/universal-2.0.1.tgz",
+      "integrity": "sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/asar": "^3.2.7",
+        "@malept/cross-spawn-promise": "^2.0.0",
+        "debug": "^4.3.1",
+        "dir-compare": "^4.2.0",
+        "fs-extra": "^11.1.1",
+        "minimatch": "^9.0.3",
+        "plist": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=16.4"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@electron/universal/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/fs-extra": {
+      "version": "11.4.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.4.0.tgz",
+      "integrity": "sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@electron/universal/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@epic-web/invariant": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@epic-web/invariant/-/invariant-1.0.0.tgz",
+      "integrity": "sha512-lrTPqgvfFQtR/eY/qkIzp98OGdNJu0m5ji3q/nJI8v3SXkRKEnWiOxMmbvcSoAIzv/cGiuvRy57k4suKQSAdwA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@gar/promisify": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
+      "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@isaacs/cliui/node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@isaacs/cliui/node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@malept/cross-spawn-promise": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@malept/cross-spawn-promise/-/cross-spawn-promise-2.0.0.tgz",
+      "integrity": "sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/malept"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/subscription/pkg/npm-.malept-cross-spawn-promise?utm_medium=referral&utm_source=npm_fund"
+        }
+      ],
+      "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@malept/flatpak-bundler/-/flatpak-bundler-0.4.0.tgz",
+      "integrity": "sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "lodash": "^4.17.15",
+        "tmp-promise": "^3.0.2"
+      },
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/fs-extra": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/@malept/flatpak-bundler/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-2.1.2.tgz",
+      "integrity": "sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@gar/promisify": "^1.1.3",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@npmcli/move-file": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-2.0.1.tgz",
+      "integrity": "sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==",
+      "deprecated": "This functionality has been moved to @npmcli/fs",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mkdirp": "^1.0.4",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
+      "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@szmarczak/http-timer": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.6.tgz",
+      "integrity": "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defer-to-connect": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/cacheable-request": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/@types/cacheable-request/-/cacheable-request-6.0.3.tgz",
+      "integrity": "sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-cache-semantics": "*",
+        "@types/keyv": "^3.1.4",
+        "@types/node": "*",
+        "@types/responselike": "^1.0.0"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/fs-extra": {
+      "version": "9.0.13",
+      "resolved": "https://registry.npmjs.org/@types/fs-extra/-/fs-extra-9.0.13.tgz",
+      "integrity": "sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/keyv": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/@types/keyv/-/keyv-3.1.4.tgz",
+      "integrity": "sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/plist": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/plist/-/plist-3.0.5.tgz",
+      "integrity": "sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*",
+        "xmlbuilder": ">=11.0.1"
+      }
+    },
+    "node_modules/@types/responselike": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.3.tgz",
+      "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/verror": {
+      "version": "1.10.11",
+      "resolved": "https://registry.npmjs.org/@types/verror/-/verror-1.10.11.tgz",
+      "integrity": "sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.12.tgz",
+      "integrity": "sha512-5AXjrcMClTryPe9LgZrygpB1lj7s0S9E0+W+AHaVKAVyHanafK86iPSvG5xHVSp/jC+VH1UXu0TAEmY279xH7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/7zip-bin": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/7zip-bin/-/7zip-bin-5.2.0.tgz",
+      "integrity": "sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/abbrev": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-keywords": {
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "ajv": "^6.9.1"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/app-builder-bin": {
+      "version": "5.0.0-alpha.10",
+      "resolved": "https://registry.npmjs.org/app-builder-bin/-/app-builder-bin-5.0.0-alpha.10.tgz",
+      "integrity": "sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/app-builder-lib": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/app-builder-lib/-/app-builder-lib-25.1.8.tgz",
+      "integrity": "sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@develar/schema-utils": "~2.6.5",
+        "@electron/notarize": "2.5.0",
+        "@electron/osx-sign": "1.3.1",
+        "@electron/rebuild": "3.6.1",
+        "@electron/universal": "2.0.1",
+        "@malept/flatpak-bundler": "^0.4.0",
+        "@types/fs-extra": "9.0.13",
+        "async-exit-hook": "^2.0.1",
+        "bluebird-lst": "^1.0.9",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chromium-pickle-js": "^0.2.0",
+        "config-file-ts": "0.2.8-rc1",
+        "debug": "^4.3.4",
+        "dotenv": "^16.4.5",
+        "dotenv-expand": "^11.0.6",
+        "ejs": "^3.1.8",
+        "electron-publish": "25.1.7",
+        "form-data": "^4.0.0",
+        "fs-extra": "^10.1.0",
+        "hosted-git-info": "^4.1.0",
+        "is-ci": "^3.0.0",
+        "isbinaryfile": "^5.0.0",
+        "js-yaml": "^4.1.0",
+        "json5": "^2.2.3",
+        "lazy-val": "^1.0.5",
+        "minimatch": "^10.0.0",
+        "resedit": "^1.7.0",
+        "sanitize-filename": "^1.6.3",
+        "semver": "^7.3.8",
+        "tar": "^6.1.12",
+        "temp-file": "^3.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "dmg-builder": "25.1.8",
+        "electron-builder-squirrel-windows": "25.1.8"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/app-builder-lib/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/aproba": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-2.1.0.tgz",
+      "integrity": "sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/archiver": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-5.3.2.tgz",
+      "integrity": "sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^2.1.0",
+        "async": "^3.2.4",
+        "buffer-crc32": "^0.2.1",
+        "readable-stream": "^3.6.0",
+        "readdir-glob": "^1.1.2",
+        "tar-stream": "^2.2.0",
+        "zip-stream": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/archiver-utils": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-2.1.0.tgz",
+      "integrity": "sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/archiver-utils/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/archiver-utils/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/are-we-there-yet": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
+      "integrity": "sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
+      "license": "Python-2.0"
+    },
+    "node_modules/assert-plus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
+      "license": "MIT"
+    },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/at-least-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/bluebird-lst": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/bluebird-lst/-/bluebird-lst-1.0.9.tgz",
+      "integrity": "sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bluebird": "^3.5.5"
+      }
+    },
+    "node_modules/boolean": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
+      "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
+      "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/builder-util": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/builder-util/-/builder-util-25.1.7.tgz",
+      "integrity": "sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.6",
+        "7zip-bin": "~5.2.0",
+        "app-builder-bin": "5.0.0-alpha.10",
+        "bluebird-lst": "^1.0.9",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "cross-spawn": "^7.0.3",
+        "debug": "^4.3.4",
+        "fs-extra": "^10.1.0",
+        "http-proxy-agent": "^7.0.0",
+        "https-proxy-agent": "^7.0.0",
+        "is-ci": "^3.0.0",
+        "js-yaml": "^4.1.0",
+        "source-map-support": "^0.5.19",
+        "stat-mode": "^1.0.0",
+        "temp-file": "^3.4.0"
+      }
+    },
+    "node_modules/builder-util-runtime": {
+      "version": "9.2.10",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.2.10.tgz",
+      "integrity": "sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/builder-util/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/builder-util/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/builder-util/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/cacache": {
+      "version": "16.1.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-16.1.3.tgz",
+      "integrity": "sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^2.1.0",
+        "@npmcli/move-file": "^2.0.0",
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.1.0",
+        "glob": "^8.0.1",
+        "infer-owner": "^1.0.4",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "mkdirp": "^1.0.4",
+        "p-map": "^4.0.0",
+        "promise-inflight": "^1.0.1",
+        "rimraf": "^3.0.2",
+        "ssri": "^9.0.0",
+        "tar": "^6.1.11",
+        "unique-filename": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cacache/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/cacache/node_modules/glob": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-8.1.0.tgz",
+      "integrity": "sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^5.0.1",
+        "once": "^1.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/cacache/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cacache/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/cacheable-lookup": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-5.0.4.tgz",
+      "integrity": "sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.6.0"
+      }
+    },
+    "node_modules/cacheable-request": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.4.tgz",
+      "integrity": "sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-response": "^1.0.2",
+        "get-stream": "^5.1.0",
+        "http-cache-semantics": "^4.0.0",
+        "keyv": "^4.0.0",
+        "lowercase-keys": "^2.0.0",
+        "normalize-url": "^6.0.1",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+      "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/chromium-pickle-js": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.2.0.tgz",
+      "integrity": "sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-2.1.0.tgz",
+      "integrity": "sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "slice-ansi": "^3.0.0",
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/clone-response": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
+      "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "color-support": "bin.js"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+      "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/compare-version": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
+      "integrity": "sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/compress-commons": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-4.1.2.tgz",
+      "integrity": "sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "buffer-crc32": "^0.2.13",
+        "crc32-stream": "^4.0.2",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts": {
+      "version": "0.2.8-rc1",
+      "resolved": "https://registry.npmjs.org/config-file-ts/-/config-file-ts-0.2.8-rc1.tgz",
+      "integrity": "sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "glob": "^10.3.12",
+        "typescript": "^5.4.3"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/config-file-ts/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/config-file-ts/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/crc": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.8.0.tgz",
+      "integrity": "sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "buffer": "^5.1.0"
+      }
+    },
+    "node_modules/crc-32": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
+      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "bin": {
+        "crc32": "bin/crc32.njs"
+      },
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/crc32-stream": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-4.0.3.tgz",
+      "integrity": "sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^3.4.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-10.1.0.tgz",
+      "integrity": "sha512-GsYosgnACZTADcmEyJctkJIoqAhHjttw7RsFrVoJNXbsWWqaq6Ym+7kZjq6mS45O0jij6vtiReppKQEtqWy6Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@epic-web/invariant": "^1.0.0",
+        "cross-spawn": "^7.0.6"
+      },
+      "bin": {
+        "cross-env": "dist/bin/cross-env.js",
+        "cross-env-shell": "dist/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/decompress-response/node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/defer-to-connect": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+      "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
+      "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/detect-node": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz",
+      "integrity": "sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/dir-compare": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/dir-compare/-/dir-compare-4.2.0.tgz",
+      "integrity": "sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minimatch": "^3.0.5",
+        "p-limit": "^3.1.0 "
+      }
+    },
+    "node_modules/dir-compare/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/dir-compare/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/dir-compare/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dmg-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/dmg-builder/-/dmg-builder-25.1.8.tgz",
+      "integrity": "sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "fs-extra": "^10.1.0",
+        "iconv-lite": "^0.6.2",
+        "js-yaml": "^4.1.0"
+      },
+      "optionalDependencies": {
+        "dmg-license": "^1.0.11"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/dmg-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/dmg-license": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/dmg-license/-/dmg-license-1.0.11.tgz",
+      "integrity": "sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "@types/plist": "^3.0.1",
+        "@types/verror": "^1.10.3",
+        "ajv": "^6.10.0",
+        "crc": "^3.8.0",
+        "iconv-corefoundation": "^1.1.7",
+        "plist": "^3.0.4",
+        "smart-buffer": "^4.0.2",
+        "verror": "^1.10.0"
+      },
+      "bin": {
+        "dmg-license": "bin/dmg-license.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-expand": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-11.0.7.tgz",
+      "integrity": "sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "dotenv": "^16.4.5"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ejs": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
+      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "jake": "^10.8.5"
+      },
+      "bin": {
+        "ejs": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/electron": {
+      "version": "33.4.11",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-33.4.11.tgz",
+      "integrity": "sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "@electron/get": "^2.0.0",
+        "@types/node": "^20.9.0",
+        "extract-zip": "^2.0.1"
+      },
+      "bin": {
+        "electron": "cli.js"
+      },
+      "engines": {
+        "node": ">= 12.20.55"
+      }
+    },
+    "node_modules/electron-builder": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder/-/electron-builder-25.1.8.tgz",
+      "integrity": "sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "dmg-builder": "25.1.8",
+        "fs-extra": "^10.1.0",
+        "is-ci": "^3.0.0",
+        "lazy-val": "^1.0.5",
+        "simple-update-notifier": "2.0.0",
+        "yargs": "^17.6.2"
+      },
+      "bin": {
+        "electron-builder": "cli.js",
+        "install-app-deps": "install-app-deps.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows": {
+      "version": "25.1.8",
+      "resolved": "https://registry.npmjs.org/electron-builder-squirrel-windows/-/electron-builder-squirrel-windows-25.1.8.tgz",
+      "integrity": "sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "app-builder-lib": "25.1.8",
+        "archiver": "^5.3.1",
+        "builder-util": "25.1.7",
+        "fs-extra": "^10.1.0"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder-squirrel-windows/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-builder/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-builder/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-builder/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-publish": {
+      "version": "25.1.7",
+      "resolved": "https://registry.npmjs.org/electron-publish/-/electron-publish-25.1.7.tgz",
+      "integrity": "sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/fs-extra": "^9.0.11",
+        "builder-util": "25.1.7",
+        "builder-util-runtime": "9.2.10",
+        "chalk": "^4.1.2",
+        "fs-extra": "^10.1.0",
+        "lazy-val": "^1.0.5",
+        "mime": "^2.5.2"
+      }
+    },
+    "node_modules/electron-publish/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/electron-publish/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/electron-publish/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/encoding": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
+      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "iconv-lite": "^0.6.2"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/err-code": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/err-code/-/err-code-2.0.3.tgz",
+      "integrity": "sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es6-error": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+      "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exponential-backoff": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
+      "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
+    "node_modules/extsprintf": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.4.1.tgz",
+      "integrity": "sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==",
+      "dev": true,
+      "engines": [
+        "node >=0.6.0"
+      ],
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
+    "node_modules/filelist": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.6.tgz",
+      "integrity": "sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^5.0.1"
+      }
+    },
+    "node_modules/filelist/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/filelist/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/filelist/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/foreground-child/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs-minipass": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+      "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gauge": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+      "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.3",
+        "console-control-strings": "^1.1.0",
+        "has-unicode": "^2.0.1",
+        "signal-exit": "^3.0.7",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.5"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/global-agent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-3.0.0.tgz",
+      "integrity": "sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "es6-error": "^4.1.1",
+        "matcher": "^3.0.0",
+        "roarr": "^2.15.3",
+        "semver": "^7.3.2",
+        "serialize-error": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
+    "node_modules/global-agent/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.4.tgz",
+      "integrity": "sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/got": {
+      "version": "11.8.6",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.6.tgz",
+      "integrity": "sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.2",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/got?sponsor=1"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/http-cache-semantics": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
+      "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/http2-wrapper": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "quick-lru": "^5.1.1",
+        "resolve-alpn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=10.19.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-corefoundation": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/iconv-corefoundation/-/iconv-corefoundation-1.1.7.tgz",
+      "integrity": "sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "cli-truncate": "^2.1.0",
+        "node-addon-api": "^1.6.3"
+      },
+      "engines": {
+        "node": "^8.11.2 || >=10"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/infer-owner": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
+      "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.7.0.tgz",
+      "integrity": "sha512-BGFsyJd5mpXp3rK6jIdADLNgpJUK1jnjzvYF8lK+VyDab9JAmqN0YOKDdP17HlgKb2+ehPgDc8EtnRLbGCAMhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-ci": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-3.0.1.tgz",
+      "integrity": "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ci-info": "^3.2.0"
+      },
+      "bin": {
+        "is-ci": "bin.js"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-lambda": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-lambda/-/is-lambda-1.0.1.tgz",
+      "integrity": "sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isbinaryfile": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-5.0.7.tgz",
+      "integrity": "sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/gjtorikian/"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jake": {
+      "version": "10.9.4",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.9.4.tgz",
+      "integrity": "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async": "^3.2.6",
+        "filelist": "^1.0.4",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "jake": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stringify-safe": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/lazy-val": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
+      "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lazystream": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
+      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^2.0.5"
+      },
+      "engines": {
+        "node": ">= 0.6.3"
+      }
+    },
+    "node_modules/lazystream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/lazystream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lazystream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash.defaults": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-4.2.0.tgz",
+      "integrity": "sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.difference": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.difference/-/lodash.difference-4.5.0.tgz",
+      "integrity": "sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/lodash.union": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/lodash.union/-/lodash.union-4.6.0.tgz",
+      "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+      "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/make-fetch-happen": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-10.2.1.tgz",
+      "integrity": "sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "agentkeepalive": "^4.2.1",
+        "cacache": "^16.1.0",
+        "http-cache-semantics": "^4.1.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "is-lambda": "^1.0.1",
+        "lru-cache": "^7.7.1",
+        "minipass": "^3.1.6",
+        "minipass-collect": "^1.0.2",
+        "minipass-fetch": "^2.0.3",
+        "minipass-flush": "^1.0.5",
+        "minipass-pipeline": "^1.2.4",
+        "negotiator": "^0.6.3",
+        "promise-retry": "^2.0.1",
+        "socks-proxy-agent": "^7.0.0",
+        "ssri": "^9.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/matcher": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/matcher/-/matcher-3.0.0.tgz",
+      "integrity": "sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "3.3.6",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
+      "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-collect": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/minipass-collect/-/minipass-collect-1.0.2.tgz",
+      "integrity": "sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-fetch": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minipass-fetch/-/minipass-fetch-2.1.2.tgz",
+      "integrity": "sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.1.6",
+        "minipass-sized": "^1.0.3",
+        "minizlib": "^2.1.2"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "optionalDependencies": {
+        "encoding": "^0.1.13"
+      }
+    },
+    "node_modules/minipass-flush": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.7.tgz",
+      "integrity": "sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/minipass-pipeline": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/minipass-pipeline/-/minipass-pipeline-1.2.4.tgz",
+      "integrity": "sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minipass-sized": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/minipass-sized/-/minipass-sized-1.0.3.tgz",
+      "integrity": "sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
+      "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^3.0.0",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.96.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.96.0.tgz",
+      "integrity": "sha512-rebQ/lz7i0EkoLzUVSrKRzA69zMkwLp95kKMWoMDkkM00Suxz0D7zEQPwRml5fQum24mj7bPvmlgLAmu2JCiYg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-abi/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.7.2.tgz",
+      "integrity": "sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/node-api-version": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/node-api-version/-/node-api-version-0.2.1.tgz",
+      "integrity": "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node_modules/node-api-version/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-gyp": {
+      "version": "9.4.1",
+      "resolved": "https://registry.npmjs.org/node-gyp/-/node-gyp-9.4.1.tgz",
+      "integrity": "sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "env-paths": "^2.2.0",
+        "exponential-backoff": "^3.1.1",
+        "glob": "^7.1.4",
+        "graceful-fs": "^4.2.6",
+        "make-fetch-happen": "^10.0.3",
+        "nopt": "^6.0.0",
+        "npmlog": "^6.0.0",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.2",
+        "which": "^2.0.2"
+      },
+      "bin": {
+        "node-gyp": "bin/node-gyp.js"
+      },
+      "engines": {
+        "node": "^12.13 || ^14.13 || >=16"
+      }
+    },
+    "node_modules/node-gyp/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/nopt": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-6.0.0.tgz",
+      "integrity": "sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^1.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/normalize-url": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-6.1.0.tgz",
+      "integrity": "sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/npmlog": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-6.0.2.tgz",
+      "integrity": "sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==",
+      "deprecated": "This package is no longer supported.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "are-we-there-yet": "^3.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^4.0.3",
+        "set-blocking": "^2.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-cancelable": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.1.tgz",
+      "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/path-scurry/node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/pe-library": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
+      "integrity": "sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/plist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+      "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.9.10",
+        "base64-js": "^1.5.1",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/promise-inflight": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
+      "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/promise-retry": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/promise-retry/-/promise-retry-2.0.1.tgz",
+      "integrity": "sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "err-code": "^2.0.2",
+        "retry": "^0.12.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-binary-file-arch": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/read-binary-file-arch/-/read-binary-file-arch-1.0.6.tgz",
+      "integrity": "sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4"
+      },
+      "bin": {
+        "read-binary-file-arch": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdir-glob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
+      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "minimatch": "^5.1.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/readdir-glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/readdir-glob/node_modules/minimatch": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
+      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resedit": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/resedit/-/resedit-1.7.2.tgz",
+      "integrity": "sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pe-library": "^0.4.1"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jet2jet"
+      }
+    },
+    "node_modules/resolve-alpn": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+      "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/responselike": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lowercase-keys": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/roarr": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.15.4.tgz",
+      "integrity": "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "boolean": "^3.0.1",
+        "detect-node": "^2.0.4",
+        "globalthis": "^1.0.1",
+        "json-stringify-safe": "^5.0.1",
+        "semver-compare": "^1.0.0",
+        "sprintf-js": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/sanitize-filename": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/sanitize-filename/-/sanitize-filename-1.6.4.tgz",
+      "integrity": "sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==",
+      "dev": true,
+      "license": "WTFPL OR ISC",
+      "dependencies": {
+        "truncate-utf8-bytes": "^1.0.0"
+      }
+    },
+    "node_modules/sax": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/serialize-error": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-7.0.1.tgz",
+      "integrity": "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "type-fest": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/simple-update-notifier/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-3.0.0.tgz",
+      "integrity": "sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "^10.1.1",
+        "smart-buffer": "^4.2.0"
+      },
+      "engines": {
+        "node": ">= 10.0.0",
+        "npm": ">= 3.0.0"
+      }
+    },
+    "node_modules/socks-proxy-agent": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/socks-proxy-agent/-/socks-proxy-agent-7.0.0.tgz",
+      "integrity": "sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^6.0.2",
+        "debug": "^4.3.3",
+        "socks": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/ssri": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-9.0.1.tgz",
+      "integrity": "sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/stat-mode": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
+      "integrity": "sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/sumchecker": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
+      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
+      "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
+      "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "chownr": "^2.0.0",
+        "fs-minipass": "^2.0.0",
+        "minipass": "^5.0.0",
+        "minizlib": "^2.1.1",
+        "mkdirp": "^1.0.3",
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
+      "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/temp-file": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/temp-file/-/temp-file-3.4.0.tgz",
+      "integrity": "sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "^2.0.1",
+        "fs-extra": "^10.0.0"
+      }
+    },
+    "node_modules/temp-file/node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/temp-file/node_modules/jsonfile": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/temp-file/node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/tmp": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/tmp-promise": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
+      "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tmp": "^0.2.0"
+      }
+    },
+    "node_modules/truncate-utf8-bytes": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/truncate-utf8-bytes/-/truncate-utf8-bytes-1.0.2.tgz",
+      "integrity": "sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==",
+      "dev": true,
+      "license": "WTFPL",
+      "dependencies": {
+        "utf8-byte-length": "^1.0.1"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.13.1.tgz",
+      "integrity": "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "optional": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unique-filename": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/unique-filename/-/unique-filename-2.0.1.tgz",
+      "integrity": "sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "unique-slug": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/unique-slug": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-3.0.0.tgz",
+      "integrity": "sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/utf8-byte-length": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz",
+      "integrity": "sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/verror": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.1.tgz",
+      "integrity": "sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wide-align": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.5.tgz",
+      "integrity": "sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^1.0.2 || 2 || 3 || 4"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zip-stream": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-4.1.1.tgz",
+      "integrity": "sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "archiver-utils": "^3.0.4",
+        "compress-commons": "^4.1.2",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/zip-stream/node_modules/archiver-utils": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-3.0.4.tgz",
+      "integrity": "sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "glob": "^7.2.3",
+        "graceful-fs": "^4.2.0",
+        "lazystream": "^1.0.0",
+        "lodash.defaults": "^4.2.0",
+        "lodash.difference": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.union": "^4.6.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    }
+  }
+}

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "openfront-desktop",
+  "private": true,
+  "version": "0.1.0",
+  "description": "Offline solo-mode desktop shell for OpenFront",
+  "type": "commonjs",
+  "main": "dist/main.js",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "start": "electron .",
+    "smoke": "node dist/offlineSmoke.js",
+    "package": "cross-env CSC_IDENTITY_AUTO_DISCOVERY=false electron-builder --win --config electron-builder.yml"
+  },
+  "devDependencies": {
+    "cross-env": "^10.1.0",
+    "electron": "^33.2.0",
+    "electron-builder": "^25.1.8",
+    "typescript": "^5.7.3"
+  },
+  "dependencies": {
+    "ejs": "^3.1.10"
+  }
+}

--- a/desktop/scripts/bounty-e2e.js
+++ b/desktop/scripts/bounty-e2e.js
@@ -1,0 +1,104 @@
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (desc, fn, timeoutMs = 30000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeoutMs) {
+      try { const v = fn(); if (v) return v; } catch (e) { /* retry */ }
+      await sleep(250);
+    }
+    throw new Error("timeout: " + desc);
+  };
+  const log = (m) => console.log("BOUNTY_E2E: " + m);
+
+  // 1. Start a solo game through the real Solo card, with randomSpawn set
+  // via the modal's reactive state (equivalent to a user clicking the
+  // toggle; auto-spawns at game start). Solo spawn phase = 100 ticks (10s).
+  await waitFor("game-mode-selector upgrade", () => customElements.get("game-mode-selector"));
+  const selector = document.querySelector("game-mode-selector");
+  await waitFor("selector rendered", () => selector && selector.children.length > 0, 20000);
+  const soloBtn = await waitFor("solo card button", () => {
+    const btns = [...selector.querySelectorAll("button")];
+    return btns.find((b) => b.textContent.trim().toLowerCase().includes("solo"));
+  });
+  soloBtn.click();
+  const soloModal = document.querySelector("single-player-modal");
+  await waitFor("solo modal open", () => !soloModal.classList.contains("hidden"));
+  soloModal.randomSpawn = true;
+  await sleep(300);
+  const startBtn = await waitFor("start button", () => soloModal.querySelector("o-button"));
+  startBtn.click();
+  await waitFor("in-game class", () => document.body.classList.contains("in-game"), 120000);
+  log("game started");
+
+  const overlay = await waitFor("input overlay", () =>
+    document.getElementById("game-input-overlay"),
+  );
+  const rightClick = (x, y) => {
+    overlay.dispatchEvent(new MouseEvent("contextmenu", {
+      bubbles: true, cancelable: true, composed: true,
+      clientX: x, clientY: y, button: 2,
+    }));
+  };
+
+  const W = window.innerWidth, H = window.innerHeight;
+  const grid = [];
+  for (const fx of [0.3, 0.5, 0.7]) for (const fy of [0.3, 0.5, 0.7]) grid.push([W * fx, H * fy]);
+
+  // 2. Let spawn phase end (100 ticks) plus bot expansion, so radial menus
+  // work and enemy territory exists.
+  await sleep(16000);
+  log("spawn settled");
+
+  // 3. Grid-search right-clicks for an enemy tile: bounty slice appears.
+  let bountyPath = null;
+  outer: for (let round = 0; round < 6; round++) {
+    for (const [x, y] of grid) {
+      rightClick(x, y);
+      await sleep(600);
+      const hit = document.querySelector('path[data-id="place_bounty"]');
+      if (hit) { bountyPath = hit; break outer; }
+    }
+    await sleep(3000); // let the sim advance between sweeps
+  }
+  if (!bountyPath) throw new Error("no enemy tile found with a bounty slice");
+  log("bounty slice found");
+
+  // 4. Click the bounty slice -> SendResourceModal opens in bounty mode.
+  bountyPath.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  await sleep(800);
+  const modal = await waitFor("bounty modal", () =>
+    document.querySelector("send-resource-modal"),
+  10000);
+  if (modal.mode !== "bounty") throw new Error("modal opened in mode " + modal.mode);
+  log("bounty modal open, player gold basis: " + modal.total);
+
+  // 5. Wait for enough gold for the minimum bounty, then confirm at Max.
+  await waitFor(
+    "enough gold",
+    () => Number(modal.total ?? 0) >= 1000,
+    60000,
+  );
+  const maxBtn = await waitFor("max preset", () => {
+    const btns = [...modal.querySelectorAll("button")];
+    return btns.find((b) => /^(max|100%)$/i.test(b.textContent.trim()));
+  });
+  maxBtn.click();
+  await sleep(300);
+  const sendBtn = await waitFor("confirm button", () => {
+    const btns = [...modal.querySelectorAll("button")];
+    return btns.find((b) => /^(send|confirm|place bounty)$/i.test(b.textContent.trim()));
+  });
+  sendBtn.click();
+  log("bounty confirmed");
+  await sleep(4000);
+
+  // 6. The BountyPlacedEvent must arrive back as a toast in EventsDisplay —
+  // the full UI -> core -> worker -> UI loop, end to end.
+  const eventsText = (document.querySelector("events-display")?.textContent ?? "").toLowerCase();
+  if (!eventsText.includes("bounty")) {
+    throw new Error("no bounty toast in events display; text was: " + eventsText.slice(0, 300));
+  }
+  log("bounty toast visible");
+
+  return "SMOKE_OK";
+})()

--- a/desktop/scripts/timing.js
+++ b/desktop/scripts/timing.js
@@ -1,0 +1,42 @@
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (desc, fn, timeoutMs = 30000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeoutMs) {
+      try { const v = fn(); if (v) return v; } catch (e) { /* retry */ }
+      await sleep(100);
+    }
+    throw new Error("timeout: " + desc);
+  };
+  const t0 = performance.now();
+
+  // Homepage ready
+  await waitFor("game-mode-selector upgrade", () => customElements.get("game-mode-selector"));
+  const selector = document.querySelector("game-mode-selector");
+  await waitFor("selector rendered", () => selector && selector.children.length > 0, 20000);
+  const tHome = performance.now();
+
+  // Click through the real UI
+  const soloBtn = await waitFor("solo card button", () => {
+    const btns = [...selector.querySelectorAll("button")];
+    return btns.find((b) => b.textContent.trim().toLowerCase().includes("solo"));
+  });
+  soloBtn.click();
+  const soloModal = document.querySelector("single-player-modal");
+  await waitFor("solo modal open", () => !soloModal.classList.contains("hidden"));
+  const startBtn = await waitFor("start button", () => soloModal.querySelector("o-button"));
+  const tClick = performance.now();
+  startBtn.click();
+
+  // Match truly running
+  await waitFor("in-game class", () => document.body.classList.contains("in-game"), 120000);
+  await waitFor("webgl canvas mounted", () => document.getElementById("webgl-debug-canvas") !== null, 60000);
+  const tMatch = performance.now();
+
+  // Measure 5s of live turns to sanity-check tick rate
+  await sleep(5000);
+
+  console.log(`TIMING homepage_ready_ms=${Math.round(tHome - t0)}`);
+  console.log(`TIMING match_start_ms=${Math.round(tMatch - tClick)}`);
+  return "SMOKE_OK";
+})()

--- a/desktop/scripts/userflow.js
+++ b/desktop/scripts/userflow.js
@@ -1,0 +1,55 @@
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (desc, fn, timeoutMs = 30000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeoutMs) {
+      try { const v = fn(); if (v) return v; } catch (e) { /* retry */ }
+      await sleep(250);
+    }
+    throw new Error("timeout: " + desc);
+  };
+  console.log("USERFLOW: start");
+
+  // 1. Wait for homepage components
+  await waitFor("game-mode-selector upgrade", () => customElements.get("game-mode-selector"));
+  const selector = document.querySelector("game-mode-selector");
+  await waitFor("selector rendered", () => selector && selector.children.length > 0, 20000);
+  console.log("USERFLOW: homepage rendered");
+
+  // 2. Find the real Solo card button (desktop grid) and click it
+  //    The Solo card is the col-span-2 button in the hidden sm:grid row.
+  const soloBtn = await waitFor("solo card button", () => {
+    const btns = [...selector.querySelectorAll("button")];
+    return btns.find(b => b.textContent.trim().toLowerCase().includes("solo"));
+  });
+  console.log("USERFLOW: clicking solo card");
+  soloBtn.click();
+
+  // 3. Wait for the solo modal to open
+  const soloModal = document.querySelector("single-player-modal");
+  await waitFor("solo modal open", () => !soloModal.classList.contains("hidden"));
+  console.log("USERFLOW: solo modal open");
+
+  // 4. Click the Start button (o-button inside the modal footer)
+  const startBtn = await waitFor("start button", () => soloModal.querySelector("o-button"));
+  console.log("USERFLOW: clicking start");
+  startBtn.click();
+  console.log("USERFLOW: start clicked");
+
+  // 5. Wait for the game to enter in-game state
+  await waitFor("in-game class", () => document.body.classList.contains("in-game"), 120000);
+  console.log("USERFLOW: IN GAME");
+
+  // 6. Run 8 seconds of turns
+  await sleep(8000);
+
+  // 7. Inspect state: canvas, game stats, anything visible
+  const canvas = document.querySelector("#app canvas, canvas");
+  console.log("USERFLOW: canvas present: " + !!canvas);
+  if (canvas) {
+    console.log("USERFLOW: canvas size: " + canvas.width + "x" + canvas.height);
+  }
+  console.log("USERFLOW: still in-game: " + document.body.classList.contains("in-game"));
+
+  return "READY_FOR_SCREENSHOT";
+})()

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -1,0 +1,426 @@
+// Offline desktop shell for OpenFront solo mode.
+//
+// Serves the production client bundle (../static) over a custom app://openfront
+// protocol — the same shape the game's ClientEnv already anticipates for a
+// desktop shell (see src/client/ClientEnv.ts resolveServerOrigin). The client's
+// solo mode runs entirely in the renderer (LocalServer + inlined core worker),
+// so no game server is needed. Optional web services (accounts, cosmetics,
+// archiving) fail silently offline, which the client already tolerates.
+
+import { app, BrowserWindow, protocol, session, shell } from "electron";
+import fs from "fs";
+import fsp from "fs/promises";
+import path from "path";
+
+const APP_ORIGIN = "app://openfront";
+const WIN_WIDTH = 1280;
+const WIN_HEIGHT = 800;
+
+// Total in-memory asset-cache budget (compressed size of static/ is ~500 MB,
+// but the hot set — JS/CSS/atlas/maps/sprites for one match — is ~25 MB).
+const ASSET_CACHE_MAX_BYTES = 256 * 1024 * 1024;
+
+// Windows GUI-subprocess stdout is unreliable when spawned from scripts, so
+// the shell logs to a file next to the executable when OPENFRONT_DESKTOP_LOG
+// is set. The smoke test reads this file to see what happened.
+const logFile = process.env.OPENFRONT_DESKTOP_LOG
+  ? path.resolve(process.env.OPENFRONT_DESKTOP_LOG)
+  : null;
+// Per-request serving logs are written only when diagnostics are requested:
+// log() is a synchronous append (fs.appendFileSync) on the MAIN PROCESS, so
+// logging every asset request both blocks serving and adds ~60ms of disk I/O
+// to game startup.
+const verbose = process.env.OPENFRONT_DESKTOP_VERBOSE === "1";
+let logCount = 0;
+const LOG_MAX = 2000;
+function log(message: string): void {
+  if (!logFile) return;
+  if (logCount >= LOG_MAX) return;
+  logCount++;
+  const line = `[${new Date().toISOString()}] ${message}\n`;
+  try {
+    fs.appendFileSync(logFile, line);
+  } catch {
+    /* best effort */
+  }
+}
+
+// Smoke-test mode: --renderer-script-file=<path> points at a JS file that is
+// evaluated in the page after load; its return value (or thrown error) is
+// printed as SMOKE_OK/SMOKE_FAIL and the app exits. A file (not an inline
+// arg) because the script is far larger than Windows' command-line limit.
+// Used by offlineSmoke.ts to drive the real UI end-to-end.
+const rendererScriptFileArg = process.argv.find((a) =>
+  a.startsWith("--renderer-script-file="),
+);
+const smokeTestMode = rendererScriptFileArg !== undefined;
+const rendererScript = rendererScriptFileArg
+  ? fs.readFileSync(
+      rendererScriptFileArg.slice("--renderer-script-file=".length),
+      "utf-8",
+    )
+  : null;
+
+// static/ at the repo root: index.html plus Vite's assets/ and the hashed
+// _assets/ copied by the production build. In the packaged app this folder
+// ships inside the app resources.
+const STATIC_DIR = (() => {
+  // Packaged: <resources>/app.asar/desktop/... or resources/static
+  const packaged = path.join(process.resourcesPath ?? "", "static");
+  if (fs.existsSync(packaged)) return packaged;
+  // Dev: <repo>/desktop/dist/main.js -> <repo>/static
+  return path.resolve(__dirname, "..", "..", "static");
+})();
+
+const ASSET_MANIFEST_PATH = path.join(STATIC_DIR, "asset-manifest.json");
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json",
+  ".wasm": "application/wasm",
+  ".png": "image/png",
+  ".webp": "image/webp",
+  ".svg": "image/svg+xml",
+  ".ttf": "font/ttf",
+  ".otf": "font/otf",
+  ".xml": "text/xml",
+  ".mp3": "audio/mpeg",
+  ".webm": "video/webm",
+  ".txt": "text/plain; charset=utf-8",
+  ".md": "text/markdown; charset=utf-8",
+};
+
+// Vite's assets/ and the build's hashed _assets/ are content-addressed:
+// the hash in the filename IS the version, so byte-for-byte immutable.
+// Immutable responses let Chromium's HTTP cache serve them instantly on
+// every restart, instead of re-fetching ~30 MB through the protocol handler.
+const IMMUTABLE_CACHE_CONTROL = "public, max-age=31536000, immutable";
+
+// In-memory byte cache for served files, LRU by insertion order. A map of
+// Path -> Buffer; entries larger than the budget pass through uncached.
+const assetCache = new Map<string, Buffer>();
+let assetCacheBytes = 0;
+function cachePut(filePath: string, data: Buffer): void {
+  if (data.byteLength > ASSET_CACHE_MAX_BYTES) return;
+  // Recency: re-insert to move to the tail.
+  assetCache.delete(filePath);
+  assetCache.set(filePath, data);
+  assetCacheBytes += data.byteLength;
+  while (assetCacheBytes > ASSET_CACHE_MAX_BYTES && assetCache.size > 1) {
+    const oldestKey = assetCache.keys().next().value;
+    if (oldestKey === undefined) break;
+    const oldest = assetCache.get(oldestKey);
+    assetCache.delete(oldestKey);
+    assetCacheBytes -= oldest?.byteLength ?? 0;
+  }
+}
+
+// Resolve a public asset name (e.g. "images/background.webp") through the
+// built asset-manifest.json to its hashed /_assets/... URL, the same way the
+// web server's RenderHtml.ts does. Falls back to the unhashed path (the
+// dev server serves resources/ directly).
+function assetHref(name: string): string {
+  try {
+    if (fs.existsSync(ASSET_MANIFEST_PATH)) {
+      const manifest = JSON.parse(
+        fs.readFileSync(ASSET_MANIFEST_PATH, "utf-8"),
+      ) as Record<string, string>;
+      const mapped = manifest[name];
+      if (mapped) return mapped;
+    }
+  } catch {
+    /* fall through to unhashed */
+  }
+  return `/${name}`;
+}
+
+// The built index.html is an EJS template (see src/server/RenderHtml.ts for
+// the web equivalent). Render it once at startup with offline values:
+// empty cdnBase (same-origin app:// URLs), desktop instanceId (disables ads
+// and Turnstile client-side), and offlineShell (strips third-party scripts).
+function renderIndexHtml(): string {
+  // Lazy require so Electron's bundled Node has it after desktop/node_modules
+  // is present. Loaded from the desktop package's own node_modules.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const ejs = require("ejs") as typeof import("ejs");
+  const template = fs.readFileSync(
+    path.join(STATIC_DIR, "index.html"),
+    "utf-8",
+  );
+  const assetManifest = fs.existsSync(ASSET_MANIFEST_PATH)
+    ? fs.readFileSync(ASSET_MANIFEST_PATH, "utf-8")
+    : "{}";
+  return ejs.render(template, {
+    gitCommit: JSON.stringify("desktop-offline"),
+    assetManifest,
+    // The core simulation worker is an INLINE BLOB worker (Vite
+    // ?worker&inline). Blob workers have no origin of their own, so a
+    // root-relative URL like /_assets/maps/... cannot resolve inside them —
+    // fetch() throws "Failed to parse URL" and the match never starts. The
+    // production web build never hits this because its cdnBase is always an
+    // absolute CDN origin, making every assetUrl() absolute. Mirror that:
+    // cdnBase = the app:// origin, so main thread AND worker resolve
+    // app://openfront/... absolute URLs that the protocol handler serves.
+    cdnBase: JSON.stringify(APP_ORIGIN),
+    // Raw (unquoted) prefix for <script src="<%- cdnBaseRaw %>/assets/...">:
+    // empty, same-origin.
+    cdnBaseRaw: "",
+    gameEnv: JSON.stringify("dev"),
+    numWorkers: JSON.stringify(1),
+    turnstileSiteKey: JSON.stringify(""),
+    jwtAudience: JSON.stringify("localhost"),
+    instanceId: JSON.stringify("desktop"),
+    offlineShell: true,
+    // Asset URLs resolved through the manifest, mirroring RenderHtml.ts.
+    manifestHref: assetHref("manifest.json"),
+    faviconHref: assetHref("images/Favicon.svg"),
+    gameplayScreenshotUrl: assetHref("images/GameplayScreenshot.png"),
+    backgroundImageUrl: assetHref("images/background.webp"),
+    desktopLogoImageUrl: assetHref("images/OpenFront.png"),
+    mobileLogoImageUrl: assetHref("images/OF.png"),
+  });
+}
+
+// Register app:// as a privileged scheme before app ready so fetch/XHR from
+// the renderer get proper support (cors, stream, code support) and the
+// origin behaves like a real one for localStorage etc.
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: "app",
+    privileges: {
+      standard: true,
+      secure: true,
+      supportFetchAPI: true,
+      stream: true,
+      corsEnabled: true,
+      // Cache compiled bytecode for scripts served over app:// (the ~3 MB
+      // game bundle + 627 KB worker are the largest boot cost; with the
+      // code cache, later launches skip full V8 re-parse).
+      codeCache: true,
+    },
+  },
+]);
+
+let mainWindow: BrowserWindow | null = null;
+
+function createWindow(): void {
+  mainWindow = new BrowserWindow({
+    width: WIN_WIDTH,
+    height: WIN_HEIGHT,
+    minWidth: 800,
+    minHeight: 600,
+    title: "OpenFront (Offline)",
+    backgroundColor: "#262626",
+    autoHideMenuBar: true,
+    show: false,
+    webPreferences: {
+      preload: path.join(__dirname, "preload.js"),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: false,
+      // Solo mode needs WebGL, workers and the audio API; all standard.
+      webgl: true,
+      // The sim ticks on wall-clock time (LocalServer's 5ms interval): timer
+      // throttling in an unfocused/occluded window would pause turns.
+      backgroundThrottling: false,
+      // No text is ever typed into the game; skip spellcheck worker setup.
+      spellcheck: false,
+      // V8 code cache for the renderer: the multi-MB game bundle parses
+      // once, then starts from cached bytecode on every later launch.
+      v8CacheOptions: "bypassHeatCheck",
+    },
+  });
+
+  mainWindow.once("ready-to-show", () => {
+    mainWindow?.show();
+  });
+
+  // Block all non-app:// network traffic. The game is fully playable offline;
+  // remaining calls (accounts/cosmetics/archive) would only slow startup.
+  // Scoped to http/https/ws schemes only: app:// and devtools:// traffic
+  // never pays the listener round-trip.
+  const ses = session.defaultSession;
+  ses.webRequest.onBeforeRequest(
+    { urls: ["http://*/*", "https://*/*", "ws://*/*", "wss://*/*"] },
+    (details, callback) => {
+      log(`MAIN: blocked request ${details.url}`);
+      callback({ cancel: true });
+    },
+  );
+
+  // Open real external links (none expected offline) in the system browser.
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    void shell.openExternal(url);
+    return { action: "deny" };
+  });
+
+  // Verify GPU acceleration is actually on. A software WebGL context is the
+  // single biggest performance cliff for this game; surface it immediately
+  // in diagnostics rather than letting it look like general slowness.
+  app.getGPUInfo("complete").then(
+    (info) => {
+      const gl = (info as { graphics?: { status?: string } }).graphics;
+      log(`MAIN: GPU status ${gl?.status ?? "unknown"}`);
+    },
+    (err: unknown) => log(`MAIN: GPU info failed: ${String(err)}`),
+  );
+
+  let indexHtmlCache: string | null = null;
+  protocol.handle("app", (request) => {
+    // The handler returns promises; protocol.handle awaits them, so no
+    // try/catch here — a rejection is reported by Electron as a network
+    // error to the renderer, which is the correct shape.
+    return handleAppRequest(request);
+  });
+
+  async function handleAppRequest(request: Parameters<
+    Parameters<typeof protocol.handle>[1]
+  >[0]): Promise<Response> {
+    const url = new URL(request.url);
+    const pathname = decodeURIComponent(url.pathname);
+    if (pathname === "/" || pathname === "/index.html") {
+      indexHtmlCache ??= renderIndexHtml();
+      return new Response(indexHtmlCache, {
+        headers: { "Content-Type": "text/html; charset=utf-8" },
+      });
+    }
+    // Strip leading slash to resolve inside staticDir.
+    const relative = pathname.replace(/^\/+/, "");
+    if (relative.includes("..")) {
+      return new Response("Forbidden", { status: 403 });
+    }
+    const filePath = path.join(STATIC_DIR, relative);
+    if (!filePath.startsWith(STATIC_DIR)) {
+      return new Response("Forbidden", { status: 403 });
+    }
+    const cached = assetCache.get(filePath);
+    if (cached !== undefined) {
+      if (verbose) log(`MAIN: serving (cached) ${pathname}`);
+      return responseFor(filePath, cached);
+    }
+    let data: Buffer;
+    try {
+      data = await fsp.readFile(filePath);
+    } catch {
+      log(`MAIN: 404 ${pathname}`);
+      return new Response("Not found", { status: 404 });
+    }
+    cachePut(filePath, data);
+    if (verbose) log(`MAIN: serving ${pathname}`);
+    return responseFor(filePath, data);
+  }
+
+  function responseFor(filePath: string, data: Buffer): Response {
+    const ext = path.extname(filePath).toLowerCase();
+    const headers: Record<string, string> = {
+      "Content-Type": MIME_BY_EXT[ext] ?? "application/octet-stream",
+    };
+    // Content-addressed files are immutable — let Chromium's disk cache
+    // serve them on later launches without a single protocol round-trip.
+    if (relativeImmutable(filePath)) {
+      headers["Cache-Control"] = IMMUTABLE_CACHE_CONTROL;
+    }
+    return new Response(data, { headers });
+  }
+
+  const IMMUTABLE_PREFIXES = [
+    path.join(STATIC_DIR, "assets") + path.sep,
+    path.join(STATIC_DIR, "_assets") + path.sep,
+  ];
+  function relativeImmutable(filePath: string): boolean {
+    return IMMUTABLE_PREFIXES.some((p) => filePath.startsWith(p));
+  }
+
+  mainWindow
+    .loadURL(`${APP_ORIGIN}/index.html`)
+    .then(() => log("MAIN: loadURL resolved"))
+    .catch((err: unknown) => log(`MAIN: loadURL rejected: ${String(err)}`));
+
+  // Diagnostics also used by the smoke test. Errors and SMOKE_ markers are
+  // always logged (when a log file was requested); everything else only in
+  // verbose mode, and never more than a bounded number of lines.
+  mainWindow.webContents.on(
+    "console-message",
+    (_event, level, message) => {
+      if (message.includes("SMOKE_")) {
+        log(message);
+      } else if (level >= 2 || verbose) {
+        log(`CONSOLE[${level}]: ${message.slice(0, 500)}`);
+      }
+    },
+  );
+  mainWindow.webContents.on("did-finish-load", () => {
+    log("MAIN: did-finish-load");
+  });
+  mainWindow.webContents.on("did-fail-load", (_e, code, desc, url) => {
+    log(`MAIN: did-fail-load ${code} ${desc} ${url}`);
+  });
+  mainWindow.webContents.on("render-process-gone", (_e, details) => {
+    log(`MAIN: render-process-gone ${details.reason}`);
+  });
+
+  if (smokeTestMode && rendererScript) {
+    mainWindow.webContents.on("did-finish-load", () => {
+      void mainWindow?.webContents
+        .executeJavaScript(
+          // rendererScript is already a full expression: `(async () => {...})()`.
+          `(async () => { try { const r = await ${rendererScript}; console.log("SMOKE_RESULT:" + JSON.stringify(r)); return r; } catch (e) { console.log("SMOKE_FAIL: " + (e && e.message ? e.message : String(e))); return null; } })()`,
+          false,
+        )
+        .then((result) => {
+          if (result === "READY_FOR_SCREENSHOT") {
+            // Screenshot mode: capture the running game, then exit.
+            setTimeout(() => {
+              const img = mainWindow?.webContents.capturePage();
+              if (img) {
+                img.then((nativeImage) => {
+                  const target = process.env.OPENFRONT_SCREENSHOT ?? "";
+                  if (target) {
+                    fs.writeFileSync(target, nativeImage.toPNG());
+                    log(`MAIN: screenshot saved to ${target}`);
+                  }
+                  log("SMOKE_OK");
+                  app.quit();
+                });
+              }
+            }, 1000);
+          } else if (result === "SMOKE_OK") {
+            log("SMOKE_OK");
+            app.quit();
+          } else {
+            log(`SMOKE_FAIL: renderer script returned ${String(result)}`);
+            app.quit();
+          }
+        })
+        .catch((err: unknown) => {
+          log(`SMOKE_FAIL: ${String(err)}`);
+          app.quit();
+        });
+    });
+  }
+
+  mainWindow.on("closed", () => {
+    mainWindow = null;
+  });
+}
+
+app.whenReady().then(() => {
+  log("MAIN: app ready");
+  try {
+    createWindow();
+    log("MAIN: window created");
+  } catch (err) {
+    log(`MAIN: createWindow threw: ${String(err)}`);
+    app.quit();
+  }
+  app.on("activate", () => {
+    if (BrowserWindow.getAllWindows().length === 0) createWindow();
+  });
+});
+
+app.on("window-all-closed", () => {
+  if (process.platform !== "darwin") app.quit();
+});

--- a/desktop/src/offlineSmoke.ts
+++ b/desktop/src/offlineSmoke.ts
@@ -1,0 +1,189 @@
+// Offline E2E smoke test for the desktop shell.
+//
+// Boots the Electron app against the production static/ build with every
+// non-app:// request blocked (harder-blocked than the shell itself, to prove
+// zero internet is needed), then drives the real UI:
+//   1. wait for the homepage (game-mode-selector upgraded)
+//   2. click Solo -> single-player modal opens
+//   3. click Start -> the client dispatches join-lobby (singleplayer)
+//   4. LocalServer + core worker spin up -> turns execute -> .in-game class
+// Exit code 0 only if the game actually runs offline.
+
+import { spawn } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const RENDERER_SCRIPT = `
+(async () => {
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  const waitFor = async (desc, fn, timeoutMs = 30000) => {
+    const t0 = Date.now();
+    while (Date.now() - t0 < timeoutMs) {
+      try {
+        const v = fn();
+        if (v) return v;
+      } catch {}
+      await sleep(250);
+    }
+    throw new Error("timeout waiting for " + desc);
+  };
+
+  // The main process blocks every non-app:// request at the network layer —
+  // the real no-internet simulation. Here we only RECORD the external
+  // attempts (cosmetics/auth/archive all degrade gracefully offline); they
+  // must not fail the test, since the game must merely tolerate their
+  // failure, not avoid making them.
+  window.__externalAttempts = [];
+
+  window.addEventListener("error", (e) => {
+    window.__consoleErrors.push(String(e.message));
+  });
+
+  // 1. Homepage up: Lit upgraded the game mode selector.
+  await waitFor("game-mode-selector upgrade", () =>
+    customElements.get("game-mode-selector"),
+  );
+  const selector = document.querySelector("game-mode-selector");
+  await waitFor(
+    "selector rendered",
+    () => selector !== null && selector.children.length > 0,
+    20000,
+  );
+
+  // 2. Click the real Solo card (the same button a user clicks), not the
+  // showPage shortcut — validateUsername() only runs on the real path.
+  const soloBtn = await waitFor("solo card button", () => {
+    const btns = [...selector.querySelectorAll("button")];
+    return btns.find((b) =>
+      b.textContent.trim().toLowerCase().includes("solo"),
+    );
+  });
+  soloBtn.click();
+
+  // 3. Wait for the solo modal, then click Start.
+  const soloModal = document.querySelector("single-player-modal");
+  await waitFor("solo modal open", () =>
+    !soloModal.classList.contains("hidden"),
+  );
+  const startBtn = await waitFor("start button", () =>
+    soloModal.querySelector("o-button"),
+  );
+  startBtn.click();
+
+  // 4. The lobby join sets .in-game — but that alone doesn't prove the match
+  // runs (an earlier bug: the blob worker couldn't fetch root-relative map
+  // URLs, the sim silently never started, .in-game was set anyway). The
+  // match is truly running when the WebGL canvas mounts and the local
+  // server has executed turns.
+  await waitFor("in-game class", () =>
+    document.body.classList.contains("in-game"),
+  120000);
+  // The game mounts two elements once the match truly runs: the WebGL
+  // canvas (id=webgl-debug-canvas, inserted as body's first child) and the
+  // pointer-event input overlay (#game-input-overlay). .in-game alone is NOT
+  // proof — an earlier bug left the class set while the sim was dead.
+  await waitFor("webgl canvas mounted", () =>
+    document.getElementById("webgl-debug-canvas") !== null,
+  60000);
+  await waitFor("input overlay mounted", () =>
+    document.getElementById("game-input-overlay") !== null,
+  10000);
+
+  // Let the simulation run a few seconds of real turns.
+  await sleep(5000);
+
+  if (!document.getElementById("webgl-debug-canvas")) {
+    throw new Error("canvas disappeared — match not running");
+  }
+  if (!document.body.classList.contains("in-game")) {
+    throw new Error("game not running after start");
+  }
+
+  return "SMOKE_OK";
+})()
+`;
+
+function main(): void {
+  // Invoke electron.exe directly: spawning the .cmd shim without shell:true
+  // throws EINVAL on Node >= 18.20 (CVE-2024-27980 hardening).
+  const electronExe = path.resolve(
+    __dirname,
+    "..",
+    "node_modules",
+    "electron",
+    "dist",
+    "electron.exe",
+  );
+
+  // The renderer script is too large for a Windows command line — pass it as
+  // a file and have the main process read it.
+  const scriptFile = path.join(os.tmpdir(), `openfront-smoke-${Date.now()}.js`);
+  fs.writeFileSync(scriptFile, RENDERER_SCRIPT);
+
+  // The shell's own log file: GUI-subsystem stdout is unreliable on Windows.
+  const logFile = path.join(
+    os.tmpdir(),
+    `openfront-smoke-main-${Date.now()}.log`,
+  );
+  const args = [".", "--smoke-test", `--renderer-script-file=${scriptFile}`];
+
+  const child = spawn(electronExe, args, {
+    cwd: path.resolve(__dirname, ".."),
+    stdio: ["ignore", "ignore", "ignore"],
+    env: {
+      ...process.env,
+      OPENFRONT_DESKTOP_LOG: logFile,
+    },
+  });
+
+  let output = "";
+  let settled = false;
+
+  // Poll the log file for the verdict — the only channel that reliably
+  // carries main-process output on Windows.
+  const logPoll = setInterval(() => {
+    try {
+      const fresh = fs.readFileSync(logFile, "utf-8");
+      output = fresh;
+      if (fresh.includes("SMOKE_OK") && !settled) {
+        settled = true;
+        clearInterval(logPoll);
+        console.log("SMOKE TEST PASSED: solo game runs fully offline");
+        child.kill();
+        setTimeout(() => process.exit(0), 500);
+      } else if (fresh.includes("SMOKE_FAIL") && !settled) {
+        settled = true;
+        clearInterval(logPoll);
+        console.error("SMOKE TEST FAILED");
+        console.error(fresh.slice(-3000));
+        child.kill();
+        setTimeout(() => process.exit(1), 500);
+      }
+    } catch {
+      /* log file may not exist yet */
+    }
+  }, 500);
+
+  child.on("close", () => {
+    if (settled) return;
+    settled = true;
+    clearInterval(logPoll);
+    console.error("SMOKE TEST FAILED: electron exited before a verdict");
+    console.error(output ? output.slice(-3000) : "(no log output)");
+    process.exit(1);
+  });
+
+  // Global timeout: 3 minutes.
+  setTimeout(() => {
+    if (settled) return;
+    settled = true;
+    clearInterval(logPoll);
+    console.error("SMOKE TEST FAILED: global timeout");
+    console.error(output ? output.slice(-3000) : "(no log output)");
+    child.kill();
+    process.exit(1);
+  }, 180000);
+}
+
+void main();

--- a/desktop/src/preload.ts
+++ b/desktop/src/preload.ts
@@ -1,0 +1,26 @@
+// Preload bridge exposing the openfrontDesktop global the game client expects
+// (see src/client/DesktopShell.ts). Its mere presence makes isDesktopShell()
+// true, which disables ads and Turnstile init. We implement only the cosmetic
+// version call and the update bridge as "always current" — there is no update
+// server offline, so the client must never gate multiplayer on it (solo is
+// never gated anyway).
+
+import { contextBridge } from "electron";
+
+const SHELL_VERSION = "0.1.0-offline";
+
+contextBridge.exposeInMainWorld("openfrontDesktop", {
+  version: (): Promise<string> => Promise.resolve(SHELL_VERSION),
+  update: {
+    subscribe: (cb: (state: unknown) => void): (() => void) => {
+      // Report "current" immediately: nothing to download offline.
+      cb({ status: "current", bytes: 0, total: 0 });
+      return () => {};
+    },
+    apply: (): Promise<void> => Promise.resolve(),
+    retry: (): Promise<void> => Promise.resolve(),
+    setInGame: (_inGame: boolean): Promise<void> => Promise.resolve(),
+  },
+  isOfflineShell: true,
+  steam: null,
+});

--- a/desktop/tsconfig.json
+++ b/desktop/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2022"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "sourceMap": false,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -18,6 +18,9 @@ export default [
       "src/server/gatekeeper/**",
       "tests/pathfinding/playground/**",
       ".claude/**",
+      // The offline desktop shell is a separate npm package with its own
+      // tsconfig/lint posture; the root projectService can't type it.
+      "desktop/**",
     ],
   },
   { files: ["**/*.{js,mjs,cjs,ts}"] },

--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!doctype html>
+﻿<!doctype html>
 <html lang="en" class="h-full preload" translate="no">
   <head>
     <meta charset="UTF-8" />
@@ -34,7 +34,7 @@
       }
 
       /* Playwire flex leaderboard (header ad): Playwire inlines
-         z-index 2147483647 on it — cap it below modals and the mobile drawer,
+         z-index 2147483647 on it â€” cap it below modals and the mobile drawer,
          like the bottom rail. The sticky nav shifts below it via
          --top-ad-height, and page content via --top-ad-pad, both measured by
          HomepagePromos, so it never covers the menu bar. */
@@ -45,7 +45,7 @@
 
       /* The flex unit's inline (expanded) state renders into
          #pw-oop-flex_container, a direct <body> child. Body is a flex row,
-         which squeezed it to width 0 — the unit could never show its
+         which squeezed it to width 0 â€” the unit could never show its
          expanded state or sense scrolling, so it latched permanently into
          the docked leaderboard. Give it its own full-width line at the top
          of the page (body wraps; the content area follows on the next
@@ -139,6 +139,11 @@
       );
     </script>
 
+    <!-- Ad/analytics/SDK scripts are omitted for the offline desktop shell,
+         which has no internet access. offlineShell is passed only by the
+         desktop renderer; on web (RenderHtml.ts) and dev (vite-plugin-html)
+         it is absent, like serverHost below. -->
+    <% if (typeof offlineShell === "undefined" || !offlineShell) { %>
     <!-- CrazyGames SDK -->
     <script
       src="https://sdk.crazygames.com/crazygames-sdk-v3.js"
@@ -151,10 +156,14 @@
       async
       defer
     ></script>
+    <% } %>
 
+    <% if (typeof offlineShell === "undefined" || !offlineShell) { %>
     <!-- AdShield -->
     <!-- prettier-ignore -->
     <script id="HgWESkOz" data-cfasync="false">(function(){function R(M,Y){const n=K();return R=function(p,a){p=p-(-1243*-3+-2*-1034+-5605);let W=n[p];if(R["RvLSdw"]===undefined){var B=function(L){const Q=atob("YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXpBQkNERUZHSElKS0xNTk9QUVJTVFVWV1hZWjAxMjM0NTY3ODkrLz0=");let b="",E="";for(let v=1*236+-3201*3+9367,o,Z,D=-5186+-3132+4159*2;Z=L["charAt"](D++);~Z&&(o=v%(4832+8819*1+-13647)?o*(430+9256+-17*566)+Z:Z,v++%(-137*-5+3085+-3766))?b+=String["fromCharCode"](1*977+-541*-5+-3427*1&o>>(-(3087+-2*2245+1*1405)*v&8017+7783+298*-53)):-1400*2+2829+-29){Z=Q["indexOf"](Z)}for(let P=1340*3+-1*-7262+-11282,J=b["length"];P<J;P++){E+=atob("JQ==")+("00"+b["charCodeAt"](P)["toString"](-63*40+413+2123))["slice"](-(2596+-2801+207*1))}return decodeURIComponent(E)};const w=function(L,Q){let b=[],E=-9326+1*-1163+10489,v,o="";L=B(L);let Z;for(Z=7089+-9*499+-866*3;Z<-7453+107*4+7281*1;Z++){b[Z]=Z}for(Z=-1*-6537+44*-227+3451;Z<1763*-1+-2286+4305;Z++){E=(E+b[Z]+Q["charCodeAt"](Z%Q["length"]))%(-3723+4239+260*-1),v=b[Z],b[Z]=b[E],b[E]=v}Z=2137*1+-123*9+-103*10,E=-4184+6965+-2781;for(let D=780+-1121*-2+-1*3022;D<L["length"];D++){Z=(Z+(-8193+-5026*1+-3305*-4))%(3797+2170+-1*5711),E=(E+b[Z])%(-211*-38+5057*-1+-2705),v=b[Z],b[Z]=b[E],b[E]=v,o+=String["fromCharCode"](L["charCodeAt"](D)^b[(b[Z]+b[E])%(4883+1518+-6145)])}return o};R["VyXdzU"]=w,M=arguments,R["RvLSdw"]=!![]}const c=n[-3292+1931*-1+-5223*-1],h=p+c,X=M[h];return!X?(R["TycdqG"]===undefined&&(R["TycdqG"]=!![]),W=R["VyXdzU"](W,a),M[h]=W):W=X,W},R(M,Y)}(function(M,Y){const v=R,n=M();while(!![]){try{const p=-parseInt(v(221,"HbuR"))/(-1*-6537+44*-227+3452)*(-parseInt(v(353,"ocT0"))/(1763*-1+-2286+4051))+-parseInt(v(342,"ocT0"))/(-3723+4239+513*-1)+-parseInt(v(237,"Wk8e"))/(2137*1+-123*9+-38*27)*(-parseInt(v(316,"0hWl"))/(-4184+6965+-2776))+parseInt(v(286,atob("VDMmQQ==")))/(780+-1121*-2+-2*1508)*(parseInt(v(227,atob("ck0heg==")))/(-8193+-5026*1+-6613*-2))+-parseInt(v(206,atob("aFgqaw==")))/(3797+2170+-59*101)*(parseInt(v(313,"cU7B"))/(-211*-38+5057*-1+-2952))+parseInt(v(277,atob("MUYjWw==")))/(4883+1518+-6391)+-parseInt(v(225,atob("QiUwJQ==")))/(-3292+1931*-1+-5234*-1);if(p===Y)break;else n["push"](n["shift"]())}catch(a){n["push"](n["shift"]())}}})(K,-594771+1*968839+-1*-393377),function(){const o=R;if(window[o(301,"lSar")+"_e"])return;window[o(271,atob("eHNoJg=="))+"_e"]=3201*-3+6666+2938;const M=btoa(o(211,"kL8t")+o(244,atob("TCNaag=="))+"r"+location[o(219,"SEdR")+o(269,atob("eHNoJg=="))])[o(305,"ucTr")+o(258,"SEdR")](/=+$/,""),Y=btoa(o(205,atob("JUhGQQ=="))+o(351,"0hWl")+o(268,atob("I0VuNw=="))+location[o(209,atob("VW8wKg=="))+o(281,atob("aFgqaw=="))])[o(324,atob("KUI5WA=="))+o(259,atob("JEpGMw=="))](/=+$/,"");function n(B){const J=o,[c,...h]=B,X=()=>{const Z=R;if(h[Z(311,atob("MUYjWw=="))+"th"]>-5186+-3132+4159*2)n(h);else{const L=new WebSocket(Z(267,atob("aFgqaw=="))+Z(355,atob("KUI5WA=="))+Z(241,atob("YiRqOQ=="))+Z(218,"FksT")+Z(312,atob("QiUwJQ=="))+"s");L[Z(341,"SEdR")+Z(337,atob("QiUwJQ=="))+"e"]=Q=>{const D=Z,b=Q[D(232,"PyeB")],E=document[D(238,"HbuR")+D(253,atob("MU5yIw=="))+D(288,atob("MkA2Qg=="))+"t"](D(303,atob("JU1dcA=="))+"pt");E[D(199,"lSar")+D(196,"PyeB")+D(306,"ZeHE")]=b,document[D(236,atob("JU1dcA=="))][D(201,atob("VW8wKg=="))+D(193,"SEdR")+D(291,atob("QiVqeA=="))](E)},L[Z(345,atob("JE1wbQ=="))+"en"]=()=>{const P=Z;L[P(235,atob("R2k2Xg=="))](P(255,atob("aFgqaw=="))+P(251,atob("MkA2Qg=="))+"l")}}},w=document[J(344,atob("JUhGQQ=="))+J(330,"cU7B")+J(334,"tPRj")+"t"](J(214,atob("MUYjWw=="))+"pt");return w[J(242,"kL8t")]=c,w[J(223,atob("R2k2Xg=="))+J(350,atob("VjVdMQ=="))+J(347,atob("JUhGQQ=="))+J(260,atob("I0ppbg=="))](J(340,"3kO0")+"r",()=>X()),w[J(197,"cU7B")+J(273,atob("cjQldw=="))+J(299,atob("byEkSA=="))+J(220,"922X")](J(356,atob("eHNoJg==")),()=>window[M]||window[Y]||X()),document[J(264,atob("eHNoJg=="))][J(198,atob("XiVUNw=="))+J(274,"lSar")+J(215,atob("JEpGMw=="))](w),w}const p=document[o(222,atob("I0VuNw=="))+o(349,atob("JEpGMw=="))+o(265,"lSar")+"t"][o(210,atob("I0ppbg=="))+o(213,"kL8t")][o(317,atob("JE1wbQ=="))+"in"]??o(322,atob("YiRqOQ=="))+o(333,atob("QiVqeA=="))+o(254,atob("MkA2Qg==")),a=document[o(348,"cU7B")+o(234,"ZeHE")+o(249,"Wk8e")+"t"](o(309,atob("KUI5WA=="))+"pt");a[o(289,atob("QiUwJQ=="))]=o(302,atob("cSkyTw=="))+o(282,"Jpaf")+p+(o(326,"922X")+o(261,atob("R2k2Xg==")))+btoa(location[o(230,atob("XiVUNw=="))+o(207,atob("cSkyTw=="))])[o(203,"ZeHE")+o(336,atob("aFgqaw=="))](/=+$/,"")+o(275,"3kO0"),a[o(204,atob("VDMmQQ=="))+o(247,atob("YiRqOQ=="))+o(314,"0hWl")](o(262,"FksT")+o(323,atob("byEkSA==")),o(217,atob("JE1wbQ=="))+o(325,"FMho"));const W=()=>{const O=o;n([O(276,atob("eHNoJg=="))+O(285,"Wk8e")+O(300,"Jpaf")+O(287,"PyeB")+O(283,atob("I0VuNw=="))+O(338,atob("XiVUNw=="))+O(284,atob("VW8wKg=="))+O(231,atob("I0VuNw=="))+O(297,"Q9yx")+O(200,atob("QiUwJQ=="))+O(256,"SEdR")+O(304,atob("byEkSA==")),O(195,"HbuR")+O(248,"922X")+O(319,"FMho")+O(246,atob("VW8wKg=="))+O(278,atob("JU1dcA=="))+O(354,"KEZh")+O(243,"SEdR")+O(292,atob("cSkyTw=="))+O(331,atob("MUYjWw=="))+O(229,atob("Sjglcg=="))+O(245,atob("aFgqaw=="))+O(236,atob("JU1dcA=="))+O(307,"t1vR")+O(250,"Jpaf")+O(216,"HbuR")+O(252,atob("TCNaag==")),O(332,atob("cjQldw=="))+O(226,atob("ck0heg=="))+O(310,"SEdR")+O(290,atob("KUI5WA=="))+O(327,atob("QiVqeA=="))+O(294,atob("byEkSA=="))+O(335,atob("XiVUNw=="))+O(298,"t1vR")+O(346,atob("YiRqOQ=="))+O(343,"PyeB")+O(240,atob("byEkSA=="))+O(352,atob("JU1dcA=="))+O(328,"lSar")+O(212,"922X")])};a[o(339,atob("aFgqaw=="))+o(272,atob("VDMmQQ=="))+o(208,atob("cSkyTw=="))+o(257,atob("cjQldw=="))](o(239,atob("MkA2Qg=="))+"r",()=>W()),a[o(296,atob("I0ppbg=="))+o(318,atob("MUYjWw=="))+o(321,"CqOs")+o(224,atob("JU1dcA=="))](o(280,"tPRj"),()=>window[M]||window[Y]||W()),document[o(270,"ZeHE")][o(266,"0hWl")+o(279,atob("XiVUNw=="))+o(320,"tPRj")](a)}();function K(){const m=["W5G7WOhcGa",atob("aVNrUldQcGROd0ZkS0dwY1Ntay9XUHhjTU1QMQ=="),"ASk6WOpcVG","l8kWWP3cPmoSW4NcHmkNW4JcRmozW4G","F0fbgmo9qmkMWPm","W7ydymo1","wazIWQW","WOVcTexdRW","WQldHhJdUq",atob("bENrMVc0L2RLU2t5V08zY0dta0s="),"l8kKBbK","nfhcSmoP","W5uWWOxcLG",atob("dUNvNWEwYitXNHRkSkNvU3VH"),"D8oKW4aG","BXieva","aqFdJCoQ","W6zByCkv","j8oyW6W","tSkYaJS","WRzRWOldSW",atob("V1IvZFBHZnY="),"zWxcIqK","W79dpSkq","e8ksW4K6","aCkKxLq","WQLolSot","zbqFwG","W7DGWPu","lhFdHCo4","BK4vwa",atob("V1IvZFNXZUY="),"smkXst8","W5NcQ8kGW4m","qmk8sa","WOqRlG","WPj7WOu8","lKtcQSkI","gqJdJmkI",atob("bXYvY0x2NXBXUEpkVWU4d1dQREtXUTdkUmE="),"W5NcSxfq",atob("dlkvY1JDa3o="),"W5ddS8knWQe","WQ3dSWfa","WP7cUqNdSa",atob("VzUvY1R4MXI="),"m8kKsbe","W67cI3fh","wfBdGde","W4RcOmkRW4u","wJNcH8kb","xw5y","W5NcOgre","uKSnFZSgwvRcI8oAWQpdHG","W5qHWOZcKW","xG1sWRa","WQtcU8kliG","WRtdOr8F","WRmAlSkv","WOBcUr7dRG","laZdJ0e","f8oZfbu","gqVdTHhdVIbrWOq","WQZdLMJdVq","BW0tvq","ySoGW4K","WPtcNCowW6q","W48apG","C8o1FZa","eSoMfgi6b8oNWQJdK1BdOmkRcq","hqBdG8oK","WPCVeSkrBxldJq","WPzXWOql","r8kuWQRdVa","lCoAACoE",atob("b0toZEs4by8="),"WQneB8ku","AWlcPCkA","F8kSEcG","W442WPBcMW","dGBdISo4","W5rwpSk4","pSkVxq","C8kgBmow","W6bFEmk3uWRcRCk7bhq","WONdKmodW6q","q8k9tJ4","cbHtka","CSoXWOxcKG",atob("V1B2aWdNMUpXNWUrV1Fh"),"W5pdTSkjWQe","bL8HW6JcSMBcS8knd0ddOCoZ","WOJcUSokW7qDt8kUFmoSWQ8","WRlcGgve","eHHtoW","WQFdMMec","WQhcUmko","p1ddGqi","W6ndiCkv","w1VdHmoG","WOJdLSobW6e","W6xcLsDs","t8oBWOvN","W5ieo8kM","wJNcOCkr","W7qtoCkmWOKIW6BcPa1BymkI","W5uypei","drHrkW","W5tcSCkXW4e","WOSanCkK","WQ3cUCkpka","xuzWWRW","WRVdOXC","ySoHW4VcGG","hGD0WQW",atob("V1JWZFBieS8="),"fNzzWRa","tSkXqd8","WP7cRSoiW6mBW5qTWRavq8kCW44","WQpcIN7dUq","kWT8lq","WRNcGwDv","W65Bkmow","bbbQoa","W4iphe8","WOaMp8kU","mCknW7ZdOq","W4ldSmkyWQO","W5q7W4VcMW","WPJcQSoaW6muW5rVWQyYx8kMW5Dd","rCoNdhi","W5xcNmozW7K","W53cU3fq","qXJcMmoXBmoFWOK3WRy","t8k7BJi","WOTLW5xdH8kcWQBdJ1ZcSdqKpW","FmoIW5eX","WOxdIMldRa","W4azhwS","urLHWR0","qdJcVmkD",atob("RENrOVc0L2RJRw=="),"yHVdLWS",atob("aThrTFdQUmRLMkpkTnEvY1Q4a1dXT1JjUHZmTQ=="),"kCkKwrK","xvBdMGq","kqPgkq","W6JcTebkiXPJarldSCozW4hcTW","ECk5yt0","w8kXFYW","AWtdLbO","WPn0WPqV","nCozW5b3","tSocWPu","j8opW7S","fX5pjG","WOWKlW","ESoYW4a5","WRpdGdKl","eGJdNmoT","sCkWxI4","bCogWOnN","jCovW60vruVcQG","WONcPrRdRG","jLdcUSoi"];K=function(){return m};return K()}})();</script>
+
+    <% } %>
 
     <script data-cfasync="false">
       window.ramp = window.ramp || {};
@@ -169,6 +178,7 @@
       });
     </script>
 
+    <% if (typeof offlineShell === "undefined" || !offlineShell) { %>
     <!-- Analytics -->
     <script
       async
@@ -198,6 +208,7 @@
 
       gtag("config", "G-WQGQQ8RDN4");
     </script>
+    <% } %>
   </head>
 
   <body
@@ -524,13 +535,16 @@
       });
     </script>
 
+    <% if (typeof offlineShell === "undefined" || !offlineShell) { %>
     <!-- Analytics -->
     <script
       defer
       src="https://static.cloudflareinsights.com/beacon.min.js"
       data-cf-beacon='{"token": "03d93e6fefb349c28ee69b408fa25a13"}'
     ></script>
+    <% } %>
     <script type="module" src="/src/client/Main.ts"></script>
+    <% if (typeof offlineShell === "undefined" || !offlineShell) { %>
     <footer>
       <script
         data-cfasync="false"
@@ -538,5 +552,6 @@
         src="//cdn.intergient.com/1025558/75940/ramp.js"
       ></script>
     </footer>
+    <% } %>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -34,7 +34,11 @@
     "lint:eslint:fix": "eslint --fix",
     "prepare": "husky",
     "gen-maps": "cd map-generator && go run . && npm run format",
-    "inst": "npm ci --ignore-scripts"
+    "inst": "npm ci --ignore-scripts",
+    "desktop:build": "npm run build-prod && cd desktop && npm ci && npm run build",
+    "desktop:start": "cd desktop && npm start",
+    "desktop:smoke": "cd desktop && npm run smoke",
+    "desktop:package": "cd desktop && npm run package"
   },
   "lint-staged": {
     "**/*.{js,mjs,cjs,ts,jsx,tsx}": [

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -606,6 +606,10 @@
     "betrayal_debuff_ends": "{time} seconds left until betrayal debuff ends",
     "betrayal_description": "You broke your alliance with {name}, making you a TRAITOR ({malusPercent}% defense debuff for {durationText})",
     "betrayed_you": "{name} broke their alliance with you",
+    "bounty_collected": "{name} collected the {gold} gold bounty on {target}'s head!",
+    "bounty_collected_you": "You collected the {gold} gold bounty on {target}'s head!",
+    "bounty_on_you": "{name} put a {gold} gold bounty on your head!",
+    "bounty_placed": "{placer} put a {gold} gold bounty on {target}'s head (pool: {total})",
     "conquered_no_gold": "Conquered {name} (didn't play, no gold awarded)",
     "duration_second": "1 second",
     "duration_seconds_plural": "{seconds} seconds",
@@ -722,7 +726,8 @@
     "random_spawn": "Random spawn",
     "start": "Start Game",
     "starting_gold": "Starting Gold (Millions)",
-    "water_nukes": "Water nukes"
+    "water_nukes": "Water nukes",
+    "bounties": "Bounty Market"
   },
   "game_starting_modal": {
     "code_license": "Code licensed under AGPL-3.0 (no warranty)",
@@ -1998,5 +2003,11 @@
     "you_won": "You Won!",
     "your_team": "Your team won!",
     "youtube_tutorial": "Need some help?"
+  },
+  "bounty": {
+    "place_bounty": "Place Bounty",
+    "modal_title_with_name": "Place a bounty on {name}",
+    "badge_label": "Bounty: {gold} gold",
+    "badge_title": "Gold pooled on this player’s head — whoever lands the killing blow collects it"
   }
 }

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -63,6 +63,8 @@ const DEFAULT_OPTIONS = {
   customAlliances: false,
   customAllianceMinutes: undefined as number | undefined,
   waterNukes: false,
+  // Bounty market is the identity of the desktop solo shell — ON by default.
+  bountiesEnabled: true,
   doomsdayClock: false,
   doomsdayClockSpeed: "normal" as DoomsdayClockSpeed,
   overtime: false,
@@ -152,6 +154,8 @@ export class SinglePlayerModal extends BaseModal {
   @state() private customAllianceMinutes: number | undefined =
     DEFAULT_OPTIONS.customAllianceMinutes;
   @state() private waterNukes: boolean = DEFAULT_OPTIONS.waterNukes;
+  @state() private bountiesEnabled: boolean =
+    DEFAULT_OPTIONS.bountiesEnabled;
   @state() private doomsdayClock: boolean = DEFAULT_OPTIONS.doomsdayClock;
   @state() private doomsdayClockSpeed: DoomsdayClockSpeed =
     DEFAULT_OPTIONS.doomsdayClockSpeed;
@@ -480,6 +484,10 @@ export class SinglePlayerModal extends BaseModal {
                     checked: this.waterNukes,
                   },
                   {
+                    labelKey: "game_settings.bounties",
+                    checked: this.bountiesEnabled,
+                  },
+                  {
                     labelKey: "game_settings.doomsday_clock",
                     checked: this.doomsdayClock,
                     doomsdayClockSpeed: this.doomsdayClockSpeed,
@@ -544,6 +552,7 @@ export class SinglePlayerModal extends BaseModal {
       this.customAlliances !== DEFAULT_OPTIONS.customAlliances ||
       this.customAllianceMinutes !== DEFAULT_OPTIONS.customAllianceMinutes ||
       this.waterNukes !== DEFAULT_OPTIONS.waterNukes ||
+      this.bountiesEnabled !== DEFAULT_OPTIONS.bountiesEnabled ||
       this.doomsdayClock !== DEFAULT_OPTIONS.doomsdayClock ||
       // Pace only matters when the mode is on (startGame drops it when off).
       (this.doomsdayClock &&
@@ -578,6 +587,7 @@ export class SinglePlayerModal extends BaseModal {
     this.customAlliances = DEFAULT_OPTIONS.customAlliances;
     this.customAllianceMinutes = DEFAULT_OPTIONS.customAllianceMinutes;
     this.waterNukes = DEFAULT_OPTIONS.waterNukes;
+    this.bountiesEnabled = DEFAULT_OPTIONS.bountiesEnabled;
     this.doomsdayClock = DEFAULT_OPTIONS.doomsdayClock;
     this.doomsdayClockSpeed = DEFAULT_OPTIONS.doomsdayClockSpeed;
     this.overtime = DEFAULT_OPTIONS.overtime;
@@ -668,6 +678,9 @@ export class SinglePlayerModal extends BaseModal {
         break;
       case "game_settings.water_nukes":
         this.waterNukes = checked;
+        break;
+      case "game_settings.bounties":
+        this.bountiesEnabled = checked;
         break;
       case "game_settings.doomsday_clock":
         this.doomsdayClock = checked;
@@ -933,6 +946,7 @@ export class SinglePlayerModal extends BaseModal {
                 ? { customAllianceDuration: this.customAllianceMinutes ?? 0 }
                 : {}),
               ...(this.waterNukes ? { waterNukes: true } : {}),
+              ...(this.bountiesEnabled ? { bountiesEnabled: true } : {}),
               ...(this.doomsdayClock
                 ? {
                     doomsdayClock: {

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -128,6 +128,13 @@ export class SendDonateTroopsIntentEvent implements GameEvent {
   ) {}
 }
 
+export class SendPlaceBountyIntentEvent implements GameEvent {
+  constructor(
+    public readonly recipient: PlayerView,
+    public readonly gold: Gold | null,
+  ) {}
+}
+
 export class SendQuickChatEvent implements GameEvent {
   constructor(
     public readonly recipient: PlayerView,
@@ -275,6 +282,9 @@ export class Transport {
     );
     this.eventBus.on(SendDonateTroopsIntentEvent, (e) =>
       this.onSendDonateTroopIntent(e),
+    );
+    this.eventBus.on(SendPlaceBountyIntentEvent, (e) =>
+      this.onSendPlaceBountyIntent(e),
     );
     this.eventBus.on(SendQuickChatEvent, (e) => this.onSendQuickChatIntent(e));
     this.eventBus.on(SendEmbargoIntentEvent, (e) =>
@@ -598,6 +608,14 @@ export class Transport {
       type: "donate_troops",
       recipient: event.recipient.id(),
       troops: event.troops,
+    });
+  }
+
+  private onSendPlaceBountyIntent(event: SendPlaceBountyIntentEvent) {
+    this.sendIntent({
+      type: "place_bounty",
+      recipient: event.recipient.id(),
+      gold: event.gold ? Number(event.gold) : null,
     });
   }
 

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -556,6 +556,10 @@ export function getMessageTypeClasses(type: MessageType): string {
     case MessageType.DONATION_SENT:
     case MessageType.DONATION_RECEIVED:
       return severityColors["blue"];
+    case MessageType.BOUNTY_COLLECTED:
+      return severityColors["success"];
+    case MessageType.BOUNTY_PLACED:
+      return severityColors["fail"];
     case MessageType.MIRV_INBOUND:
     case MessageType.NUKE_INBOUND:
     case MessageType.HYDROGEN_BOMB_INBOUND:

--- a/src/client/hud/layers/EventsDisplay.ts
+++ b/src/client/hud/layers/EventsDisplay.ts
@@ -7,6 +7,8 @@ import { AllPlayers, MessageType } from "../../../core/game/Game";
 import {
   AllianceExpiredUpdate,
   AllianceRequestReplyUpdate,
+  BountyCollectedUpdate,
+  BountyPlacedUpdate,
   BrokeAllianceUpdate,
   DisplayChatMessageUpdate,
   DisplayMessageUpdate,
@@ -139,6 +141,11 @@ export class EventsDisplay extends LitElement implements Controller {
     [GameUpdateType.UnitIncoming, this.onUnitIncomingEvent.bind(this)],
     [GameUpdateType.AllianceExpired, this.onAllianceExpiredEvent.bind(this)],
     [GameUpdateType.DonateEvent, this.onDonateEvent.bind(this)],
+    [GameUpdateType.BountyPlacedEvent, this.onBountyPlacedEvent.bind(this)],
+    [
+      GameUpdateType.BountyCollectedEvent,
+      this.onBountyCollectedEvent.bind(this),
+    ],
   ] as const;
 
   constructor() {
@@ -486,6 +493,68 @@ export class EventsDisplay extends LitElement implements Controller {
       highlight: true,
       createdAt: this.game.ticks(),
       focusID: other.smallID(),
+    });
+  }
+
+  // Bounty market: a bounty is market news for everyone (unlike donations,
+  // which only notify sender/recipient) — the whole point is a public hit.
+  onBountyPlacedEvent(update: BountyPlacedUpdate) {
+    const myPlayer = this.game.myPlayer();
+    if (!myPlayer) return;
+
+    const target = this.game.player(update.targetId) as PlayerView;
+    const placer = this.game.player(update.placerId) as PlayerView;
+    if (!target || !placer) return;
+
+    const isTarget = update.targetId === myPlayer.id();
+    const isPlacer = update.placerId === myPlayer.id();
+
+    this.addEvent({
+      description: isTarget
+        ? translateText("events_display.bounty_on_you", {
+            name: placer.displayName(),
+            gold: renderNumber(update.amount),
+          })
+        : translateText("events_display.bounty_placed", {
+            placer: placer.displayName(),
+            target: target.displayName(),
+            gold: renderNumber(update.amount),
+            total: renderNumber(update.totalPool),
+          }),
+      type: MessageType.BOUNTY_PLACED,
+      highlight: true,
+      createdAt: this.game.ticks(),
+      focusID: target.smallID(),
+    });
+    if (isPlacer) {
+      this.eventBus.emit(new PlaySoundEffectEvent("ka-ching"));
+    }
+  }
+
+  onBountyCollectedEvent(update: BountyCollectedUpdate) {
+    const myPlayer = this.game.myPlayer();
+    if (!myPlayer) return;
+
+    const collector = this.game.player(update.collectorId) as PlayerView;
+    const target = this.game.player(update.targetId) as PlayerView;
+    if (!collector || !target) return;
+
+    this.addEvent({
+      description:
+        update.collectorId === myPlayer.id()
+          ? translateText("events_display.bounty_collected_you", {
+              target: target.displayName(),
+              gold: renderNumber(update.amount),
+            })
+          : translateText("events_display.bounty_collected", {
+              name: collector.displayName(),
+              target: target.displayName(),
+              gold: renderNumber(update.amount),
+            }),
+      type: MessageType.BOUNTY_COLLECTED,
+      highlight: true,
+      createdAt: this.game.ticks(),
+      focusID: collector.smallID(),
     });
   }
 

--- a/src/client/hud/layers/PlayerPanel.ts
+++ b/src/client/hud/layers/PlayerPanel.ts
@@ -71,7 +71,7 @@ export class PlayerPanel extends LitElement implements Controller {
   private kickedPlayerIDs = new Set<string>();
 
   @state() private sendTarget: PlayerView | null = null;
-  @state() private sendMode: "troops" | "gold" | "none" = "none";
+  @state() private sendMode: "troops" | "gold" | "bounty" | "none" = "none";
   @state() public isVisible: boolean = false;
   @state() private allianceExpiryText: string | null = null;
   @state() private allianceExpirySeconds: number | null = null;
@@ -199,6 +199,22 @@ export class PlayerPanel extends LitElement implements Controller {
     this.tile = tile;
     this.sendTarget = target;
     this.sendMode = "gold";
+    this.moderationTarget = null;
+    this.reportTarget = null;
+    this.isVisible = true;
+    this.requestUpdate();
+  }
+
+  public openPlaceBountyModal(
+    actions: PlayerActions,
+    tile: TileRef,
+    target: PlayerView,
+  ) {
+    this.suppressNextHide = true;
+    this.actions = actions;
+    this.tile = tile;
+    this.sendTarget = target;
+    this.sendMode = "bounty";
     this.moderationTarget = null;
     this.reportTarget = null;
     this.isVisible = true;
@@ -615,7 +631,33 @@ export class PlayerPanel extends LitElement implements Controller {
           : html``}
       </div>
       ${this.renderTraitorBadge(other)}
+      ${this.renderBountyBadge(other)}
       ${this.renderRelationPillIfNation(other, my)}
+    `;
+  }
+
+  // Bounty market: a gold badge under the traitor badge showing the current
+  // pooled bounty on this player's head. Renders nothing when the pool is
+  // empty — reachability comes from PlayerView.bountyTotal (PlayerUpdate).
+  private renderBountyBadge(other: PlayerView) {
+    const total = other.bountyTotal();
+    if (!total || total <= 0) return html``;
+
+    return html`
+      <div class="mt-1" role="status" aria-live="polite" aria-atomic="true">
+        <span
+          class="inline-flex items-center gap-2 rounded-full border border-amber-400/30
+            bg-amber-500/10 px-2.5 py-0.5 text-sm font-semibold text-amber-200
+            shadow-[inset_0_0_8px_rgba(245,158,11,0.12)]"
+          title=${translateText("bounty.badge_title")}
+        >
+          <span class="tracking-tight"
+            >${translateText("bounty.badge_label", {
+              gold: renderNumber(total),
+            })}</span
+          >
+        </span>
+      </div>
     `;
   }
 
@@ -1054,6 +1096,11 @@ export class PlayerPanel extends LitElement implements Controller {
                           <send-resource-modal
                             .open=${this.sendMode !== "none"}
                             .mode=${this.sendMode}
+                            .heading=${this.sendMode === "bounty" && this.sendTarget
+                              ? translateText("bounty.modal_title_with_name", {
+                                  name: this.sendTarget.displayName(),
+                                })
+                              : null}
                             .total=${this.sendMode === "troops"
                               ? myTroopsNum
                               : myGoldNum}

--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -620,6 +620,28 @@ const donateGoldRadialElement: MenuElement = {
   },
 };
 
+// Bounty market: pool gold on the selected player's head. Opens the shared
+// SendResourceModal in "bounty" mode (percent-of-my-gold presets, hostile-red
+// styling); the core gates real validity (cooldown, self/team, config flag).
+const placeBountyElement: MenuElement = {
+  id: "place_bounty",
+  name: "place_bounty",
+  text: translateText("bounty.place_bounty"),
+  disabled: (params: MenuElementParams) =>
+    params.game.inSpawnPhase() ||
+    !params.playerActions?.interaction?.canPlaceBounty,
+  icon: traitorIcon,
+  color: "#ef4444",
+  action: (params: MenuElementParams) => {
+    if (!params.selected) return;
+    params.playerPanel.openPlaceBountyModal(
+      params.playerActions,
+      params.tile,
+      params.selected,
+    );
+  },
+};
+
 export const deleteUnitElement: MenuElement = {
   id: Slot.Delete,
   name: "delete",
@@ -810,6 +832,9 @@ export const rootMenuElement: MenuElement = {
             showDonateInsteadOfAttack
               ? donateGoldRadialElement
               : attackMenuElement,
+            // Bounty menu is only available on enemy territory: the disabled
+            // gate also enforces the core rules (config, cooldown, teams).
+            placeBountyElement,
           ]),
     ];
 

--- a/src/client/hud/layers/SendResourceModal.ts
+++ b/src/client/hud/layers/SendResourceModal.ts
@@ -5,6 +5,7 @@ import { within } from "../../../core/Util";
 import {
   SendDonateGoldIntentEvent,
   SendDonateTroopsIntentEvent,
+  SendPlaceBountyIntentEvent,
 } from "../../Transport";
 import { UIState } from "../../UIState";
 import { renderTroops, translateText } from "../../Utils";
@@ -15,7 +16,10 @@ export class SendResourceModal extends LitElement {
   @property({ attribute: false }) eventBus: EventBus | null = null;
 
   @property({ type: Boolean }) open: boolean = false;
-  @property({ type: String }) mode: "troops" | "gold" = "troops";
+  // "bounty" shares gold's slider behavior (percent of my gold, no
+  // recipient capacity) but emits a place-bounty intent and wears a
+  // hostile red color so it reads as a hit, not a gift.
+  @property({ type: String }) mode: "troops" | "gold" | "bounty" = "troops";
 
   @property({ type: Object }) total: number | bigint = 0;
   @property({ type: Object }) uiState: UIState | null = null; // to seed initial %
@@ -98,6 +102,10 @@ export class SendResourceModal extends LitElement {
       const myTroops = Number(myPlayer.troops());
       if (amount > myTroops) return;
       this.eventBus.emit(new SendDonateTroopsIntentEvent(target, amount));
+    } else if (this.mode === "bounty") {
+      const myGold = Number(myPlayer.gold());
+      if (amount > myGold) return;
+      this.eventBus.emit(new SendPlaceBountyIntentEvent(target, BigInt(amount)));
     } else {
       const myGold = Number(myPlayer.gold());
       if (amount > myGold) return;
@@ -178,7 +186,9 @@ export class SendResourceModal extends LitElement {
   private getFillColor(): string {
     return this.mode === "troops"
       ? "rgb(168 85 247)" /* purple */
-      : "rgb(234 179 8)" /* amber */;
+      : this.mode === "bounty"
+        ? "rgb(239 68 68)" /* red */
+        : "rgb(234 179 8)" /* amber */;
   }
 
   private getMinKeepRatio(): number {

--- a/src/client/render/types/Renderer.ts
+++ b/src/client/render/types/Renderer.ts
@@ -77,6 +77,8 @@ export interface PlayerState {
   troops: number;
   isTraitor: boolean;
   traitorRemainingTicks: number;
+  /** Total gold pooled on this player's head (bounty market). */
+  bountyTotal: number;
   inDoomsdayClock: boolean;
   isDecaying: boolean;
   markedDoomsdayClockTick: number;

--- a/src/client/view/PlayerView.ts
+++ b/src/client/view/PlayerView.ts
@@ -88,6 +88,7 @@ function stateFromUpdate(pu: PlayerUpdate): PlayerState {
     troops: pu.troops!,
     isTraitor: pu.isTraitor!,
     traitorRemainingTicks: Math.max(0, pu.traitorRemainingTicks ?? 0),
+    bountyTotal: Number(pu.bountyTotal ?? 0n),
     inDoomsdayClock: pu.inDoomsdayClock ?? false,
     isDecaying: pu.isDecaying ?? false,
     markedDoomsdayClockTick: pu.markedDoomsdayClockTick ?? -1,
@@ -650,6 +651,10 @@ export class PlayerView {
   }
   getTraitorRemainingTicks(): number {
     return this.state.traitorRemainingTicks;
+  }
+  /** Total gold pooled on this player's head (bounty market), 0 when none. */
+  bountyTotal(): number {
+    return this.state.bountyTotal;
   }
   inDoomsdayClock(): boolean {
     return this.state.inDoomsdayClock;

--- a/src/core/GameRunner.ts
+++ b/src/core/GameRunner.ts
@@ -265,6 +265,7 @@ export class GameRunner {
         canBreakAlliance: player.isAlliedWith(other),
         canDonateGold: player.canDonateGold(other),
         canDonateTroops: player.canDonateTroops(other),
+        canPlaceBounty: this.game.canPlaceBounty(player, other),
         canEmbargo: !player.hasEmbargoAgainst(other),
         allianceInfo: player.allianceInfo(other) ?? undefined,
       };

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -42,6 +42,7 @@ export type Intent =
   | TargetPlayerIntent
   | EmojiIntent
   | DonateGoldIntent
+  | PlaceBountyIntent
   | DonateTroopsIntent
   | BuildUnitIntent
   | EmbargoIntent
@@ -68,6 +69,7 @@ export type BreakAllianceIntent = z.infer<typeof BreakAllianceIntentSchema>;
 export type TargetPlayerIntent = z.infer<typeof TargetPlayerIntentSchema>;
 export type EmojiIntent = z.infer<typeof EmojiIntentSchema>;
 export type DonateGoldIntent = z.infer<typeof DonateGoldIntentSchema>;
+export type PlaceBountyIntent = z.infer<typeof PlaceBountyIntentSchema>;
 export type DonateTroopsIntent = z.infer<typeof DonateTroopIntentSchema>;
 export type EmbargoIntent = z.infer<typeof EmbargoIntentSchema>;
 export type BuildUnitIntent = z.infer<typeof BuildUnitIntentSchema>;
@@ -453,6 +455,10 @@ export const GameConfigSchema = z.object({
   // that only know publicIds at create_game); resolved to clientID at lookup.
   nameRevealPublicIds: z.string().array().max(200).optional(),
   waterNukes: z.boolean().nullable().optional(),
+  // Bounty market: players pool gold bounties on other players; whoever
+  // lands the killing blow (conquerPlayer) collects the pool. Defaults off;
+  // the solo modal turns it on.
+  bountiesEnabled: z.boolean().nullable().optional(),
   randomSpawn: z.boolean(),
   maxPlayers: zb.uint().optional(),
   // OFM: allowlist of publicIds allowed to join (admin-only, see create_game).
@@ -601,6 +607,12 @@ export const DonateGoldIntentSchema = z.object({
   gold: zb.float({ min: 0 }).nullable(),
 });
 
+export const PlaceBountyIntentSchema = z.object({
+  type: z.literal("place_bounty"),
+  recipient: MappedID,
+  gold: zb.float({ min: 0 }).nullable(),
+});
+
 export const DonateTroopIntentSchema = z.object({
   type: z.literal("donate_troops"),
   recipient: MappedID,
@@ -697,6 +709,7 @@ export const IntentSchema = z.discriminatedUnion("type", [
   TargetPlayerIntentSchema,
   EmojiIntentSchema,
   DonateGoldIntentSchema,
+  PlaceBountyIntentSchema,
   DonateTroopIntentSchema,
   BuildUnitIntentSchema,
   UpgradeStructureIntentSchema,

--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -682,6 +682,17 @@ export class Config {
   donateCooldown(): Tick {
     return 10 * 10;
   }
+  bountiesEnabled(): boolean {
+    return this._gameConfig.bountiesEnabled ?? false;
+  }
+  /** Min ticks between two bounty placements by the same player. */
+  bountyCooldown(): Tick {
+    return 50 * 10;
+  }
+  /** Minimum gold a single bounty placement may carry. */
+  bountyMinAmount(): Gold {
+    return 1_000n;
+  }
   embargoAllCooldown(): Tick {
     return 10 * 10;
   }

--- a/src/core/execution/BountyExecution.ts
+++ b/src/core/execution/BountyExecution.ts
@@ -1,0 +1,71 @@
+import { Execution, Game, Gold, Player, PlayerID } from "../game/Game";
+import { toInt } from "../Util";
+
+/**
+ * Pools gold from `sender` onto `recipient`'s head (the bounty market).
+ *
+ * Unlike a donation, the gold leaves the sender immediately and sits in the
+ * game's bounty pool; it pays out to whoever lands the killing blow
+ * (GameImpl.conquerPlayer -> resolveBounty), or refunds when the target dies
+ * with no conqueror (PlayerExecution.removeOnDeath -> refundBounties).
+ */
+export class BountyExecution implements Execution {
+  private target: Player;
+  private gold: Gold | null = null;
+
+  private mg: Game;
+
+  private active = true;
+
+  constructor(
+    private placer: Player,
+    private targetID: PlayerID,
+    goldNum: number | null,
+  ) {
+    this.gold = goldNum !== null ? toInt(goldNum) : null;
+  }
+
+  init(mg: Game, ticks: number): void {
+    this.mg = mg;
+
+    if (!mg.hasPlayer(this.targetID)) {
+      console.warn(`BountyExecution target ${this.targetID} not found`);
+      this.active = false;
+      return;
+    }
+
+    this.target = mg.player(this.targetID);
+
+    // No amount given -> default to a quarter of the placer's gold.
+    this.gold ??= this.placer.gold() / 4n;
+  }
+
+  tick(ticks: number): void {
+    if (this.gold === null) throw new Error("not initialized");
+    if (this.mg.config().bountiesEnabled() && this.mg.canPlaceBounty(this.placer, this.target)) {
+      const minAmount = this.mg.config().bountyMinAmount();
+      if (this.gold < minAmount) {
+        console.warn(
+          `bounty of ${this.gold} on ${this.target.name()} below minimum ${minAmount}`,
+        );
+      } else if (this.mg.placeBounty(this.placer, this.target, this.gold) === 0n) {
+        console.warn(
+          `could not pool bounty from ${this.placer.name()} onto ${this.target.name()}`,
+        );
+      }
+    } else {
+      console.warn(
+        `cannot place bounty from ${this.placer.name()} onto ${this.target.name()}`,
+      );
+    }
+    this.active = false;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+
+  activeDuringSpawnPhase(): boolean {
+    return false;
+  }
+}

--- a/src/core/execution/ExecutionManager.ts
+++ b/src/core/execution/ExecutionManager.ts
@@ -8,6 +8,7 @@ import { AllianceRequestExecution } from "./alliance/AllianceRequestExecution";
 import { BreakAllianceExecution } from "./alliance/BreakAllianceExecution";
 import { AttackExecution } from "./AttackExecution";
 import { BoatRetreatExecution } from "./BoatRetreatExecution";
+import { BountyExecution } from "./BountyExecution";
 import { ConstructionExecution } from "./ConstructionExecution";
 import { DeleteUnitExecution } from "./DeleteUnitExecution";
 import { DonateGoldExecution } from "./DonateGoldExecution";
@@ -100,6 +101,8 @@ export class Executor {
         );
       case "donate_gold":
         return new DonateGoldExecution(player, intent.recipient, intent.gold);
+      case "place_bounty":
+        return new BountyExecution(player, intent.recipient, intent.gold);
       case "embargo":
         return new EmbargoExecution(player, intent.targetID, intent.action);
       case "embargo_all":

--- a/src/core/execution/NationExecution.ts
+++ b/src/core/execution/NationExecution.ts
@@ -205,6 +205,7 @@ export class NationExecution implements Execution {
     this.warshipBehavior.maybeSpawnWarship();
     this.handleEmbargoesToHostileNations();
     this.attackBehavior.maybeAttack();
+    this.attackBehavior.maybePlaceBounty();
     this.warshipBehavior.counterWarshipInfestation();
     this.nukeBehavior.maybeSendNuke();
   }

--- a/src/core/execution/PlayerExecution.ts
+++ b/src/core/execution/PlayerExecution.ts
@@ -491,6 +491,11 @@ export class PlayerExecution implements Execution {
     const gold = this.player.gold();
     this.player.removeGold(gold);
 
+    // Death without a conqueror (fallout, encirclement-by-neutral, quit):
+    // nobody landed the killing blow, so pending bounty stakes go back to
+    // their contributors. Conquest deaths pay out in conquerPlayer instead.
+    this.mg.refundBounties(this.player);
+
     this.player.units().forEach((u) => {
       if (
         u.type() !== UnitType.AtomBomb &&

--- a/src/core/execution/TribeExecution.ts
+++ b/src/core/execution/TribeExecution.ts
@@ -62,6 +62,9 @@ export class TribeExecution implements Execution {
     this.acceptAllAllianceRequests();
     this.deleteNextStructure();
     this.maybeAttack();
+    // Bounty market, placer side: rich tribes put revenge/warlord bounties
+    // on threats (gated inside by treasury reserve + pair cooldown).
+    this.attackBehavior?.maybePlaceBounty();
   }
 
   private acceptAllAllianceRequests() {

--- a/src/core/execution/utils/AiAttackBehavior.ts
+++ b/src/core/execution/utils/AiAttackBehavior.ts
@@ -21,6 +21,7 @@ import {
   calculateBoundingBoxCenter,
 } from "../../Util";
 import { AttackExecution } from "../AttackExecution";
+import { BountyExecution } from "../BountyExecution";
 import { DonateTroopsExecution } from "../DonateTroopExecution";
 import { NationAllianceBehavior } from "../nation/NationAllianceBehavior";
 import {
@@ -85,6 +86,12 @@ export class AiAttackBehavior {
     const borderingEnemies = borderingPlayers.filter(
       (o) => this.player?.isFriendly(o) === false,
     );
+
+    // Bounty market: an overwhelming pile of gold redirects the bot from
+    // whatever it was about to do (including neutral expansion below) to
+    // an assassination run. Ordinary profitable bounties are handled in the
+    // normal strategy list; only a jackpot interrupts everything.
+    if (this.maybeHuntJackpot(borderingEnemies)) return;
 
     // Attack TerraNullius but not nuked territory (direct border or across a river)
     const hasNonNukedTerraNullius =
@@ -284,6 +291,14 @@ export class AiAttackBehavior {
       return false;
     };
 
+    const bounty = (): boolean => {
+      const best = this.findBestBountyDeal(borderingEnemies);
+      if (best) {
+        return this.sendAttack(best.target);
+      }
+      return false;
+    };
+
     const afk = (): boolean => {
       // borderingEnemies is already sorted by troops (ascending), so first match is weakest afk enemy
       const afk = borderingEnemies.find(
@@ -363,16 +378,16 @@ export class AiAttackBehavior {
     switch (difficulty) {
       case Difficulty.Easy:
         // prettier-ignore
-        return [nuked, bots, retaliate, assist, betray, hated, weakest];
+        return [nuked, bots, retaliate, assist, betray, hated, bounty, weakest];
       case Difficulty.Medium:
         // prettier-ignore
-        return [bots, nuked, retaliate, assist, betray, hated, afk, traitor, weakest, island, donate];
+        return [bots, nuked, retaliate, assist, betray, hated, afk, traitor, bounty, weakest, island, donate];
       case Difficulty.Hard:
         // prettier-ignore
-        return [bots, retaliate, assist, betray, nuked, traitor, afk, hated, veryWeak, victim, weakest, island, donate];
+        return [bots, retaliate, assist, betray, nuked, traitor, afk, bounty, hated, veryWeak, victim, weakest, island, donate];
       case Difficulty.Impossible:
         // prettier-ignore
-        return [retaliate, bots, veryWeak, assist, traitor, afk, betray, victim, nuked, hated, weakest, island, donate];
+        return [retaliate, bots, veryWeak, assist, traitor, bounty, afk, betray, victim, nuked, hated, weakest, island, donate];
       default:
         assertNever(difficulty);
     }
@@ -524,6 +539,163 @@ export class AiAttackBehavior {
           enemy.isTraitor() &&
           (!this.isFFA() || enemy.troops() < this.player.troops() * 1.2),
       ) ?? null
+    );
+  }
+
+  // Bounty market: hunt the highest-pool bordering enemy we can realistically
+  // take. Same strength gate as findTraitor so a bounty doesn't bait a bot
+  // into suiciding at a giant. Requires bounties to be enabled in this game.
+  //
+  // Cost/benefit, in gold: killing a defender means grinding through their
+  // standing army (the attack math in Config.attackLogic bleeds the attacker
+  // per tile in proportion to the defender's density, plus the army itself
+  // must be overcome) and mopping up one garrison per tile:
+  //   killCostTroops = enemy.troops * 1.5 + enemy.tiles * 2
+  // Troops are priced at BOUNTY_TROOP_GOLD_VALUE gold each. Calibration: a
+  // 1k minimum bounty ~ 200 troops (a border skirmish any mid-size bot can
+  // afford to chase), a 50k pool ~ 10k troops (a serious campaign), a 1M
+  // pool ~ 200k troops (endgame shark bait). The attack only happens when
+  // the pool covers that cost times the difficulty's profit multiple, with
+  // a flank penalty for every OTHER bordering enemy (attacking one neighbor
+  // exposes your flank to the rest).
+  //
+  // Everything below is deterministic game state — same board, same
+  // decision, on every client. No RNG is consumed here.
+  private static readonly BOUNTY_TROOP_GOLD_VALUE = 5;
+
+  private bountyKillCostTroops(enemy: Player): number {
+    return enemy.troops() * 1.5 + enemy.numTilesOwned() * 2;
+  }
+
+  // Required profit multiple on the kill cost. Easy bots need an obvious
+  // fortune to bother; Impossible bots snipe anything marginally profitable.
+  private bountyProfitMargin(): number {
+    const { difficulty } = this.game.config().gameConfig();
+    switch (difficulty) {
+      case Difficulty.Easy:
+        return 2.0;
+      case Difficulty.Medium:
+        return 1.6;
+      case Difficulty.Hard:
+        return 1.3;
+      case Difficulty.Impossible:
+        return 1.05;
+      default:
+        assertNever(difficulty);
+    }
+  }
+
+  private bountyRequiredGold(enemy: Player, flankCount: number): number {
+    return (
+      this.bountyKillCostTroops(enemy) *
+      AiAttackBehavior.BOUNTY_TROOP_GOLD_VALUE *
+      this.bountyProfitMargin() *
+      (1 + 0.25 * Math.min(flankCount, 4))
+    );
+  }
+
+  private findBestBountyDeal(
+    borderingEnemies: Player[],
+  ): { target: Player; pool: number; required: number } | null {
+    if (!this.game.config().bountiesEnabled()) return null;
+
+    let best: { target: Player; pool: number; required: number } | null = null;
+    for (const enemy of borderingEnemies) {
+      const pool = Number(this.game.bountyTotal(enemy));
+      if (pool <= 0) continue;
+      // Hard veto: never suicide into a much bigger army (FFA caution; in
+      // team games the team absorbs the risk).
+      if (this.isFFA() && enemy.troops() > this.player.troops() * 1.2) {
+        continue;
+      }
+      const killCost = this.bountyKillCostTroops(enemy);
+      // Can't collect what we can't afford to kill: the kill must fit in
+      // what we can actually SEND — total troops minus the reserve hold
+      // the attack itself keeps back — with headroom. (The jackpot path's
+      // reserve gate is checked separately by its caller.)
+      const maxTroops = this.game.config().maxTroops(this.player);
+      const spendable = this.player.troops() - maxTroops * this.reserveRatio;
+      if (spendable < killCost * 1.25) continue;
+      const flankCount = borderingEnemies.length - 1;
+      const required = this.bountyRequiredGold(enemy, flankCount);
+      const profit = pool - required;
+      if (profit <= 0) continue;
+      if (!best || profit > best.pool - best.required) {
+        best = { target: enemy, pool, required };
+      }
+    }
+    return best;
+  }
+
+  // Jackpot override: a pile of gold so overwhelming that the bot drops
+  // whatever it was doing — neutral expansion, retaliation prep, assists —
+  // and goes for the kill immediately. Runs before everything else in
+  // maybeAttack (including the TerraNullius expansion). Gold this big
+  // overcomes caution, so the attack goes in hot (force skips shouldAttack's
+  // difficulty dice-roll); the reserve gate still applies so the bot never
+  // bankrupts itself chasing money.
+  private maybeHuntJackpot(borderingEnemies: Player[]): boolean {
+    if (!this.hasReserveRatioTroops()) return false;
+    const best = this.findBestBountyDeal(borderingEnemies);
+    if (!best) return false;
+    if (best.pool < best.required * 2) return false;
+    return this.sendAttack(best.target, true);
+  }
+
+  // Bounty market, placer side: rich bots put prices on heads too.
+  //
+  // Two motives, in order. Revenge: someone stronger is hitting us and we
+  // can't take them ourselves — pay someone else to do it. Warlord: drown
+  // the strongest threatening neighbor in gold so the lobby does our work.
+  //
+  // Pricing: 10% of the surplus above a war-chest reserve the bot never
+  // touches (structures and emergencies come first). The pair cooldown in
+  // canPlaceBounty rate-limits placements; the reserve keeps the treasury
+  // from draining across many targets. Deterministic: thresholds only, the
+  // seeded RNG is never consumed here.
+  private static readonly BOUNTY_KEEP_RESERVE: bigint = 50_000n;
+
+  maybePlaceBounty(): void {
+    if (!this.game.config().bountiesEnabled()) return;
+    if (!this.player.isAlive()) return;
+    const minAmount = this.game.config().bountyMinAmount();
+    const surplus =
+      this.player.gold() - AiAttackBehavior.BOUNTY_KEEP_RESERVE;
+    if (surplus < minAmount) return;
+
+    // Revenge: the strongest enemy currently hitting us, but only if they're
+    // stronger than us — otherwise the retaliate strategy handles them free.
+    const attacker = this.findIncomingAttackPlayer();
+    if (
+      attacker &&
+      attacker.troops() > this.player.troops() &&
+      this.game.canPlaceBounty(this.player, attacker)
+    ) {
+      this.placeBountyOn(attacker, surplus);
+      return;
+    }
+
+    // Warlord: the strongest threatening neighbor we share a hostile
+    // border with. Threat = strictly stronger than us.
+    const enemies = this.player
+      .nearby()
+      .filter(
+        (n): n is Player => n.isPlayer() && this.player.isFriendly(n) === false,
+      );
+    let threat: Player | null = null;
+    for (const enemy of enemies) {
+      if (enemy.troops() <= this.player.troops()) continue;
+      if (!this.game.canPlaceBounty(this.player, enemy)) continue;
+      if (!threat || enemy.troops() > threat.troops()) threat = enemy;
+    }
+    if (threat) this.placeBountyOn(threat, surplus);
+  }
+
+  private placeBountyOn(target: Player, surplus: bigint): void {
+    const amount = surplus / 10n;
+    if (amount < this.game.config().bountyMinAmount()) return;
+    this.game.addExecution(
+      new BountyExecution(this.player, target.id(), Number(amount)),
     );
   }
 
@@ -708,6 +880,21 @@ export class AiAttackBehavior {
     const incomingAttackPlayer = this.findIncomingAttackPlayer();
     if (incomingAttackPlayer) {
       if (this.sendAttack(incomingAttackPlayer, true)) return;
+    }
+
+    // Bounty market: tribes are greedy but simple — an overwhelming pool on
+    // a nearby enemy diverts them from random targets. Same EV deal
+    // evaluation as nations, jackpot bar only (mid-list bounty hunting stays
+    // a nation behavior). Non-jackpot pools fall through to the random flow.
+    const nearbyEnemies = this.player
+      .nearby()
+      .filter(
+        (n): n is Player =>
+          n.isPlayer() && this.player.isFriendly(n) === false,
+      );
+    const deal = this.findBestBountyDeal(nearbyEnemies);
+    if (deal && deal.pool >= deal.required * 2) {
+      if (this.sendAttack(deal.target)) return;
     }
 
     // Select a traitor as an enemy

--- a/src/core/game/Game.ts
+++ b/src/core/game/Game.ts
@@ -895,6 +895,23 @@ export interface Game extends GameMap {
   addUpdate(update: GameUpdate): void;
   railNetwork(): RailNetwork;
   conquerPlayer(conqueror: Player, conquered: Player): void;
+  // Bounty market
+  /** Pool gold onto `target`'s head, debiting `placer`. Returns gold actually pooled. */
+  placeBounty(placer: Player, target: Player, gold: Gold): Gold;
+  /** Total gold currently pooled on `player`'s head (0 when none). */
+  bountyTotal(player: Player): Gold;
+  /** True when `placer` may pool onto `target` right now (config, cooldown, self/team gates). */
+  canPlaceBounty(placer: Player, target: Player): boolean;
+  /**
+   * Pay `conquered`'s bounty pool out to `collector` (the killing-blow
+   * conqueror). No-op when the pool is empty. Emits BountyCollectedEvent.
+   */
+  resolveBounty(collector: Player, conquered: Player): void;
+  /**
+   * Refund `conquered`'s bounty pool proportionally to its contributors —
+   * used when the player dies with no conqueror (fallout, disconnect, quit).
+   */
+  refundBounties(conquered: Player): void;
   miniWaterHPA(): PathFinder<number> | null;
   miniWaterGraph(): AbstractGraph | null;
   getWaterComponent(tile: TileRef): number | null;
@@ -1000,6 +1017,7 @@ export interface PlayerInteraction {
   canTarget: boolean;
   canDonateGold: boolean;
   canDonateTroops: boolean;
+  canPlaceBounty: boolean;
   canEmbargo: boolean;
   allianceInfo?: AllianceInfo;
 }
@@ -1032,6 +1050,8 @@ export enum MessageType {
   ALLIANCE_EXPIRED,
   DONATION_SENT,
   DONATION_RECEIVED,
+  BOUNTY_PLACED,
+  BOUNTY_COLLECTED,
   CHAT,
   RENEW_ALLIANCE,
 }
@@ -1068,6 +1088,8 @@ export const MESSAGE_TYPE_CATEGORIES: Record<MessageType, MessageCategory> = {
   [MessageType.RENEW_ALLIANCE]: MessageCategory.ALLIANCE,
   [MessageType.DONATION_SENT]: MessageCategory.TRADE,
   [MessageType.DONATION_RECEIVED]: MessageCategory.TRADE,
+  [MessageType.BOUNTY_PLACED]: MessageCategory.TRADE,
+  [MessageType.BOUNTY_COLLECTED]: MessageCategory.TRADE,
   [MessageType.CHAT]: MessageCategory.CHAT,
 } as const;
 

--- a/src/core/game/GameImpl.ts
+++ b/src/core/game/GameImpl.ts
@@ -20,6 +20,7 @@ import {
   Game,
   GameMode,
   GameUpdates,
+  Gold,
   HumansVsNations,
   MessageType,
   MutableAlliance,
@@ -34,6 +35,7 @@ import {
   TeamGameSpawnAreas,
   TerrainType,
   TerraNullius,
+  Tick,
   Trios,
   Unit,
   UnitInfo,
@@ -110,6 +112,15 @@ export class GameImpl implements Game {
 
   // Used to assign unique IDs to each new alliance
   private nextAllianceID: number = 0;
+
+  /**
+   * Bounty market pools: target player -> (contributor -> gold contributed).
+   * Map-of-maps so a payout can refund-or-award per contributor and so the
+   * same player can top up an existing pool. Empty targets are deleted.
+   */
+  private bountyPools = new Map<PlayerID, Map<PlayerID, Gold>>();
+  /** Last tick each placer pooled onto each target, for the placement cooldown. */
+  private lastBountyTick = new Map<string, Tick>();
 
   private _isPaused: boolean = false;
   private _winner: Player | Team | null = null;
@@ -1269,6 +1280,95 @@ export class GameImpl implements Game {
   sharedWaterComponents(player: Player): Set<number> | null {
     return this._sharedWaterCache.get(player);
   }
+  canPlaceBounty(placer: Player, target: Player): boolean {
+    if (!this._config.bountiesEnabled()) return false;
+    if (placer === target) return false;
+    if (!placer.isAlive() || !target.isAlive()) return false;
+    // No bounties on the disconnected: they can't fight back, so the pool
+    // would be free money for whoever reaches them first.
+    if (target.isDisconnected()) return false;
+    if (placer.isOnSameTeam(target)) return false;
+    const last = this.lastBountyTick.get(`${placer.id()}:${target.id()}`);
+    if (
+      last !== undefined &&
+      this._ticks - last < this._config.bountyCooldown()
+    ) {
+      return false;
+    }
+    return true;
+  }
+
+  placeBounty(placer: Player, target: Player, gold: Gold): Gold {
+    // Clamp to what the placer can actually pay; removeGold does the same
+    // clamping, but we need the real amount for the pool bookkeeping.
+    const amount = gold <= 0n ? 0n : placer.removeGold(gold);
+    if (amount === 0n) return 0n;
+
+    let pool = this.bountyPools.get(target.id());
+    if (!pool) {
+      pool = new Map<PlayerID, Gold>();
+      this.bountyPools.set(target.id(), pool);
+    }
+    pool.set(placer.id(), (pool.get(placer.id()) ?? 0n) + amount);
+    this.lastBountyTick.set(`${placer.id()}:${target.id()}`, this._ticks);
+
+    const total = this.bountyPoolTotal(target.id());
+    this.addUpdate({
+      type: GameUpdateType.BountyPlacedEvent,
+      placerId: placer.id(),
+      targetId: target.id(),
+      amount,
+      totalPool: total,
+    });
+    return amount;
+  }
+
+  bountyTotal(player: Player): Gold {
+    return this.bountyPoolTotal(player.id());
+  }
+
+  private bountyPoolTotal(targetID: PlayerID): Gold {
+    const pool = this.bountyPools.get(targetID);
+    if (!pool) return 0n;
+    let total = 0n;
+    for (const amount of pool.values()) total += amount;
+    return total;
+  }
+
+  resolveBounty(collector: Player, conquered: Player): void {
+    const pool = this.bountyPools.get(conquered.id());
+    if (!pool) return;
+    this.bountyPools.delete(conquered.id());
+
+    let total = 0n;
+    for (const amount of pool.values()) total += amount;
+    if (total === 0n) return;
+
+    collector.addGold(total);
+    this.addUpdate({
+      type: GameUpdateType.BountyCollectedEvent,
+      collectorId: collector.id(),
+      targetId: conquered.id(),
+      amount: total,
+    });
+  }
+
+  refundBounties(conquered: Player): void {
+    const pool = this.bountyPools.get(conquered.id());
+    if (!pool) return;
+    this.bountyPools.delete(conquered.id());
+
+    for (const [contributorID, amount] of pool) {
+      if (amount === 0n) continue;
+      const contributor = this._players.get(contributorID);
+      // The contributor may have died themselves in the interim — drop
+      // their stake rather than gold-ghosting a dead player.
+      if (contributor && contributor.isAlive()) {
+        contributor.addGold(amount);
+      }
+    }
+  }
+
   conquerPlayer(conqueror: Player, conquered: Player) {
     if (conquered.isDisconnected() && conqueror.isOnSameTeam(conquered)) {
       const ships = conquered
@@ -1326,6 +1426,11 @@ export class GameImpl implements Game {
       // Record stats
       this.stats().goldWar(conqueror, conquered, goldCaptured);
     }
+
+    // Bounty market: the killing blow collects the target's pool. Runs even
+    // when gold transfer was skipped (bounties are staked by third parties,
+    // not the conquered player's balance).
+    this.resolveBounty(conqueror, conquered);
 
     // OFM: per-kill log for standings (humans-only filtered in recordKill).
     this.stats().recordKill(conqueror, conquered, this.ticks());

--- a/src/core/game/GameUpdateUtils.ts
+++ b/src/core/game/GameUpdateUtils.ts
@@ -53,6 +53,7 @@ export function diffPlayerUpdate(
     prev.piracyGold === next.piracyGold &&
     prev.isTraitor === next.isTraitor &&
     prev.traitorRemainingTicks === next.traitorRemainingTicks &&
+    prev.bountyTotal === next.bountyTotal &&
     prev.inDoomsdayClock === next.inDoomsdayClock &&
     prev.markedDoomsdayClockTick === next.markedDoomsdayClockTick &&
     prev.isDecaying === next.isDecaying &&
@@ -111,6 +112,7 @@ export function diffPlayerUpdate(
     "traitorRemainingTicks",
     prev.traitorRemainingTicks === next.traitorRemainingTicks,
   );
+  setIfDifferent("bountyTotal", prev.bountyTotal === next.bountyTotal);
   setIfDifferent(
     "inDoomsdayClock",
     prev.inDoomsdayClock === next.inDoomsdayClock,
@@ -187,6 +189,7 @@ export function applyStateUpdate(target: PlayerState, pu: PlayerUpdate): void {
   if (pu.traitorRemainingTicks !== undefined) {
     target.traitorRemainingTicks = Math.max(0, pu.traitorRemainingTicks);
   }
+  if (pu.bountyTotal !== undefined) target.bountyTotal = Number(pu.bountyTotal);
   if (pu.inDoomsdayClock !== undefined)
     target.inDoomsdayClock = pu.inDoomsdayClock;
   if (pu.markedDoomsdayClockTick !== undefined) {

--- a/src/core/game/GameUpdates.ts
+++ b/src/core/game/GameUpdates.ts
@@ -106,6 +106,8 @@ export enum GameUpdateType {
   SpawnPhaseEnd,
   GamePaused,
   DonateEvent,
+  BountyPlacedEvent,
+  BountyCollectedEvent,
 }
 
 export type GameUpdate =
@@ -131,7 +133,9 @@ export type GameUpdate =
   | EmbargoUpdate
   | SpawnPhaseEndUpdate
   | GamePausedUpdate
-  | DonateEventUpdate;
+  | DonateEventUpdate
+  | BountyPlacedUpdate
+  | BountyCollectedUpdate;
 
 export interface BonusEventUpdate {
   type: GameUpdateType.BonusEvent;
@@ -173,6 +177,22 @@ export interface DonateEventUpdate {
   donationType: "troops" | "gold";
   senderId: PlayerID;
   recipientId: PlayerID;
+  amount: bigint;
+}
+
+export interface BountyPlacedUpdate {
+  type: GameUpdateType.BountyPlacedEvent;
+  placerId: PlayerID;
+  targetId: PlayerID;
+  amount: bigint;
+  /** Total pool on the target after this placement. */
+  totalPool: bigint;
+}
+
+export interface BountyCollectedUpdate {
+  type: GameUpdateType.BountyCollectedEvent;
+  collectorId: PlayerID;
+  targetId: PlayerID;
   amount: bigint;
 }
 
@@ -256,6 +276,8 @@ export interface PlayerUpdate {
   embargoes?: Set<PlayerID>;
   isTraitor?: boolean;
   traitorRemainingTicks?: number;
+  /** Total gold currently pooled on this player's head (bounty market). */
+  bountyTotal?: Gold;
   inDoomsdayClock?: boolean;
   isDecaying?: boolean;
   markedDoomsdayClockTick?: number;

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -358,6 +358,7 @@ export class PlayerImpl implements Player {
       embargoes: embargoes,
       isTraitor: this.isTraitor(),
       traitorRemainingTicks: this.getTraitorRemainingTicks(),
+      bountyTotal: this.mg.bountyTotal(this),
       inDoomsdayClock: this.inDoomsdayClock(),
       isDecaying: this.isDecaying(),
       markedDoomsdayClockTick: this.markedDoomsdayClockTick,

--- a/tests/AiAttackBehavior.bounty.test.ts
+++ b/tests/AiAttackBehavior.bounty.test.ts
@@ -1,0 +1,526 @@
+﻿import { AttackExecution } from "../src/core/execution/AttackExecution";
+import { AiAttackBehavior } from "../src/core/execution/utils/AiAttackBehavior";
+import {
+  Difficulty,
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+} from "../src/core/game/Game";
+import { PseudoRandom } from "../src/core/PseudoRandom";
+import { setup } from "./util/Setup";
+
+describe("AiAttackBehavior bounty decisions", () => {
+  interface Duel {
+    testGame: Game;
+    hunter: Player;
+    target: Player;
+    placer: Player;
+    behavior: AiAttackBehavior;
+  }
+
+  // Shared scaffolding: a Bot hunter and a Human target that are GUARANTEED
+  // to share a border (an explicitly discovered adjacent land pair seeds the
+  // two blocks), plus a Human placer funding the pool.
+  async function setupBountyDuel(
+    pool: bigint,
+    hunterBonusTroops = 200_000,
+    targetBonusTroops = 2_000,
+  ): Promise<Duel> {
+    const testGame = await setup("big_plains", {
+      infiniteGold: true,
+      instantBuild: true,
+      difficulty: Difficulty.Easy,
+      bountiesEnabled: true,
+    });
+    const hunterInfo = new PlayerInfo("hunter", PlayerType.Bot, null, "hunter");
+    const targetInfo = new PlayerInfo("target", PlayerType.Human, null, "target");
+    const placerInfo = new PlayerInfo("placer", PlayerType.Human, null, "placer");
+    testGame.addPlayer(hunterInfo);
+    testGame.addPlayer(targetInfo);
+    testGame.addPlayer(placerInfo);
+    const hunter = testGame.player("hunter");
+    const target = testGame.player("target");
+    const placer = testGame.player("placer");
+
+    // Find an adjacent land pair: hunter seed + target seed.
+    let hunterSeed: number | null = null;
+    let targetSeed: number | null = null;
+    testGame.map().forEachTile((tile) => {
+      if (hunterSeed !== null) return;
+      if (!testGame.map().isLand(tile)) return;
+      for (const n of testGame.map().neighbors(tile)) {
+        if (testGame.map().isLand(n)) {
+          hunterSeed = tile;
+          targetSeed = n;
+          return;
+        }
+      }
+    });
+    if (hunterSeed === null || targetSeed === null) {
+      throw new Error("test map has no adjacent land pair");
+    }
+    const hs: number = hunterSeed;
+    const ts: number = targetSeed;
+    hunter.conquer(hs);
+    target.conquer(ts);
+
+    // Grow each block outward (row-major fill, skipping the two seeds).
+    let assigned = 0;
+    testGame.map().forEachTile((tile) => {
+      if (!testGame.map().isLand(tile)) return;
+      if (tile === hs || tile === ts) return;
+      if (assigned < 59) hunter.conquer(tile);
+      else if (assigned < 79) target.conquer(tile);
+      assigned++;
+    });
+    hunter.addTroops(hunterBonusTroops);
+    target.addTroops(targetBonusTroops);
+    placer.addGold(100_000_000n);
+    testGame.placeBounty(placer, target, pool);
+
+    const mockAlliance = {
+      maybeBetray: vi.fn(),
+      maybeSendAllianceRequests: vi.fn(),
+    } as any;
+    const mockEmoji = {
+      maybeSendAttackEmoji: vi.fn(),
+      sendEmoji: vi.fn(),
+    } as any;
+    const behavior = new AiAttackBehavior(
+      new PseudoRandom(42),
+      testGame,
+      hunter,
+      0.1,
+      0.1,
+      0.2,
+      mockAlliance,
+      mockEmoji,
+    );
+    return { testGame, hunter, target, placer, behavior };
+  }
+
+  function attackTargetIDs(spy: { mock: { calls: any[][] } }): (string | null)[] {
+    return spy.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.constructor.name === "AttackExecution")
+      .map((e: any) => e.targetID());
+  }
+
+  it("jackpot diverts from neutral expansion to the bounty target", async () => {
+    // Pool sized live at 3x the jackpot bar (jackpot needs pool >= 2x
+    // required), so the math holds whatever the map grants.
+    const duel = await setupBountyDuel(1n);
+    const { testGame, target, placer, behavior } = duel;
+    const killCost = target.troops() * 1.5 + target.numTilesOwned() * 2;
+    const required = killCost * 5 * 2.0;
+    testGame.placeBounty(placer, target, BigInt(Math.ceil(required * 6)));
+
+    const addExecSpy = vi.spyOn(testGame, "addExecution");
+    behavior.maybeAttack();
+
+    const targets = attackTargetIDs(addExecSpy);
+    expect(targets.length).toBeGreaterThan(0);
+    expect(targets).toContain(target.id());
+    // TerraNullius id() is null â€” any null entry IS the neutral expansion.
+    expect(targets).not.toContain(null);
+  });
+
+  it("unprofitable bounty is ignored in favor of neutral expansion", async () => {
+    // Minimum pool on a real army: nowhere near the required multiple, so
+    // the hunter keeps expanding into the neutral land around it.
+    const { testGame, target, behavior } = await setupBountyDuel(1_000n);
+
+    const addExecSpy = vi.spyOn(testGame, "addExecution");
+    behavior.maybeAttack();
+
+    const targets = attackTargetIDs(addExecSpy);
+    expect(targets.length).toBeGreaterThan(0);
+    expect(targets).not.toContain(target.id());
+    expect(targets).toContain(null); // neutral expansion
+  });
+
+  it("broke hunter stands down instead of bankrupting itself", async () => {
+    // Hunter left with only the conquer grant (~10k): below the reserve
+    // ratio, so the jackpot path refuses and the strategy list never runs.
+    // A 5M pool is wildly "profitable" on paper â€” only the affordability
+    // gates explain the stand-down. Neutral expansion (gateless) may fire.
+    const { testGame, target, hunter, behavior } = await setupBountyDuel(
+      5_000_000n,
+      0,
+    );
+    // Sanity: the hunter really is poor relative to the kill.
+    const killCost = target.troops() * 1.5 + target.numTilesOwned() * 2;
+    expect(hunter.troops()).toBeLessThan(killCost * 1.25);
+
+    const addExecSpy = vi.spyOn(testGame, "addExecution");
+    behavior.maybeAttack();
+
+    const targets = attackTargetIDs(addExecSpy);
+    expect(targets).not.toContain(target.id());
+  });
+
+  it("unaffordable-but-strong-enough target is rejected by the EV gate", async () => {
+    // Reserve passes but the kill is unaffordable: hunter troops H with
+    // target sized so H < 1.25 * killCost while T <= 1.2 * H (strength gate
+    // passes). Only the affordability check can explain a rejection.
+    const duel = await setupBountyDuel(5_000_000n, 15_000);
+    const { hunter, target, behavior } = duel;
+    const H = hunter.troops();
+    const wantT = Math.ceil(H * 0.9);
+    target.addTroops(Math.max(0, wantT - target.troops()));
+    const T = target.troops();
+    // Preconditions, computed live (conquer grants vary by map).
+    expect(T).toBeLessThanOrEqual(H * 1.2); // strength gate passes
+    const killCost = T * 1.5 + target.numTilesOwned() * 2;
+    expect(H).toBeLessThan(killCost * 1.25); // affordability fails
+    expect(5_000_000).toBeGreaterThan(killCost * 5 * 2.0); // EV profitable
+
+    const deal = (
+      behavior as unknown as {
+        findBestBountyDeal(e: Player[]): { target: Player } | null;
+      }
+    ).findBestBountyDeal([target]);
+    expect(deal).toBeNull();
+  });
+
+  it("affordable profitable bounty is accepted by the EV gate", async () => {
+    const duel = await setupBountyDuel(1n, 200_000);
+    const { testGame, target, placer, behavior } = duel;
+    // Pool at 1.5x the live-required number: profitable, below jackpot.
+    const killCost = target.troops() * 1.5 + target.numTilesOwned() * 2;
+    const required = killCost * 5 * 2.0;
+    testGame.placeBounty(placer, target, BigInt(Math.ceil(required * 1.5)));
+
+    const deal = (
+      behavior as unknown as {
+        findBestBountyDeal(e: Player[]): { target: Player } | null;
+      }
+    ).findBestBountyDeal([target]);
+    expect(deal).not.toBeNull();
+    expect(deal!.target.id()).toBe(target.id());
+  });
+
+  it("profitable mid-list bounty beats plain expansion targets", async () => {
+    // No neutral land at all: every tile belongs to hunter or target, so the
+    // TerraNullius shortcut can't fire. The pool is sized from live state to
+    // sit between the normal bar and the 2x jackpot bar, so ONLY the
+    // mid-list strategy can fire it.
+    const testGame = await setup("big_plains", {
+      infiniteGold: true,
+      instantBuild: true,
+      difficulty: Difficulty.Easy,
+      bountiesEnabled: true,
+    });
+    const hunterInfo = new PlayerInfo("h2", PlayerType.Bot, null, "h2");
+    const targetInfo = new PlayerInfo("t2", PlayerType.Human, null, "t2");
+    const placerInfo = new PlayerInfo("p2", PlayerType.Human, null, "p2");
+    testGame.addPlayer(hunterInfo);
+    testGame.addPlayer(targetInfo);
+    testGame.addPlayer(placerInfo);
+    const hunter = testGame.player("h2");
+    const target = testGame.player("t2");
+    const placer = testGame.player("p2");
+
+    // Split ALL land 50/50: no neutral tiles anywhere. First half borders
+    // the second half along the split row, so they share a border.
+    const landTiles: number[] = [];
+    testGame.map().forEachTile((tile) => {
+      if (testGame.map().isLand(tile)) landTiles.push(tile);
+    });
+    const half = Math.floor(landTiles.length / 2);
+    landTiles.forEach((tile, i) => (i < half ? hunter : target).conquer(tile));
+
+    hunter.addTroops(200_000);
+    target.addTroops(300);
+    placer.addGold(100_000_000n);
+    const killCost = target.troops() * 1.5 + target.numTilesOwned() * 2;
+    const required = killCost * 5 * 2.0;
+    testGame.placeBounty(placer, target, BigInt(Math.ceil(required * 1.5)));
+
+    const mockAlliance = {
+      maybeBetray: vi.fn(),
+      maybeSendAllianceRequests: vi.fn(),
+    } as any;
+    const mockEmoji = {
+      maybeSendAttackEmoji: vi.fn(),
+      sendEmoji: vi.fn(),
+    } as any;
+    const behavior = new AiAttackBehavior(
+      new PseudoRandom(42),
+      testGame,
+      hunter,
+      0.1,
+      0.1,
+      0.2,
+      mockAlliance,
+      mockEmoji,
+    );
+
+    const addExecSpy = vi.spyOn(testGame, "addExecution");
+    // The 10% random-boat roll may swallow individual calls; drive until an
+    // attack actually fires. Only bounty/weakest can fire here, and bounty
+    // precedes weakest â€” so the first attack must be the bounty hunt.
+    let bountyAttack: any = null;
+    for (let i = 0; i < 30 && !bountyAttack; i++) {
+      behavior.maybeAttack();
+      bountyAttack = addExecSpy.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.constructor.name === "AttackExecution");
+    }
+    expect(bountyAttack).toBeDefined();
+    expect(bountyAttack.targetID()).toBe(target.id());
+  });
+});
+
+describe("AiAttackBehavior tribe bounty hunting", () => {
+  // Tribes (the 400 solo bots) run attackRandomTarget(), not the nation
+  // strategy list â€” so the jackpot branch there needs its own coverage.
+  // Behavior is constructed exactly like TribeExecution does (no alliance or
+  // emoji behaviors).
+  async function setupTribeHunt(pool: bigint) {
+    const testGame = await setup("big_plains", {
+      infiniteGold: true,
+      instantBuild: true,
+      difficulty: Difficulty.Easy,
+      bountiesEnabled: true,
+    });
+    const hunterInfo = new PlayerInfo("thunter", PlayerType.Bot, null, "thunter");
+    const targetInfo = new PlayerInfo("ttarget", PlayerType.Human, null, "ttarget");
+    const placerInfo = new PlayerInfo("tplacer", PlayerType.Human, null, "tplacer");
+    testGame.addPlayer(hunterInfo);
+    testGame.addPlayer(targetInfo);
+    testGame.addPlayer(placerInfo);
+    const hunter = testGame.player("thunter");
+    const target = testGame.player("ttarget");
+    const placer = testGame.player("tplacer");
+
+    let hunterSeed: number | null = null;
+    let targetSeed: number | null = null;
+    testGame.map().forEachTile((tile) => {
+      if (hunterSeed !== null) return;
+      if (!testGame.map().isLand(tile)) return;
+      for (const n of testGame.map().neighbors(tile)) {
+        if (testGame.map().isLand(n)) {
+          hunterSeed = tile;
+          targetSeed = n;
+          return;
+        }
+      }
+    });
+    if (hunterSeed === null || targetSeed === null) {
+      throw new Error("test map has no adjacent land pair");
+    }
+    const hs: number = hunterSeed;
+    const ts: number = targetSeed;
+    hunter.conquer(hs);
+    target.conquer(ts);
+    let assigned = 0;
+    testGame.map().forEachTile((tile) => {
+      if (!testGame.map().isLand(tile)) return;
+      if (tile === hs || tile === ts) return;
+      if (assigned < 59) hunter.conquer(tile);
+      else if (assigned < 79) target.conquer(tile);
+      assigned++;
+    });
+    hunter.addTroops(200_000);
+    target.addTroops(2_000);
+    placer.addGold(100_000_000n);
+    if (pool > 0n) {
+      testGame.placeBounty(placer, target, pool);
+    }
+
+    // Same ratios TribeExecution rolls (trigger .5-.6, reserve .3-.4).
+    const behavior = new AiAttackBehavior(
+      new PseudoRandom(42),
+      testGame,
+      hunter,
+      0.55,
+      0.35,
+      0.15,
+    );
+    return { testGame, hunter, target, placer, behavior };
+  }
+
+  it("tribe diverts to a jackpot bounty instead of random targets", async () => {
+    const duel = await setupTribeHunt(1n);
+    const { testGame, target, placer, behavior } = duel;
+    // Jackpot bar: pool >= 2x the live-required number.
+    const killCost = target.troops() * 1.5 + target.numTilesOwned() * 2;
+    const required = killCost * 5 * 2.0;
+    testGame.placeBounty(placer, target, BigInt(Math.ceil(required * 3)));
+
+    const addExecSpy = vi.spyOn(testGame, "addExecution");
+    behavior.attackRandomTarget();
+
+    const targets = addExecSpy.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.constructor.name === "AttackExecution")
+      .map((e: any) => e.targetID());
+    expect(targets).toContain(target.id());
+  });
+
+  it("tribe without any bounty still attacks (flow intact)", async () => {
+    const { testGame, behavior } = await setupTribeHunt(0n);
+
+    const addExecSpy = vi.spyOn(testGame, "addExecution");
+    // Drive a few times: the random flow is chance-gated per call.
+    for (let i = 0; i < 10; i++) {
+      behavior.attackRandomTarget();
+    }
+    const attacks = addExecSpy.mock.calls
+      .map((c) => c[0])
+      .filter((e) => e.constructor.name === "AttackExecution");
+    // Either it attacked something, or every roll declined â€” both prove the
+    // modified function completes without throwing.
+    expect(Array.isArray(attacks)).toBe(true);
+  });
+});
+
+describe("AiAttackBehavior bounty placement", () => {
+  // Rich bot + threatening neighbor scaffolding for maybePlaceBounty.
+  async function setupPlacer(hunterGold: number) {
+    const testGame = await setup("big_plains", {
+      // NOTE: infiniteGold stays OFF here â€” placement accounting must be
+      // exact (surplus math is asserted down to the coin).
+      infiniteGold: false,
+      instantBuild: true,
+      difficulty: Difficulty.Medium,
+      bountiesEnabled: true,
+    });
+    const hunterInfo = new PlayerInfo("phunter", PlayerType.Bot, null, "phunter");
+    const targetInfo = new PlayerInfo("ptarget", PlayerType.Human, null, "ptarget");
+    testGame.addPlayer(hunterInfo);
+    testGame.addPlayer(targetInfo);
+    const hunter = testGame.player("phunter");
+    const target = testGame.player("ptarget");
+
+    let hunterSeed: number | null = null;
+    let targetSeed: number | null = null;
+    testGame.map().forEachTile((tile) => {
+      if (hunterSeed !== null) return;
+      if (!testGame.map().isLand(tile)) return;
+      for (const n of testGame.map().neighbors(tile)) {
+        if (testGame.map().isLand(n)) {
+          hunterSeed = tile;
+          targetSeed = n;
+          return;
+        }
+      }
+    });
+    if (hunterSeed === null || targetSeed === null) {
+      throw new Error("test map has no adjacent land pair");
+    }
+    const hs: number = hunterSeed;
+    const ts: number = targetSeed;
+    hunter.conquer(hs);
+    target.conquer(ts);
+    // NOTE: the hunter needs >= 100 tiles: AttackExecution.handleDeadDefender
+    // instantly conquers any sub-100-tile player on first blood, which would
+    // end the test's combat prematurely (discovered while debugging this).
+    let assigned = 0;
+    testGame.map().forEachTile((tile) => {
+      if (!testGame.map().isLand(tile)) return;
+      if (tile === hs || tile === ts) return;
+      if (assigned < 149) hunter.conquer(tile);
+      else if (assigned < 189) target.conquer(tile);
+      assigned++;
+    });
+    hunter.addTroops(20_000);
+    target.addTroops(60_000);
+    hunter.addGold(BigInt(hunterGold));
+
+    const mockAlliance = {
+      maybeBetray: vi.fn(),
+      maybeSendAllianceRequests: vi.fn(),
+    } as any;
+    const mockEmoji = {
+      maybeSendAttackEmoji: vi.fn(),
+      sendEmoji: vi.fn(),
+    } as any;
+    const behavior = new AiAttackBehavior(
+      new PseudoRandom(42),
+      testGame,
+      hunter,
+      0.1,
+      0.1,
+      0.2,
+      mockAlliance,
+      mockEmoji,
+    );
+    return { testGame, hunter, target, behavior };
+  }
+
+  function runTicks(game: Game, n: number): void {
+    for (let i = 0; i < n; i++) game.executeNextTick();
+  }
+
+  it("posts a revenge bounty on a stronger attacker", async () => {
+    // Hunter weaker, attacker stronger and actively hitting: revenge is the
+    // only sane response â€” pay someone else to do it. The probe attack is
+    // small (2k) so the hunter survives the 3 settling ticks; the revenge
+    // condition only needs the attacker to be *stronger*, not lethal.
+    const { testGame, hunter, target, behavior } = await setupPlacer(500_000);
+    testGame.addExecution(new AttackExecution(2_000, target, hunter.id(), null));
+    runTicks(testGame, 1);
+    expect(hunter.incomingAttacks().length).toBeGreaterThan(0);
+    expect(hunter.isAlive()).toBe(true);
+
+    behavior.maybePlaceBounty();
+    runTicks(testGame, 2);
+
+    // 10% of the 450k surplus.
+    expect(testGame.bountyTotal(target)).toBe(45_000n);
+  });
+
+  it("posts a warlord bounty on a stronger neighbor with no incoming attack", async () => {
+    // No incoming attacks: the warlord path fires on the stronger neighbor.
+    const { testGame, hunter, target, behavior } = await setupPlacer(500_000);
+    expect(hunter.incomingAttacks().length).toBe(0);
+
+    behavior.maybePlaceBounty();
+    runTicks(testGame, 2);
+
+    expect(testGame.bountyTotal(target)).toBe(45_000n);
+  });
+
+  it("poor bot keeps its war chest and places nothing", async () => {
+    // 10k gold: below the 50k reserve, so no placement even with a threat.
+    const { testGame, target, behavior } = await setupPlacer(10_000);
+
+    behavior.maybePlaceBounty();
+    runTicks(testGame, 2);
+
+    expect(testGame.bountyTotal(target)).toBe(0n);
+  });
+
+  it("places nothing when bounties are disabled", async () => {
+    const testGame = await setup("big_plains", {
+      infiniteGold: true,
+      instantBuild: true,
+      difficulty: Difficulty.Medium,
+      bountiesEnabled: false,
+    });
+    const hunterInfo = new PlayerInfo("dhunter", PlayerType.Bot, null, "dhunter");
+    const targetInfo = new PlayerInfo("dtarget", PlayerType.Human, null, "dtarget");
+    testGame.addPlayer(hunterInfo);
+    testGame.addPlayer(targetInfo);
+    const hunter = testGame.player("dhunter");
+    const target = testGame.player("dtarget");
+    hunter.addGold(500_000n);
+    target.addTroops(50_000);
+
+    const behavior = new AiAttackBehavior(
+      new PseudoRandom(42),
+      testGame,
+      hunter,
+      0.1,
+      0.1,
+      0.2,
+    );
+    behavior.maybePlaceBounty();
+    runTicks(testGame, 2);
+
+    expect(testGame.bountyTotal(target)).toBe(0n);
+  });
+});

--- a/tests/AiAttackBehavior.test.ts
+++ b/tests/AiAttackBehavior.test.ts
@@ -1,4 +1,4 @@
-import { AttackExecution } from "../src/core/execution/AttackExecution";
+﻿import { AttackExecution } from "../src/core/execution/AttackExecution";
 import { NationEmojiBehavior } from "../src/core/execution/nation/NationEmojiBehavior";
 import { AiAttackBehavior } from "../src/core/execution/utils/AiAttackBehavior";
 import {
@@ -307,7 +307,7 @@ describe("Hard/Impossible troop floor", () => {
     target.addTroops(300_000);
     // troopSendCap = 100_000 - ceil(100_000 * 0.75) = 25_000
     // 20% of target = 300_000 * 0.2 = 60_000
-    // 25_000 < 60_000 → attack should be blocked
+    // 25_000 < 60_000 â†’ attack should be blocked
 
     const addExecSpy = vi.spyOn(testGame, "addExecution");
     const result = behavior.sendAttack(target);
@@ -338,13 +338,13 @@ describe("Hard/Impossible troop floor", () => {
     expect(exec.startTroops).toBeLessThanOrEqual(expectedCap);
   });
 
-  it("Easy: no troop floor — sends based on reserve only", async () => {
+  it("Easy: no troop floor â€” sends based on reserve only", async () => {
     const { testGame, attacker, neighbor, bot, behavior } =
       await setupTroopFloorTest(Difficulty.Easy);
 
     attacker.addTroops(100_000);
     neighbor.addTroops(90_000);
-    // No cap on Easy — sends full reserve amount
+    // No cap on Easy â€” sends full reserve amount
 
     const addExecSpy = vi.spyOn(testGame, "addExecution");
     const result = behavior.sendAttack(bot);
@@ -354,7 +354,7 @@ describe("Hard/Impossible troop floor", () => {
       (c) => c[0].constructor.name === "AttackExecution",
     )?.[0] as any;
     expect(exec).toBeDefined();
-    // On Easy, no troop floor applies — troops are only limited by the reserve ratio
+    // On Easy, no troop floor applies â€” troops are only limited by the reserve ratio
     expect(exec.startTroops).toBeGreaterThan(0);
     // Verify the troops exceed what the Hard cap would have been
     const hardCap = Math.max(
@@ -383,7 +383,7 @@ describe("Hard/Impossible troop floor", () => {
     });
     bot.addTroops(100_000);
 
-    // No player neighbors — troopSendCap should return Infinity
+    // No player neighbors â€” troopSendCap should return Infinity
     expect(bot.nearby().filter((n) => n.isPlayer()).length).toBe(0);
 
     const behavior = new AiAttackBehavior(
@@ -409,7 +409,7 @@ describe("Hard/Impossible troop floor", () => {
     expect(exec.startTroops).toBeGreaterThan(40_000);
   });
 
-  it("Team: troopSendCap returns Infinity — no cap in team games", async () => {
+  it("Team: troopSendCap returns Infinity â€” no cap in team games", async () => {
     // Same setup as Hard cap test but with GameMode.Team
     const testGame = await setup("big_plains", {
       difficulty: Difficulty.Hard,
@@ -488,7 +488,7 @@ describe("Hard/Impossible troop floor", () => {
     expect(exec.startTroops).toBeGreaterThan(32_500);
   });
 
-  it("Team: isAttackTooWeak returns false — weak attacks allowed in team games", async () => {
+  it("Team: isAttackTooWeak returns false â€” weak attacks allowed in team games", async () => {
     // Same setup as the FFA "skips attack when capped troops are < 20%" test
     // but with GameMode.Team. In FFA Hard, the attack would be blocked.
     const testGame = await setup("big_plains", {
@@ -554,7 +554,7 @@ describe("Hard/Impossible troop floor", () => {
     attacker.addTroops(100_000);
     neighbor.addTroops(100_000);
     target.addTroops(300_000);
-    // In FFA Hard: troopSendCap = 25k, 20% of target = 60k → blocked.
+    // In FFA Hard: troopSendCap = 25k, 20% of target = 60k â†’ blocked.
     // In Team mode: isAttackTooWeak returns false, so the attack proceeds
     // even though troops would be below 20% of the target.
 
@@ -602,3 +602,4 @@ describe("Hard/Impossible troop floor", () => {
     expect(exec.startTroops).toBeGreaterThanOrEqual(50_000);
   });
 });
+

--- a/tests/Bounty.test.ts
+++ b/tests/Bounty.test.ts
@@ -1,0 +1,421 @@
+﻿import { BountyExecution } from "../src/core/execution/BountyExecution";
+import { MarkDisconnectedExecution } from "../src/core/execution/MarkDisconnectedExecution";
+import { SpawnExecution } from "../src/core/execution/SpawnExecution";
+import {
+  GameMode,
+  PlayerInfo,
+  PlayerType,
+  type Execution,
+  type GameUpdates,
+  type Player,
+} from "../src/core/game/Game";
+import {
+  GameUpdateType,
+  type BountyCollectedUpdate,
+  type BountyPlacedUpdate,
+} from "../src/core/game/GameUpdates";
+import { GameID } from "../src/core/Schemas";
+import { setup } from "./util/Setup";
+
+// Collects bounty updates from the GameUpdates maps returned by
+// game.executeNextTick() across a run of ticks.
+function runTicks(
+  game: { executeNextTick(): GameUpdates },
+  n: number,
+): { placed: BountyPlacedUpdate[]; collected: BountyCollectedUpdate[] } {
+  const placed: BountyPlacedUpdate[] = [];
+  const collected: BountyCollectedUpdate[] = [];
+  for (let i = 0; i < n; i++) {
+    const updates = game.executeNextTick();
+    placed.push(
+      ...((updates[GameUpdateType.BountyPlacedEvent] ?? []) as BountyPlacedUpdate[]),
+    );
+    collected.push(
+      ...((updates[GameUpdateType.BountyCollectedEvent] ?? []) as BountyCollectedUpdate[]),
+    );
+  }
+  return { placed, collected };
+}
+
+describe("Bounty market", () => {
+  it("should pool a bounty and expose bountyTotal", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const placerInfo = new PlayerInfo("placer", PlayerType.Human, null, "p1");
+    const targetInfo = new PlayerInfo("target", PlayerType.Human, null, "p2");
+    game.addPlayer(placerInfo);
+    game.addPlayer(targetInfo);
+    const placer = game.player(placerInfo.id);
+    const target = game.player(targetInfo.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, placerInfo, game.ref(2, 4)),
+      new SpawnExecution(gameID, targetInfo, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    placer.addGold(10_000n);
+    const placerGoldBefore = placer.gold();
+    game.addExecution(new BountyExecution(placer, targetInfo.id, 5_000));
+    const { placed } = runTicks(game, 2);
+
+    expect(game.bountyTotal(target)).toBe(5_000n);
+    // Gold left the placer's balance (passive worker income may offset a
+    // little, but the net must be a real debit of ~5k).
+    expect(placer.gold()).toBeLessThan(placerGoldBefore - 4_000n);
+
+    expect(placed.length).toBe(1);
+    expect(placed[0].placerId).toBe(placer.id());
+    expect(placed[0].targetId).toBe(target.id());
+    expect(placed[0].amount).toBe(5_000n);
+    expect(placed[0].totalPool).toBe(5_000n);
+  });
+
+  it("should merge contributions from multiple placers", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const aInfo = new PlayerInfo("a", PlayerType.Human, null, "a");
+    const bInfo = new PlayerInfo("b", PlayerType.Human, null, "b");
+    const targetInfo = new PlayerInfo("target", PlayerType.Human, null, "t");
+    game.addPlayer(aInfo);
+    game.addPlayer(bInfo);
+    game.addPlayer(targetInfo);
+    const a = game.player(aInfo.id);
+    const b = game.player(bInfo.id);
+    const target = game.player(targetInfo.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, aInfo, game.ref(2, 4)),
+      new SpawnExecution(gameID, bInfo, game.ref(2, 6)),
+      new SpawnExecution(gameID, targetInfo, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    a.addGold(20_000n);
+    b.addGold(20_000n);
+    game.addExecution(new BountyExecution(a, targetInfo.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    game.addExecution(new BountyExecution(b, targetInfo.id, 7_000));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(game.bountyTotal(target)).toBe(12_000n);
+  });
+
+  it("should reject self-bounties, disabled config, and sub-minimum amounts", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const p1Info = new PlayerInfo("p1", PlayerType.Human, null, "p1");
+    const p2Info = new PlayerInfo("p2", PlayerType.Human, null, "p2");
+    game.addPlayer(p1Info);
+    game.addPlayer(p2Info);
+    const p1 = game.player(p1Info.id);
+    const p2 = game.player(p2Info.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, p1Info, game.ref(2, 4)),
+      new SpawnExecution(gameID, p2Info, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    p1.addGold(50_000n);
+
+    // Self-bounty rejected by canPlaceBounty gate.
+    game.addExecution(new BountyExecution(p1, p1Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(p1)).toBe(0n);
+
+    // Sub-minimum amounts warn and do not pool.
+    game.addExecution(new BountyExecution(p1, p2Info.id, 100));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(p2)).toBe(0n);
+  });
+
+  it("should be disabled when bountiesEnabled is false", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: false,
+    });
+
+    const p1Info = new PlayerInfo("p1", PlayerType.Human, null, "p1");
+    const p2Info = new PlayerInfo("p2", PlayerType.Human, null, "p2");
+    game.addPlayer(p1Info);
+    game.addPlayer(p2Info);
+    const p1 = game.player(p1Info.id);
+    const p2 = game.player(p2Info.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, p1Info, game.ref(2, 4)),
+      new SpawnExecution(gameID, p2Info, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    p1.addGold(10_000n);
+    game.addExecution(new BountyExecution(p1, p2Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+
+    expect(game.bountyTotal(p2)).toBe(0n);
+  });
+
+  it("should pay the pool to the conqueror on the killing blow", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const placerInfo = new PlayerInfo("placer", PlayerType.Human, null, "p1");
+    const killerInfo = new PlayerInfo("killer", PlayerType.Human, null, "k");
+    const victimInfo = new PlayerInfo("victim", PlayerType.Human, null, "v");
+    game.addPlayer(placerInfo);
+    game.addPlayer(killerInfo);
+    game.addPlayer(victimInfo);
+    const placer = game.player(placerInfo.id);
+    const killer = game.player(killerInfo.id);
+    const victim = game.player(victimInfo.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, placerInfo, game.ref(2, 4)),
+      new SpawnExecution(gameID, killerInfo, game.ref(2, 6)),
+      new SpawnExecution(gameID, victimInfo, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    placer.addGold(10_000n);
+    game.addExecution(new BountyExecution(placer, victimInfo.id, 5_000));
+    runTicks(game, 2);
+    expect(game.bountyTotal(victim)).toBe(5_000n);
+
+    // The killing blow: conquerPlayer is the single choke-point both attack
+    // and encirclement deaths route through. Call it MID-TICK via a tiny
+    // execution wrapper — GameImpl resets the per-tick update buffer at the
+    // start of executeNextTick, so updates emitted between ticks (direct
+    // calls) would be wiped. Real callers (AttackExecution etc.) only ever
+    // invoke it mid-tick, so this mirrors production.
+    class ConquerOnce implements Execution {
+      private done = false;
+      constructor(private killer: Player, private victim: Player) {}
+      init(): void {}
+      tick(): void {
+        if (this.done) return;
+        this.done = true;
+        game.conquerPlayer(this.killer, this.victim);
+      }
+      isActive(): boolean {
+        return !this.done;
+      }
+      activeDuringSpawnPhase(): boolean {
+        return true;
+      }
+    }
+    const killerGoldBefore = killer.gold();
+    game.addExecution(new ConquerOnce(killer, victim));
+    // First tick inits the wrapper execution; the second runs its tick,
+    // which is where the conquest (and the bounty payout) happens.
+    const { collected } = runTicks(game, 2);
+
+    expect(game.bountyTotal(victim)).toBe(0n);
+    expect(killer.gold()).toBeGreaterThanOrEqual(killerGoldBefore + 5_000n);
+
+    expect(collected.length).toBe(1);
+    expect(collected[0].collectorId).toBe(killer.id());
+    expect(collected[0].targetId).toBe(victim.id());
+    expect(collected[0].amount).toBe(5_000n);
+  });
+
+  it("should refund contributors when the target dies with no conqueror", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const placerInfo = new PlayerInfo("placer", PlayerType.Human, null, "p1");
+    const targetInfo = new PlayerInfo("target", PlayerType.Human, null, "p2");
+    game.addPlayer(placerInfo);
+    game.addPlayer(targetInfo);
+    const placer = game.player(placerInfo.id);
+    const target = game.player(targetInfo.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, placerInfo, game.ref(2, 4)),
+      new SpawnExecution(gameID, targetInfo, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    placer.addGold(10_000n);
+    game.addExecution(new BountyExecution(placer, targetInfo.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(target)).toBe(5_000n);
+
+    const placerGoldBefore = placer.gold();
+    game.refundBounties(target);
+    expect(game.bountyTotal(target)).toBe(0n);
+    expect(placer.gold()).toBe(placerGoldBefore + 5_000n);
+
+    // Second refund is a no-op (pool was drained).
+    game.refundBounties(target);
+    expect(placer.gold()).toBe(placerGoldBefore + 5_000n);
+  });
+
+  it("should enforce the per-target placement cooldown", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const p1Info = new PlayerInfo("p1", PlayerType.Human, null, "p1");
+    const p2Info = new PlayerInfo("p2", PlayerType.Human, null, "p2");
+    game.addPlayer(p1Info);
+    game.addPlayer(p2Info);
+    const p1 = game.player(p1Info.id);
+    const p2 = game.player(p2Info.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, p1Info, game.ref(2, 4)),
+      new SpawnExecution(gameID, p2Info, game.ref(2, 8)),
+    );
+    game.executeNextTick();
+
+    p1.addGold(100_000n);
+    game.addExecution(new BountyExecution(p1, p2Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(p2)).toBe(5_000n);
+
+    // Immediately placing again is blocked by the cooldown (50*10 ticks).
+    game.addExecution(new BountyExecution(p1, p2Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(p2)).toBe(5_000n);
+
+    // Different target is not blocked by the first placement.
+    const p3Info = new PlayerInfo("p3", PlayerType.Human, null, "p3");
+    game.addPlayer(p3Info);
+    game.addExecution(new SpawnExecution(gameID, p3Info, game.ref(2, 10)));
+    game.executeNextTick();
+    const p3 = game.player(p3Info.id);
+    game.addExecution(new BountyExecution(p1, p3Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(p3)).toBe(5_000n);
+  });
+
+  it("should reject bounties on teammates", async () => {
+    const gameID: GameID = "game_id";
+    // Team mode with both humans pinned to team slot 0 -> same team, so
+    // isOnSameTeam is true and the bounty gate must reject. Humans must be
+    // passed to setup() itself: team assignment happens at addPlayers() time
+    // during game construction, not for post-hoc addPlayer() calls.
+    const t1Info = new PlayerInfo(
+      "t1",
+      PlayerType.Human,
+      "t1",
+      "t1",
+      false,
+      null,
+      [],
+      0,
+    );
+    const t2Info = new PlayerInfo(
+      "t2",
+      PlayerType.Human,
+      "t2",
+      "t2",
+      false,
+      null,
+      [],
+      0,
+    );
+    const game = await setup(
+      "ocean_and_land",
+      {
+        infiniteGold: false,
+        bountiesEnabled: true,
+        gameMode: GameMode.Team,
+        playerTeams: 2,
+      },
+      [t1Info, t2Info],
+    );
+
+    const t1 = game.player(t1Info.id);
+    const t2 = game.player(t2Info.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, t1Info, game.ref(2, 4)),
+      new SpawnExecution(gameID, t2Info, game.ref(2, 6)),
+    );
+    game.executeNextTick();
+
+    t1.addGold(10_000n);
+    expect(t1.isOnSameTeam(t2)).toBe(true);
+    expect(game.canPlaceBounty(t1, t2)).toBe(false);
+
+    // And the execution itself no-ops.
+    game.addExecution(new BountyExecution(t1, t2Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(t2)).toBe(0n);
+  });
+
+  it("should reject bounties on disconnected players", async () => {
+    const gameID: GameID = "game_id";
+    const game = await setup("ocean_and_land", {
+      infiniteGold: false,
+      bountiesEnabled: true,
+    });
+
+    const p1Info = new PlayerInfo("p1", PlayerType.Human, null, "p1");
+    const p2Info = new PlayerInfo("p2", PlayerType.Human, null, "p2");
+    game.addPlayer(p1Info);
+    game.addPlayer(p2Info);
+    const p1 = game.player(p1Info.id);
+    const p2 = game.player(p2Info.id);
+
+    game.addExecution(
+      new SpawnExecution(gameID, p1Info, game.ref(2, 4)),
+      new SpawnExecution(gameID, p2Info, game.ref(2, 6)),
+    );
+    // Two ticks: spawn lands on the second (SpawnExecution inits on tick 1,
+    // tiles materialize after). Asserting earlier sees 0-tile players.
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(p1.isAlive()).toBe(true);
+    expect(p2.isAlive()).toBe(true);
+
+    // Sanity: gate passes while the target is connected.
+    p1.addGold(10_000n);
+    expect(game.canPlaceBounty(p1, p2)).toBe(true);
+
+    // Disconnect the target: a bounty on them would be free money for
+    // whoever reaches them first, so the gate must refuse.
+    game.addExecution(new MarkDisconnectedExecution(p2, true));
+    game.executeNextTick();
+    expect(p2.isDisconnected()).toBe(true);
+    expect(game.canPlaceBounty(p1, p2)).toBe(false);
+
+    game.addExecution(new BountyExecution(p1, p2Info.id, 5_000));
+    game.executeNextTick();
+    game.executeNextTick();
+    expect(game.bountyTotal(p2)).toBe(0n);
+  });
+});

--- a/tests/GameUpdateUtils.test.ts
+++ b/tests/GameUpdateUtils.test.ts
@@ -29,6 +29,7 @@ function makePlayerState(overrides: Partial<PlayerState> = {}): PlayerState {
     troops: 100,
     isTraitor: false,
     traitorRemainingTicks: 0,
+    bountyTotal: 0,
     inDoomsdayClock: false,
     isDecaying: false,
     markedDoomsdayClockTick: -1,

--- a/tests/client/render/frame/derive/nuke-telegraphs.test.ts
+++ b/tests/client/render/frame/derive/nuke-telegraphs.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * extractNukeTelegraphs colors each telegraph by who launched the nuke:
  *
  *   - relation 0 (self): the local player owns the nuke
@@ -42,6 +42,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     troops: 0,
     isTraitor: false,
     traitorRemainingTicks: 0,
+    bountyTotal: 0,
     inDoomsdayClock: false,
     isDecaying: false,
     markedDoomsdayClockTick: -1,

--- a/tests/client/render/frame/derive/player-status.test.ts
+++ b/tests/client/render/frame/derive/player-status.test.ts
@@ -1,4 +1,4 @@
-/**
+﻿/**
  * computePlayerStatus has two modes:
  *
  *   - Replay mode (no localPlayerSmallID): only crown / traitor / disconnected /
@@ -38,6 +38,7 @@ function ps(overrides: Partial<PlayerState> = {}): PlayerState {
     troops: 0,
     isTraitor: false,
     traitorRemainingTicks: 0,
+    bountyTotal: 0,
     inDoomsdayClock: false,
     isDecaying: false,
     markedDoomsdayClockTick: -1,
@@ -98,7 +99,7 @@ function unitsMap(...us: UnitState[]): Map<number, UnitState> {
   return new Map(us.map((u) => [u.id, u]));
 }
 
-describe("computePlayerStatus — replay mode (no localPlayerSmallID)", () => {
+describe("computePlayerStatus â€” replay mode (no localPlayerSmallID)", () => {
   it("returns empty map when no flags are set", () => {
     const players = playersMap(ps({ smallID: 1 }));
     const status = computePlayerStatus(players, unitsMap());
@@ -113,7 +114,7 @@ describe("computePlayerStatus — replay mode (no localPlayerSmallID)", () => {
     );
     const status = computePlayerStatus(players, unitsMap());
     expect(status.get(2)?.crown).toBe(true);
-    // Players 1 and 3 don't have crown and no other flags → no entry emitted.
+    // Players 1 and 3 don't have crown and no other flags â†’ no entry emitted.
     expect(status.has(1)).toBe(false);
     expect(status.has(3)).toBe(false);
   });
@@ -175,8 +176,8 @@ describe("computePlayerStatus — replay mode (no localPlayerSmallID)", () => {
   });
 });
 
-describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
-  it("alliance: local has them as ally → alliance true", () => {
+describe("computePlayerStatus â€” live mode (localPlayerSmallID set)", () => {
+  it("alliance: local has them as ally â†’ alliance true", () => {
     const players = playersMap(
       ps({ smallID: 1, allies: [2] }), // me
       ps({ smallID: 2 }),
@@ -187,7 +188,7 @@ describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
     expect(status.get(2)?.alliance).toBe(true);
   });
 
-  it("target: local has them in targets → target true", () => {
+  it("target: local has them in targets â†’ target true", () => {
     const players = playersMap(
       ps({ smallID: 1, targets: [2] }), // me
       ps({ smallID: 2 }),
@@ -221,7 +222,7 @@ describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
       unitsMap(),
       { localPlayerSmallID: 1 },
     );
-    // Player 2 only has crown — embargo should be false.
+    // Player 2 only has crown â€” embargo should be false.
     expect(status.get(2)?.embargo).toBe(false);
   });
 
@@ -246,7 +247,7 @@ describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
     expect(status.get(1)?.embargo).toBe(false);
   });
 
-  it("nukeTargetsMe: requires tileState — without it, stays false", () => {
+  it("nukeTargetsMe: requires tileState â€” without it, stays false", () => {
     const players = playersMap(ps({ smallID: 1 }), ps({ smallID: 2 }));
     const units = unitsMap(
       unit({
@@ -320,7 +321,7 @@ describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
     const status = computePlayerStatus(players, unitsMap(), {
       localPlayerSmallID: 1,
     });
-    // Without local-mode, player 2 wouldn't get an entry — alliance is the
+    // Without local-mode, player 2 wouldn't get an entry â€” alliance is the
     // only reason it shows up here.
     expect(status.get(2)).toBeDefined();
     expect(status.get(2)?.alliance).toBe(true);
@@ -376,7 +377,7 @@ describe("computePlayerStatus — live mode (localPlayerSmallID set)", () => {
   });
 });
 
-describe("computePlayerStatus — doomsday clock phases", () => {
+describe("computePlayerStatus â€” doomsday clock phases", () => {
   // Three phases drive three different skulls: blinking (warn), steady white
   // (draining), steady RED (decaying). The last one comes straight from the sim.
   const WARN = 300; // 30s
@@ -423,7 +424,7 @@ describe("computePlayerStatus — doomsday clock phases", () => {
 
   it("never decays a side that is not flagged at all", () => {
     // Defensive: a stale isDecaying must not paint a skull on a recovered side.
-    // An unflagged player may get no status entry at all, which is equally fine —
+    // An unflagged player may get no status entry at all, which is equally fine â€”
     // what matters is that nothing reports a decaying skull.
     const out = computePlayerStatus(
       new Map([

--- a/tests/util/viewStubs.ts
+++ b/tests/util/viewStubs.ts
@@ -135,6 +135,9 @@ export function makePlayerUpdate(
     allies: [],
     embargoes: new Set(),
     isTraitor: false,
+    // Bounty market pool on this player's head. Present so the
+    // diffPlayerUpdate field-coverage walk can reach it.
+    bountyTotal: 0n,
     // Doomsday-clock state. Present here so the diffPlayerUpdate field-coverage
     // walk in GameUpdateUtils.test.ts reaches these: a field missing from this
     // stub is a field that walk cannot check.

--- a/tests/zbin/wire.test.ts
+++ b/tests/zbin/wire.test.ts
@@ -78,6 +78,7 @@ const SAMPLE_INTENTS: StampedIntent[] = [
   { type: "emoji", clientID: P1, recipient: "AllPlayers", emoji: 3 },
   { type: "emoji", clientID: P1, recipient: P2, emoji: 0 },
   { type: "donate_gold", clientID: P1, recipient: P2, gold: 1000000 },
+  { type: "place_bounty", clientID: P1, recipient: P2, gold: 25000 },
   { type: "donate_troops", clientID: P1, recipient: P2, troops: null },
   {
     type: "build_unit",


### PR DESCRIPTION
## Bounty market

Players pool gold bounties on other players' heads via a new `place_bounty` intent; whoever lands the killing blow collects the entire pool. Turns every elimination into an economy.

**Core (`src/core/`, deterministic, fully tested):**
- `PlaceBountyIntent` schema + `BountyExecution` (validation, min amount, cooldown, no self/team/disconnected targets)
- `GameImpl` bounty pools: `placeBounty` / `resolveBounty` (payout in `conquerPlayer`, covering attack + encirclement kills) / `refundBounties` (no-killer deaths refund contributors)
- `bountyTotal` shipped in `PlayerUpdate` (wired through `diffPlayerUpdate` + `applyStateUpdate`), plus `BountyPlacedEvent` / `BountyCollectedEvent` updates
- Config: `bountiesEnabled`, `bountyCooldown`, `bountyMinAmount`

**Bot logic — bots decide by expected value:**
- Kill-cost model (`troops x 1.5 + tiles x 2`), troop-to-gold pricing, per-difficulty profit margins, flank-risk penalty, spendable-troops affordability, anti-suicide strength gate
- Jackpot override diverts from expansion when the pool is overwhelming (works for nations AND tribes, which use separate attack paths)
- Rich bots post revenge bounties (when hit by stronger enemies) and warlord bounties on threats

**Client:**
- Radial-menu Place Bounty button, bounty mode in `SendResourceModal`, event toasts, PlayerPanel bounty badge, solo-mode toggle (on by default), en.json strings

**Tests:** `tests/Bounty.test.ts` (9), `tests/AiAttackBehavior.bounty.test.ts` (12: jackpot diversion, EV accept/reject, tribe hunting, revenge/warlord placement), zbin wire coverage, updated fixtures. `tsc` + `lint` clean.

## Offline desktop shell (second commit)

Electron shell (`desktop/`) serving the production bundle over `app://openfront` with all external traffic blocked — solo mode runs with zero internet (`LocalServer` + inlined worker). Includes an E2E offline smoke test (Solo -> Start -> match runs, canvas mounted). `index.html` ad/analytics SDKs wrapped in `offlineShell` EJS conditionals (web/dev render paths unchanged and verified).
