### PR TITLE
Hold the tutorial's spawn step until the multiplayer spawn timer ends

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -1959,6 +1959,7 @@
       "send_boat": "Boats send your troops across water. Right-click an enemy coastline across the water to open the radial menu, then select the boat.",
       "silo_loading": "Your Missile Silo is loading — a nuke can be launched once it's fully ready.",
       "spawn": "Click anywhere on the map to pick where you spawn.",
+      "spawn_wait": "Spot picked! You can still move it until the timer runs out — the game starts then.",
       "traitor_info": "Traitors get a large defense debuff for 30 seconds, so be careful.",
       "troop_rate": "This is your troop growth rate. Growth slows down and turns orange once your troops approach half of your max.",
       "troops": "Keep an eye on your troop count. Attacking with too few troops leaves you weak — let them regrow between attacks."

--- a/src/client/hud/Tutorial.ts
+++ b/src/client/hud/Tutorial.ts
@@ -29,6 +29,8 @@ export class TutorialHighlightEvent implements GameEvent {
 /** Snapshot of the player's state that the steps are evaluated against. */
 export interface TutorialContext {
   hasSpawned: boolean;
+  /** Multiplayer: the spawn timer is still running, so attacking is blocked. */
+  inSpawnPhase: boolean;
   /** Any outgoing attack, wilderness or player. */
   attacking: boolean;
   /** The attack ratio changed this tick (slider drag or hotkey). */
@@ -96,7 +98,9 @@ export interface TutorialStep {
 }
 
 export const TUTORIAL_STEPS: readonly TutorialStep[] = [
-  { id: "spawn", isDone: (c) => c.hasSpawned },
+  // Waits out the multiplayer spawn timer too: the next step asks the
+  // player to expand, which is impossible until the game actually starts.
+  { id: "spawn", isDone: (c) => c.hasSpawned && !c.inSpawnPhase },
   // Keeps the spawn ring on the player's territory so they can find it.
   // Any attack counts so a player who hits a bot first doesn't get stuck.
   {

--- a/src/client/hud/layers/TutorialPanel.ts
+++ b/src/client/hud/layers/TutorialPanel.ts
@@ -332,6 +332,7 @@ export class TutorialPanel extends LitElement implements Controller {
     this.lastAttackRatio = attackRatio;
     return {
       hasSpawned: player.hasSpawned(),
+      inSpawnPhase: this.game.inSpawnPhase(),
       attacking: attacks.length > 0,
       attackRatioMoved,
       boatsDisabled: this.game.config().isUnitDisabled(UnitType.TransportShip),
@@ -522,6 +523,11 @@ export class TutorialPanel extends LitElement implements Controller {
   }
 
   private stepText(step: TutorialStep, done: boolean): string {
+    // Multiplayer: the spot is picked but the spawn timer is still running,
+    // so don't keep asking the player to pick one.
+    if (!done && step.id === "spawn" && this.ctx?.hasSpawned) {
+      return translateText("tutorial.step.spawn_wait");
+    }
     // Boats and ports need shore; landlocked players are sent to get some.
     if (!done && COAST_STEPS.has(step.id) && this.hasCoast === false) {
       return translateText("tutorial.step.no_coast");

--- a/tests/Tutorial.test.ts
+++ b/tests/Tutorial.test.ts
@@ -8,6 +8,7 @@ import {
 function ctx(overrides: Partial<TutorialContext> = {}): TutorialContext {
   return {
     hasSpawned: false,
+    inSpawnPhase: false,
     attacking: false,
     attackRatioMoved: false,
     boatsDisabled: false,
@@ -86,6 +87,19 @@ describe("TutorialProgress", () => {
       }),
     );
     expect(p.current()?.id).toBe("buy_city");
+  });
+
+  it("holds the spawn step until the multiplayer spawn timer ends", () => {
+    const p = new TutorialProgress();
+    // Spot picked, but the spawn phase is still running: stay put.
+    for (let i = 0; i < 100; i++) {
+      p.update(ctx({ hasSpawned: true, inSpawnPhase: true }));
+    }
+    expect(p.current()?.id).toBe("spawn");
+    expect(p.stepDone()).toBe(false);
+
+    settle(p, ctx({ hasSpawned: true }));
+    expect(p.current()?.id).toBe("attack_wilderness");
   });
 
   it("lingers on a completed step before advancing", () => {


### PR DESCRIPTION
## Summary

- In multiplayer, the tutorial's spawn step completed as soon as the player picked a spot, so the next step ("expand into unclaimed land") appeared while the spawn timer was still running and attacking was blocked. The spawn step's `isDone` is now `hasSpawned && !inSpawnPhase`, so the expand instruction only shows once the game has actually started. Singleplayer is unaffected — the phase ends the moment you spawn.
- While the spot is picked but the timer is still counting down, the panel swaps the stale "click to pick where you spawn" text for a new `tutorial.step.spawn_wait` message (same override pattern as `no_coast`/`silo_loading`), which also tells the player they can still move their spawn.

## Test plan

- `npx vitest tests/Tutorial.test.ts --run` — 12/12 passing, including a new case holding `inSpawnPhase: true` for 100 ticks and asserting the step stays pending, then advances to `attack_wilderness` once the phase ends.
- `npm run lint`, `npx tsc --noEmit`, prettier check on touched files — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)