### PR TITLE
test(i18n): give the en.json sync test starvation headroom (OPE-269)

### DIFF
--- a/tests/TranslationSystem.test.ts
+++ b/tests/TranslationSystem.test.ts
@@ -370,7 +370,9 @@ function scanTsFile(
     filePath,
     content,
     ts.ScriptTarget.Latest,
-    true,
+    // setParentNodes: nothing in this file reads node.parent, and building the
+    // parent pointers is about 15% of the parse cost across 566 files.
+    false,
     filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS,
   );
 
@@ -630,5 +632,17 @@ describe("Translation System", () => {
 
     expect(missingKeys).toEqual([]);
     expect(unusedKeys).toEqual([]);
-  }, 30000);
+    // 60s, raised from the 30s added in #3861 (May 2026). This is starvation
+    // headroom, not a budget. Measured over 566 source files (5.0MB): ~1.7s
+    // locally, split read 0.28s / TS parse 0.68s / AST walk 0.70s, and ~4.0s
+    // under the v8 coverage CI actually runs (`npm run test:coverage`,
+    // ci.yml:47) -- down from ~5.0s before the setParentNodes change above.
+    // That 20% is the whole of what optimisation can buy: parse and walk are
+    // 82% of the cost and are inherent to reading every source file with the
+    // TypeScript compiler. What exhausted the old 30s on 1 Sept 2026 was
+    // >12x starvation from concurrent suites on one machine, which no
+    // speedup of this size survives. A timeout here reads exactly like the
+    // i18n regression this test exists to catch, and costs an investigation
+    // every time, so the margin is deliberately generous.
+  }, 60000);
 });


### PR DESCRIPTION
## What

The `"en.json keys stay in sync with source usage"` test walks and TypeScript-parses every source file. Under parallel load it exhausts its timeout and fails **as a timeout, not an assertion** — and it does so precisely on the PRs where an i18n regression would be plausible, namely any PR adding keys to `en.json`. The red says nothing about the branch under test while looking exactly like the defect the test exists to catch, so each occurrence costs an investigation before it is dismissed.

Test-only change.

## Two changes

**1. `setParentNodes: false`.** Nothing in the file reads `node.parent`, so the parent pointers were being built for all 566 files and thrown away.

**2. Raise the existing `30000` to `60000`**, with the measurements recorded beside it. Note this is raising a timeout that is already there — `}, 30000)` was added in #3861 (May 2026) — not adding one.

## Why headroom, and not just optimisation

Measured over 566 source files (5.0 MB):

| | local | under coverage |
| --- | --- | --- |
| before | ~1.7s | **4.97s** |
| after | ~1.7s | **3.96s** |

Coverage numbers are medians of three runs of `vitest run --coverage`, which is what CI actually runs (`npm run test:coverage`, `ci.yml:47`); v8 instrumentation both inflates the cost and makes the parse change worth more (~20%, versus ~6% locally).

Phase split of the 1.68 s local body: read 0.28 s, **TS parse 0.68 s**, regexes 0.01 s, **AST walk 0.70 s**. Parse and walk are 82% of the cost and are inherent to reading every source file with the TypeScript compiler — so ~20% is the whole of what optimisation can buy here. The 1 Sept failure was >12x starvation (two lanes plus an `npm ci` on one machine), which no speedup of that magnitude survives. Headroom is the only lever that addresses the actual cause.

Two things measured and rejected rather than assumed: the regexes are 0.7% of runtime, so precompiling or hoisting them is worthless; and `getAllFiles` already walks only `src/`, so `node_modules`/`dist` were never being traversed.

A content pre-filter to skip parsing was considered and **not** taken. The check counts a key as used if any string literal in any file matches it (a deliberately permissive rule, so unused-key reports are not false), and nothing tests that a pre-filter would preserve that. Trading a correctness guard for 20% is the wrong direction for a test whose whole job is catching i18n drift.

## Correctness

No behaviour changes, so no new test. The existing test passing **is** the check on the parse change: a key dropped by a parse difference would stop being seen as used and surface in `unusedKeys`, failing `expect(unusedKeys).toEqual([])`. All 3 tests in the file pass; `tsc --noEmit`, `npm run lint` and `prettier` are clean.

Based on `main` @ `4cd8c4dcb`.

Resolves OPE-269 — https://linear.app/openfront/issue/OPE-269/translationsystems-enjson-sync-test-times-out-under-load-so-any-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
