### PR TITLE
refactor(client): one parser for the debt refusal across spend paths (OPE-378)

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -631,6 +631,43 @@ export async function getMyTribeNames(): Promise<
   }
 }
 
+// The branch key the shared spend helper returns when a refund or chargeback
+// has left the wallet negative. A machine key, never prose: it must not reach
+// the player, which is what happened before the debt paths were handled.
+const DEBT_REFUSAL_REASON = "insufficient_balance_debt";
+
+// Reads the debt refusal off a 400 body for every spend path. Returns
+// undefined when this is not that refusal, so the caller carries on matching
+// its own reasons; otherwise it returns the result the caller should return.
+//
+// The amount IS the message ("your balance is X in debt"), so a debt we
+// cannot state is worse than a generic failure — it would render a blank, or
+// "[object Object]", at the player. Digits only: the API sends a stringified
+// positive bigint, so anything else (missing, empty, negative, an object)
+// fails closed.
+//
+// `context` is the calling function's name as a literal at each call site.
+// Nothing from the body reaches the warn: an amount we rejected is by
+// definition one we do not understand.
+function parseDebtRefusal(
+  body: unknown,
+  context: string,
+):
+  | { ok: false; code: "debt"; debt: string }
+  | { ok: false; code: "failed" }
+  | undefined {
+  const reason = (body as { reason?: unknown } | null | undefined)?.reason;
+  if (reason !== DEBT_REFUSAL_REASON) return undefined;
+  const debt = String(
+    (body as { debt?: unknown } | null | undefined)?.debt ?? "",
+  );
+  if (!/^\d+$/.test(debt)) {
+    console.warn(`${context}: debt refusal with no usable amount`);
+    return { ok: false, code: "failed" };
+  }
+  return { ok: false, code: "debt", debt };
+}
+
 export type PurchaseTribeNameResult =
   | { ok: true; data: PostTribeNameResponse }
   // 400 "Insufficient balance": the balance moved since the client's
