### PR TITLE
Reduce the multiplayer spawn phase from 30s to 20s

### DIFF
--- a/src/core/configuration/Config.ts
+++ b/src/core/configuration/Config.ts
@@ -781,7 +781,7 @@ export class Config {
     if (this.isRandomSpawn()) {
       return 150;
     }
-    return 300;
+    return 200;
   }
   numBots(): number {
     return this.bots();

--- a/tests/core/configuration/SpawnPhaseTurns.test.ts
+++ b/tests/core/configuration/SpawnPhaseTurns.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "vitest";
+import { GameType } from "../../../src/core/game/Game";
+import { setup } from "../../util/Setup";
+
+// 10 ticks = 1 second of game time.
+describe("numSpawnPhaseTurns", () => {
+  test("multiplayer spawn phase lasts 20 seconds", async () => {
+    const game = await setup("plains", { gameType: GameType.Public });
+    expect(game.config().numSpawnPhaseTurns()).toBe(200);
+  });
+
+  test("random spawn shortens the spawn phase to 15 seconds", async () => {
+    const game = await setup("plains", {
+      gameType: GameType.Public,
+      randomSpawn: true,
+    });
+    expect(game.config().numSpawnPhaseTurns()).toBe(150);
+  });
+
+  test("singleplayer spawn phase is 100 ticks regardless of random spawn", async () => {
+    const game = await setup("plains", {
+      gameType: GameType.Singleplayer,
+      randomSpawn: true,
+    });
+    expect(game.config().numSpawnPhaseTurns()).toBe(100);
+  });
+});


### PR DESCRIPTION
## Summary

- Shortens the normal multiplayer spawn phase from 300 ticks (30s) to 200 ticks (20s) in `numSpawnPhaseTurns()`.
- Random spawn keeps its existing 150-tick (15s) timer, and singleplayer keeps its untimed 100 ticks.
- Adds `tests/core/configuration/SpawnPhaseTurns.test.ts` locking in all three durations.
- No other changes needed: the countdown HUD, spawn progress bar, and nation alliance cutoffs all read `numSpawnPhaseTurns()` dynamically.

## Test plan

- New `SpawnPhaseTurns.test.ts` passes.
- Full `npm test` suite passes (both projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)