### PR TITLE
fix(client): suppress the update prompt on versioned replay shells

### DIFF
--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -45,6 +45,7 @@ import {
   renderDuration,
   translateText,
 } from "./Utils";
+import { isReplayShellHost } from "./VersionedReplay";
 
 const PRIMARY_ACTION =
   "bg-malibu-blue hover:bg-aquarius active:bg-malibu-blue/80 hover:scale-y-105 hover:scale-x-[1.01]";
@@ -133,6 +134,13 @@ export class GameModeSelector extends LitElement {
     // DesktopUpdateBar). Reloading here would only re-run the old overlay,
     // reconnect, and trigger this again until the download finishes.
     if (isDesktopShell()) return;
+    // A versioned replay shell is pinned to the archived game's build on
+    // purpose (VersionedReplay.ts), but its baked-in serverHost points at a
+    // live deployment running a newer build — so the lobby socket's commit
+    // compare (or a drain signal) fires on every load. "Update" is
+    // meaningless here, and reloading re-serves the same immutable shell,
+    // which would loop the prompt forever.
+    if (isReplayShellHost(window.location.hostname)) return;
     // A blocking reload prompt during a lobby wait would eject the player
     // from a lobby the draining deployment deliberately lets finish — and a
     // private lobby's members are all pinned to the same deployment, so they

--- a/tests/GameModeSelectorRestart.test.ts
+++ b/tests/GameModeSelectorRestart.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { PublicGames } from "../src/core/Schemas";
 
 // OPE-255. The component stops its public-lobby socket when a game starts
@@ -26,7 +26,21 @@ vi.mock("../src/client/LobbySocket", () => ({
   },
 }));
 
+// The suppression tests below need to see whether the prompt actually fired;
+// everything else in InGameModal stays real.
+vi.mock("../src/client/InGameModal", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../src/client/InGameModal")>();
+  return {
+    ...actual,
+    // Never resolves: the real flow reloads the page after the alert, which
+    // has no business running under jsdom.
+    showInGameAlert: vi.fn(() => new Promise<void>(() => {})),
+  };
+});
+
 import { GameModeSelector } from "../src/client/GameModeSelector";
+import { showInGameAlert } from "../src/client/InGameModal";
 
 describe("GameModeSelector lobby-socket lifecycle", () => {
   beforeEach(() => {
@@ -87,5 +101,36 @@ describe("GameModeSelector update prompt deferral", () => {
 
     expect(prompt).toHaveBeenCalledTimes(1);
     expect(selector.updateDeferred).toBe(false);
+  });
+});
+
+// A versioned replay shell (replay.<domain>/<gameId>) is pinned to the
+// archived game's build on purpose, but its baked-in serverHost points at a
+// live deployment running a newer build — so the lobby socket's commit
+// compare fires on every load, and reloading re-serves the same immutable
+// shell: the prompt would loop forever.
+describe("GameModeSelector update prompt on the replay shell host", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.mocked(showInGameAlert).mockClear();
+  });
+
+  it("suppresses the prompt on replay.<domain>", () => {
+    vi.stubGlobal("location", { hostname: "replay.openfront.io" });
+    const selector = new GameModeSelector() as any;
+
+    selector.handleUpdateAvailable();
+
+    expect(showInGameAlert).not.toHaveBeenCalled();
+    expect(selector.updateDeferred).toBe(false);
+  });
+
+  it("still prompts on ordinary hosts", () => {
+    vi.stubGlobal("location", { hostname: "openfront.io" });
+    const selector = new GameModeSelector() as any;
+
+    selector.handleUpdateAvailable();
+
+    expect(showInGameAlert).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary

- Opening a versioned replay (`replay.<domain>/<gameId>`, #4959) always showed the blocking "A new version of OpenFront is available. The page will now refresh to update." modal in an infinite reload loop, making replays unreachable.
- Root cause: every deployed shell bakes its deployment's own host into `BOOTSTRAP_CONFIG.serverHost` (#5164), and since multi-server (#5316) those hosts outlive the build. The pinned replay shell's public-lobby socket therefore connects to a live deployment running a newer build, whose commit compare fires the update prompt — and reloading re-serves the same immutable shell.
- Fix: `GameModeSelector.handleUpdateAvailable` now early-returns on `replay.*` hosts (`isReplayShellHost`). An "update" is meaningless on a shell that is version-pinned on purpose.
- Already-uploaded shells can't pick up a bundle fix; a companion PR in the API repo strips the baked `serverHost` line at serve time, which fixes those (and removes the live lobby list from replay pages as a side effect).

## Test plan

- `npx vitest tests/GameModeSelectorRestart.test.ts tests/VersionedReplay.test.ts --run` — 13 passed, including two new tests: the prompt is suppressed on `replay.<domain>` and still fires on ordinary hosts.
- `npx eslint` + `prettier --check` on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)