### PR TITLE
feat(settings): split a Graphics tab out of Gameplay (OPE-173)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2104,7 +2104,7 @@
     "nuke_alliance_safety_label": "Ally friendly-fire safety",
     "off": "Off",
     "on": "On",
-    "open_settings_desc": "Gameplay, audio and keybind settings",
+    "open_settings_desc": "Gameplay, graphics, audio and keybind settings",
     "open_settings_label": "Settings",
     "pause_game": "Pause",
     "pause_game_desc": "Pause or resume the game (single player and custom games for host).",

--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2129,6 +2129,7 @@
     "swap_direction_desc": "Toggle rocket launch direction (up/down).",
     "tab_audio": "Audio",
     "tab_gameplay": "Gameplay",
+    "tab_graphics": "Graphics",
     "tab_keybinds": "Keybinds",
     "territory_patterns_desc": "Choose whether to display territory skin designs in game",
     "territory_patterns_label": "Territory Skins",

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -438,6 +438,7 @@ export class UserSettingModal extends BaseModal {
     return {
       tabs: [
         { key: "gameplay", label: translateText("user_setting.tab_gameplay") },
+        { key: "graphics", label: translateText("user_setting.tab_graphics") },
         // PR B inserts { key: "display", ... } here, gated on desktopDisplay().
         { key: "audio", label: translateText("user_setting.tab_audio") },
         { key: "keybinds", label: translateText("user_setting.tab_keybinds") },
@@ -462,6 +463,9 @@ export class UserSettingModal extends BaseModal {
         break;
       case "audio":
         body = this.renderAudioSettings();
+        break;
+      case "graphics":
+        body = this.renderGraphicsSettings();
         break;
       // PR B: case "display": body = this.renderDisplaySettings(); break;
       default:
@@ -920,7 +924,12 @@ export class UserSettingModal extends BaseModal {
     `;
   }
 
-  private renderGameplaySettings() {
+  /**
+   * Purely visual switches — how the map and HUD are drawn. Anything that
+   * changes how the game is played, or what the game tells you, belongs in
+   * renderGameplaySettings() instead.
+   */
+  private renderGraphicsSettings() {
     return html`
       <!-- 🎨 Graphics preset -->
       <div
@@ -937,6 +946,15 @@ export class UserSettingModal extends BaseModal {
         <graphics-preset-selector></graphics-preset-selector>
       </div>
 
+      <!-- 🏳️ Territory Patterns -->
+      <setting-toggle
+        label="${translateText("user_setting.territory_patterns_label")}"
+        description="${translateText("user_setting.territory_patterns_desc")}"
+        id="territory-patterns-toggle"
+        .checked=${this.userSettings.territoryPatterns()}
+        @change=${this.toggleTerritoryPatterns}
+      ></setting-toggle>
+
       <!-- 😊 Emojis -->
       <setting-toggle
         label="${translateText("user_setting.emojis_label")}"
@@ -946,6 +964,19 @@ export class UserSettingModal extends BaseModal {
         @change=${this.toggleEmojis}
       ></setting-toggle>
 
+      <!-- 📱 Performance Overlay -->
+      <setting-toggle
+        label="${translateText("user_setting.performance_overlay_label")}"
+        description="${translateText("user_setting.performance_overlay_desc")}"
+        id="performance-overlay-toggle"
+        .checked=${this.userSettings.performanceOverlay()}
+        @change=${this.togglePerformanceOverlay}
+      ></setting-toggle>
+    `;
+  }
+
+  private renderGameplaySettings() {
+    return html`
       <!-- 🚨 Alert frame -->
       <setting-toggle
         label="${translateText("user_setting.alert_frame_label")}"
@@ -991,15 +1022,6 @@ export class UserSettingModal extends BaseModal {
         @change=${this.toggleLobbyIdVisibility}
       ></setting-toggle>
 
-      <!-- 🏳️ Territory Patterns -->
-      <setting-toggle
-        label="${translateText("user_setting.territory_patterns_label")}"
-        description="${translateText("user_setting.territory_patterns_desc")}"
-        id="territory-patterns-toggle"
-        .checked=${this.userSettings.territoryPatterns()}
-        @change=${this.toggleTerritoryPatterns}
-      ></setting-toggle>
-
       <!-- 🔍 Go to player -->
       <setting-toggle
         label="${translateText("user_setting.go_to_player_label")}"
@@ -1009,7 +1031,6 @@ export class UserSettingModal extends BaseModal {
         @change=${this.toggleGoToPlayer}
       ></setting-toggle>
 
-      <!-- 📱 Performance Overlay -->
       <!-- Help messages (moved here from the in-game menu) -->
       <setting-toggle
         label="${translateText("user_setting.help_messages_label")}"
@@ -1028,14 +1049,6 @@ export class UserSettingModal extends BaseModal {
         id="attacking-troops-overlay-toggle"
         .checked=${this.userSettings.attackingTroopsOverlay()}
         @change=${this.toggleAttackingTroopsOverlay}
-      ></setting-toggle>
-
-      <setting-toggle
-        label="${translateText("user_setting.performance_overlay_label")}"
-        description="${translateText("user_setting.performance_overlay_desc")}"
-        id="performance-overlay-toggle"
-        .checked=${this.userSettings.performanceOverlay()}
-        @change=${this.togglePerformanceOverlay}
       ></setting-toggle>
 
       <!-- ⚔️ Attack Ratio -->

--- a/tests/client/InGameSettingsMenu.test.ts
+++ b/tests/client/InGameSettingsMenu.test.ts
@@ -14,6 +14,8 @@ type TestMenu = SettingsModal & { updateComplete: Promise<unknown> };
 type TestSettings = UserSettingModal & {
   updateComplete: Promise<unknown>;
   activeTab: string;
+  setActiveTab(key: string): void;
+  modalConfig(): { tabs?: { key: string; label: string }[] };
 };
 
 describe("in-game menu opens the shared settings modal", () => {
@@ -82,6 +84,29 @@ describe("in-game menu opens the shared settings modal", () => {
     expect(settings.isOpen()).toBe(true);
     expect(settings.activeTab).toBe("gameplay");
     expect(pauses).toEqual([true]);
+  });
+
+  it("reaches Graphics from the in-game instance, without changing the landing tab", async () => {
+    await openMenu();
+    openSettingsRow()!.click();
+    await settle();
+
+    // The in-game entry point still lands on Gameplay...
+    expect(settings.activeTab).toBe("gameplay");
+    expect(settings.querySelector("graphics-preset-selector")).toBeNull();
+
+    // ...and Graphics is a tab the player can reach from there.
+    expect(settings.modalConfig().tabs?.map((t) => t.key)).toContain(
+      "graphics",
+    );
+    settings.setActiveTab("graphics");
+    await settle();
+
+    expect(settings.activeTab).toBe("graphics");
+    expect(settings.querySelector("graphics-preset-selector")).not.toBeNull();
+    expect(
+      settings.querySelector("#performance-overlay-toggle"),
+    ).not.toBeNull();
   });
 
   it("reopens the menu when the settings modal closes", async () => {

--- a/tests/client/UserSettingModal.tabs.test.ts
+++ b/tests/client/UserSettingModal.tabs.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it } from "vitest";
 
+import en from "../../resources/lang/en.json";
 import { modalRouter } from "../../src/client/ModalRouter";
 import type { UIState } from "../../src/client/UIState";
 import "../../src/client/UserSettingModal";
@@ -32,13 +33,23 @@ describe("user-setting tabs", () => {
     });
   });
 
-  it("groups the settings as Gameplay, Audio and Keybinds", async () => {
+  it("groups the settings as Gameplay, Graphics, Audio and Keybinds, in that order", async () => {
     const el = await mount(false);
     expect(el.modalConfig().tabs?.map((t) => t.key)).toEqual([
       "gameplay",
+      "graphics",
       "audio",
       "keybinds",
     ]);
+  });
+
+  it("has an en.json label for every tab, so none renders as a raw key", async () => {
+    const el = await mount(false);
+    const strings = en.user_setting as Record<string, string | undefined>;
+    for (const tab of el.modalConfig().tabs ?? []) {
+      expect(strings[`tab_${tab.key}`]).toBeTruthy();
+    }
+    expect(strings.tab_graphics).toBe("Graphics");
   });
 
   it("opens on the requested tab", async () => {
@@ -63,9 +74,71 @@ describe("user-setting tabs", () => {
     await el.updateComplete;
     expect(el.querySelector("#help-messages-toggle")).not.toBeNull();
     expect(el.querySelector("#attacking-troops-overlay-toggle")).not.toBeNull();
-    // The graphics preset stays at the top of Gameplay rather than getting a
-    // tab of its own.
-    expect(el.querySelector("graphics-preset-selector")).not.toBeNull();
+  });
+
+  // The visual switches live on Graphics and nowhere else. Each selector is
+  // asserted on both tabs, so moving one back to Gameplay fails the second
+  // half of the pair rather than silently passing.
+  const GRAPHICS_CONTROLS = [
+    "graphics-preset-selector",
+    "#territory-patterns-toggle",
+    "#emoji-toggle",
+    "#performance-overlay-toggle",
+  ];
+
+  // Everything that changes how the game is played, or what the game tells
+  // you, stays on Gameplay.
+  const GAMEPLAY_CONTROLS = [
+    "#alert-frame-toggle",
+    "#cursor_cost_label-toggle",
+    "#left-click-toggle",
+    "#anonymous-names-toggle",
+    "#lobby-id-visibility-toggle",
+    "#go-to-player-toggle",
+    "#help-messages-toggle",
+    "#attacking-troops-overlay-toggle",
+    "#attack-ratio-slider",
+  ];
+
+  it.each(GRAPHICS_CONTROLS)("renders %s on Graphics", async (selector) => {
+    const el = await mount(false);
+    el.open({ tab: "graphics" });
+    await el.updateComplete;
+    expect(el.querySelector(selector)).not.toBeNull();
+  });
+
+  it.each(GRAPHICS_CONTROLS)(
+    "does not render %s on Gameplay",
+    async (selector) => {
+      const el = await mount(false);
+      el.open({ tab: "gameplay" });
+      await el.updateComplete;
+      expect(el.querySelector(selector)).toBeNull();
+    },
+  );
+
+  it.each(GAMEPLAY_CONTROLS)("keeps %s on Gameplay", async (selector) => {
+    const el = await mount(false);
+    el.open({ tab: "gameplay" });
+    await el.updateComplete;
+    expect(el.querySelector(selector)).not.toBeNull();
+  });
+
+  it.each(GAMEPLAY_CONTROLS)(
+    "does not render %s on Graphics",
+    async (selector) => {
+      const el = await mount(false);
+      el.open({ tab: "graphics" });
+      await el.updateComplete;
+      expect(el.querySelector(selector)).toBeNull();
+    },
+  );
+
+  it("opens on Graphics when asked", async () => {
+    const el = await mount(false);
+    el.open({ tab: "graphics" });
+    await el.updateComplete;
+    expect(el.activeTab).toBe("graphics");
   });
 
   it("re-reads keybinds on every open, so two instances never diverge", async () => {


### PR DESCRIPTION
The Gameplay tab that #5341 created had grown into a mixed list: the graphics preset and three purely visual switches sat alongside the controls that change how the game is actually played. This splits the visual ones into their own **Graphics** tab, second in the strip.

Tab order is now **Gameplay, Graphics, Audio, Keybinds** (PR B still inserts Display after Graphics, gated on desktop).

This is a **pure relocation — no toggle changes behaviour**. Every control keeps its existing element id, label/description keys and change handler; only which `render*Settings()` method emits it has changed.

## Toggle → tab

| Control | Tab | Why |
| --- | --- | --- |
| `graphics-preset-selector` | **Graphics** | Chooses the preset look of the map |
| `#territory-patterns-toggle` | **Graphics** | Territory pattern texturing |
| `#emoji-toggle` | **Graphics** | Purely a visual overlay on the map |
| `#performance-overlay-toggle` | **Graphics** | FPS / performance readout |
| `#alert-frame-toggle` | Gameplay | An alert, not a render option |
| `#cursor_cost_label-toggle` | Gameplay | Tells you what something costs |
| `#left-click-toggle` | Gameplay | Input behaviour |
| `#anonymous-names-toggle` | Gameplay | Privacy, not rendering |
| `#lobby-id-visibility-toggle` | Gameplay | Privacy, not rendering |
| `#go-to-player-toggle` | Gameplay | Camera behaviour at game start |
| `#help-messages-toggle` | Gameplay | Tells you things during play |
| `#attacking-troops-overlay-toggle` | Gameplay | Surfaces troop counts — game information |
| `#attack-ratio-slider`, attack ratio increment | Gameplay | Changes how you attack |
| Nuke alliance safety, easter-egg rows | Gameplay | Unchanged |

The two judgement calls were `#attacking-troops-overlay-toggle` and `#alert-frame-toggle`. Both convey game state rather than adjusting how the map is drawn, so both stay in Gameplay.

## The in-game advanced graphics modal is untouched

`hud/layers/GraphicsSettingsModal.ts` — the in-game FX/quality modal behind the `graphics_setting.*` keys — is **not** part of this change. The new tab holds the handful of visual switches that already lived in this modal; it does not absorb or duplicate the advanced renderer settings.

## In-game menu

The in-game menu reuses this same modal via `open({ tab, onReturn })`, so Graphics is reachable there automatically. Its landing tab stays `gameplay`, which is asserted rather than assumed.

## Translations

One new key, `user_setting.tab_graphics` = `"Graphics"`, inserted alphabetically in `resources/lang/en.json` and rendered through `translateText`. No other language file is touched.

## Tests

`tests/client/UserSettingModal.tabs.test.ts`

- `groups the settings as Gameplay, Graphics, Audio and Keybinds, in that order`
- `has an en.json label for every tab, so none renders as a raw key`
- `renders %s on Graphics` / `does not render %s on Gameplay` (each of the 4 moved controls)
- `keeps %s on Gameplay` / `does not render %s on Graphics` (each of the 9 retained controls)
- `opens on Graphics when asked`

`tests/client/InGameSettingsMenu.test.ts`

- `reaches Graphics from the in-game instance, without changing the landing tab`

Each moved control is asserted on **both** tabs, so moving one back to Gameplay fails a test rather than passing quietly. Verified by mutation: putting `#emoji-toggle` back on Gameplay fails exactly the two tests naming it.

Part of [OPE-173](https://linear.app/openfront/issue/OPE-173).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
