### PR TITLE
fix(client): key tribe-name refusals on the server's machine code (OPE-239)

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -640,14 +640,26 @@ export async function getMyTribeNames(): Promise<
 // because the token is the same either way.
 const DEBT_REFUSAL_CODE = "insufficient_balance_debt";
 
+// Stands in for a `code` key that is present but is not a usable machine key
+// (42, "", null). That is not the same as absent: the server did mean to send
+// a code, so falling back to matching its English would be reading a body we
+// have already established we do not understand. Nothing maps this, so every
+// caller lands on its generic failure. Not a valid identifier, so no code the
+// API could ever add collides with it.
+const UNUSABLE_REFUSAL_CODE = " unusable";
+
 // The stable machine key the API puts beside the prose `reason` in a 400
-// (OPE-389). `undefined` means either an older server that predates the
-// codes or a body that is not a refusal at all; both leave the caller on its
-// pre-OPE-389 string matching. Nothing but the presence and identity of this
-// key is trusted — it is never rendered or logged.
+// (OPE-389). `undefined` means the key is absent — an older server that
+// predates the codes, or a body that is not a refusal at all — and only that
+// leaves the caller on its pre-OPE-389 string matching. Nothing but the
+// presence and identity of this key is trusted: it is never rendered or
+// logged.
 function refusalCode(body: unknown): string | undefined {
-  const code = (body as { code?: unknown } | null | undefined)?.code;
-  return typeof code === "string" && code !== "" ? code : undefined;
+  if (body === null || typeof body !== "object" || !("code" in body)) {
+    return undefined;
+  }
+  const code = (body as { code?: unknown }).code;
+  return typeof code === "string" && code !== "" ? code : UNUSABLE_REFUSAL_CODE;
 }
 
 // Reads the debt refusal off a 400 body for every spend path. Returns
@@ -731,29 +743,35 @@ export type PurchaseTribeNameResult =
 // `no_letter` is renamed on the way in: the caller's `invalid_no_letter` is
 // pre-existing public API of this module, so the two vocabularies are mapped
 // here rather than one being churned to match the other.
-const TRIBE_NAME_REFUSAL_CODES: Record<
+//
+// A Map rather than an object literal because the key comes off the wire:
+// a plain lookup of "constructor" or "toString" returns something from
+// Object.prototype instead of undefined, and that is not a refusal code.
+const TRIBE_NAME_REFUSAL_CODES = new Map<
   string,
   "invalid_charset" | "invalid_no_letter" | "not_allowed"
-> = {
-  invalid_charset: "invalid_charset",
-  no_letter: "invalid_no_letter",
-  not_allowed: "not_allowed",
-};
+>([
+  ["invalid_charset", "invalid_charset"],
+  ["no_letter", "invalid_no_letter"],
+  ["not_allowed", "not_allowed"],
+]);
 
 // The same refusals keyed on the server's exact English, for a server that
 // predates OPE-389 and sends no `code`. Production can lag the API, so this
 // stays — but only as the fallback. If the API rewords one of these on an
 // older deployment the player gets the generic failure, which is the safe
 // direction.
-const LEGACY_TRIBE_NAME_REFUSAL_REASONS: Record<
+const LEGACY_TRIBE_NAME_REFUSAL_REASONS = new Map<
   string,
   "invalid_charset" | "invalid_no_letter" | "not_allowed"
-> = {
-  "Name may only contain letters, numbers, spaces, and ' - . _ ! ?":
+>([
+  [
+    "Name may only contain letters, numbers, spaces, and ' - . _ ! ?",
     "invalid_charset",
-  "Name must contain a letter": "invalid_no_letter",
-  "This name is not allowed": "not_allowed",
-};
+  ],
+  ["Name must contain a letter", "invalid_no_letter"],
+  ["This name is not allowed", "not_allowed"],
+]);
 // The length rule interpolates its bounds ("Name must be 3-24 characters"),
 // so on a pre-OPE-389 server — where the numbers are only in the prose — it
 // is matched by shape rather than listed. Anchored and digit-specific: a
@@ -775,9 +793,8 @@ function legacyTribeNameInvalidResult(
       max: Number(length[2]),
     };
   }
-  const code = LEGACY_TRIBE_NAME_REFUSAL_REASONS[reason];
-  if (code !== undefined) return { ok: false, code };
-  return undefined;
+  const code = LEGACY_TRIBE_NAME_REFUSAL_REASONS.get(reason);
+  return code === undefined ? undefined : { ok: false, code };
 }
 
 // A `length` bound off the body. The bounds are what the message says, so an
@@ -789,6 +806,18 @@ function refusalBound(body: unknown, field: "min" | "max"): number | undefined {
     : undefined;
 }
 
+// The `length` bounds as a range, or nothing. Checked as a pair rather than
+// one at a time: `{min: 24, max: 3}` is two individually plausible numbers
+// and one impossible range, and it would render as "24-3" at the player.
+function refusalBounds(
+  body: unknown,
+): { min: number; max: number } | undefined {
+  const min = refusalBound(body, "min");
+  const max = refusalBound(body, "max");
+  if (min === undefined || max === undefined || min > max) return undefined;
+  return { min, max };
+}
+
 // Why the name was refused, keyed on the server's machine `code` (OPE-389).
 // Returns undefined for a code this client does not know, which the caller
 // turns into a generic failure — the code is never rendered.
