### PR TITLE
Disable the aftergame in singleplayer 🛡️

### DIFF
--- a/src/client/hud/layers/RadialMenuElements.ts
+++ b/src/client/hud/layers/RadialMenuElements.ts
@@ -790,8 +790,9 @@ export const rootMenuElement: MenuElement = {
     const inExtensionWindow =
       params.playerActions.interaction?.allianceInfo?.inExtensionWindow;
 
-    // After game-over, nukes can target teammates (nukeSpawn allows it).
-    // Show the attack submenu so mobile users can access nukes in the aftergame.
+    // After game-over, nukes can target teammates in multiplayer (nukeSpawn allows it,
+    // but not in singleplayer). Show the attack submenu so mobile users can access
+    // nukes in the aftergame.
     const hasBuildableAttacks =
       params.playerActions.buildableUnits?.some(
         (bu) => BuildableAttacks.has(bu.type) && bu.canBuild !== false,

--- a/src/core/execution/SAMLauncherExecution.ts
+++ b/src/core/execution/SAMLauncherExecution.ts
@@ -1,4 +1,12 @@
-import { Execution, Game, isUnit, Player, Unit, UnitType } from "../game/Game";
+import {
+  Execution,
+  Game,
+  GameType,
+  isUnit,
+  Player,
+  Unit,
+  UnitType,
+} from "../game/Game";
 import { TileRef } from "../game/GameMap";
 import { PseudoRandom } from "../PseudoRandom";
 import { SAMMissileExecution } from "./SAMMissileExecution";
@@ -165,7 +173,11 @@ class SAMTargetingSystem {
     const samOwner = this.sam.owner();
     const nukeOwner = unit.owner();
     if (samOwner.isFriendly(nukeOwner)) {
-      return this.mg.getWinner() !== null && samOwner.isOnSameTeam(nukeOwner);
+      // Aftergame fun (nuking teammates once the game is over) is disabled in singleplayer.
+      const gameOver =
+        this.mg.getWinner() !== null &&
+        this.mg.config().gameConfig().gameType !== GameType.Singleplayer;
+      return gameOver && samOwner.isOnSameTeam(nukeOwner);
     }
     return true;
   }

--- a/src/core/game/PlayerImpl.ts
+++ b/src/core/game/PlayerImpl.ts
@@ -22,6 +22,7 @@ import {
   Embargo,
   EmojiMessage,
   GameMode,
+  GameType,
   Gold,
   MAX_UPGRADE_AMOUNT,
   MutableAlliance,
@@ -1607,8 +1608,10 @@ export class PlayerImpl implements Player {
       return false;
     }
     const owner = this.mg.owner(tile);
-    // Allow nuking teammates after the game is over (aftergame fun)
-    const gameOver = mg.getWinner() !== null;
+    // Allow nuking teammates after the game is over (aftergame fun), but not in singleplayer.
+    const gameOver =
+      mg.getWinner() !== null &&
+      mg.config().gameConfig().gameType !== GameType.Singleplayer;
     if (owner.isPlayer()) {
       if (this.isOnSameTeam(owner) && !gameOver) {
         return false;

--- a/tests/AftergameSingleplayer.test.ts
+++ b/tests/AftergameSingleplayer.test.ts
@@ -1,0 +1,118 @@
+import { SAMLauncherExecution } from "../src/core/execution/SAMLauncherExecution";
+import {
+  Game,
+  GameMode,
+  GameType,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+import { executeTicks } from "./util/utils";
+
+// Aftergame fun (nuking your own teammate once a winner is decided) is meant for
+// human vs human multiplayer. In singleplayer a team can "insta-win" while the
+// human is still actively playing against AI teammates, so the feature must stay
+// disabled there. Covers PlayerImpl.nukeSpawn and SAMTargetingSystem.isValidNukeTarget.
+describe("Aftergame teammate nuking", () => {
+  async function setupTeammates(
+    gameType: GameType,
+  ): Promise<{ game: Game; p1: Player; p2: Player }> {
+    const game = await setup(
+      "plains",
+      {
+        gameType,
+        gameMode: GameMode.Team,
+        playerTeams: 2,
+        infiniteGold: true,
+        instantBuild: true,
+      },
+      [
+        new PlayerInfo("p1", PlayerType.Human, "c1", "p1", false, null, [], 0),
+        new PlayerInfo("p2", PlayerType.Human, "c2", "p2", false, null, [], 0),
+      ],
+    );
+
+    const p1 = game.player("p1");
+    const p2 = game.player("p2");
+    expect(p1.isOnSameTeam(p2)).toBe(true);
+
+    p1.conquer(game.ref(0, 0));
+    p2.conquer(game.ref(5, 5));
+    p1.buildUnit(UnitType.MissileSilo, game.ref(0, 0), {});
+
+    return { game, p1, p2 };
+  }
+
+  describe("PlayerImpl.nukeSpawn (targeting a teammate)", () => {
+    test("singleplayer: teammate stays un-nukeable even after the game is won", async () => {
+      const { game, p1 } = await setupTeammates(GameType.Singleplayer);
+
+      // Normal pre-game behavior: teammates are never nukeable.
+      expect(p1.canBuild(UnitType.AtomBomb, game.ref(5, 5))).toBe(false);
+
+      game.setWinner(p1, game.stats().stats());
+      expect(game.getWinner()).not.toBeNull();
+
+      // Aftergame is disabled in singleplayer, so this stays blocked.
+      expect(p1.canBuild(UnitType.AtomBomb, game.ref(5, 5))).toBe(false);
+    });
+
+    test("multiplayer: teammate becomes nukeable once the game is won", async () => {
+      const { game, p1 } = await setupTeammates(GameType.Public);
+
+      // Normal pre-game behavior: teammates are never nukeable.
+      expect(p1.canBuild(UnitType.AtomBomb, game.ref(5, 5))).toBe(false);
+
+      game.setWinner(p1, game.stats().stats());
+      expect(game.getWinner()).not.toBeNull();
+
+      // Aftergame fun is preserved for human vs human multiplayer.
+      expect(p1.canBuild(UnitType.AtomBomb, game.ref(5, 5))).not.toBe(false);
+    });
+  });
+
+  describe("SAMTargetingSystem.isValidNukeTarget (intercepting a teammate's nuke)", () => {
+    function launchNukeNearSam(p1: Player, game: Game) {
+      return p1.buildUnit(UnitType.AtomBomb, game.ref(1, 1), {
+        targetTile: game.ref(3, 1),
+        trajectory: [
+          { tile: game.ref(1, 1), targetable: true },
+          { tile: game.ref(2, 1), targetable: true },
+          { tile: game.ref(3, 1), targetable: true },
+        ],
+      });
+    }
+
+    test("singleplayer: a teammate's SAM does not intercept a teammate's nuke after the game is won", async () => {
+      const { game, p1, p2 } = await setupTeammates(GameType.Singleplayer);
+      game.setWinner(p1, game.stats().stats());
+
+      const sam = p2.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+      game.addExecution(new SAMLauncherExecution(p2, null, sam));
+
+      launchNukeNearSam(p1, game);
+      executeTicks(game, 3);
+
+      // SAM never fires on the teammate's nuke, so it stays in flight.
+      expect(sam.isInCooldown()).toBeFalsy();
+      expect(p1.units(UnitType.AtomBomb)).toHaveLength(1);
+    });
+
+    test("multiplayer: a teammate's SAM intercepts a teammate's nuke after the game is won (aftergame fun)", async () => {
+      const { game, p1, p2 } = await setupTeammates(GameType.Public);
+      game.setWinner(p1, game.stats().stats());
+
+      const sam = p2.buildUnit(UnitType.SAMLauncher, game.ref(1, 1), {});
+      game.addExecution(new SAMLauncherExecution(p2, null, sam));
+
+      launchNukeNearSam(p1, game);
+      executeTicks(game, 3);
+
+      // Aftergame fun is preserved: the SAM shoots the teammate's nuke down.
+      expect(sam.isInCooldown()).toBeTruthy();
+      expect(p1.units(UnitType.AtomBomb)).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Description:

The "aftergame" mechanic lets teammates nuke each other for fun once a winner is decided, but it was also active in singleplayer. In HumansVsNations-style games with many bot nations, one team can insta-win by territory, after which bot teammates enter the aftergame state and their SAM launchers intercept nukes fired at the human player. This disables the aftergame mechanic (nuking teammates and SAM interception of teammate nukes) when the game type is Singleplayer, while leaving it intact for human vs human multiplayer.

Noticed it in this YT Vid (Solo against 400 nations): https://www.youtube.com/watch?v=709JPXBXfno

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
