### PR TITLE
Seed desktop update state on connect so the multiplayer gate applies (OPE-396)

### DIFF
--- a/src/client/DesktopShell.ts
+++ b/src/client/DesktopShell.ts
@@ -131,6 +131,50 @@ export function desktopUpdate(): DesktopUpdateBridge | null {
   return desktop?.update ?? null;
 }
 
+let __updateState: DesktopUpdateState | null = null;
+
+/**
+ * The shell's current update state, or null before the first one has been
+ * published -- always the case on the web, where there is no bridge at all.
+ *
+ * This exists for the same reason getDesktopSessionState() does in Auth.ts,
+ * and it fixes the mirror-image bug (OPE-396). The bridge replays its current
+ * state to every new subscriber SYNCHRONOUSLY, so DesktopStatusBar -- the one
+ * subscriber, and therefore the one publisher of `desktop-update-state` --
+ * dispatches during its own upgrade. <game-mode-selector> cannot exist yet at
+ * that moment: it is rendered by <play-page> on a Lit microtask, which cannot
+ * run until module evaluation has already finished. The dispatch is one-shot,
+ * so a component that mounts afterwards never hears it and gates on null.
+ *
+ * That costs nothing on a cold launch (the updater is still `checking`, and
+ * every later state arrives as an ordinary change event), and everything when
+ * the renderer loads a document while the updater ALREADY holds `staged` --
+ * the host navigating to the next lobby, a post-purchase refresh, a failed
+ * apply(). There the replay was the only delivery, so the bar correctly reads
+ * "Update ready" while the gate silently never applies.
+ *
+ * Seeding at the consumer rather than re-dispatching later at the publisher:
+ * a second dispatch would only move the race to whoever mounts after IT.
+ */
+export function getDesktopUpdateState(): DesktopUpdateState | null {
+  return __updateState;
+}
+
+/**
+ * Caches `state` and broadcasts it, so entry-point components can gate
+ * without each opening its own subscription to the bridge. Mirrors Auth.ts's
+ * setSessionState: cache first, then dispatch, so a listener that reads the
+ * accessor during the event sees the value it was just handed.
+ *
+ * Only DesktopStatusBar calls this -- it owns the bridge subscription.
+ */
+export function publishDesktopUpdateState(state: DesktopUpdateState): void {
+  __updateState = state;
+  document.dispatchEvent(
+    new CustomEvent("desktop-update-state", { detail: state }),
+  );
+}
+
 /**
  * Whether multiplayer should be available in a given update state.
  *

--- a/src/client/GameModeSelector.ts
+++ b/src/client/GameModeSelector.ts
@@ -24,6 +24,7 @@ import {
 } from "./components/LobbyCard";
 import { crazyGamesSDK } from "./CrazyGamesSDK";
 import {
+  getDesktopUpdateState,
   isDesktopShell,
   multiplayerAllowed,
   multiplayerAllowedForSession,
@@ -175,6 +176,12 @@ export class GameModeSelector extends LitElement {
     );
     document.addEventListener("userMeResponse", this.onUserMe);
     if (isDesktopShell()) {
+      // Seed BOTH from their current values. This element is rendered by
+      // <play-page> on a Lit microtask, so it cannot exist yet when the status
+      // bar dispatches the update bridge's synchronous replay -- without the
+      // seed the update half of the gate stays null and silently never
+      // applies (OPE-396).
+      this.desktopUpdateState = getDesktopUpdateState();
       this.desktopSessionState = getDesktopSessionState();
     }
     document.addEventListener(

--- a/src/client/components/DesktopStatusBar.ts
+++ b/src/client/components/DesktopStatusBar.ts
@@ -6,6 +6,7 @@ import {
   desktopUpdate,
   isDesktopShell,
   multiplayerAllowedForSession,
+  publishDesktopUpdateState,
   type DesktopSessionState,
   type DesktopUpdateState,
 } from "../DesktopShell";
@@ -79,10 +80,12 @@ export class DesktopStatusBar extends LitElement {
       this.unsubscribe = bridge.subscribe((state) => {
         this.updateState = state;
         // Broadcast so entry-point components can gate without each opening
-        // its own subscription to the bridge.
-        document.dispatchEvent(
-          new CustomEvent("desktop-update-state", { detail: state }),
-        );
+        // its own subscription to the bridge. Routed through DesktopShell so
+        // the value is also CACHED: the bridge replays synchronously during
+        // this element's upgrade, long before <game-mode-selector> exists,
+        // and a component that mounts afterwards has nothing but the cache to
+        // read (OPE-396).
+        publishDesktopUpdateState(state);
       });
     }
 

--- a/src/client/components/DetailedGameViewModal.ts
+++ b/src/client/components/DetailedGameViewModal.ts
@@ -7,6 +7,7 @@ import { PublicGameInfo, PublicGames } from "../../core/Schemas";
 import { getDesktopSessionState } from "../Auth";
 import { crazyGamesSDK } from "../CrazyGamesSDK";
 import {
+  getDesktopUpdateState,
   isDesktopShell,
   type DesktopSessionState,
   type DesktopUpdateState,
@@ -179,6 +180,10 @@ export class DetailedGameViewModal extends BaseModal {
     );
     document.addEventListener("userMeResponse", this.onUserMe);
     if (isDesktopShell()) {
+      // Seed BOTH from their current values -- this modal mounts well after
+      // the update bridge's synchronous replay has already been dispatched
+      // and lost, so without the seed its join() gate sees null (OPE-396).
+      this.desktopUpdateState = getDesktopUpdateState();
       this.desktopSessionState = getDesktopSessionState();
     }
     document.addEventListener(

--- a/tests/DesktopUpdateStateSeeding.test.ts
+++ b/tests/DesktopUpdateStateSeeding.test.ts
@@ -1,0 +1,254 @@
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+  type Mock,
+} from "vitest";
+import { ClientEnv } from "../src/client/ClientEnv";
+import type {
+  DesktopUpdateBridge,
+  DesktopUpdateState,
+} from "../src/client/DesktopShell";
+import { GameMapType, GameMode } from "../src/core/game/Game";
+import type {
+  GameConfig,
+  PublicGameInfo,
+  PublicGames,
+} from "../src/core/Schemas";
+
+// Both consumers open a public-lobby WebSocket the moment they connect. jsdom
+// has no WebSocket worth talking to and this file is about the seed, not the
+// lobby list, so the socket is a no-op -- except for retaining the update
+// callback the real socket would drive off the wire, which is the only way a
+// lobby card ever renders.
+const { lobbiesCallbackRef } = vi.hoisted(() => ({
+  lobbiesCallbackRef: { current: null as ((g: PublicGames) => void) | null },
+}));
+
+vi.mock("../src/client/LobbySocket", () => ({
+  PublicLobbySocket: class {
+    constructor(onUpdate: (g: PublicGames) => void) {
+      lobbiesCallbackRef.current = onUpdate;
+    }
+    start(): void {}
+    stop(): void {}
+  },
+}));
+
+// Each registers its custom element as a side effect. The status bar is
+// imported FIRST on purpose: that is the order Main.ts uses, and it is the
+// whole reason the bug exists.
+import { DesktopStatusBar } from "../src/client/components/DesktopStatusBar";
+import { DetailedGameViewModal } from "../src/client/components/DetailedGameViewModal";
+import "../src/client/GameModeSelector";
+
+/**
+ * OPE-396. The sibling wiring tests mount a consumer and THEN dispatch
+ * `desktop-update-state` by hand, which proves each entry point consults the
+ * gate. By construction they cannot see the delivery failure underneath it:
+ * the shell bridge replays its current state to a new subscriber
+ * SYNCHRONOUSLY, so DesktopStatusBar -- the sole subscriber and therefore the
+ * sole publisher of that event -- dispatches during its own upgrade, before
+ * <game-mode-selector> can exist. The dispatch is one-shot, so a consumer that
+ * mounts afterwards used to gate on `null` forever: the bar read
+ * "Update ready -- Reload" while multiplayer stayed wide open, which is
+ * exactly the pair of symptoms reported from the Steam Playtest.
+ *
+ * So every test here expresses the opposite order to those files: publish
+ * first, through the real bridge and the real status bar, then mount.
+ */
+let wiggle: Mock<() => void>;
+let joinOpen: ReturnType<typeof vi.fn>;
+let hostOpen: ReturnType<typeof vi.fn>;
+let joinLobby: ReturnType<typeof vi.fn>;
+
+function stub(tag: string, methods: Record<string, unknown>): void {
+  const el = document.createElement(tag);
+  Object.assign(el, methods);
+  document.body.appendChild(el);
+}
+
+function publicLobby(gameID: string): PublicGameInfo {
+  return {
+    gameID,
+    numClients: 3,
+    publicGameType: "ffa",
+    gameConfig: {
+      gameMap: GameMapType.World,
+      gameMode: GameMode.FFA,
+      maxPlayers: 8,
+    } as unknown as GameConfig,
+  };
+}
+
+/**
+ * Mounts the real <desktop-status-bar> against a bridge that ALREADY holds
+ * `state`, replaying it synchronously on subscribe exactly as
+ * openfront-desktop's updater does. The publish therefore happens here, during
+ * the bar's upgrade -- before any consumer in these tests exists.
+ */
+function publishBeforeAnyConsumerMounts(state: DesktopUpdateState): void {
+  const bridge: DesktopUpdateBridge = {
+    subscribe(cb) {
+      cb(state); // the synchronous replay -- see updater.ts's subscribe()
+      return () => {};
+    },
+    apply: async () => {},
+    retry: async () => {},
+  };
+  (window as { openfrontDesktop?: unknown }).openfrontDesktop = {
+    update: bridge,
+  };
+  document.body.appendChild(document.createElement("desktop-status-bar"));
+}
+
+/** Mounts <game-mode-selector> and lets it render. */
+async function mountSelector(): Promise<
+  HTMLElement & { updateComplete: Promise<unknown> }
+> {
+  const selector = document.createElement(
+    "game-mode-selector",
+  ) as HTMLElement & { updateComplete: Promise<unknown> };
+  document.body.appendChild(selector);
+  await selector.updateComplete;
+  return selector;
+}
+
+/** Mounts <detailed-view-modal> with one rendered lobby card. */
+async function mountModal(): Promise<
+  HTMLElement & { updateComplete: Promise<unknown> }
+> {
+  // `new DetailedGameViewModal()` rather than document.createElement: the
+  // constructor sets `this.id`, which jsdom's spec-strict createElement path
+  // rejects. See DetailedGameViewModalGatingWiring.test.ts.
+  const modal = new DetailedGameViewModal() as unknown as HTMLElement & {
+    updateComplete: Promise<unknown>;
+  };
+  document.body.appendChild(modal);
+  await modal.updateComplete;
+  lobbiesCallbackRef.current?.({
+    serverTime: Date.now(),
+    games: { ffa: [publicLobby("public-1")] },
+  });
+  await modal.updateComplete;
+  return modal;
+}
+
+/** Clicks every button a component renders. Returns how many it clicked. */
+function clickEveryButton(host: HTMLElement): number {
+  const buttons = Array.from(host.querySelectorAll("button"));
+  for (const button of buttons) button.click();
+  return buttons.length;
+}
+
+const STAGED: DesktopUpdateState = { status: "staged", bytes: 10, total: 10 };
+const CURRENT: DesktopUpdateState = { status: "current", bytes: 0, total: 0 };
+
+beforeEach(() => {
+  // GameModeSelector's connectedCallback reads ClientEnv.gameCreationRate(),
+  // which throws without the config the server injects into index.html.
+  window.BOOTSTRAP_CONFIG = {
+    gameEnv: "dev",
+    numWorkers: 1,
+    turnstileSiteKey: "",
+    jwtAudience: "test",
+    instanceId: "test",
+    gitCommit: "test",
+  };
+  ClientEnv.reset();
+
+  joinOpen = vi.fn();
+  hostOpen = vi.fn();
+  joinLobby = vi.fn();
+  stub("join-lobby-modal", { open: joinOpen });
+  stub("host-lobby-modal", { open: hostOpen });
+  stub("single-player-modal", { open: vi.fn() });
+  // The real bar is the publisher here, so spy on the real method rather than
+  // standing in a fake element the way the wiring tests do.
+  wiggle = vi.fn<() => void>();
+  vi.spyOn(DesktopStatusBar.prototype, "wiggle").mockImplementation(wiggle);
+
+  document.addEventListener("join-lobby", joinLobby as EventListener);
+  lobbiesCallbackRef.current = null;
+});
+
+afterEach(() => {
+  document.removeEventListener("join-lobby", joinLobby as EventListener);
+  document.body.innerHTML = "";
+  (window as { openfrontDesktop?: unknown }).openfrontDesktop = undefined;
+  window.BOOTSTRAP_CONFIG = undefined;
+  ClientEnv.reset();
+  vi.restoreAllMocks();
+});
+
+describe("a consumer mounting AFTER the update state was published", () => {
+  it("gates every GameModeSelector entry point on a staged update", async () => {
+    publishBeforeAnyConsumerMounts(STAGED);
+
+    const selector = await mountSelector();
+
+    // No `desktop-update-state` event is dispatched anywhere below: the only
+    // one this document will ever see already fired, during the status bar's
+    // upgrade above. The seed is the sole path by which the selector can know.
+    expect(clickEveryButton(selector)).toBeGreaterThan(0);
+
+    expect(joinOpen).not.toHaveBeenCalled();
+    expect(hostOpen).not.toHaveBeenCalled();
+    // Refusing silently would look like a broken button.
+    expect(wiggle).toHaveBeenCalled();
+  });
+
+  it("marks the selector's multiplayer buttons aria-disabled", async () => {
+    publishBeforeAnyConsumerMounts(STAGED);
+
+    const selector = await mountSelector();
+
+    expect(
+      selector.querySelectorAll('button[aria-disabled="true"]').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("still lets the selector through when the state published was healthy", async () => {
+    // The control. Without it, a selector that gated for some unrelated reason
+    // -- or never mounted at all -- would pass the assertions above.
+    publishBeforeAnyConsumerMounts(CURRENT);
+
+    const selector = await mountSelector();
+    expect(clickEveryButton(selector)).toBeGreaterThan(0);
+
+    expect(joinOpen).toHaveBeenCalled();
+    expect(hostOpen).toHaveBeenCalled();
+    expect(wiggle).not.toHaveBeenCalled();
+  });
+
+  it("gates DetailedGameViewModal's join() on a staged update", async () => {
+    publishBeforeAnyConsumerMounts(STAGED);
+
+    const modal = await mountModal();
+    const card = modal.querySelector<HTMLButtonElement>(
+      '[data-lobby-slot="public-1"] button.group',
+    );
+    expect(card).not.toBeNull();
+    card!.click();
+
+    expect(joinLobby).not.toHaveBeenCalled();
+    expect(wiggle).toHaveBeenCalled();
+  });
+
+  it("still lets the modal through when the state published was healthy", async () => {
+    publishBeforeAnyConsumerMounts(CURRENT);
+
+    const modal = await mountModal();
+    const card = modal.querySelector<HTMLButtonElement>(
+      '[data-lobby-slot="public-1"] button.group',
+    );
+    expect(card).not.toBeNull();
+    card!.click();
+
+    expect(joinLobby).toHaveBeenCalled();
+    expect(joinLobby.mock.calls[0][0].detail.gameID).toBe("public-1");
+  });
+});


### PR DESCRIPTION
Fixes [OPE-396](https://linear.app/openfront/issue/OPE-396/multiplayer-gate-misses-a-staged-update-because-no-consumer-is-seeded).

## The problem

The gating code is present and correct. The *delivery* of the state to the gate is what was broken.

`DesktopStatusBar` is the only publisher of `desktop-update-state`, and the shell's update bridge replays its current state to every new subscriber **synchronously** (`openfront-desktop src/main/update/updater.ts:97`). So the bar dispatches during its own upgrade. No consumer can exist yet at that moment:

- `Main.ts:116` imports `./components/DesktopStatusBar`, `Main.ts:130` imports `./components/PlayPage` — the bar is defined and upgraded first.
- `<game-mode-selector>` is not in `index.html` at all; `<play-page>` renders it, and Lit schedules first render as a microtask, which cannot run until module evaluation (and the bar's synchronous dispatch) has already finished.

The dispatch is one-shot, so `desktopUpdateState` stayed `null` and `shouldBlockMultiplayerAction(null, session)` skipped the update half of the gate entirely.

This costs nothing on a cold launch — the updater is still `checking`, and `downloading`/`staged` arrive later as ordinary change events. It breaks when the renderer loads a document while the updater **already holds** `staged`: the host navigating to the next lobby, the post-purchase full-page refresh (OPE-338), a `bridge.apply()` whose activation did not take. There the replay was the only delivery, so the bar correctly reads "Update ready — Reload" while the gate silently never applies — exactly the pair of symptoms from Evan's Playtest session.

## The fix

Session state already had `getDesktopSessionState()` for precisely this reason; update state had no equivalent. This adds one:

- `src/client/DesktopShell.ts` — module-level cache plus `getDesktopUpdateState()` accessor and `publishDesktopUpdateState()`, mirroring Auth.ts's `setSessionState` (cache first, then dispatch).
- `src/client/components/DesktopStatusBar.ts` — the subscribe callback routes its broadcast through that publisher instead of dispatching inline, so the value is cached as well as broadcast.
- `src/client/GameModeSelector.ts` and `src/client/components/DetailedGameViewModal.ts` — seed `desktopUpdateState` in `connectedCallback` alongside the session seed that is already there.

Fixed at the consumer, not by re-dispatching later at the publisher: a second dispatch would only move the race to whoever mounts after *that*.

Scope note: item 3 of the issue — whether "update required" deserves stronger visual treatment than the bottom bar — is a design decision and is deliberately not in this PR.

## Test

`tests/DesktopUpdateStateSeeding.test.ts`. The existing wiring tests mount a consumer and *then* dispatch `desktop-update-state` by hand, so by construction they can never exercise a state published before the component existed. This one expresses the opposite order: it mounts the real `<desktop-status-bar>` against a real-shaped bridge that already holds `staged` and replays synchronously on subscribe, and only then mounts each consumer. No event is dispatched after the mount — the seed is the sole path by which the consumer can know.

Verified against the unfixed code (`git stash push -- src`): **3 of the 5 cases fail**, and the two healthy-state controls pass either way, which is what makes them controls.

```
FAIL  gates every GameModeSelector entry point on a staged update
FAIL  marks the selector's multiplayer buttons aria-disabled
FAIL  gates DetailedGameViewModal's join() on a staged update
```

With the fix, all 5 pass. Also green: `tests/GameModeSelectorGatingWiring.test.ts`, `tests/DetailedGameViewModalGatingWiring.test.ts`, `tests/GameModeSelectorGating.test.ts`, `tests/DesktopStatusBar.test.ts`, `tests/DesktopShell*.test.ts`, `tests/GameModeSelectorRestart.test.ts` (100 tests), plus `tsc --noEmit`, `npm run lint`, and `prettier --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqYfRtgGASp1TGynBosToq
