### PR TITLE
Survive a lit update that lands after its environment is gone

### DIFF
--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -464,6 +464,16 @@ function getCachedLangSelector(): LangSelector | null {
   const cached = self.langSelector as LangSelector | null | undefined;
   if (cached && cached.isConnected) return cached;
 
+  // A lit update is scheduled on a microtask, so a component can render once
+  // more after its environment has gone -- which in tests means `document` is
+  // no longer defined by the time this runs. Returning null makes
+  // translateText fall back to the key instead of throwing an unhandled
+  // rejection that fails the whole run.
+  if (typeof document === "undefined") {
+    self.langSelector = null;
+    return null;
+  }
+
   const found = document.querySelector("lang-selector") as LangSelector | null;
   self.langSelector = found ?? null;
   return found;


### PR DESCRIPTION
**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

CI on `main` is red. Every test passes — 409 files, 409 passed — and the job still exits 1 on an unhandled rejection:

```
⎯⎯⎯⎯ Unhandled Rejection ⎯⎯⎯⎯⎯
ReferenceError: document is not defined
 ❯ getCachedLangSelector src/client/Utils.ts:467:17
 ❯ translateText src/client/Utils.ts:480:24
 ❯ UserSettingModal.modalConfig src/client/UserSettingModal.ts:512:35
 ❯ UserSettingModal.willUpdate src/client/components/BaseModal.ts:131:23
 ❯ UserSettingModal.performUpdate  (lit reactive-element)
 ❯ UserSettingModal.scheduleUpdate (lit reactive-element)
 ❯ UserSettingModal.__enqueueUpdate (lit reactive-element)
 ❯ processTicksAndRejections
```

lit schedules an update on a microtask, so a component can render once more after the test that mounted it has finished and its jsdom environment has been torn down. `getCachedLangSelector` then reaches for `document`, which is no longer defined, and the rejection fails the whole run regardless of test results.

This guards the lookup: with no `document`, return null and let `translateText` fall back to returning the key, which is what it already does whenever no `lang-selector` is present.

It does not change behaviour in a browser, where `document` always exists.

Worth noting this is a guard, not a cure. The underlying pattern — components rendering after teardown — is still there and will keep producing noise; it is just no longer fatal. Fixing that properly means auditing modal cleanup across the components that do it, which is a bigger change than an unblock should carry.

## Please complete the following:

- [x] I have added screenshots for all UI updates — n/a, no UI change
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — n/a, no new strings
- [x] I have added relevant tests to the test directory — n/a; the failure is an environment teardown race with no deterministic unit test. Verified by running CI's own command (`npm run test:coverage`) locally, before and after.

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish
