### PR TITLE
Exclude git worktrees from the vitest file glob

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -266,6 +266,16 @@ export default defineConfig(({ mode }) => {
       globals: true,
       environment: "jsdom",
       setupFiles: "./tests/setup.ts",
+      // Git worktrees live inside the repo, so their tests match the default
+      // glob and run against that worktree's own (often stale) source and
+      // node_modules. Anyone with a worktree checked out sees failures that
+      // have nothing to do with their branch.
+      exclude: [
+        "**/node_modules/**",
+        "**/dist/**",
+        "**/.worktrees/**",
+        "**/.claude/worktrees/**",
+      ],
     },
     root: "./",
     base: "/",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 import { defineConfig, loadEnv, type Plugin } from "vite";
 import { createHtmlPlugin } from "vite-plugin-html";
+import { configDefaults } from "vitest/config";
 import {
   type AssetManifest,
   buildAssetUrl,
@@ -270,9 +271,12 @@ export default defineConfig(({ mode }) => {
       // glob and run against that worktree's own (often stale) source and
       // node_modules. Anyone with a worktree checked out sees failures that
       // have nothing to do with their branch.
+      // Spread the defaults rather than restating them: setting `exclude`
+      // replaces vitest's built-in list, and hand-copying a subset silently
+      // drops the dot-directory pattern (.git, .cache, .output, ...) --
+      // reintroducing the same stray-file problem this is here to fix.
       exclude: [
-        "**/node_modules/**",
-        "**/dist/**",
+        ...configDefaults.exclude,
         "**/.worktrees/**",
         "**/.claude/worktrees/**",
       ],


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

Git worktrees live inside the repo, so their test files match vitest's default glob. Vitest then runs them against that worktree's own source and `node_modules`, which belong to a different branch and are often stale.

Measured locally with four worktrees checked out:

| | test files collected | from worktrees |
|---|---|---|
| before | 1295 | 889 |
| after | 406 | 0 |

So about 69% of what the suite ran belonged to other branches. Two visible effects:

- **Failures that aren't yours.** A full run on a clean branch reported 20 failed files and 2 failed tests, every one of them from a stale worktree. Nothing in the working branch was wrong, but you cannot tell that from the summary — the paths scroll past and the counts look real.
- **Runs take roughly three times longer** than the repo's own tests need.

Adds an `exclude` to the vitest config covering `.worktrees/` and `.claude/worktrees/`, alongside the `node_modules`/`dist` defaults that have to be restated once `exclude` is set at all.

No behaviour change to anything that ships.

## Please complete the following:

- [x] I have added screenshots for all UI updates — n/a, build config only
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — n/a, no user-facing text
- [x] I have added relevant tests to the test directory — n/a, this is test collection config; verified with `vitest list --filesOnly` before and after (counts above)

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish
