### PR TITLE
MIRV betrayal only applies once the launch is validated

### DIFF
--- a/src/core/execution/MIRVExecution.ts
+++ b/src/core/execution/MIRVExecution.ts
@@ -68,18 +68,6 @@ export class MirvExecution implements Execution {
     this.baseX = this.mg.x(this.dst);
     this.baseY = this.mg.y(this.dst);
     this.stagedTargets = [this.dst];
-
-    // Betrayal on launch
-    if (this.targetPlayer.isPlayer()) {
-      const alliance = this.player.allianceWith(this.targetPlayer);
-      if (alliance !== null) {
-        this.player.breakAlliance(alliance);
-      }
-      if (this.targetPlayer !== this.player) {
-        this.targetPlayer.updateRelation(this.player, -100);
-        this.player.updateRelation(this.targetPlayer, -100);
-      }
-    }
   }
 
   tick(ticks: number): void {
@@ -96,6 +84,19 @@ export class MirvExecution implements Execution {
         targetPlayer: this.targetPlayer,
       });
       this.mg.stats().bombLaunch(this.player, this.targetPlayer, UnitType.MIRV);
+
+      // Betrayal on launch — only once the missile has actually spawned, so
+      // a fizzled launch pays no diplomatic cost.
+      if (this.targetPlayer.isPlayer()) {
+        const alliance = this.player.allianceWith(this.targetPlayer);
+        if (alliance !== null) {
+          this.player.breakAlliance(alliance);
+        }
+        if (this.targetPlayer !== this.player) {
+          this.targetPlayer.updateRelation(this.player, -100);
+          this.player.updateRelation(this.targetPlayer, -100);
+        }
+      }
       const x = Math.floor((this.baseX + this.mg.x(this.nuke.tile())) / 2);
       const y = Math.max(0, this.baseY - 500) + 50;
       this.separateDst = this.mg.ref(x, y);

--- a/tests/MirvBetrayal.test.ts
+++ b/tests/MirvBetrayal.test.ts
@@ -1,0 +1,60 @@
+import { AllianceRequestExecution } from "../src/core/execution/alliance/AllianceRequestExecution";
+import { MirvExecution } from "../src/core/execution/MIRVExecution";
+import {
+  Game,
+  Player,
+  PlayerInfo,
+  PlayerType,
+  UnitType,
+} from "../src/core/game/Game";
+import { setup } from "./util/Setup";
+import { executeTicks } from "./util/utils";
+
+let game: Game;
+let player1: Player;
+let player2: Player;
+
+describe("MIRV betrayal side effects", () => {
+  beforeEach(async () => {
+    game = await setup("plains", { instantBuild: true }, [
+      new PlayerInfo("player1", PlayerType.Human, "c1", "p1"),
+      new PlayerInfo("player2", PlayerType.Human, "c2", "p2"),
+    ]);
+
+    player1 = game.player("p1");
+    player2 = game.player("p2");
+
+    player1.conquer(game.ref(0, 0));
+    player2.conquer(game.ref(10, 10));
+
+    player1.addGold(1_000_000_000n);
+    player2.addGold(1_000_000_000n);
+
+    game.addExecution(new AllianceRequestExecution(player1, player2.id()));
+    game.executeNextTick();
+    game.addExecution(new AllianceRequestExecution(player2, player1.id()));
+    game.executeNextTick();
+    expect(player1.isAlliedWith(player2)).toBe(true);
+  });
+
+  test("a successful launch breaks the alliance and marks the launcher a traitor", () => {
+    player1.buildUnit(UnitType.MissileSilo, game.ref(0, 0), {});
+
+    game.addExecution(new MirvExecution(player1, game.ref(10, 10)));
+    executeTicks(game, 2); // init + spawn
+
+    expect(player1.units(UnitType.MIRV)).toHaveLength(1);
+    expect(player1.isAlliedWith(player2)).toBe(false);
+    expect(player1.isTraitor()).toBe(true);
+  });
+
+  test("a fizzled launch applies no betrayal side effects", () => {
+    // player1 has no silo, so canBuild fails and the execution fizzles.
+    game.addExecution(new MirvExecution(player1, game.ref(10, 10)));
+    executeTicks(game, 2);
+
+    expect(player1.units(UnitType.MIRV)).toHaveLength(0);
+    expect(player1.isAlliedWith(player2)).toBe(true);
+    expect(player1.isTraitor()).toBe(false);
+  });
+});


### PR DESCRIPTION
Follow-up to #5349, fixing the [review finding](https://github.com/openfrontio/OpenFrontIO/pull/5349#issuecomment-5628817174) there.

## Summary

The revert restored the pre-#5281 ordering in `MirvExecution`: `init()` broke the alliance and applied the −100/−100 relation penalty immediately, while the `canBuild` validation (gold, ready silo) only runs in `tick()` a tick later. A launch that fizzled at that check still paid the full diplomatic cost — alliance broken, traitor mark, relations tanked — with no missile spawned and no gold spent.

This moves the betrayal block into `tick()`, right after the spawn is confirmed, so a fizzled launch applies no betrayal side effects. No cooldown mechanism is reintroduced; the change is scoped purely to "only penalize if the launch actually succeeds."

## Test plan

- New `tests/MirvBetrayal.test.ts`: a successful launch still breaks the alliance and marks the launcher a traitor; a fizzled launch (no silo) leaves the alliance intact and the launcher untainted.
- Full suite passes (399 files / 5090 tests + server suite), plus `tsc --noEmit`, lint, and prettier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)