@@ -728,9 +765,8 @@ export async function purchaseTribeName(
       const reason = typeof body?.reason === "string" ? body.reason : "";
       // Balance reasons first: both are branch keys the shared spend helper
       // emits, not prose to echo at the player.
-      if (reason === "insufficient_balance_debt") {
-        return { ok: false, code: "debt", debt: String(body.debt ?? "") };
-      }
+      const debt = parseDebtRefusal(body, "purchaseTribeName");
+      if (debt !== undefined) return debt;
       if (reason === "Insufficient balance") {
         return { ok: false, code: "insufficient_balance" };
       }
@@ -814,17 +850,16 @@ export async function boostTribeName(
     }
     if (response.status === 400) {
       const body = await response.json().catch(() => null);
-      // {"reason": "..."} is the player-facing 400 (insufficient balance, or
-      // a wallet left negative by a refund/chargeback); {"resource": "id"}
-      // means a malformed id — a client bug, not a player error, so it falls
-      // through to the generic failure.
+      // Debt first, ahead of the catch-all below: collapsing it into
+      // insufficient_balance sends a player with a negative wallet to the
+      // top-up dialog, which cannot clear it. Safe above the string-reason
+      // check — a body without a string reason is never the debt refusal.
+      const debt = parseDebtRefusal(body, "boostTribeName");
+      if (debt !== undefined) return debt;
+      // Any other {"reason": "..."} is the player-facing 400 (a shortfall);
+      // {"resource": "id"} means a malformed id — a client bug, not a player
+      // error, so it falls through to the generic failure.
       if (typeof body?.reason === "string") {
-        // Checked before the catch-all: collapsing debt into
-        // insufficient_balance sends a player with a negative wallet to the
-        // top-up dialog, which does not clear the debt.
-        if (body.reason === "insufficient_balance_debt") {
-          return { ok: false, code: "debt", debt: String(body.debt ?? "") };
-        }
         return { ok: false, code: "insufficient_balance" };
       }
       // Body-free on purpose: an unrecognised 400 is exactly the case where we
@@ -936,20 +971,8 @@ export async function purchaseWithCurrency(
     if (response.status === 400) {
       const body = await response.json().catch(() => null);
       const reason = typeof body?.reason === "string" ? body.reason : "";
-      if (reason === "insufficient_balance_debt") {
-        // The amount is the whole message ("your balance is X in debt"), so a
-        // debt we can't state is worse than a generic failure: it would render
-        // a blank or "[object Object]" at the player. Digits only — the API
-        // sends a stringified positive bigint.
-        const debt = String(body?.debt ?? "");
-        if (!/^\d+$/.test(debt)) {
-          console.warn(
-            "purchaseWithCurrency: debt refusal with no usable amount",
-          );
-          return { ok: false, code: "failed" };
-        }
-        return { ok: false, code: "debt", debt };
-      }
+      const debt = parseDebtRefusal(body, "purchaseWithCurrency");
+      if (debt !== undefined) return debt;
       if (reason === "Insufficient balance") {
         return { ok: false, code: "insufficient_balance" };
       }
@@ -1028,11 +1051,12 @@ export async function purchaseCosmeticPack(
     if (response.status === 400) {
       const body = await response.json().catch(() => null);
       const reason = typeof body?.reason === "string" ? body.reason : "";
+      // Hoisted above the shortfall match: the two reasons are distinct exact
+      // strings, so the order between them makes no difference.
+      const debt = parseDebtRefusal(body, "purchaseCosmeticPack");
+      if (debt !== undefined) return debt;
       if (reason === "Insufficient balance") {
         return { ok: false, code: "insufficient_balance" };
-      }
-      if (reason === "insufficient_balance_debt") {
-        return { ok: false, code: "debt", debt: String(body.debt ?? "") };
       }
       if (PACK_UNAVAILABLE_REASONS.includes(reason)) {
         return { ok: false, code: "unavailable" };

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -642,9 +642,14 @@ const DEBT_REFUSAL_REASON = "insufficient_balance_debt";
 //
 // The amount IS the message ("your balance is X in debt"), so a debt we
 // cannot state is worse than a generic failure — it would render a blank, or
-// "[object Object]", at the player. Digits only: the API sends a stringified
-// positive bigint, so anything else (missing, empty, negative, an object)
-// fails closed.
+// "[object Object]", at the player. A string of digits only: the API sends a
+// stringified positive bigint, so everything else (missing, empty, negative,
+// an object) fails closed.
+//
+// Type-checked before the pattern rather than stringified into it, because
+// String() launders things that are not amounts into ones that look like
+// amounts: String(300) and String([300]) are both "300". Whatever the API
+// starts sending, it has to be the string it promises.
 //
 // `context` is the calling function's name as a literal at each call site.
 // Nothing from the body reaches the warn: an amount we rejected is by
@@ -658,10 +663,8 @@ function parseDebtRefusal(
   | undefined {
   const reason = (body as { reason?: unknown } | null | undefined)?.reason;
   if (reason !== DEBT_REFUSAL_REASON) return undefined;
-  const debt = String(
-    (body as { debt?: unknown } | null | undefined)?.debt ?? "",
-  );
-  if (!/^\d+$/.test(debt)) {
+  const debt = (body as { debt?: unknown } | null | undefined)?.debt;
+  if (typeof debt !== "string" || !/^\d+$/.test(debt)) {
     console.warn(`${context}: debt refusal with no usable amount`);
     return { ok: false, code: "failed" };
   }

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -147,6 +147,8 @@ describe("purchaseCosmeticPack", () => {
     ["not a number", { debt: "lots" }],
     ["an object", { debt: { amount: 300 } }],
     ["negative", { debt: "-300" }],
+    ["a number", { debt: 300 }],
+    ["a one-element array", { debt: ["300"] }],
   ])(
     "falls back to a generic failure when the amount is %s",
     async (_label, extra) => {
@@ -243,6 +245,9 @@ describe("purchaseWithCurrency", () => {
     ["not a number", { debt: "lots" }],
     ["an object", { debt: { amount: 150 } }],
     ["negative", { debt: "-150" }],
+    // String() would launder both of these into a valid-looking "150".
+    ["a number", { debt: 150 }],
+    ["a one-element array", { debt: ["150"] }],
   ])(
     "falls back to a generic failure when the amount is %s",
     async (_l, extra) => {

--- a/tests/client/PurchaseCosmeticPack.test.ts
+++ b/tests/client/PurchaseCosmeticPack.test.ts
@@ -137,6 +137,35 @@ describe("purchaseCosmeticPack", () => {
     expect(vi.mocked(console.warn).mock.calls[0]).toHaveLength(1);
   });
 
+  // The amount IS the message ("your balance is X in debt"), so a debt we
+  // cannot state is worse than a generic failure — it would render a blank,
+  // or "[object Object]", at the player. Same rule as the single-cosmetic
+  // path, which is the point of the shared parser.
+  it.each([
+    ["missing", {}],
+    ["empty", { debt: "" }],
+    ["not a number", { debt: "lots" }],
+    ["an object", { debt: { amount: 300 } }],
+    ["negative", { debt: "-300" }],
+  ])(
+    "falls back to a generic failure when the amount is %s",
+    async (_label, extra) => {
+      respond(400, {
+        reason: "insufficient_balance_debt",
+        canary: CANARY,
+        ...extra,
+      });
+      expect(await purchaseCosmeticPack("starter")).toEqual({
+        ok: false,
+        code: "failed",
+      });
+      expectNoConsoleCallContains(CANARY);
+      expect(console.error).not.toHaveBeenCalled();
+      expect(console.warn).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(console.warn).mock.calls[0]).toHaveLength(1);
+    },
+  );
+
   it("reports which items are already owned on 409", async () => {
     respond(409, {
       error: "Conflict",

--- a/tests/client/TribeNameDebt.test.ts
+++ b/tests/client/TribeNameDebt.test.ts
@@ -92,6 +92,9 @@ describe("tribe-name spend paths map the debt reason", () => {
       ["not a number", { debt: "lots" }],
       ["an object", { debt: { amount: 250 } }],
       ["negative", { debt: "-250" }],
+      // String() would launder both of these into a valid-looking "250".
+      ["a number", { debt: 250 }],
+      ["a one-element array", { debt: ["250"] }],
     ])(
       "falls back to a generic failure when the amount is %s",
       async (_label, extra) => {
@@ -224,6 +227,8 @@ describe("tribe-name spend paths map the debt reason", () => {
       ["not a number", { debt: "lots" }],
       ["an object", { debt: { amount: 80 } }],
       ["negative", { debt: "-80" }],
+      ["a number", { debt: 80 }],
+      ["a one-element array", { debt: ["80"] }],
     ])(
       "falls back to a generic failure when the amount is %s",
       async (_label, extra) => {

--- a/tests/client/TribeNameDebt.test.ts
+++ b/tests/client/TribeNameDebt.test.ts
@@ -22,6 +22,11 @@ import { ClientEnv } from "../../src/client/ClientEnv";
 
 let fetchMock: ReturnType<typeof vi.fn>;
 
+// Planted in the bodies of the rejected-amount cases: an amount we refused to
+// use is by definition one we did not understand, so none of it may reach a
+// log line.
+const CANARY = "CANARY-9f3c1d";
+
 function respond(status: number, body: unknown) {
   fetchMock.mockResolvedValueOnce(
     new Response(JSON.stringify(body), {
@@ -29,6 +34,16 @@ function respond(status: number, body: unknown) {
       headers: { "content-type": "application/json" },
     }),
   );
+}
+
+// A rejected debt amount warns exactly once, with exactly one argument, and
+// says nothing about the body. The single-argument shape is the OPE-376 rule.
+function expectRejectedAmountWarn() {
+  expect(console.error).not.toHaveBeenCalled();
+  expect(console.warn).toHaveBeenCalledTimes(1);
+  const call = vi.mocked(console.warn).mock.calls[0];
+  expect(call).toHaveLength(1);
+  expect(String(call[0])).not.toContain(CANARY);
 }
 
 describe("tribe-name spend paths map the debt reason", () => {
@@ -67,17 +82,31 @@ describe("tribe-name spend paths map the debt reason", () => {
       });
     });
 
-    // The reason is the branch key; the amount is only there to quote back.
-    // A body without it must still take the debt branch rather than falling
-    // through to a generic failure.
-    it("still reports a debt whose amount is missing", async () => {
-      respond(400, { reason: "insufficient_balance_debt" });
-      expect(await purchaseTribeName("Ninja")).toEqual({
-        ok: false,
-        code: "debt",
-        debt: "",
-      });
-    });
+    // The amount IS the message ("your balance is X in debt"), so a debt we
+    // cannot state is worse than a generic failure — it would render "your
+    // balance is  in debt" at the player. Digits only: the API sends a
+    // stringified positive bigint, so everything else fails closed.
+    it.each([
+      ["missing", {}],
+      ["empty", { debt: "" }],
+      ["not a number", { debt: "lots" }],
+      ["an object", { debt: { amount: 250 } }],
+      ["negative", { debt: "-250" }],
+    ])(
+      "falls back to a generic failure when the amount is %s",
+      async (_label, extra) => {
+        respond(400, {
+          reason: "insufficient_balance_debt",
+          canary: CANARY,
+          ...extra,
+        });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "failed",
+        });
+        expectRejectedAmountWarn();
+      },
+    );
 
     // Previously this fell into "invalid", which the panel prints verbatim —
     // so the English server string was shown where a shortfall and a top-up
@@ -184,6 +213,32 @@ describe("tribe-name spend paths map the debt reason", () => {
         debt: "80",
       });
     });
+
+    // Same rule as the purchase path. These rows also pin the branch order:
+    // the debt reason is read before the catch-all that turns any other
+    // string reason into insufficient_balance, so a regression that
+    // re-collapsed the two would return insufficient_balance here.
+    it.each([
+      ["missing", {}],
+      ["empty", { debt: "" }],
+      ["not a number", { debt: "lots" }],
+      ["an object", { debt: { amount: 80 } }],
+      ["negative", { debt: "-80" }],
+    ])(
+      "falls back to a generic failure when the amount is %s",
+      async (_label, extra) => {
+        respond(400, {
+          reason: "insufficient_balance_debt",
+          canary: CANARY,
+          ...extra,
+        });
+        expect(await boostTribeName("7", "key")).toEqual({
+          ok: false,
+          code: "failed",
+        });
+        expectRejectedAmountWarn();
+      },
+    );
 
     // This path collapsed every reason string into insufficient_balance,
     // which sends a player with a negative wallet to a top-up dialog that


### PR DESCRIPTION
## What

The shared spend helper in the API refuses with `{reason: "insufficient_balance_debt", debt}` whenever a refund or chargeback has left a wallet negative. Four client paths in `src/client/Api.ts` read that refusal — `purchaseTribeName`, `boostTribeName`, `purchaseWithCurrency` and `purchaseCosmeticPack` — and after #5307, #5309, #5319 and #5320 they did it four slightly different ways.

Only `purchaseWithCurrency` validated the amount. The other three rendered `String(body.debt ?? "")` into the message unchecked, so a refusal that arrived without a usable amount read:

> Your Plutonium balance is  in debt.

This puts all four behind one module-private `parseDebtRefusal(body, context)` applying the strict rule everywhere: digits only, since the API sends a stringified positive bigint. A debt we cannot state falls back to the generic failure with a body-free, single-argument warn — the amount **is** the message, so a blank claim is worse than no claim.

## Why the amount is validated rather than defaulted

The whole message is the number. There is no sensible default: `""` renders the sentence above, and a non-string `debt` renders `[object Object]` at the player. Failing closed is the only option that never puts a broken sentence on screen.

## What does not change

The helper returns `undefined` for anything that is not the debt refusal, so every call site carries on matching its own reasons in its existing order, and each site's rendering is untouched. The only player-visible difference is the missing/invalid-`debt` case on the three tribe/pack paths, which is unreachable against current infra — the helper always sends a positive amount with that reason.

## Two things deliberately not unified

The ticket asks whether the `insufficient_balance` mapping and the unrecognised-400 warns can share the same helper. Checked; both would change behaviour rather than deduplicate, so they are left alone:

1. **The `insufficient_balance` mapping.** `boostTribeName` maps *any* non-debt string reason to `insufficient_balance` — a catch-all, pinned by `tests/client/BoostTribeNameBadRequest.test.ts`. The other three match the exact string `"Insufficient balance"`. Folding them together would make a reworded or unknown reason on the boost path return `failed` where it returns `insufficient_balance` today. Out of scope here.
2. **The unrecognised-400 warn wording.** Two sites say `unrecognised 400 reason`, two say `unrecognised 400 response`. Unifying is churn with no behavioural content.

## One ordering note for review

`boostTribeName`'s debt check now sits above its `typeof body?.reason === "string"` guard rather than nested inside it. Equivalent, because the helper returns `undefined` for a non-string reason — the existing malformed-id (`{"resource": "id"}`) and non-JSON-body cases still fall through to the same body-free warn, and their tests pass unchanged. Likewise in `purchaseCosmeticPack` the debt check is hoisted above the `"Insufficient balance"` match; the two reasons are distinct exact strings, so the order between them makes no difference.

## Tests

`tests/client/TribeNameDebt.test.ts` previously enshrined the blank-amount rendering with a case asserting `debt: ""`. That is flipped, and the rejected-amount table already covering `purchaseWithCurrency` (missing / empty / not a number / an object / negative) is now applied to the other three paths. Each row asserts the generic failure, that `console.warn` is called exactly once with exactly one argument, that `console.error` is not called, and that a canary planted in the body reaches no log line.

The boost rows also pin the branch order: a regression that re-collapsed debt into `insufficient_balance` would fail them.

Run in the worktree at `a6c5c58`:

- `npx vitest tests/client --run` — 147 files, 1952 tests, all pass
- `npx tsc --noEmit` — clean
- `npm run lint` (oxlint + eslint) — clean
- `npx prettier --write` on the three changed files — all unchanged

**Revert-proof:** restoring `src/client/Api.ts` from `origin/main` and re-running fails 15 rows — five each for `purchaseTribeName`, `boostTribeName` and `purchaseCosmeticPack`.

Resolves OPE-378 — https://linear.app/openfront/issue/OPE-378/unify-debt-response-parsing-across-the-four-client-spend-paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)
