### PR TITLE
Say Steam doesn't share the email, not that none exists (OPE-397)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -67,7 +67,7 @@
     "manage_subscription_on_web": "Manage or change your billing on the OpenFront website.",
     "marketing_desc": "Occasional news, events, and game updates. Unsubscribe anytime.",
     "marketing_no_email": "Link an email to your account to subscribe to updates.",
-    "marketing_no_email_steam": "Steam accounts don't have an email on file, so there's nothing to send updates to yet.",
+    "marketing_no_email_steam": "Steam doesn't share your email address with us, so there's nothing to send updates to.",
     "marketing_title": "Email updates",
     "no_games": "No games played yet.",
     "no_stats": "No stats available yet. Play some games to start tracking.",


### PR DESCRIPTION
Follow-up to #5333 (OPE-397), copy only — one string value, no behaviour change.

The Steam-only marketing-consent line read:

> Steam accounts don't have an email on file, so there's nothing to send updates to yet.

That isn't accurate. A Steam account *does* have an email address — Valve holds it and simply doesn't pass it to us. As written, a player could reasonably conclude we're wrong about their account rather than about our own access to it.

Now reads:

> Steam doesn't share your email address with us, so there's nothing to send updates to.

`account_modal.marketing_no_email_steam` in `resources/lang/en.json` only. The key was added in #5333 and Crowdin hasn't picked it up yet, so no translations are invalidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqYfRtgGASp1TGynBosToq
