### PR TITLE
Alt-view always shows your own relations, not the hovered player's

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -834,8 +834,6 @@
     "advanced_label": "Advanced settings",
     "alt_view_fill_alpha_desc": "How opaque the relation-colored territory fill is while holding the alt-view key (Space)",
     "alt_view_fill_alpha_label": "Alt-view fill opacity",
-    "alt_view_hover_perspective_desc": "In alt-view (Space), hovering another player shows their allies and embargoes instead of yours",
-    "alt_view_hover_perspective_label": "Alt-view hover perspective",
     "background_color_desc": "Color of the area outside the map and impassable terrain.",
     "background_color_label": "Background color",
     "black": "Black",

--- a/src/client/hud/layers/GraphicsSettingsModal.ts
+++ b/src/client/hud/layers/GraphicsSettingsModal.ts
@@ -510,19 +510,6 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     this.patchMapOverlay({ territoryAlpha: value });
   }
 
-  private currentAltViewHoverPerspective(): boolean {
-    return (
-      this.userSettings.graphicsOverrides().altView?.hoverPerspective ??
-      renderDefaults.altView.hoverPerspective
-    );
-  }
-
-  private onToggleAltViewHoverPerspective() {
-    this.patchAltView({
-      hoverPerspective: !this.currentAltViewHoverPerspective(),
-    });
-  }
-
   private onAltViewFillAlphaChange(event: Event) {
     const value = parseFloat((event.target as HTMLInputElement).value);
     this.patchAltView({ fillAlpha: value });
@@ -1042,7 +1029,6 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
     const territorySat = this.currentTerritorySat();
     const territoryAlpha = this.currentTerritoryAlpha();
     const altViewFillAlpha = this.currentAltViewFillAlpha();
-    const altViewHoverPerspective = this.currentAltViewHoverPerspective();
     const coordinateGridOpacity = this.currentCoordinateGridOpacity();
     const railDrawDistance = RAIL_ZOOM_MAX - this.currentRailMinZoom();
     const railThickness = this.currentRailThickness();
@@ -1523,27 +1509,6 @@ export class GraphicsSettingsModal extends LitElement implements Controller {
           ${altViewFillAlpha.toFixed(2)}
         </div>
       </div>
-
-      <button
-        class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"
-        @click=${this.onToggleAltViewHoverPerspective}
-      >
-        <div class="flex-1">
-          <div class="font-medium">
-            ${translateText(
-              "graphics_setting.alt_view_hover_perspective_label",
-            )}
-          </div>
-          <div class="text-sm text-slate-400">
-            ${translateText("graphics_setting.alt_view_hover_perspective_desc")}
-          </div>
-        </div>
-        <div class="text-sm text-slate-400">
-          ${altViewHoverPerspective
-            ? translateText("user_setting.on")
-            : translateText("user_setting.off")}
-        </div>
-      </button>
 
       <div
         class="flex gap-3 items-center w-full text-left p-3 hover:bg-slate-700 rounded-sm text-white transition-colors"

--- a/src/client/render/gl/GraphicsOverrides.ts
+++ b/src/client/render/gl/GraphicsOverrides.ts
@@ -57,9 +57,6 @@ export const GraphicsOverridesSchema = z
         // Opacity of the translucent relation-colored territory fill shown
         // while holding the alt-view key (0 = borders only, 1 = opaque).
         fillAlpha: z.number(),
-        // When true, hovering another player's territory shows alt-view from
-        // their diplomacy; false always uses your own.
-        hoverPerspective: z.boolean(),
       })
       .partial(),
     affiliation: z