@@ -797,11 +826,8 @@ function tribeNameInvalidResult(
   body: unknown,
 ): PurchaseTribeNameResult | undefined {
   if (code === "length") {
-    const min = refusalBound(body, "min");
-    const max = refusalBound(body, "max");
-    if (min !== undefined && max !== undefined) {
-      return { ok: false, code: "length", min, max };
-    }
+    const bounds = refusalBounds(body);
+    if (bounds !== undefined) return { ok: false, code: "length", ...bounds };
     // The bounds ARE the message, so there is nothing to render without
     // them. The prose still carries them on every server that sends this
     // code, so read them out of it rather than showing a blank range. Only
@@ -819,7 +845,7 @@ function tribeNameInvalidResult(
           max: Number(parsed[2]),
         };
   }
-  const mapped = TRIBE_NAME_REFUSAL_CODES[code];
+  const mapped = TRIBE_NAME_REFUSAL_CODES.get(code);
   return mapped === undefined ? undefined : { ok: false, code: mapped };
 }
 

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -784,38 +784,45 @@ const TRIBE_NAME_LENGTH_REASON_RE = /^Name must be (\d+)-(\d+) characters$/;
 function legacyTribeNameInvalidResult(
   reason: string,
 ): PurchaseTribeNameResult | undefined {
-  const length = TRIBE_NAME_LENGTH_REASON_RE.exec(reason);
-  if (length !== null) {
-    return {
-      ok: false,
-      code: "length",
-      min: Number(length[1]),
-      max: Number(length[2]),
-    };
-  }
+  const bounds = proseBounds(reason);
+  if (bounds !== undefined) return { ok: false, code: "length", ...bounds };
   const code = LEGACY_TRIBE_NAME_REFUSAL_REASONS.get(reason);
   return code === undefined ? undefined : { ok: false, code };
 }
 
-// A `length` bound off the body. The bounds are what the message says, so an
+// A single `length` bound. The bounds are what the message says, so an
 // unusable one is not usable at all: a positive safe integer or nothing.
