### PR TITLE
Fix nations never building cities on very crowded maps 🏙️

### DIFF
--- a/src/core/execution/nation/NationStructureBehavior.ts
+++ b/src/core/execution/nation/NationStructureBehavior.ts
@@ -469,13 +469,9 @@ export class NationStructureBehavior {
     // On crowded maps the first structure is a port (or factory if landlocked)
     // instead of a city, so nations can get income earlier.
     // Mainly intended for private 200+ nation HvN games.
-    // Uses its own one-shot flag (not unitsOwned(City) or placementsCount):
-    // this branch never builds a city itself, so gating on city count would
-    // re-fire it forever and starve the nation of cities; gating on
-    // placementsCount would let the high-gold SAM-first branch above consume
-    // its only chance. The flag is set only on success, so it keeps retrying
-    // across calls (e.g. while unaffordable) until it places one structure,
-    // then never fires again.
+    // Own one-shot flag, set only on success: unitsOwned(City) never clears
+    // (starves cities forever) and placementsCount can get consumed by the
+    // SAM-first branch above.
     if (
       !citiesDisabled &&
       !this.builtCrowdedMapFirstStructure &&

--- a/src/core/execution/nation/NationStructureBehavior.ts
+++ b/src/core/execution/nation/NationStructureBehavior.ts
@@ -141,6 +141,7 @@ export class NationStructureBehavior {
   private _sharedWaterComponents: Set<number> | null = null;
   private lastStructureTick: number | null = null;
   private placementsCount = 0;
+  private builtCrowdedMapFirstStructure = false;
   private _hasHighStartingGold: boolean | null = null;
   private _postSaveUpStartTick: number | null = null;
 
@@ -468,19 +469,26 @@ export class NationStructureBehavior {
     // On crowded maps the first structure is a port (or factory if landlocked)
     // instead of a city, so nations can get income earlier.
     // Mainly intended for private 200+ nation HvN games.
+    // Uses its own one-shot flag (not unitsOwned(City) or placementsCount):
+    // this branch never builds a city itself, so gating on city count would
+    // re-fire it forever and starve the nation of cities; gating on
+    // placementsCount would let the high-gold SAM-first branch above consume
+    // its only chance. The flag is set only on success, so it keeps retrying
+    // across calls (e.g. while unaffordable) until it places one structure,
+    // then never fires again.
     if (
       !citiesDisabled &&
-      this.player.unitsOwned(UnitType.City) === 0 &&
+      !this.builtCrowdedMapFirstStructure &&
       this.isHighNationDensity()
     ) {
       const preferredFirst =
         hasCoastalTiles && !config.isUnitDisabled(UnitType.Port)
           ? UnitType.Port
           : UnitType.Factory;
-      if (
-        !config.isUnitDisabled(preferredFirst) &&
-        this.maybeSpawnStructure(preferredFirst)
-      ) {
+      if (config.isUnitDisabled(preferredFirst)) {
+        this.builtCrowdedMapFirstStructure = true;
+      } else if (this.maybeSpawnStructure(preferredFirst)) {
+        this.builtCrowdedMapFirstStructure = true;
         return true;
       }
     }

--- a/tests/NationStructureBehavior.test.ts
+++ b/tests/NationStructureBehavior.test.ts
@@ -1,7 +1,7 @@
 import { vi } from "vitest";
 import { ConstructionExecution } from "../src/core/execution/ConstructionExecution";
 import { NationStructureBehavior } from "../src/core/execution/nation/NationStructureBehavior";
-import { Difficulty, PlayerType } from "../src/core/game/Game";
+import { Difficulty, PlayerType, UnitType } from "../src/core/game/Game";
 import { Cluster } from "../src/core/game/TrainStation";
 import { PseudoRandom } from "../src/core/PseudoRandom";
 
@@ -852,6 +852,88 @@ describe("NationStructureBehavior.countDefensePostsNearFront", () => {
   it("sums posts near different sections of the front", () => {
     const threshold = (OUTER_RANGE * 1.5) ** 2;
     expect(count([10, 20], [1, 2], () => threshold - 1)).toBe(2);
+  });
+});
+
+// ── doHandleStructures — crowded-map first-structure exception ──────────────
+// Regression tests for a bug where the "first structure is a port/factory on
+// crowded maps" exception was gated on unitsOwned(City) === 0. Since that
+// branch never builds a city itself, unitsOwned(City) stayed 0 forever, so
+// the exception kept re-firing on every call and the nation could never
+// reach the actual city-building code. It now uses its own one-shot flag,
+// consumed only on success, so it neither loops forever nor loses its only
+// chance to the unrelated high-gold SAM-first branch.
+
+describe("NationStructureBehavior.doHandleStructures — crowded-map exception", () => {
+  function makeCrowdedGame(opts: { difficulty?: Difficulty } = {}): any {
+    return {
+      config: () => ({
+        isUnitDisabled: () => false,
+        gameConfig: () => ({
+          difficulty: opts.difficulty ?? Difficulty.Medium,
+        }),
+        startingGold: () => 0n,
+      }),
+      sharedWaterComponents: () => null, // landlocked -> Factory preferred
+      nations: () => Array(400).fill({}),
+      numLandTiles: () => 1_000_000, // 400 / 1_000_000 > 1/7500 -> high density
+    };
+  }
+
+  function makeCrowdedPlayer(): any {
+    return {
+      unitsOwned: () => 0, // never owns a city
+      numTilesOwned: () => 100_000,
+      info: () => ({}),
+    };
+  }
+
+  it("builds a Factory (not a City) on the very first structure decision", () => {
+    const behavior = makeBehavior(makeCrowdedGame(), makeCrowdedPlayer());
+    const spy = vi
+      .spyOn(behavior as any, "maybeSpawnStructure")
+      .mockReturnValue(true);
+
+    expect((behavior as any).doHandleStructures()).toBe(true);
+    expect(spy).toHaveBeenCalledWith(UnitType.Factory);
+    expect(spy).not.toHaveBeenCalledWith(UnitType.City);
+  });
+
+  it("does not re-fire once it has already succeeded, even though the player still owns no cities", () => {
+    const behavior = makeBehavior(makeCrowdedGame(), makeCrowdedPlayer());
+    (behavior as any).builtCrowdedMapFirstStructure = true; // already succeeded once
+    const spy = vi
+      .spyOn(behavior as any, "maybeSpawnStructure")
+      .mockReturnValue(true);
+
+    expect((behavior as any).doHandleStructures()).toBe(true);
+    expect(spy).toHaveBeenCalledWith(UnitType.City);
+    expect(spy).not.toHaveBeenCalledWith(UnitType.Factory);
+  });
+
+  it("still gets its chance after the high-gold SAM-first branch has already placed the nation's literal first structure", () => {
+    const game = makeCrowdedGame({ difficulty: Difficulty.Impossible });
+    game.config = () => ({
+      isUnitDisabled: () => false,
+      gameConfig: () => ({ difficulty: Difficulty.Impossible }),
+      startingGold: () => 10_000_000n, // above HIGH_STARTING_GOLD_THRESHOLD
+    });
+    const behavior = makeBehavior(game, makeCrowdedPlayer());
+    const spy = vi
+      .spyOn(behavior as any, "maybeSpawnStructure")
+      .mockReturnValue(true);
+
+    // Structure #1: the unrelated high-gold SAM-first branch fires.
+    expect((behavior as any).doHandleStructures()).toBe(true);
+    expect(spy).toHaveBeenLastCalledWith(UnitType.SAMLauncher);
+    expect((behavior as any).builtCrowdedMapFirstStructure).toBe(false);
+    (behavior as any).placementsCount = 1; // what handleStructures() would do
+
+    // Structure #2: the crowded-map branch must still fire here, not be
+    // skipped just because placementsCount is no longer 0.
+    expect((behavior as any).doHandleStructures()).toBe(true);
+    expect(spy).toHaveBeenLastCalledWith(UnitType.Factory);
+    expect((behavior as any).builtCrowdedMapFirstStructure).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Description:

On games with high nation density (many nations relative to land tiles, e.g. 400 nation games), nations would build Ports/Factories forever and never build a single City.

NationStructureBehavior has a special case that lets a nation build a Port (or Factory if landlocked) as its very first structure instead of a City, so it can get income sooner on crowded maps. This was gated on unitsOwned(City) === 0. Since that branch never builds a City itself, that condition never became false, so it kept re-triggering on every structure decision the nation ever made, permanently blocking it from reaching the actual City-building code further down.

The fix gates this branch on its own one-shot flag, consumed only once the branch actually succeeds in placing a structure. A shared counter like placementsCount doesn't work here: nations that are both high-starting-gold Hard/Impossible and on a crowded map already have an unrelated branch that builds a SAM launcher as their literal first structure, which would consume a shared "first structure" slot and cause this branch to be skipped entirely for those nations. The dedicated flag keeps retrying on later calls if an attempt fails (e.g. temporarily unaffordable) and fires independently of whatever else the nation has already built, while still only ever succeeding once.

Noticed this problem by watching https://www.youtube.com/watch?v=709JPXBXfno

<img width="1117" height="804" alt="Screenshot 2026-09-10 224519" src="https://github.com/user-attachments/assets/aa9cba09-1ba5-4663-9c63-c6039aa0cf1f" />
<img width="910" height="789" alt="Screenshot 2026-09-10 225041" src="https://github.com/user-attachments/assets/b405d70c-a465-4d19-a2e3-1f13298a060c" />

## Please complete the following:

- [X] I have added screenshots for all UI updates
- [X] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [X] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

FloPinguin
