### PR TITLE
test(server): stop ClanSpectatorConversion leaking turn timers (OPE-384)

### DIFF
--- a/tests/server/ClanSpectatorConversion.test.ts
+++ b/tests/server/ClanSpectatorConversion.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "vitest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   Duos,
   GameMapType,
@@ -7,6 +7,7 @@ import {
   Trios,
 } from "../../src/core/game/Game";
 import { ServerStartGameMessage } from "../../src/core/Schemas";
+import { createGameWireContext } from "../../src/core/ZbinWire";
 import {
   cid,
   makeClient,
@@ -15,7 +16,25 @@ import {
   startGame,
 } from "../util/GameServerHarness";
 
+// One turn of the server clock; ServerEnv.turnIntervalMs().
+const TURN_MS = 100;
+
 describe("GameServer - Clan Overflow Spectator Conversion", () => {
+  // start() schedules a 100 ms turn interval that only end() clears, and no
+  // test here ends its game -- every one of them used to leave a live timer
+  // behind. When one fired after the run it encoded a turn against gone
+  // fixtures and failed the whole job from outside any test. Faking the clock
+  // makes the leak structurally impossible rather than something each test has
+  // to remember to clean up.
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
   test("Clan members overflowing maxTeamSize are converted to spectators", () => {
     const game = makeGame({
       config: {
@@ -98,7 +117,7 @@ describe("GameServer - Clan Overflow Spectator Conversion", () => {
     expect(clients.every((c) => !c.spectator)).toBe(true);
   });
 
-  test("Queued intents from converted clan overflow spectators are pruned", () => {
+  test("Queued intents from converted clan overflow spectators are pruned", async () => {
     const game = makeGame({
       config: {
         gameMode: GameMode.Team,
@@ -122,34 +141,45 @@ describe("GameServer - Clan Overflow Spectator Conversion", () => {
       game.joinClient(c);
     }
 
-    // Queue intent from c1 (kept) and c5 (converted to spectator)
-    const serverAny = game as any;
-    serverAny.intents.push({
-      type: "chat",
-      clientID: cid("c1"),
-      text: "hello",
+    // Queue an intent from c1 (kept) and c5 (converted to spectator) through
+    // the socket a real client uses, rather than pushing onto the private
+    // queue: gameplay intents are queued regardless of stage (the default
+    // branch of handleIntent), so this works before the start.
+    await mockWsOf(clients[0]).emit({
+      type: "intent",
+      intent: { type: "spawn", tile: 1 },
     });
-    serverAny.intents.push({
-      type: "chat",
-      clientID: cid("c5"),
-      text: "overflow message",
+    await mockWsOf(clients[4]).emit({
+      type: "intent",
+      intent: { type: "spawn", tile: 2 },
     });
-
-    expect(serverAny.intents.some((i: any) => i.clientID === cid("c5"))).toBe(
-      true,
-    );
 
     startGame(game);
 
-    // c5 converted to spectator, so its intent was pruned
+    // c5 is over the clan cap, so it is converted to a spectator.
     expect(clients[4].spectator).toBe(true);
-    expect(serverAny.intents.some((i: any) => i.clientID === cid("c5"))).toBe(
-      false,
-    );
-    // c1 intent retained
-    expect(serverAny.intents.some((i: any) => i.clientID === cid("c1"))).toBe(
-      true,
-    );
+
+    // Assert on what actually reaches the wire, not on the private array: the
+    // first turn frame is the observable consequence of the pruning.
+    const startMsg = mockWsOf(clients[0])
+      .sent()
+      .find((m): m is ServerStartGameMessage => m.type === "start");
+    expect(startMsg).toBeDefined();
+    const ctx = createGameWireContext(startMsg!.gameStartInfo.players);
+
+    vi.advanceTimersByTime(TURN_MS);
+
+    const turn = mockWsOf(clients[0])
+      .sent(ctx)
+      .find((m) => m.type === "turn");
+    expect(turn?.type).toBe("turn");
+    if (turn?.type !== "turn") return;
+
+    const intentClientIDs = turn.turn.intents.map((i) => i.clientID);
+    // The converted spectator's queued intent never reaches a turn...
+    expect(intentClientIDs).not.toContain(cid("c5"));
+    // ...while the kept player's does.
+    expect(intentClientIDs).toContain(cid("c1"));
   });
 
   test("Pinned matchmaking players seeded by index are exempt from conversion", () => {


### PR DESCRIPTION
## What

`tests/server/ClanSpectatorConversion.test.ts` left live `GameServer` turn timers behind. When one fired after the run it encoded a turn against gone fixtures, threw `ZbEncodeError: $: no variant for type=chat` from outside any test, and failed the whole job — with all 4842+ tests passing. Hit twice on 9 Sept on unrelated client-only PRs (#5307, #5308); a re-run passed both times.

Test-only change. No `src/` file is touched.

## Is the `type=chat` encode failure a real server bug? No.

That is the ticket's open question, and the answer is that it was an artefact of this test.

- `IntentSchema` (`src/core/Schemas.ts:757`) is a `z.discriminatedUnion("type", [...])` with **no `chat` variant**. The real chat intent is `quick_chat`.
- A `chat` intent cannot arrive over the wire either. `SocketIngress.receive` decodes with zbin (`SocketIngress.ts:103`) — which has no `chat` variant, so it throws and the client is kicked — and then validates with `ClientMessageSchema.safeParse` (`:113`), kicking on failure. Nothing else queues intents; `addIntent` (`GameServer.ts:1232`) is private and reached only from `handleIntent`.
- The only `type:"chat"` anywhere in the repo was this test file, which pushed a fabricated intent onto the private `intents` array through `game as any` to stand in for "some intent with a clientID".

So there is no production path to the crash and no follow-up ticket is needed. The unencodable intent existed solely because the test invented it.

## The timer leak, measured

`start()` schedules a 100 ms turn interval (`GameServer.ts:1037`) that only `end()` clears (`:1326`). **No test in this file ends its game.** This is not one careless test: instrumenting `vi.getTimerCount()` before teardown shows **every one of the 9 tests leaves 2–6 pending timers**. Only one of them happened to hold an intent that could not be encoded, which is the only reason the others were invisible.

The suite's own tests take 38 ms against a 100 ms interval, so the timer normally lost the race to process exit — hence intermittent, and hence always green on a re-run.

Reproduced deterministically before fixing: queue the fabricated intent, `startGame`, await 250 ms of real time, and the exact CI stack appears with vitest exiting 1:

```
ZbEncodeError: $: no variant for type=chat
 ❯ encodeServerMessage src/core/ZbinWire.ts:54:30
 ❯ GameServer.endTurn src/server/GameServer.ts:1309:17
 ❯ Timeout._onTimeout src/server/GameServer.ts:1038:18
```

## Fix

**Fake timers file-wide**, with `clearAllTimers()` + `useRealTimers()` in `afterEach` (the pattern already in `GameServerWire.test.ts:31-39`). Chosen over ending the game in the one offending test because twelve tests start games and none ends one — this makes the leak *structurally impossible* rather than something each new test has to remember.

**Real intents instead of a fabricated one.** The test now queues a `spawn` intent through the mock socket for both the kept client and the one about to be converted. Gameplay intents queue regardless of stage (the default branch of `handleIntent`), so this works pre-start, and it matches what `SpectatorJoin.test.ts:151-159` already does. `game as any` is gone.

**Assert at the wire, not the private array.** After `advanceTimersByTime(100)` the test decodes the `turn` frame and asserts the converted spectator's clientID is absent from its intents while the kept player's is present. That is the observable consequence the private-array reads only approximated.

## Evidence

- `tests/server/ClanSpectatorConversion.test.ts`: 9 passed. Full `tests/server`: **62 files, 643 tests, exit 0** — fake timers disturb nothing else in the suite.
- `npx tsc --noEmit`, `npm run lint`, `prettier` clean.
- **Revert-proof:** disabling the intent pruning in `GameServer.ts` fails the new assertion with `expected [ 'c1000000', 'c2000000', …(8) ] to not include 'c5000000'` — so the test genuinely covers the behaviour, not just the crash.

Based on `main` @ `4cd8c4dcb`.

Resolves OPE-384 — https://linear.app/openfront/issue/OPE-384/flaky-ci-clanspectatorconversion-test-leaves-a-gameserver-turn-timer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
