### PR TITLE
Fix RTL rendering of Persian and Arabic text in the help and tutorial UI

### DIFF
--- a/src/client/HelpModal.ts
+++ b/src/client/HelpModal.ts
@@ -1,6 +1,10 @@
 import { html } from "lit";
 import { customElement, query, state } from "lit/decorators.js";
-import { translateText, TUTORIAL_VIDEO_URL } from "../client/Utils";
+import {
+  textDirection,
+  translateText,
+  TUTORIAL_VIDEO_URL,
+} from "../client/Utils";
 import { assetUrl } from "../core/AssetUrls";
 import { UserSettings } from "../core/game/UserSettings";
 import { BaseModal } from "./components/BaseModal";
@@ -53,7 +57,10 @@ export class HelpModal extends BaseModal {
 
   private renderKey(code: string) {
     const label = this.getKeyLabel(code);
+    // Key names stay left-to-right even inside RTL locales so the badges
+    // (and combos like "Shift + click") never scramble.
     return html`<span
+      dir="ltr"
       class="inline-block min-w-[32px] text-center px-2 py-1 rounded bg-[#2a2a2a] border-b-2 border-[#1a1a1a] text-white font-mono text-xs font-bold mx-0.5"
       >${label}</span
     >`;
@@ -72,14 +79,18 @@ export class HelpModal extends BaseModal {
 
     return html`
       <div
+        dir=${textDirection()}
         class="prose prose-invert prose-sm max-w-none px-6 py-3
           [&_a]:text-blue-400 [&_a:hover]:text-blue-300 transition-colors
           [&_h1]:text-2xl [&_h1]:font-bold [&_h1]:mb-4 [&_h1]:text-white [&_h1]:border-b [&_h1]:border-white/10 [&_h1]:pb-2
           [&_h2]:text-xl [&_h2]:font-bold [&_h2]:mt-6 [&_h2]:mb-3 [&_h2]:text-blue-200
           [&_h3]:text-lg [&_h3]:font-semibold [&_h3]:mt-4 [&_h3]:mb-2 [&_h3]:text-blue-100
-          [&_ul]:pl-5 [&_ul]:list-disc [&_ul]:space-y-1
+          [&_ul]:ps-5 [&_ul]:list-disc [&_ul]:space-y-1
           [&_li]:text-gray-300 [&_li]:leading-relaxed
-          [&_p]:text-gray-300 [&_p]:mb-3 [&_strong]:text-white [&_strong]:font-bold"
+          [&_p]:text-gray-300 [&_p]:mb-3 [&_strong]:text-white [&_strong]:font-bold
+          [&_p]:[unicode-bidi:plaintext] [&_li]:[unicode-bidi:plaintext]
+          [&_td:nth-child(2)]:[unicode-bidi:plaintext]
+          [&_td:nth-child(3)]:[unicode-bidi:plaintext]"
       >
           <!-- In-game tutorial: starts a default solo game with the guide on -->
           <section
@@ -231,9 +242,9 @@ export class HelpModal extends BaseModal {
               <table class="w-full text-sm border-separate border-spacing-y-1">
                 <thead>
                   <tr
-                    class="text-white/40 text-xs uppercase tracking-wider text-left"
+                    class="text-white/40 text-xs uppercase tracking-wider text-start"
                   >
-                    <th class="pb-2 pl-4">
+                    <th class="pb-2 ps-4">
                       ${translateText("help_modal.table_key")}
                     </th>
                     <th class="pb-2">
@@ -243,7 +254,7 @@ export class HelpModal extends BaseModal {
                 </thead>
                 <tbody class="text-white/80">
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey("Escape")}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -251,7 +262,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey("Enter")}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -259,7 +270,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey(keybinds.toggleView)}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -267,7 +278,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey(keybinds.coordinateGrid)}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -275,7 +286,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey(keybinds.swapDirection)}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -283,7 +294,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="inline-flex items-center gap-2">
                         ${this.renderKey(keybinds.shiftKey)}
                         <span class="text-white/40 font-bold">+</span>
@@ -304,7 +315,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="inline-flex items-center gap-2">
                         ${this.renderKey(keybinds.buildMenuModifier)}
                         <span class="text-white/40 font-bold">+</span>
@@ -325,7 +336,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="inline-flex items-center gap-2">
                         ${this.renderKey(keybinds.emojiMenuModifier)}
                         <span class="text-white/40 font-bold">+</span>
@@ -346,7 +357,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey(keybinds.centerCamera)}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -354,7 +365,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey(keybinds.pauseGame)}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -362,7 +373,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="flex flex-wrap gap-2">
                         ${this.renderKey(keybinds.gameSpeedDown)}
                         ${this.renderKey(keybinds.gameSpeedUp)}
@@ -373,7 +384,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="flex flex-wrap gap-2">
                         ${this.renderKey(keybinds.zoomOut)}
                         ${this.renderKey(keybinds.zoomIn)}
@@ -384,7 +395,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="flex flex-wrap gap-1 max-w-[200px]">
                         ${this.renderKey(keybinds.moveUp)}
                         ${this.renderKey(keybinds.moveLeft)}
@@ -397,7 +408,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="flex flex-wrap gap-2">
                         ${this.renderKey(keybinds.attackRatioDown)}
                         ${this.renderKey(keybinds.attackRatioUp)}
@@ -408,7 +419,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="inline-flex items-center gap-2">
                         ${this.renderKey(keybinds.shiftKey)}
                         <span class="text-white/40 font-bold">+</span>
@@ -432,7 +443,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="inline-flex items-center gap-2">
                         ${this.renderKey(keybinds.altKey)}
                         <span class="text-white/40 font-bold">+</span>
@@ -444,7 +455,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div
                         class="w-5 h-8 border border-white/40 rounded-full relative"
                       >
@@ -458,7 +469,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       <div class="inline-flex items-center gap-2">
                         ${this.renderKey(keybinds.boxSelectWarships)}
                         <span class="text-white/40 font-bold">+</span>
@@ -472,7 +483,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="hover:bg-white/5 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5">
+                    <td class="py-3 ps-4 border-b border-white/5">
                       ${this.renderKey(keybinds.selectAllWarships)}
                     </td>
                     <td class="py-3 border-b border-white/5 text-white/70">
@@ -558,7 +569,7 @@ export class HelpModal extends BaseModal {
                   <p class="mb-4 leading-relaxed">
                     ${translateText("help_modal.ui_control_desc")}
                   </p>
-                  <ul class="space-y-2 list-disc pl-4 text-white/60">
+                  <ul class="space-y-2 list-disc ps-4 text-white/60">
                     <li>${translateText("help_modal.ui_gold")}</li>
                     <li>${translateText("help_modal.ui_attack_ratio")}</li>
                   </ul>
@@ -593,7 +604,7 @@ export class HelpModal extends BaseModal {
                   <p class="mb-4 leading-relaxed">
                     ${translateText("help_modal.ui_events_desc")}
                   </p>
-                  <ul class="space-y-2 list-disc pl-4 text-white/60">
+                  <ul class="space-y-2 list-disc ps-4 text-white/60">
                     <li>${translateText("help_modal.ui_events_alliance")}</li>
                     <li>${translateText("help_modal.ui_events_attack")}</li>
                     <li>${translateText("help_modal.ui_events_quickchat")}</li>
@@ -621,7 +632,7 @@ export class HelpModal extends BaseModal {
                   <p class="mb-4 leading-relaxed">
                     ${translateText("help_modal.ui_options_desc")}
                   </p>
-                  <ul class="space-y-2 list-disc pl-4 text-white/60">
+                  <ul class="space-y-2 list-disc ps-4 text-white/60">
                     <li>${translateText("help_modal.option_timer")}</li>
                     <li>${translateText("help_modal.option_speed")}</li>
                     <li>${translateText("help_modal.option_pause")}</li>
@@ -946,17 +957,17 @@ export class HelpModal extends BaseModal {
                 <thead class="bg-white/10">
                   <tr>
                     <th
-                      class="py-3 pl-4 text-left text-xs font-bold uppercase tracking-wider text-blue-300 w-[20%]"
+                      class="py-3 ps-4 text-start text-xs font-bold uppercase tracking-wider text-blue-300 w-[20%]"
                     >
                       ${translateText("help_modal.build_name")}
                     </th>
                     <th
-                      class="py-3 text-left text-xs font-bold uppercase tracking-wider text-blue-300 w-[8%]"
+                      class="py-3 text-start text-xs font-bold uppercase tracking-wider text-blue-300 w-[8%]"
                     >
                       ${translateText("help_modal.build_icon")}
                     </th>
                     <th
-                      class="py-3 text-left text-xs font-bold uppercase tracking-wider text-blue-300"
+                      class="py-3 text-start text-xs font-bold uppercase tracking-wider text-blue-300"
                     >
                       ${translateText("help_modal.build_desc")}
                     </th>
@@ -964,7 +975,7 @@ export class HelpModal extends BaseModal {
                 </thead>
                 <tbody class="text-white/80">
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.city")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -980,7 +991,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.defense_post")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -996,7 +1007,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.port")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1012,7 +1023,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.factory")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1028,7 +1039,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.warship")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1044,7 +1055,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.missile_silo")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1060,7 +1071,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.sam_launcher")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1076,7 +1087,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.atom_bomb")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1092,7 +1103,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.hydrogen_bomb")}
                     </td>
                     <td class="py-3 border-b border-white/5">
@@ -1108,7 +1119,7 @@ export class HelpModal extends BaseModal {
                     </td>
                   </tr>
                   <tr class="bg-white/5 hover:bg-white/10 transition-colors">
-                    <td class="py-3 pl-4 border-b border-white/5 font-medium">
+                    <td class="py-3 ps-4 border-b border-white/5 font-medium">
                       ${translateText("unit_type.mirv")}
                     </td>
                     <td class="py-3 border-b border-white/5">

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -249,6 +249,7 @@ export class LangSelector extends LitElement {
       "steam-wishlist",
       "steam-wishlist-button",
       "streaming-now",
+      "tutorial-panel",
     ];
 
     document.title = this.translateText("main.title") ?? document.title;

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -469,6 +469,27 @@ function getCachedLangSelector(): LangSelector | null {
   return found;
 }
 
+/** Language codes whose script reads right-to-left (resources/lang/metadata.json). */
+const RTL_LANGUAGES = new Set(["ar", "fa", "he"]);
+
+/**
+ * True when the given language renders right-to-left. Defaults to the
+ * currently selected UI language, so callers can simply write `isRTL()`.
+ */
+export const isRTL = (lang?: string): boolean => {
+  const code = (lang ?? getCachedLangSelector()?.currentLang ?? "en").split(
+    "-",
+  )[0];
+  return RTL_LANGUAGES.has(code);
+};
+
+/**
+ * Value for the HTML `dir` attribute matching the current UI language.
+ * Apply it to containers whose text comes from translateText() so Persian,
+ * Arabic and Hebrew render right-to-left with correct mixed-content ordering.
+ */
+export const textDirection = (): "rtl" | "ltr" => (isRTL() ? "rtl" : "ltr");
+
 export const translateText = (
   key: string,
   params?: Record<string, string | number>,

--- a/src/client/hud/layers/TutorialPanel.ts
+++ b/src/client/hud/layers/TutorialPanel.ts
@@ -7,7 +7,7 @@ import { Controller } from "../../Controller";
 import { Platform } from "../../Platform";
 import { GoToPlayerEvent } from "../../TransformHandler";
 import { UIState } from "../../UIState";
-import { renderNumber, translateText } from "../../Utils";
+import { renderNumber, textDirection, translateText } from "../../Utils";
 import { GameView } from "../../view";
 import { PlayerView } from "../../view/PlayerView";
 import {
@@ -412,6 +412,7 @@ export class TutorialPanel extends LitElement implements Controller {
     if (!this.active) return nothing;
     return html`
       <div
+        dir=${textDirection()}
         class="pointer-events-auto w-full sm:rounded-lg bg-gray-800/92 backdrop-blur-sm shadow-lg text-white text-base p-2 sm:mb-1"
         @contextmenu=${(e: MouseEvent) => e.preventDefault()}
       >
@@ -511,12 +512,18 @@ export class TutorialPanel extends LitElement implements Controller {
           ? nothing
           : html`<span class="shrink-0">${done ? "✓" : "•"}</span>`}
         ${step.bullets
-          ? html`<ul class="list-disc ml-4 flex flex-col gap-1">
+          ? html`<ul class="list-disc ms-4 flex flex-col gap-1">
               ${step.bullets.map(
-                (b) => html`<li>${translateText(`tutorial.step.${b}`)}</li>`,
+                // dir=auto keeps step text on its content's side while the
+                // panel chrome mirrors — untranslated steps (English fallback)
+                // then keep their punctuation on the correct end.
+                (b) =>
+                  html`<li dir="auto">
+                    ${translateText(`tutorial.step.${b}`)}
+                  </li>`,
               )}
             </ul>`
-          : html`<span>${this.stepText(step, done)}</span>`}
+          : html`<span dir="auto">${this.stepText(step, done)}</span>`}
       </p>
     `;
   }

--- a/tests/TextDirection.test.ts
+++ b/tests/TextDirection.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isRTL } from "../src/client/Utils";
+
+describe("RTL language detection", () => {
+  it("marks right-to-left languages as RTL", () => {
+    expect(isRTL("ar")).toBe(true);
+    expect(isRTL("fa")).toBe(true);
+    expect(isRTL("he")).toBe(true);
+  });
+
+  it("marks left-to-right languages as not RTL", () => {
+    expect(isRTL("en")).toBe(false);
+    expect(isRTL("de")).toBe(false);
+    expect(isRTL("zh-CN")).toBe(false);
+    expect(isRTL("pt-BR")).toBe(false);
+  });
+
+  it("ignores regional subtags when detecting the script", () => {
+    expect(isRTL("ar-EG")).toBe(true);
+    expect(isRTL("fa-IR")).toBe(true);
+  });
+
+  it("falls back to LTR for unknown or empty languages", () => {
+    expect(isRTL("")).toBe(false);
+    expect(isRTL("xx")).toBe(false);
+  });
+});


### PR DESCRIPTION
Resolves #5247

## Description

Persian, Arabic and Hebrew are right-to-left languages, but the help / tutorial UI laid their translated text out left-to-right: paragraphs hugged the left edge, the hotkey table ran in LTR column order, and the punctuation of mixed Persian/English strings (key names, numbers, Latin brand words) landed on the wrong side of sentences — e.g. `.منو را میبندد` instead of `منو را میبندد.`

This PR adds bidi direction support to the two tutorial surfaces without touching the rest of the UI:

- **`src/client/Utils.ts`** — new `isRTL()` / `textDirection()` helpers keyed off the currently selected UI language (`ar`, `fa`, `he` — the RTL languages shipped in `resources/lang/metadata.json`).
- **`HelpModal.ts`** — the modal body now gets `dir` from the UI language, so translated sections flow right-to-left and right-align; rows, cards and table columns mirror naturally. Physical spacing classes become logical ones (`ps-4`/`text-start`) so cells and list markers mirror correctly while rendering identically for LTR languages. Key badges stay `dir="ltr"` so key names and combos like `Shift + click` never scramble.
- **`TutorialPanel.ts`** — the in-game tutorial panel mirrors the same way (title/steps header, bullets, close button). Step text uses `dir="auto"` so steps that fall back to English (the `tutorial.*` strings are not yet translated on Crowdin) keep their punctuation on the correct end.
- **`LangSelector.ts`** — `tutorial-panel` joins the re-render list so switching language mid-session updates the direction immediately.
- **Leaf text** (`p`, `li`, action/description table cells) uses `unicode-bidi: plaintext` so any string not yet translated keeps sane LTR flow inside the mirrored chrome, while translated Persian/Arabic flows RTL.

No game logic is touched, and for English (and all LTR languages) the rendered HTML is unchanged — `textDirection()` returns `"ltr"` and logical properties behave exactly like the physical ones they replace.

## Screenshots

### Help modal — Keyboard shortcuts (Persian)

**Before:** left-aligned Persian text, LTR column order, punctuation scrambled.

**After:** mirrored table, right-aligned text, correct punctuation, key badges untouched.

| Before | After |
| --- | --- |
| ![before hotkeys](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/before-hotkeys-persian.png) | ![after hotkeys](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/after-hotkeys-persian.png) |

### Help modal — UI guide section (Persian)

| Before | After |
| --- | --- |
| ![before ui](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/before-ui-section-persian.png) | ![after ui](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/after-ui-section-persian.png) |

### Help modal — top (Persian)

| Before | After |
| --- | --- |
| ![before help](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/before-help-modal-persian.png) | ![after help](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/after-help-modal-persian.png) |

### In-game tutorial panel (Persian locale)

Chrome mirrors (title right, step counter left); the English fallback step text keeps correct punctuation via `dir="auto"`.

| Before | After |
| --- | --- |
| ![before tutorial](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/before-tutorial-panel-persian.png) | ![after tutorial](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/after-tutorial-panel-persian.png) |

### No regression for LTR languages (English)

![after hotkeys english](https://raw.githubusercontent.com/MRGhust/OpenFrontIO/pr-assets/5247/screenshots/after-hotkeys-english.png)

## Testing performed

- `npx tsc --noEmit` — clean
- `npm run lint` (oxlint + eslint) — clean
- `npm test` — 399 test files / 5091 tests + server suite (62 files / 649 tests) all pass
- New `tests/TextDirection.test.ts` covers `isRTL()` (RTL codes, regional subtags like `fa-IR`, unknown codes)
- Manually verified in the browser (dev server, Persian + English locales): help modal sections, hotkey table, build-menu table, in-game tutorial panel, and language switching

## Notes for review

- Only the two tutorial surfaces get `dir` — the rest of the UI (HUD, spawn timer, chat, ...) intentionally stays as-is so the change stays reviewable; the helpers are ready to be reused in a follow-up if maintainers want full-app RTL.
- Screenshot assets live on a separate branch (`pr-assets/5247`) so the PR diff stays code-only.


## Discord username

<!-- TODO(MRGhust): fill in before marking ready — maintainers use it for follow-ups -->
NOBODYiran


