### PR TITLE
Check for browser globals at call time in Platform

### DIFF
--- a/src/client/Platform.ts
+++ b/src/client/Platform.ts
@@ -1,5 +1,8 @@
 export const Platform = (() => {
-  const isBrowser =
+  // Evaluated on every call, never cached: a jsdom environment can be torn
+  // down while lit still has a microtask-scheduled render queued, so a flag
+  // captured at module load would outlive the globals it describes.
+  const isBrowser = () =>
     typeof window !== "undefined" && typeof navigator !== "undefined";
 
   const normalizePlatform = (platform: string): string => {
@@ -28,7 +31,7 @@ export const Platform = (() => {
 
   // OS Extraction
   const extractOS = (): string => {
-    if (!isBrowser) return "Unknown";
+    if (!isBrowser()) return "Unknown";
 
     const uaData = (navigator as any).userAgentData;
     if (uaData?.platform) {
@@ -74,7 +77,7 @@ export const Platform = (() => {
 
     // Detect the user agent when the `nodeIntegration` option is set to false
     if (
-      isBrowser &&
+      isBrowser() &&
       typeof navigator.userAgent === "string" &&
       navigator.userAgent.indexOf("Electron") >= 0
     ) {
@@ -96,23 +99,23 @@ export const Platform = (() => {
     isElectron: performElectronCheck(),
 
     get isMobileWidth(): boolean {
-      return isBrowser ? window.innerWidth < 768 : false;
+      return isBrowser() ? window.innerWidth < 768 : false;
     },
 
     get isTabletWidth(): boolean {
-      return isBrowser
+      return isBrowser()
         ? window.innerWidth >= 768 && window.innerWidth < 1024
         : false;
     },
 
     get isDesktopWidth(): boolean {
-      return isBrowser ? window.innerWidth >= 1024 : false;
+      return isBrowser() ? window.innerWidth >= 1024 : false;
     },
 
     /** Touch devices (phones, tablets) report a coarse primary pointer. */
     get isTouch(): boolean {
       return (
-        isBrowser &&
+        isBrowser() &&
         typeof window.matchMedia === "function" &&
         window.matchMedia("(pointer: coarse)").matches
       );

--- a/tests/client/Platform.test.ts
+++ b/tests/client/Platform.test.ts
@@ -131,4 +131,25 @@ describe("Platform", () => {
     expect(platform.isTabletWidth).toBe(false);
     expect(platform.isDesktopWidth).toBe(true);
   });
+
+  it("re-checks for browser globals instead of trusting a load-time flag", async () => {
+    const platform = await loadPlatform({
+      userAgent:
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15",
+    });
+
+    setInnerWidth(1280);
+    expect(platform.isDesktopWidth).toBe(true);
+
+    // A queued lit update can run after the test environment is torn down, so
+    // every accessor has to survive the browser globals disappearing.
+    vi.stubGlobal("window", undefined);
+    vi.stubGlobal("navigator", undefined);
+
+    expect(() => platform.isTouch).not.toThrow();
+    expect(platform.isTouch).toBe(false);
+    expect(platform.isMobileWidth).toBe(false);
+    expect(platform.isTabletWidth).toBe(false);
+    expect(platform.isDesktopWidth).toBe(false);
+  });
 });


### PR DESCRIPTION
> **Before opening a PR:** discuss new features on [Discord](https://discord.gg/K9zernJB5z) first, and file bugs or small improvements as [issues](https://github.com/openfrontio/OpenFrontIO/issues/new/choose). You must be assigned to an `approved` issue — unsolicited PRs will be auto-closed.

**Add approved & assigned issue number here:**

Resolves #(issue number)

## Description:

Unblocks CI. The `🔬 Test` job currently reports **every test passing and still exits 1**, on an unhandled rejection:

```
ReferenceError: window is not defined
 ❯ Object.get isTouch [as isTouch] src/client/Platform.ts:116:16
 ❯ UserSettingModal.modalConfig src/client/UserSettingModal.ts:540:22
 ❯ UserSettingModal.willUpdate src/client/components/BaseModal.ts:131:23
 ❯ UserSettingModal.performUpdate / scheduleUpdate / __enqueueUpdate  (lit reactive-element)
 ❯ processTicksAndRejections
Originated in tests/client/UserSettingModal.audio.test.ts
```

### Cause

`Platform.ts` computed its `isBrowser` flag **once, at module load**:

```ts
const isBrowser =
  typeof window !== "undefined" && typeof navigator !== "undefined";
```

lit schedules updates on a microtask, so a component can render one more time *after* the test that mounted it has finished and jsdom has been torn down. At that point the cached flag still says `true` — it describes an environment that no longer exists — so `isTouch` (and `isMobileWidth`, `isTabletWidth`, `isDesktopWidth`) walks straight into `window.*` and throws.

### Fix

Make `isBrowser` a function, so the check is evaluated at call time rather than frozen at import time, and update its call sites. A cached "am I in a browser" flag is simply wrong when the environment can go away. Behaviour in a real browser is unchanged — the globals never disappear there — and `os` / `isElectron` are still resolved once at load, as before.

### This is the second instance of the same bug

#5357 fixed exactly this teardown race for `getCachedLangSelector` in `src/client/Utils.ts`. That closed one door; this is the next one behind it.

**The underlying pattern is still unfixed and deserves its own issue.** Guarding individual modules against a vanished `window` treats the symptom. The real cure is for `BaseModal` to cancel its pending lit update on disconnect, so components never render after teardown at all — that is a larger change than should ride along on a CI unblock, so it is deliberately not in this PR.

### Verification

- `npx tsc --noEmit` — clean
- `npm run build-prod` — clean (bundle + `tsc --noEmit`)
- `npm run lint` — clean
- `npm run test:coverage` (the command CI runs) — no `Unhandled Rejection` and no `window is not defined` in the output
- Added a regression test in `tests/client/Platform.test.ts` that drops the browser globals after the module has loaded and asserts the accessors return `false` instead of throwing. It fails on `main` (`TypeError: Cannot read properties of undefined (reading 'matchMedia')`) and passes here.

## Please complete the following:

- [ ] I have added screenshots for all UI updates — no UI change
- [ ] I process any text displayed to the user through translateText() and I've added it to the en.json file — no user-facing text
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish
