### PR TITLE
Disable (not hide) the email-updates toggle for Steam-only accounts (OPE-397)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -67,6 +67,7 @@
     "manage_subscription_on_web": "Manage or change your billing on the OpenFront website.",
     "marketing_desc": "Occasional news, events, and game updates. Unsubscribe anytime.",
     "marketing_no_email": "Link an email to your account to subscribe to updates.",
+    "marketing_no_email_steam": "Steam accounts don't have an email on file, so there's nothing to send updates to yet.",
     "marketing_title": "Email updates",
     "no_games": "No games played yet.",
     "no_stats": "No stats available yet. Play some games to start tracking.",

--- a/src/client/components/AccountSettingsPanel.ts
+++ b/src/client/components/AccountSettingsPanel.ts
@@ -76,6 +76,12 @@ export class AccountSettingsPanel extends LitElement {
     if (!consent) return nothing;
     const hasEmail = consent.hasEmail;
     const on = consent.consented === "approved";
+    // Steam is primary and there's no email on the account: renderEmailBinding()
+    // is suppressed below (no linking UI for Steam in v1), so this is the one
+    // combination with no route to ever get an email. The toggle still renders
+    // — disabled, not omitted — so the card isn't just a heading and a
+    // description with nothing where the control belongs (OPE-397).
+    const steamNoEmail = !hasEmail && this.isSteamPrimary();
     return html`
       <div class="bg-white/5 rounded-xl border border-white/10 p-6">
         <!-- Centred against the title+description block, like the delete card. -->
@@ -87,15 +93,17 @@ export class AccountSettingsPanel extends LitElement {
             <div class="text-white/50 text-sm mt-1">
               ${hasEmail
                 ? translateText("account_modal.marketing_desc")
-                : translateText("account_modal.marketing_no_email")}
+                : steamNoEmail
+                  ? translateText("account_modal.marketing_no_email_steam")
+                  : translateText("account_modal.marketing_no_email")}
             </div>
           </div>
-          ${hasEmail
+          ${hasEmail || steamNoEmail
             ? html`<button
                 role="switch"
                 aria-checked=${on ? "true" : "false"}
                 aria-label=${translateText("account_modal.marketing_title")}
-                ?disabled=${this.consentBusy}
+                ?disabled=${this.consentBusy || steamNoEmail}
                 @click=${() => this.setConsent(!on)}
                 class="relative inline-flex h-6 w-11 shrink-0 items-center rounded-full transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-malibu-blue/50 disabled:opacity-60 ${on
                   ? "bg-malibu-blue shadow-[var(--shadow-malibu-blue-pill)]"
@@ -258,7 +266,9 @@ export class AccountSettingsPanel extends LitElement {
 
   private async setConsent(consented: boolean): Promise<void> {
     const consent = this.player?.marketingConsent;
-    if (!consent || this.consentBusy) return;
+    // No email to subscribe means no consent request to make — belt-and-
+    // braces alongside the `disabled` attribute on the Steam-no-email toggle.
+    if (!consent || !consent.hasEmail || this.consentBusy) return;
     const previous = consent.consented;
     const next = consented ? "approved" : "denied";
     if (previous === next) return;

--- a/tests/client/components/AccountSettingsPanel.test.ts
+++ b/tests/client/components/AccountSettingsPanel.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AccountSettingsPanel } from "../../../src/client/components/AccountSettingsPanel";
+import type { UserMeResponse } from "../../../src/core/ApiSchemas";
+
+type UserMePlayer = UserMeResponse["player"];
+type UserMeUser = UserMeResponse["user"];
+
+// Mock translateText as identity so key assertions are exact, mirroring
+// AccountModal.rendering.test.ts.
+vi.mock("../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+}));
+
+vi.mock("../../../src/client/Api", () => ({
+  setMarketingConsent: vi.fn(async () => true),
+  deleteAccount: vi.fn(async () => ({ ok: true })),
+}));
+
+vi.mock("../../../src/client/Auth", () => ({
+  clearLocalSession: vi.fn(),
+  linkGoogle: vi.fn(async () => true),
+  sendMagicLink: vi.fn(async () => true),
+}));
+
+function makePlayer(overrides: Partial<UserMePlayer> = {}): UserMePlayer {
+  return {
+    publicId: "test-player",
+    adfree: false,
+    unlimitedRanked: false,
+    canCreatePublicLobbies: false,
+    achievements: { singleplayerMap: [] },
+    friends: [],
+    subscription: null,
+    currency: { soft: 100, hard: 10 },
+    ...overrides,
+  } as UserMePlayer;
+}
+
+describe("AccountSettingsPanel — marketing-consent card", () => {
+  let panel: AccountSettingsPanel;
+
+  beforeEach(async () => {
+    if (!customElements.get("account-settings-panel")) {
+      customElements.define("account-settings-panel", AccountSettingsPanel);
+    }
+    panel = document.createElement(
+      "account-settings-panel",
+    ) as AccountSettingsPanel;
+    document.body.appendChild(panel);
+    await panel.updateComplete;
+  });
+
+  afterEach(() => {
+    document.body.removeChild(panel);
+    vi.clearAllMocks();
+  });
+
+  async function setState(
+    player: UserMePlayer,
+    user: UserMeUser,
+  ): Promise<void> {
+    panel.player = player;
+    panel.user = user;
+    await panel.updateComplete;
+  }
+
+  function findSwitch(): HTMLButtonElement | null {
+    return panel.querySelector(
+      'button[role="switch"]',
+    ) as HTMLButtonElement | null;
+  }
+
+  // The bug (OPE-397): Steam-primary AND no email hits both suppressions at
+  // once, collapsing the card's only control to nothing.
+  it("renders the toggle DISABLED, with Steam-specific copy, for a Steam-primary user with no email", async () => {
+    await setState(
+      makePlayer({
+        marketingConsent: { consented: "no_response", hasEmail: false },
+      }),
+      { steam: { steamId: "1", personaName: "P", avatarUrl: null } },
+    );
+
+    const text = panel.textContent ?? "";
+    // The description must not instruct a remedy the build doesn't offer.
+    expect(text).toContain("account_modal.marketing_no_email_steam");
+    // Not the generic "link an email" copy — that instructs a remedy this
+    // build doesn't offer to a Steam-primary player. (Its key is a prefix of
+    // the Steam-specific one asserted above, so this can't use toContain.)
+    expect(text).not.toMatch(/marketing_no_email(?!_steam)/);
+    expect(text).not.toContain("account_modal.marketing_desc");
+
+    // The toggle is present (not omitted) and disabled — the row stays
+    // visually intact instead of collapsing to text.
+    const toggle = findSwitch();
+    expect(toggle).toBeTruthy();
+    expect(toggle!.disabled).toBe(true);
+
+    // No email-binding fallback either — Steam is primary, no linking UI.
+    expect(panel.querySelector("input[type=email]")).toBeNull();
+  });
+
+  // Clicking a disabled control should never fire a consent request — belt
+  // and braces alongside the `disabled` attribute (setConsent's own guard).
+  it("does not call setMarketingConsent when the disabled Steam toggle is clicked", async () => {
+    const { setMarketingConsent } = await import("../../../src/client/Api");
+    await setState(
+      makePlayer({
+        marketingConsent: { consented: "no_response", hasEmail: false },
+      }),
+      { steam: { steamId: "1", personaName: "P", avatarUrl: null } },
+    );
+
+    findSwitch()!.click();
+    await panel.updateComplete;
+
+    expect(setMarketingConsent).not.toHaveBeenCalled();
+  });
+
+  // Unaffected combination: has email → the working, enabled toggle.
+  it("renders a working enabled toggle when the account has an email", async () => {
+    const { setMarketingConsent } = await import("../../../src/client/Api");
+    await setState(
+      makePlayer({
+        marketingConsent: { consented: "denied", hasEmail: true },
+      }),
+      { email: "player@example.com" },
+    );
+
+    const text = panel.textContent ?? "";
+    expect(text).toContain("account_modal.marketing_desc");
+    expect(text).not.toContain("account_modal.marketing_no_email");
+
+    const toggle = findSwitch();
+    expect(toggle).toBeTruthy();
+    expect(toggle!.disabled).toBe(false);
+
+    toggle!.click();
+    await panel.updateComplete;
+    expect(setMarketingConsent).toHaveBeenCalledWith(true);
+  });
+
+  // Unaffected combination: no email, NOT Steam-primary → existing
+  // email-binding UI (magic link + Google), toggle stays omitted.
+  it("keeps the email-binding UI (no toggle) for a no-email, non-Steam user", async () => {
+    await setState(
+      makePlayer({
+        marketingConsent: { consented: "no_response", hasEmail: false },
+      }),
+      {
+        discord: {
+          id: "1",
+          avatar: null,
+          username: "player",
+          global_name: null,
+          discriminator: "0",
+        },
+      },
+    );
+
+    const text = panel.textContent ?? "";
+    expect(text).toContain("account_modal.marketing_no_email");
+    expect(text).not.toContain("account_modal.marketing_no_email_steam");
+
+    // No toggle at all in this branch — unchanged from before OPE-397.
+    expect(findSwitch()).toBeNull();
+    expect(panel.querySelector("input[type=email]")).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
Fixes OPE-397: a Steam-only player's "Email updates" card rendered a title, a description telling them to link an email, and then blank space where the toggle should be. Two independent suppressions in `AccountSettingsPanel.renderMarketingCard()` met — no verified email hides the consent toggle, and Steam-as-primary-identity hides the email-binding fallback — and a Steam launch is the *default* no-email state, not an edge case.

- The consent toggle now renders **disabled** (not omitted) for the Steam-primary + no-email case, so the row stays visually intact.
- The description for that case now states the actual situation — no email on file for a Steam account — instead of instructing a remedy (linking an email) that this build doesn't offer to Steam players.
- Every other combination is unchanged: has email → working toggle; no email and not Steam-primary → existing email-binding UI (magic link / Google).
- New translation key `account_modal.marketing_no_email_steam` added to `resources/lang/en.json` only (other languages come from Crowdin).

## Explicitly out of scope
The issue raises an open product question: should Steam players get *some* route to attach an email (the magic-link half of `renderEmailBinding()` has no Steam-specific problem, only the Google-link half does)? That's a real decision but not part of this fix — this PR only stops the copy pointing at an action with no affordance. Left for a follow-up.

## Test plan
- Added `tests/client/components/AccountSettingsPanel.test.ts` covering all four combinations, notably the Steam-primary/no-email case: disabled toggle rendered, Steam-specific copy shown, no email-binding UI, and clicking the disabled toggle does not call `setMarketingConsent` (guarded in `setConsent` too, belt-and-braces alongside the `disabled` attribute).
- `npx vitest tests/client/components/AccountSettingsPanel.test.ts --run` — 4/4 pass.
- `npx vitest tests/client/AccountModal.rendering.test.ts --run` — 18/18 pass (no regression in the embedding modal).
- `npx vitest tests/EnJsonSorted.test.ts tests/TranslationSystem.test.ts --run` — 4/4 pass (new key stays alphabetically sorted, source stays in sync).
- `npx tsc --noEmit -p .` — clean.
- `npx eslint` on changed files — clean.
- `npx prettier --check .` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqYfRtgGASp1TGynBosToq