--- a/src/client/render/gl/RenderOverrides.ts
+++ b/src/client/render/gl/RenderOverrides.ts
@@ -107,9 +107,6 @@ export function applyGraphicsOverrides(
   if (overrides.altView?.fillAlpha !== undefined) {
     settings.altView.fillAlpha = overrides.altView.fillAlpha;
   }
-  if (overrides.altView?.hoverPerspective !== undefined) {
-    settings.altView.hoverPerspective = overrides.altView.hoverPerspective;
-  }
   if (overrides.affiliation?.selfColor !== undefined) {
     applyHexColor(overrides.affiliation.selfColor, (r, g, b) => {
       settings.affiliation.selfR = r;

--- a/src/client/render/gl/RenderSettings.ts
+++ b/src/client/render/gl/RenderSettings.ts
@@ -409,11 +409,6 @@ export interface RenderSettings {
     recolorStructures: boolean;
     /** Opacity of the translucent affiliation-colored territory fill. */
     fillAlpha: number;
-    /**
-     * When true, hovering another player's territory recolors alt-view from
-     * that player's diplomacy; when false, always use the local player's.
-     */
-    hoverPerspective: boolean;
   };
   tileDrip: {
     /**

--- a/src/client/render/gl/Renderer.ts
+++ b/src/client/render/gl/Renderer.ts
@@ -1095,7 +1095,6 @@ export class GPURenderer {
     this.namePass.setHighlightOwner(ownerID);
     this.structurePass.setHighlightOwner(ownerID);
     this.railroadPass.setHighlightOwner(ownerID);
-    this.affiliationPalette.setHoveredOwner(ownerID);
   }
   setMouseWorldPos(x: number, y: number): void {
     this.namePass.setMouseWorldPos(x, y);

--- a/src/client/render/gl/debug/Layout.ts
+++ b/src/client/render/gl/debug/Layout.ts
@@ -839,7 +839,6 @@ export function buildTree(s: RenderSettings, d: RenderSettings): DebugNode[] {
       slider(s.altView, "gridFontSize", d.altView, 6, 32, 1, "Grid Font Size"),
       toggle(s.altView, "recolorStructures", d.altView, "Recolor Structures"),
       slider(s.altView, "fillAlpha", d.altView, 0, 1, 0.01, "Fill Alpha"),
-      toggle(s.altView, "hoverPerspective", d.altView, "Hover Perspective"),
     ]),
 
     folder(

--- a/src/client/render/gl/render-settings.json
+++ b/src/client/render/gl/render-settings.json
@@ -347,7 +347,6 @@
   "altView": {
     "gridFontSize": 24,
     "fillAlpha": 0.15,
-    "hoverPerspective": true,
     "recolorStructures": true
   },
   "tileDrip": {

--- a/src/client/render/gl/utils/Affiliation.ts
+++ b/src/client/render/gl/utils/Affiliation.ts
@@ -5,10 +5,9 @@
  *   Row 0: border colors (4-state: self/ally/neutral/embargo)
  *   Row 1: unit colors (3-state: self/ally/enemy)
  *
- * Colors are computed from the perspective of the hovered player when the
- * cursor is over someone else's territory, otherwise the local player.
+ * Colors are computed from the local player's perspective.
  *
- * Rebuilt when the perspective or relationship data changes.
+ * Rebuilt when the local player or relationship data changes.
  */
 
 import type { RenderSettings } from "../RenderSettings";
@@ -31,7 +30,6 @@ export class AffiliationPalette {
 
   // Cached inputs for rebuilding
   private localPlayerID = 0;
-  private hoveredOwnerID = 0;
   private relationData: Uint8Array | null = null;
   private relationSize = 0;
 
@@ -63,23 +61,6 @@ export class AffiliationPalette {
     this.rebuild();
   }
 
-  /**
-   * Hovered tile owner (0 = none/water). A non-zero owner other than the
-   * local player becomes the perspective the colors are computed from.
-   */
-  setHoveredOwner(id: number): void {
-    if (id === this.hoveredOwnerID) return;
-    const before = this.perspective();
-    this.hoveredOwnerID = id;
-    if (this.perspective() !== before) this.rebuild();
-  }
-
-  private perspective(): number {
-    return this.settings.altView.hoverPerspective && this.hoveredOwnerID > 0
-      ? this.hoveredOwnerID
-      : this.localPlayerID;
-  }
-
   updateRelations(data: Uint8Array, size: number): void {
     this.relationData = data;
     this.relationSize = size;
@@ -107,7 +88,7 @@ export class AffiliationPalette {
 
   private rebuild(): void {
     const d = this.cpuData;
-    const lp = this.perspective();
+    const lp = this.localPlayerID;
     const rel = this.relationData;
     const rs = this.relationSize;
 

--- a/tests/GraphicsOverrides.test.ts
+++ b/tests/GraphicsOverrides.test.ts
@@ -74,15 +74,6 @@ describe("GraphicsOverridesSchema", () => {
       GraphicsOverridesSchema.safeParse({ altView: { fillAlpha: "faint" } })
         .success,
     ).toBe(false);
-    expect(
-      GraphicsOverridesSchema.safeParse({
-        altView: { hoverPerspective: false },
-      }).success,
-    ).toBe(true);
-    expect(
-      GraphicsOverridesSchema.safeParse({ altView: { hoverPerspective: "no" } })
-        .success,
-    ).toBe(false);
   });
 
   test("accepts partial railroad overrides", () => {
@@ -387,13 +378,6 @@ describe("applyGraphicsOverrides", () => {
     expect(gen({}).altView.fillAlpha).toBe(
       createRenderSettings().altView.fillAlpha,
     );
-  });
-
-  test("applies altView.hoverPerspective override (default on)", () => {
-    expect(gen({}).altView.hoverPerspective).toBe(true);
-    expect(
-      gen({ altView: { hoverPerspective: false } }).altView.hoverPerspective,
-    ).toBe(false);
   });
 
   test("mapOverlay override leaves other mapOverlay fields at defaults", () => {


### PR DESCRIPTION
## Summary
- Removes the alt-view hover-perspective behavior introduced in #5162: hovering another player's territory no longer recolors alt-view from that player's diplomacy. The affiliation palette is now always built from the local player's relations.
- Deletes the feature entirely rather than defaulting it off: the `altView.hoverPerspective` render setting, its graphics override (schema + apply), the "Alt-view hover perspective" toggle in Graphics Settings, the debug-panel toggle, and the `setHoveredOwner` push from `Renderer.setHighlightOwner`.
- The translucent relation-colored fill and its opacity slider from the same PR are untouched.
- Users with `hoverPerspective` saved in their graphics overrides are unaffected — Zod strips unknown keys on parse. The stale `alt_view_hover_perspective_*` strings in non-English language files are left for Crowdin to sync out.

## Test plan
- `npx tsc --noEmit` clean, `npm run lint` clean.
- `npx vitest tests/GraphicsOverrides.test.ts tests/GraphicsPresets.test.ts --run` (59 tests) and `tests/client/graphics` (77 tests) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)