-function refusalBound(body: unknown, field: "min" | "max"): number | undefined {
-  const value = (body as Record<string, unknown> | null | undefined)?.[field];
-  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
-    ? value
-    : undefined;
+function isUsableBound(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
 }
 
-// The `length` bounds as a range, or nothing. Checked as a pair rather than
+// The `length` bounds as a range, or nothing. Validated as a pair rather than
 // one at a time: `{min: 24, max: 3}` is two individually plausible numbers
 // and one impossible range, and it would render as "24-3" at the player.
-function refusalBounds(
-  body: unknown,
+//
+// Every source of bounds goes through here, including the ones scraped out of
+// the prose. Digits in a sentence are not more trustworthy than numbers in a
+// field — "Name must be 24-3 characters" and a 30-digit bound both parse.
+function usableBounds(
+  min: unknown,
+  max: unknown,
 ): { min: number; max: number } | undefined {
-  const min = refusalBound(body, "min");
-  const max = refusalBound(body, "max");
-  if (min === undefined || max === undefined || min > max) return undefined;
+  if (!isUsableBound(min) || !isUsableBound(max) || min > max) return undefined;
   return { min, max };
+}
+
+// The bounds the API sends as fields (OPE-389).
+function bodyBounds(body: unknown): { min: number; max: number } | undefined {
+  const record = body as Record<string, unknown> | null | undefined;
+  return usableBounds(record?.min, record?.max);
+}
+
+// The bounds a pre-OPE-389 server only puts in the sentence.
+function proseBounds(reason: string): { min: number; max: number } | undefined {
+  const parsed = TRIBE_NAME_LENGTH_REASON_RE.exec(reason);
+  return parsed === null
+    ? undefined
+    : usableBounds(Number(parsed[1]), Number(parsed[2]));
 }
 
 // Why the name was refused, keyed on the server's machine `code` (OPE-389).
@@ -826,24 +833,24 @@ function tribeNameInvalidResult(
   body: unknown,
 ): PurchaseTribeNameResult | undefined {
   if (code === "length") {
-    const bounds = refusalBounds(body);
-    if (bounds !== undefined) return { ok: false, code: "length", ...bounds };
+    const fromBody = bodyBounds(body);
+    if (fromBody !== undefined) {
+      return { ok: false, code: "length", ...fromBody };
+    }
     // The bounds ARE the message, so there is nothing to render without
     // them. The prose still carries them on every server that sends this
-    // code, so read them out of it rather than showing a blank range. Only
-    // the length pattern is tried here: a `length` code sitting next to some
-    // other refusal's prose is a body we do not understand.
+    // code, so read them out of it rather than showing a blank range — and
+    // hold them to the same standard, since a sentence can carry an
+    // impossible range as easily as a field can. Only the length pattern is
+    // tried here: a `length` code sitting next to some other refusal's prose
+    // is a body we do not understand. Nothing usable either way is the
+    // caller's generic failure.
     const reason = (body as { reason?: unknown } | null | undefined)?.reason;
     if (typeof reason !== "string") return undefined;
-    const parsed = TRIBE_NAME_LENGTH_REASON_RE.exec(reason);
-    return parsed === null
+    const fromProse = proseBounds(reason);
+    return fromProse === undefined
       ? undefined
-      : {
-          ok: false,
-          code: "length",
-          min: Number(parsed[1]),
-          max: Number(parsed[2]),
-        };
+      : { ok: false, code: "length", ...fromProse };
   }
   const mapped = TRIBE_NAME_REFUSAL_CODES.get(code);
   return mapped === undefined ? undefined : { ok: false, code: mapped };

--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -634,7 +634,21 @@ export async function getMyTribeNames(): Promise<
 // The branch key the shared spend helper returns when a refund or chargeback
 // has left the wallet negative. A machine key, never prose: it must not reach
 // the player, which is what happened before the debt paths were handled.
-const DEBT_REFUSAL_REASON = "insufficient_balance_debt";
+//
+// Since OPE-389 the API sends it as `code`; before that the same token was
+// the `reason`, which is exactly why it used to be rendered. One constant
+// because the token is the same either way.
+const DEBT_REFUSAL_CODE = "insufficient_balance_debt";
+
+// The stable machine key the API puts beside the prose `reason` in a 400
+// (OPE-389). `undefined` means either an older server that predates the
+// codes or a body that is not a refusal at all; both leave the caller on its
+// pre-OPE-389 string matching. Nothing but the presence and identity of this
+// key is trusted — it is never rendered or logged.
+function refusalCode(body: unknown): string | undefined {
+  const code = (body as { code?: unknown } | null | undefined)?.code;
+  return typeof code === "string" && code !== "" ? code : undefined;
+}
 
 // Reads the debt refusal off a 400 body for every spend path. Returns
 // undefined when this is not that refusal, so the caller carries on matching
@@ -661,8 +675,16 @@ function parseDebtRefusal(
   | { ok: false; code: "debt"; debt: string }
   | { ok: false; code: "failed" }
   | undefined {
-  const reason = (body as { reason?: unknown } | null | undefined)?.reason;
-  if (reason !== DEBT_REFUSAL_REASON) return undefined;
+  const code = refusalCode(body);
+  // `code` when the server sends one, the old prose token only when it does
+  // not: production can lag the API, so the string match stays as a fallback
+  // and never as an override.
+  const isDebt =
+    code !== undefined
+      ? code === DEBT_REFUSAL_CODE
+      : (body as { reason?: unknown } | null | undefined)?.reason ===
+        DEBT_REFUSAL_CODE;
+  if (!isDebt) return undefined;
   const debt = (body as { debt?: unknown } | null | undefined)?.debt;
   if (typeof debt !== "string" || !/^\d+$/.test(debt)) {
     console.warn(`${context}: debt refusal with no usable amount`);
@@ -680,10 +702,10 @@ export type PurchaseTribeNameResult =
   // negative; `debt` (bigint string) must be settled before anything is
   // spendable. Nothing charged.
   | { ok: false; code: "debt"; debt: string }
-  // 400: the name itself was refused. Each of the server's player-facing
-  // reasons maps to a code the caller translates — none of them reach the
-  // player as the server's English. See TRIBE_NAME_REFUSAL_CODES for why the
-  // set is an allowlist.
+  // 400: the name itself was refused. Each of the server's refusal codes
+  // maps to a code the caller translates — none of them reach the player as
+  // the server's English. See TRIBE_NAME_REFUSAL_CODES for why the set is an
+  // allowlist.
   | { ok: false; code: "invalid_charset" }
   | { ok: false; code: "invalid_no_letter" }
   | { ok: false; code: "not_allowed" }
@@ -696,20 +718,34 @@ export type PurchaseTribeNameResult =
   | { ok: false; code: "rate_limited"; retryAfterSeconds: number | null }
   | { ok: false; code: "failed" };
 
-// The endpoint's name-validation and moderation reasons, mapped to codes the
-// caller translates. Recognising a reason is what turns it into a localized
-// message; nothing is ever rendered from the server's English.
+// The endpoint's refusal codes, mapped to the codes the caller translates
+// (OPE-389). The server's `code` is the branch key; its `reason` is English
+// documentation and is never read for meaning and never rendered.
 //
-// An allowlist rather than a denylist of the machine keys, because the failure
-// mode is asymmetric. Anything unrecognised becomes a generic failure — mildly
-// unhelpful if it was prose. Echoing anything unrecognised puts the next
-// machine branch key the API adds straight on the player's screen, which is
-// how "insufficient_balance_debt" came to be displayed as an error message.
+// An allowlist rather than a denylist, because the failure mode is
+// asymmetric. Anything unrecognised becomes a generic failure — mildly
+// unhelpful. Echoing anything unrecognised puts the next machine branch key
+// the API adds straight on the player's screen, which is how
+// "insufficient_balance_debt" came to be displayed as an error message.
 //
-// Matched on the exact English because that is what the endpoint sends and
-// there is no code in the body to key off. If the API ever rewords one, the
-// player gets the generic failure until this is updated — the safe direction.
+// `no_letter` is renamed on the way in: the caller's `invalid_no_letter` is
+// pre-existing public API of this module, so the two vocabularies are mapped
+// here rather than one being churned to match the other.
 const TRIBE_NAME_REFUSAL_CODES: Record<
+  string,
+  "invalid_charset" | "invalid_no_letter" | "not_allowed"
+> = {
+  invalid_charset: "invalid_charset",
+  no_letter: "invalid_no_letter",
+  not_allowed: "not_allowed",
+};
+
+// The same refusals keyed on the server's exact English, for a server that
+// predates OPE-389 and sends no `code`. Production can lag the API, so this
+// stays — but only as the fallback. If the API rewords one of these on an
+// older deployment the player gets the generic failure, which is the safe
+// direction.
+const LEGACY_TRIBE_NAME_REFUSAL_REASONS: Record<
   string,
   "invalid_charset" | "invalid_no_letter" | "not_allowed"
 > = {
@@ -718,15 +754,16 @@ const TRIBE_NAME_REFUSAL_CODES: Record<
   "Name must contain a letter": "invalid_no_letter",
   "This name is not allowed": "not_allowed",
 };
-// The length rule interpolates its bounds ("Name must be 3-24 characters"), so
-// it is matched by shape rather than listed. Anchored and digit-specific: a
+// The length rule interpolates its bounds ("Name must be 3-24 characters"),
+// so on a pre-OPE-389 server — where the numbers are only in the prose — it
+// is matched by shape rather than listed. Anchored and digit-specific: a
 // bare "Name must be " prefix would pass through anything the API ever chose
 // to start that way, which is the denylist failure this is meant to avoid.
 // The bounds are captured so the caller can translate the message instead of
 // rendering the server's English.
 const TRIBE_NAME_LENGTH_REASON_RE = /^Name must be (\d+)-(\d+) characters$/;
 
-function tribeNameInvalidResult(
+function legacyTribeNameInvalidResult(
   reason: string,
 ): PurchaseTribeNameResult | undefined {
   const length = TRIBE_NAME_LENGTH_REASON_RE.exec(reason);
@@ -738,9 +775,52 @@ function tribeNameInvalidResult(
       max: Number(length[2]),
     };
   }
-  const code = TRIBE_NAME_REFUSAL_CODES[reason];
+  const code = LEGACY_TRIBE_NAME_REFUSAL_REASONS[reason];
   if (code !== undefined) return { ok: false, code };
   return undefined;
+}
+
+// A `length` bound off the body. The bounds are what the message says, so an
+// unusable one is not usable at all: a positive safe integer or nothing.
+function refusalBound(body: unknown, field: "min" | "max"): number | undefined {
+  const value = (body as Record<string, unknown> | null | undefined)?.[field];
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0
+    ? value
+    : undefined;
+}
+
+// Why the name was refused, keyed on the server's machine `code` (OPE-389).
+// Returns undefined for a code this client does not know, which the caller
+// turns into a generic failure — the code is never rendered.
+function tribeNameInvalidResult(
+  code: string,
+  body: unknown,
+): PurchaseTribeNameResult | undefined {
+  if (code === "length") {
+    const min = refusalBound(body, "min");
+    const max = refusalBound(body, "max");
+    if (min !== undefined && max !== undefined) {
+      return { ok: false, code: "length", min, max };
+    }
+    // The bounds ARE the message, so there is nothing to render without
+    // them. The prose still carries them on every server that sends this
+    // code, so read them out of it rather than showing a blank range. Only
+    // the length pattern is tried here: a `length` code sitting next to some
+    // other refusal's prose is a body we do not understand.
+    const reason = (body as { reason?: unknown } | null | undefined)?.reason;
+    if (typeof reason !== "string") return undefined;
+    const parsed = TRIBE_NAME_LENGTH_REASON_RE.exec(reason);
+    return parsed === null
+      ? undefined
+      : {
+          ok: false,
+          code: "length",
+          min: Number(parsed[1]),
+          max: Number(parsed[2]),
+        };
+  }
+  const mapped = TRIBE_NAME_REFUSAL_CODES[code];
+  return mapped === undefined ? undefined : { ok: false, code: mapped };
 }
 
 // POST /users/@me/tribe_names — buy a custom tribe name (200 plutonium). The
@@ -766,17 +846,27 @@ export async function purchaseTribeName(
     if (response.status === 400) {
       const body = await response.json().catch(() => null);
       const reason = typeof body?.reason === "string" ? body.reason : "";
-      // Balance reasons first: both are branch keys the shared spend helper
+      const code = refusalCode(body);
+      // Balance refusals first: both are branch keys the shared spend helper
       // emits, not prose to echo at the player.
       const debt = parseDebtRefusal(body, "purchaseTribeName");
       if (debt !== undefined) return debt;
-      if (reason === "Insufficient balance") {
+      if (
+        code === undefined
+          ? reason === "Insufficient balance"
+          : code === "insufficient_balance"
+      ) {
         return { ok: false, code: "insufficient_balance" };
       }
-      const invalid = tribeNameInvalidResult(reason);
+      // `code` when the server sends one (OPE-389), the English only when it
+      // does not — production can lag the API.
+      const invalid =
+        code === undefined
+          ? legacyTribeNameInvalidResult(reason)
+          : tribeNameInvalidResult(code, body);
       if (invalid !== undefined) return invalid;
-      // Not logging the body: an unrecognised reason is exactly the case where
-      // we don't know what it contains.
+      // Not logging the body: an unrecognised refusal is exactly the case
+      // where we don't know what it contains.
       console.warn("purchaseTribeName: unrecognised 400 reason");
       return { ok: false, code: "failed" };
     }
@@ -859,9 +949,21 @@ export async function boostTribeName(
       // check — a body without a string reason is never the debt refusal.
       const debt = parseDebtRefusal(body, "boostTribeName");
       if (debt !== undefined) return debt;
-      // Any other {"reason": "..."} is the player-facing 400 (a shortfall);
-      // {"resource": "id"} means a malformed id — a client bug, not a player
-      // error, so it falls through to the generic failure.
+      const code = refusalCode(body);
+      if (code !== undefined) {
+        // OPE-389: the only other refusal this endpoint has is the plain
+        // shortfall. Anything else is a code this client has never heard of,
+        // and guessing it is a shortfall would send the player to a top-up
+        // that cannot help — the bug the debt branch was added to fix.
+        if (code === "insufficient_balance") {
+          return { ok: false, code: "insufficient_balance" };
+        }
+        console.warn("boostTribeName: unrecognised 400 code");
+        return { ok: false, code: "failed" };
+      }
+      // Pre-OPE-389 server: any {"reason": "..."} is the player-facing 400
+      // (a shortfall); {"resource": "id"} means a malformed id — a client
+      // bug, not a player error, so it falls through to the generic failure.
       if (typeof body?.reason === "string") {
         return { ok: false, code: "insufficient_balance" };
       }

--- a/tests/client/TribeNameDebt.test.ts
+++ b/tests/client/TribeNameDebt.test.ts
@@ -182,6 +182,25 @@ describe("tribe-name spend paths map the debt reason", () => {
       });
     });
 
+    // Matching the shape is not the same as the numbers being a range. The
+    // prose bounds are held to the same standard as the body's: digits in a
+    // sentence are not more trustworthy than numbers in a field.
+    it.each([
+      ["reversed", "Name must be 24-3 characters"],
+      ["zero", "Name must be 0-24 characters"],
+      // Beyond Number.MAX_SAFE_INTEGER, so Number() has already lost it.
+      ["unsafe", "Name must be 3-9007199254740993 characters"],
+    ])(
+      "gives a generic failure when the prose bounds are %s",
+      async (_label, reason) => {
+        respond(400, { reason });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "failed",
+        });
+      },
+    );
+
     // The reasons are allowlisted rather than the machine keys denylisted, so
     // the next branch key the API grows does not land on the player's screen
     // the way "insufficient_balance_debt" did.
@@ -278,6 +297,20 @@ describe("tribe-name spend paths map the debt reason", () => {
 
       it("gives a generic failure when neither bounds nor prose parse", async () => {
         respond(400, { code: "length", reason: UNMATCHED_PROSE });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "failed",
+        });
+      });
+
+      // The prose fallback is a second source of bounds, not a way around
+      // checking them: with no usable body bounds and a reversed range in the
+      // sentence, there is no message to render.
+      it("gives a generic failure when the prose bounds are reversed", async () => {
+        respond(400, {
+          code: "length",
+          reason: "Name must be 24-3 characters",
+        });
         expect(await purchaseTribeName("Ninja")).toEqual({
           ok: false,
           code: "failed",

--- a/tests/client/TribeNameDebt.test.ts
+++ b/tests/client/TribeNameDebt.test.ts
@@ -126,6 +126,10 @@ describe("tribe-name spend paths map the debt reason", () => {
     // Nothing reaches the player as the server's English, so a non-English
     // locale gets a localized reason rather than a localized shell around an
     // English sentence.
+    //
+    // These bodies carry no `code`, so they are the pre-OPE-389 fallback:
+    // production can lag the API, and a server that has not shipped the codes
+    // yet must still produce a translated refusal.
     it.each([
       [
         "Name may only contain letters, numbers, spaces, and ' - . _ ! ?",
@@ -133,10 +137,13 @@ describe("tribe-name spend paths map the debt reason", () => {
       ],
       ["Name must contain a letter", "invalid_no_letter"],
       ["This name is not allowed", "not_allowed"],
-    ])("maps the refusal %s to a code", async (reason, code) => {
-      respond(400, { reason });
-      expect(await purchaseTribeName("Ninja")).toEqual({ ok: false, code });
-    });
+    ])(
+      "falls back to the reason %s when the body has no code",
+      async (reason, code) => {
+        respond(400, { reason });
+        expect(await purchaseTribeName("Ninja")).toEqual({ ok: false, code });
+      },
+    );
 
     // The reasons are matched on their exact English, so a reworded one is
     // unrecognised — the generic failure, never the raw server text.
@@ -205,6 +212,112 @@ describe("tribe-name spend paths map the debt reason", () => {
         code: "failed",
       });
     });
+
+    // OPE-389: the API now sends a stable machine `code` beside the prose.
+    // Every body below pairs a real code with prose this client does not
+    // recognise, which is the whole point — `reason` is documentation, and a
+    // reworded or localized one must not change what the player is told.
+    describe("branches on the machine code", () => {
+      const UNMATCHED_PROSE = "Refusal prose this client never matched";
+
+      it.each([
+        ["invalid_charset", "invalid_charset"],
+        ["no_letter", "invalid_no_letter"],
+        ["not_allowed", "not_allowed"],
+      ])("maps code %s regardless of the reason", async (sent, code) => {
+        respond(400, { code: sent, reason: UNMATCHED_PROSE });
+        const result = await purchaseTribeName("Ninja");
+        expect(result).toEqual({ ok: false, code });
+        expect(Object.values(result)).not.toContain(UNMATCHED_PROSE);
+      });
+
+      // The bounds come off the body rather than out of the sentence, so the
+      // client stops depending on the server's number formatting — and on
+      // the server writing them in English at all.
+      it("takes the length bounds from min/max, not the prose", async () => {
+        respond(400, {
+          code: "length",
+          reason: UNMATCHED_PROSE,
+          min: 5,
+          max: 30,
+        });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "length",
+          min: 5,
+          max: 30,
+        });
+      });
+
+      // The bounds ARE the message. An unusable pair is not a message, so it
+      // falls back to the prose the same server still sends.
+      it.each([
+        ["missing", {}],
+        ["a string", { min: "3", max: "24" }],
+        ["zero", { min: 0, max: 24 }],
+        ["fractional", { min: 3.5, max: 24 }],
+      ])(
+        "falls back to the prose bounds when min/max are %s",
+        async (_label, bounds) => {
+          respond(400, {
+            code: "length",
+            reason: "Name must be 3-24 characters",
+            ...bounds,
+          });
+          expect(await purchaseTribeName("Ninja")).toEqual({
+            ok: false,
+            code: "length",
+            min: 3,
+            max: 24,
+          });
+        },
+      );
+
+      it("gives a generic failure when neither bounds nor prose parse", async () => {
+        respond(400, { code: "length", reason: UNMATCHED_PROSE });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "failed",
+        });
+      });
+
+      // The code wins over the reason, so a code this client does not know is
+      // a generic failure even when a recognised English sentence sits beside
+      // it — the API is telling us it means something we have not handled.
+      it("gives a generic failure for a code it does not know", async () => {
+        respond(400, {
+          code: "some_future_code",
+          reason: "Name must contain a letter",
+        });
+        const result = await purchaseTribeName("Ninja");
+        expect(result).toEqual({ ok: false, code: "failed" });
+        expect(Object.values(result)).not.toContain("some_future_code");
+      });
+
+      it("maps the shortfall code past a reworded reason", async () => {
+        respond(400, {
+          code: "insufficient_balance",
+          reason: UNMATCHED_PROSE,
+        });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "insufficient_balance",
+        });
+      });
+
+      it("maps the debt code past a reworded reason", async () => {
+        respond(400, {
+          code: "insufficient_balance_debt",
+          reason: UNMATCHED_PROSE,
+          debt: "250",
+        });
+        expect(await purchaseTribeName("Ninja")).toEqual({
+          ok: false,
+          code: "debt",
+          debt: "250",
+        });
+      });
+    });
   });
 
   describe("boostTribeName", () => {
@@ -261,6 +374,47 @@ describe("tribe-name spend paths map the debt reason", () => {
       expect(await boostTribeName("nope", "key")).toEqual({
         ok: false,
         code: "failed",
+      });
+    });
+
+    // OPE-389. This path used to treat any string reason as a shortfall,
+    // which is only safe while balance is the endpoint's only refusal. With
+    // a code in the body it no longer has to assume.
+    describe("branches on the machine code", () => {
+      const UNMATCHED_PROSE = "Refusal prose this client never matched";
+
+      it("maps the shortfall code past a reworded reason", async () => {
+        respond(400, {
+          code: "insufficient_balance",
+          reason: UNMATCHED_PROSE,
+        });
+        expect(await boostTribeName("7", "key")).toEqual({
+          ok: false,
+          code: "insufficient_balance",
+        });
+      });
+
+      it("maps the debt code past a reworded reason", async () => {
+        respond(400, {
+          code: "insufficient_balance_debt",
+          reason: UNMATCHED_PROSE,
+          debt: "80",
+        });
+        expect(await boostTribeName("7", "key")).toEqual({
+          ok: false,
+          code: "debt",
+          debt: "80",
+        });
+      });
+
+      // Guessing a shortfall here would offer a top-up for a refusal that a
+      // top-up may not clear — the same mistake the debt branch exists to
+      // undo.
+      it("does not guess a shortfall for a code it does not know", async () => {
+        respond(400, { code: "some_future_code", reason: UNMATCHED_PROSE });
+        const result = await boostTribeName("7", "key");
+        expect(result).toEqual({ ok: false, code: "failed" });
+        expect(Object.values(result)).not.toContain("some_future_code");
       });
     });
   });

--- a/tests/client/TribeNameDebt.test.ts
+++ b/tests/client/TribeNameDebt.test.ts
@@ -256,6 +256,9 @@ describe("tribe-name spend paths map the debt reason", () => {
         ["a string", { min: "3", max: "24" }],
         ["zero", { min: 0, max: 24 }],
         ["fractional", { min: 3.5, max: 24 }],
+        // Two plausible numbers and one impossible range: it would render
+        // "24-3" at the player.
+        ["inverted", { min: 24, max: 3 }],
       ])(
         "falls back to the prose bounds when min/max are %s",
         async (_label, bounds) => {
@@ -293,6 +296,28 @@ describe("tribe-name spend paths map the debt reason", () => {
         expect(result).toEqual({ ok: false, code: "failed" });
         expect(Object.values(result)).not.toContain("some_future_code");
       });
+
+      // A `code` key that is present but unusable is not the same as an
+      // absent one: the server meant to send a code, so reading its English
+      // instead would be interpreting a body we have established we do not
+      // understand. Each row pairs it with a reason the legacy path matches,
+      // so a fall-through to that path returns invalid_no_letter here.
+      it.each([
+        ["empty", ""],
+        ["a number", 42],
+        ["null", null],
+        // A bare map lookup would return Object.prototype.constructor.
+        ["constructor", "constructor"],
+      ])(
+        "treats a code that is %s as unknown, not absent",
+        async (_l, code) => {
+          respond(400, { code, reason: "Name must contain a letter" });
+          expect(await purchaseTribeName("Ninja")).toEqual({
+            ok: false,
+            code: "failed",
+          });
+        },
+      );
 
       it("maps the shortfall code past a reworded reason", async () => {
         respond(400, {

--- a/tests/client/TribeNameDebtEndToEnd.test.ts
+++ b/tests/client/TribeNameDebtEndToEnd.test.ts
@@ -214,15 +214,21 @@ describe("buying a tribe name in debt, panel through Api", () => {
 
     // A code this client has never heard of must not reach the screen either
     // — that is the whole point of allowlisting them.
+    //
+    // Deliberately paired with a reason the legacy path DOES match: the code
+    // is the branch key, so reinstating the string matching would render
+    // store.tribe_name_no_letter here and fail this test. With unmatched
+    // prose it would pass either way and prove nothing.
     it("an unknown code renders the generic purchase failure", async () => {
       const el = await mountAndBuy(400, {
         code: "some_future_code",
-        reason: UNMATCHED_PROSE,
+        reason: "Name must contain a letter",
       });
 
       expect(el.textContent).toContain("store.purchase_failed");
+      expect(el.textContent).not.toContain("store.tribe_name_no_letter");
       expect(el.textContent).not.toContain("some_future_code");
-      expect(el.textContent).not.toContain(UNMATCHED_PROSE);
+      expect(el.textContent).not.toContain("Name must contain a letter");
       // Otherwise this passes just as well when the request never happens.
       expect(fetchMock).toHaveBeenCalledTimes(1);
     });

--- a/tests/client/TribeNameDebtEndToEnd.test.ts
+++ b/tests/client/TribeNameDebtEndToEnd.test.ts
@@ -168,4 +168,63 @@ describe("buying a tribe name in debt, panel through Api", () => {
       'store.tribe_name_length:{"min":3,"max":24}',
     );
   });
+
+  // OPE-389: the API sends a stable machine `code`, so this is the table that
+  // matters — server code in, translation key out. Every body pairs its code
+  // with prose this client does not recognise, so a row that still passed by
+  // matching the English would fail here.
+  describe("each refusal code reaches its translation key", () => {
+    const UNMATCHED_PROSE = "Refusal prose this client never matched";
+
+    it.each([
+      ["invalid_charset", "store.tribe_name_charset"],
+      ["no_letter", "store.tribe_name_no_letter"],
+      ["not_allowed", "store.tribe_name_not_allowed"],
+    ])("%s renders %s", async (code, key) => {
+      const el = await mountAndBuy(400, { code, reason: UNMATCHED_PROSE });
+
+      expect(el.textContent).toContain(key);
+      expect(el.textContent).not.toContain(UNMATCHED_PROSE);
+    });
+
+    it("length renders the key with the bounds from the body", async () => {
+      const el = await mountAndBuy(400, {
+        code: "length",
+        reason: UNMATCHED_PROSE,
+        min: 5,
+        max: 30,
+      });
+
+      expect(el.textContent).toContain(
+        'store.tribe_name_length:{"min":5,"max":30}',
+      );
+      expect(el.textContent).not.toContain(UNMATCHED_PROSE);
+    });
+
+    it("insufficient_balance_debt renders the debt message", async () => {
+      const el = await mountAndBuy(400, {
+        code: "insufficient_balance_debt",
+        reason: UNMATCHED_PROSE,
+        debt: "250",
+      });
+
+      expect(el.textContent).toContain('store.pack_debt:{"debt":"250"}');
+      expect(el.textContent).not.toContain("insufficient_balance_debt");
+    });
+
+    // A code this client has never heard of must not reach the screen either
+    // — that is the whole point of allowlisting them.
+    it("an unknown code renders the generic purchase failure", async () => {
+      const el = await mountAndBuy(400, {
+        code: "some_future_code",
+        reason: UNMATCHED_PROSE,
+      });
+
+      expect(el.textContent).toContain("store.purchase_failed");
+      expect(el.textContent).not.toContain("some_future_code");
+      expect(el.textContent).not.toContain(UNMATCHED_PROSE);
+      // Otherwise this passes just as well when the request never happens.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/tests/client/TribeNameDebtEndToEnd.test.ts
+++ b/tests/client/TribeNameDebtEndToEnd.test.ts
@@ -201,6 +201,20 @@ describe("buying a tribe name in debt, panel through Api", () => {
       expect(el.textContent).not.toContain(UNMATCHED_PROSE);
     });
 
+    // The prose is the fallback source of bounds, not a way around checking
+    // them: no usable min/max and a reversed range in the sentence leaves
+    // nothing to render, and "24-3" must not be what the player sees.
+    it("length with reversed prose bounds renders the generic failure", async () => {
+      const el = await mountAndBuy(400, {
+        code: "length",
+        reason: "Name must be 24-3 characters",
+      });
+
+      expect(el.textContent).toContain("store.purchase_failed");
+      expect(el.textContent).not.toContain("store.tribe_name_length");
+      expect(el.textContent).not.toContain("24-3");
+    });
+
     it("insufficient_balance_debt renders the debt message", async () => {
       const el = await mountAndBuy(400, {
         code: "insufficient_balance_debt",


### PR DESCRIPTION
## What

The API now sends a stable machine `code` beside the prose `reason` in every 400 from the tribe-name purchase and boost endpoints (openfrontio/infra#686, OPE-389). The client branches on that code and treats `reason` as documentation: never read for meaning, never rendered, never logged.

Since #5307 the client matched four exact English sentences. Any rewording on the server silently downgraded a specific, actionable refusal to "purchase failed", and the length bounds were scraped out of the sentence with a regex.

## Code to translation key

| server `code` | `PurchaseTribeNameResult` | rendered |
| --- | --- | --- |
| `length` (+ `min`/`max`) | `length` | `store.tribe_name_length` with `{min}`/`{max}` |
| `invalid_charset` | `invalid_charset` | `store.tribe_name_charset` |
| `no_letter` | `invalid_no_letter` | `store.tribe_name_no_letter` |
| `not_allowed` | `not_allowed` | `store.tribe_name_not_allowed` |
| `insufficient_balance` | `insufficient_balance` | the shortfall / top-up dialog |
| `insufficient_balance_debt` | `debt` | `store.pack_debt` |
| anything else | `failed` | `store.purchase_failed` |

No new translation keys — `store.tribe_name_length` already takes `{min}`/`{max}`.

## The fallback rule

The pre-#5307 English matching runs only when the `code` key is **absent** — production can lag the API — and never as an override; a `code` that is present but unusable (`42`, `""`, `null`) is an unknown code, not an absent one, because the server did mean to send one.

Two smaller consequences of the same rule. The `length` bounds come off `min`/`max` (a pair of positive safe integers with `min <= max`, so `{min: 24, max: 3}` cannot render as "24-3"), falling back to the prose numbers only when they are unusable, because the bounds are the message. And the boost path stops treating any string `reason` as a shortfall once a code is present: an unknown code no longer offers a top-up that may not be the remedy, which is the bug the debt branch was added to fix.

`parseDebtRefusal` — shared with the pack and shop spend paths since #5329 — prefers `code` under the same rule, which is behaviour-identical for those two since the API sends both fields.

Both refusal tables are `Map`s rather than object literals: the keys come off the wire, and a plain lookup of `"constructor"` returns a function rather than `undefined`.

## Tests

Extended the two suites from #5307 rather than adding a third.

`tests/client/TribeNameDebt.test.ts` — `purchaseTribeName > branches on the machine code`: each code mapped regardless of the reason (3 rows), the length bounds taken from `min`/`max` rather than the prose, the prose fallback when the bounds are unusable (missing / a string / zero / fractional / inverted), a generic failure when neither bounds nor prose parse, a present-but-unusable code treated as unknown (`""` / `42` / `null` / `"constructor"`), and the shortfall and debt codes mapped past a reworded reason. `boostTribeName > branches on the machine code`: shortfall and debt past a reworded reason, and no guessed shortfall for an unknown code. The existing no-`code` cases were retitled as the pre-OPE-389 fallback they now are.

`tests/client/TribeNameDebtEndToEnd.test.ts` — `each refusal code reaches its translation key`: the real panel over the real `Api.ts`, one row per code, plus the length bounds interpolated from the body and an unknown code rendering the generic failure. Every body pairs its code with prose the client does not match, so a row that still passed by matching the English fails here; the unknown-code case inverts that and pairs with a sentence the legacy path *does* match, so reinstating string matching fails it.

**26 of these fail against `origin/main`** and pass on this branch.

```
npx vitest tests/client/TribeNameDebt.test.ts tests/client/TribeNameDebtEndToEnd.test.ts \
  tests/client/TribesPanelDebt.test.ts tests/client/BoostTribeNameBadRequest.test.ts \
  tests/client/PurchaseCosmeticPack.test.ts tests/client/CosmeticPurchaseDebt.test.ts \
  tests/EnJsonSorted.test.ts tests/TranslationSystem.test.ts --run   # 121 passed
npx tsc --noEmit                       # clean
npm run lint                           # clean
npx prettier --check <changed files>   # clean
```

Part of OPE-239 — https://linear.app/openfront/issue/OPE-239

🤖 Generated with [Claude Code](https://claude.com/claude-code)
