### PR TITLE
feat(presence): server-minted opaque group token for Steam playing-together (OPE-423)

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -49,7 +49,7 @@ import {
   TickMetricsEvent,
   ToggleRenderDebugGuiEvent,
 } from "./InputHandler";
-import { groupTokenOf } from "./PresenceGroup";
+import { groupTokenOf, loggableStartMessage } from "./PresenceGroup";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 import { GoToPlayerEvent } from "./TransformHandler";
 import {
@@ -254,10 +254,12 @@ export function joinLobby(
       // Everything in the start message EXCEPT the group token. This log is
       // the whole message verbatim and players paste it into bug reports;
       // the token is the one field in it that must not travel that way.
-      const loggable: Record<string, unknown> = { ...message };
-      delete loggable.groupToken;
       console.log(
-        `lobby: game started: ${JSON.stringify(loggable, replacer, 2)}`,
+        `lobby: game started: ${JSON.stringify(
+          loggableStartMessage(message),
+          replacer,
+          2,
+        )}`,
       );
       // Server tells us our assigned clientID (also sent on start for late joins)
       clientID = message.myClientID;

--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -7,6 +7,7 @@ import {
   GameID,
   GameRecord,
   GameStartInfo,
+  GroupTokenEvent,
   LobbyInfoEvent,
   PlayerCosmeticRefs,
   ServerMessage,
@@ -48,6 +49,7 @@ import {
   TickMetricsEvent,
   ToggleRenderDebugGuiEvent,
 } from "./InputHandler";
+import { groupTokenOf } from "./PresenceGroup";
 import { terrainMapFileLoader } from "./TerrainMapFileLoader";
 import { GoToPlayerEvent } from "./TransformHandler";
 import {
@@ -201,6 +203,12 @@ export function joinLobby(
   };
 
   const onmessage = (message: ServerMessage) => {
+    // Before the per-type handling below: the token rides two different
+    // messages and the listener does not care which one delivered it.
+    const groupToken = groupTokenOf(message);
+    if (groupToken !== undefined) {
+      eventBus.emit(new GroupTokenEvent(groupToken));
+    }
     if (message.type === "lobby_info") {
       // Server tells us our assigned clientID
       clientID = message.myClientID;
@@ -243,8 +251,13 @@ export function joinLobby(
     if (message.type === "start") {
       // Trigger prestart for singleplayer games
       resolvePrestart();
+      // Everything in the start message EXCEPT the group token. This log is
+      // the whole message verbatim and players paste it into bug reports;
+      // the token is the one field in it that must not travel that way.
+      const loggable: Record<string, unknown> = { ...message };
+      delete loggable.groupToken;
       console.log(
-        `lobby: game started: ${JSON.stringify(message, replacer, 2)}`,
+        `lobby: game started: ${JSON.stringify(loggable, replacer, 2)}`,
       );
       // Server tells us our assigned clientID (also sent on start for late joins)
       clientID = message.myClientID;

--- a/src/client/DesktopPresence.ts
+++ b/src/client/DesktopPresence.ts
@@ -16,6 +16,12 @@ export interface PresencePayload {
   lobbyId?: string;
   teamId?: string;
   teamSize?: number;
+  // Opaque server-minted token identifying this game, for grouping players
+  // outside the game (the shell publishes it as Steam's player group). Absent
+  // for singleplayer and replays, which have no server game to group, and for
+  // the menu. NOT the lobby id and not derived from it — see GroupToken in
+  // src/core/Schemas.ts for why those must stay separable.
+  groupToken?: string;
 }
 
 interface PresenceBridge {

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -85,7 +85,7 @@ import { initNavigation } from "./Navigation";
 import "./NewsModal";
 import { fallbackPlayerName, LAPSE_NOTICE_KEY } from "./PlayerName";
 import "./PlayerProfileModal";
-import { withGroupToken } from "./PresenceGroup";
+import { GroupTokenTracker, withGroupToken } from "./PresenceGroup";
 import { RewardsModal } from "./RewardsModal";
 import "./SinglePlayerModal";
 import { SinglePlayerModal } from "./SinglePlayerModal";
@@ -277,10 +277,10 @@ class Client {
   private presenceSpectating = false;
   private presenceInGame = false;
   // Held apart from presenceDetail because that object is REPLACED wholesale
-  // on every lobby_info, and the token arrives on its own schedule (once,
-  // from whichever of lobby_info / start got here first). Merged back in at
-  // emit time.
-  private presenceGroupToken: string | undefined;
+  // on every lobby_info, and the token rides every one of those (once a
+  // second) as well as the start message. Merged back in at emit time; see
+  // GroupTokenTracker for why a repeat must not re-emit.
+  private readonly presenceGroup = new GroupTokenTracker();
 
   private turnstileTokenPromise: Promise<{
     token: string;
@@ -477,8 +477,9 @@ class Client {
     // they are in the same group, and it is the shell that decides what a
     // spectator does to the group's size.
     this.eventBus.on(GroupTokenEvent, (event) => {
-      this.presenceGroupToken = event.groupToken;
-      this.emitPresence();
+      if (this.presenceGroup.accept(event.groupToken)) {
+        this.emitPresence();
+      }
     });
 
     document.addEventListener("join-lobby", (event) => {
@@ -1207,7 +1208,7 @@ class Client {
     this.presenceSpectating = lobby.spectator === true;
     // Dropped here, not on leaving: a game we are joining must never inherit
     // the previous one's group, and singleplayer must carry none at all.
-    this.presenceGroupToken = undefined;
+    this.presenceGroup.clear();
     this.presenceDetail = {
       gameType: joinConfig?.gameType,
       gameMode: joinConfig?.gameMode,
@@ -1423,7 +1424,7 @@ class Client {
               : "lobby",
           ...this.presenceDetail,
         },
-        this.presenceGroupToken,
+        this.presenceGroup.current(),
       ),
     );
   }
@@ -1434,7 +1435,7 @@ class Client {
     this.presenceDetail = {};
     this.presenceSpectating = false;
     this.presenceInGame = false;
-    this.presenceGroupToken = undefined;
+    this.presenceGroup.clear();
     desktopPresence.set({ state: "menu" });
   }
 

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -8,6 +8,7 @@ import {
   GameInfo,
   GameRecord,
   GameStartInfo,
+  GroupTokenEvent,
   LobbyInfoEvent,
   PublicGameInfo,
 } from "../core/Schemas";
@@ -84,6 +85,7 @@ import { initNavigation } from "./Navigation";
 import "./NewsModal";
 import { fallbackPlayerName, LAPSE_NOTICE_KEY } from "./PlayerName";
 import "./PlayerProfileModal";
+import { withGroupToken } from "./PresenceGroup";
 import { RewardsModal } from "./RewardsModal";
 import "./SinglePlayerModal";
 import { SinglePlayerModal } from "./SinglePlayerModal";
@@ -274,6 +276,11 @@ class Client {
   private presenceDetail: Omit<PresencePayload, "state"> = {};
   private presenceSpectating = false;
   private presenceInGame = false;
+  // Held apart from presenceDetail because that object is REPLACED wholesale
+  // on every lobby_info, and the token arrives on its own schedule (once,
+  // from whichever of lobby_info / start got here first). Merged back in at
+  // emit time.
+  private presenceGroupToken: string | undefined;
 
   private turnstileTokenPromise: Promise<{
     token: string;
@@ -462,6 +469,15 @@ class Client {
       this.presenceSpectating =
         event.lobby.clients?.find((c) => c.clientID === event.myClientID)
           ?.spectator === true;
+      this.emitPresence();
+    });
+
+    // The game's grouping token, from lobby_info in the lobby or from the
+    // start message for someone who joined after it. Spectators get it too:
+    // they are in the same group, and it is the shell that decides what a
+    // spectator does to the group's size.
+    this.eventBus.on(GroupTokenEvent, (event) => {
+      this.presenceGroupToken = event.groupToken;
       this.emitPresence();
     });
 
@@ -1189,6 +1205,9 @@ class Client {
     const joinInfo = lobby.publicLobbyInfo;
     this.presenceInGame = false;
     this.presenceSpectating = lobby.spectator === true;
+    // Dropped here, not on leaving: a game we are joining must never inherit
+    // the previous one's group, and singleplayer must carry none at all.
+    this.presenceGroupToken = undefined;
     this.presenceDetail = {
       gameType: joinConfig?.gameType,
       gameMode: joinConfig?.gameMode,
@@ -1394,14 +1413,19 @@ class Client {
   // "spectating" outranks. Emitting is idempotent -- the shell diffs -- so
   // callers never have to know whether anything actually changed.
   private emitPresence() {
-    desktopPresence.set({
-      state: this.presenceSpectating
-        ? "spectating"
-        : this.presenceInGame
-          ? "game"
-          : "lobby",
-      ...this.presenceDetail,
-    });
+    desktopPresence.set(
+      withGroupToken(
+        {
+          state: this.presenceSpectating
+            ? "spectating"
+            : this.presenceInGame
+              ? "game"
+              : "lobby",
+          ...this.presenceDetail,
+        },
+        this.presenceGroupToken,
+      ),
+    );
   }
 
   // Back to the menu, forgetting the lobby we were describing so a later one
@@ -1410,6 +1434,7 @@ class Client {
     this.presenceDetail = {};
     this.presenceSpectating = false;
     this.presenceInGame = false;
+    this.presenceGroupToken = undefined;
     desktopPresence.set({ state: "menu" });
   }
 

--- a/src/client/PresenceGroup.ts
+++ b/src/client/PresenceGroup.ts
@@ -1,0 +1,39 @@
+// The two rules for the per-game grouping token on the client: where it comes
+// from, and how it joins a presence payload.
+//
+// They live here rather than inline in ClientGameRunner and Main because both
+// are unreachable from a test — one drags in WebGL, the other the whole boot
+// sequence — and these are precisely the parts that must not drift: a token
+// picked up from only one of its two carrier messages silently leaves late
+// joiners out of the group, and one merged in unconditionally would publish
+// `groupToken: undefined` for every singleplayer game.
+
+import type { ServerMessage } from "../core/Schemas";
+import type { PresencePayload } from "./DesktopPresence";
+
+// The token this server message carries, if it carries one.
+//
+// Two messages carry it, and every participant of a server game sees at least
+// one: lobby_info reaches everyone present during the lobby phase (players and
+// spectators alike, once a second), and the start message reaches everyone at
+// start plus anyone who joins afterwards. Every other message type, and any
+// message from a game with no server behind it (singleplayer, replays), has
+// none.
+export function groupTokenOf(message: ServerMessage): string | undefined {
+  if (message.type === "lobby_info" || message.type === "start") {
+    return message.groupToken;
+  }
+  return undefined;
+}
+
+// Attach the token to a presence payload, or leave the payload alone.
+//
+// Omitting the key entirely rather than setting it to undefined matters: the
+// shell diffs payloads, and `{ groupToken: undefined }` is not the same object
+// as one without the key.
+export function withGroupToken(
+  payload: PresencePayload,
+  groupToken: string | undefined,
+): PresencePayload {
+  return groupToken === undefined ? payload : { ...payload, groupToken };
+}

--- a/src/client/PresenceGroup.ts
+++ b/src/client/PresenceGroup.ts
@@ -1,14 +1,16 @@
-// The two rules for the per-game grouping token on the client: where it comes
-// from, and how it joins a presence payload.
+// The rules for the per-game grouping token on the client: where it comes
+// from, what may be logged of the message that carried it, how often it is
+// worth telling the shell, and how it joins a presence payload.
 //
 // They live here rather than inline in ClientGameRunner and Main because both
 // are unreachable from a test — one drags in WebGL, the other the whole boot
 // sequence — and these are precisely the parts that must not drift: a token
 // picked up from only one of its two carrier messages silently leaves late
-// joiners out of the group, and one merged in unconditionally would publish
-// `groupToken: undefined` for every singleplayer game.
+// joiners out of the group, one merged in unconditionally would publish
+// `groupToken: undefined` for every singleplayer game, and a strip that only
+// exists as a line inside a console.log call is a strip nothing defends.
 
-import type { ServerMessage } from "../core/Schemas";
+import type { ServerMessage, ServerStartGameMessage } from "../core/Schemas";
 import type { PresencePayload } from "./DesktopPresence";
 
 // The token this server message carries, if it carries one.
@@ -24,6 +26,53 @@ export function groupTokenOf(message: ServerMessage): string | undefined {
     return message.groupToken;
   }
   return undefined;
+}
+
+// The start message as it is safe to log: everything except the token.
+//
+// ClientGameRunner dumps the whole start message to the console, and players
+// paste consoles into bug reports and Discord threads. Every other field in it
+// is already public to that player; the token is the one that is not, and a
+// log line is a copy of it in a file, a log shipper and a support ticket.
+export function loggableStartMessage(
+  message: ServerStartGameMessage,
+): Record<string, unknown> {
+  const loggable: Record<string, unknown> = { ...message };
+  delete loggable.groupToken;
+  return loggable;
+}
+
+// The token seen so far, and whether a newly arrived one is worth acting on.
+//
+// lobby_info arrives once a second for the whole lobby phase and carries the
+// token every time, but the token never changes within a game. Re-emitting
+// presence on each one would double the presence IPC rate for no new
+// information — and worse, this event is handled before the LobbyInfoEvent
+// from the same frame, so the extra emit would publish the previous tick's
+// roster. Only a genuine change is worth telling the shell about.
+//
+// `clear()` and the token live together so the two Main reset paths (leaving
+// to the menu, joining a different game) cannot forget one: a tracker that
+// remembered a token across a reset would drop the next game's identical
+// token as a duplicate.
+export class GroupTokenTracker {
+  private token: string | undefined;
+
+  current(): string | undefined {
+    return this.token;
+  }
+
+  // True when this call changed the tracked token, i.e. the caller should
+  // re-emit presence.
+  accept(token: string): boolean {
+    if (this.token === token) return false;
+    this.token = token;
+    return true;
+  }
+
+  clear(): void {
+    this.token = undefined;
+  }
 }
 
 // Attach the token to a presence payload, or leave the payload alone.

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -462,7 +462,17 @@ export class Transport {
         this.flushBuffer();
         this.onmessage(msg);
       } catch (e) {
-        console.error("Error in onmessage handler:", e, event.data);
+        // Deliberately NOT the frame. This catch wraps the downstream
+        // handler as well as the decode, so it fires on ordinary
+        // application errors too — and the desktop shell persists
+        // console.error by default, while a lobby_info or start frame
+        // carries the game's group token in the clear. For a decode failure
+        // the size is the part that actually helps.
+        const frame =
+          event.data instanceof ArrayBuffer
+            ? `${event.data.byteLength} bytes`
+            : typeof event.data;
+        console.error(`Error in onmessage handler (frame: ${frame}):`, e);
         return;
       }
     };

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -468,11 +468,17 @@ export class Transport {
         // console.error by default, while a lobby_info or start frame
         // carries the game's group token in the clear. For a decode failure
         // the size is the part that actually helps.
+        //
+        // The size goes in its own argument rather than interpolated into
+        // the first one: console.* treats argument one as a format string
+        // (%s, %d, %o), so building it from anything that came off the wire
+        // is a format-string sink even when the value can only ever be
+        // digits (CodeQL js/tainted-format-string).
         const frame =
           event.data instanceof ArrayBuffer
             ? `${event.data.byteLength} bytes`
             : typeof event.data;
-        console.error(`Error in onmessage handler (frame: ${frame}):`, e);
+        console.error("Error in onmessage handler:", e, "frame:", frame);
         return;
       }
     };

--- a/src/core/Schemas.ts
+++ b/src/core/Schemas.ts
@@ -397,6 +397,15 @@ export class LobbyInfoEvent implements GameEvent {
   ) {}
 }
 
+// This game's opaque grouping token arrived (see GroupToken in the server
+// message schemas). One event for both carriers — lobby_info for anyone who
+// sat in the lobby, the start message for a late joiner who never saw one —
+// so a listener does not have to know which message it came from. Never
+// emitted for singleplayer or a replay: there is no server game to group.
+export class GroupTokenEvent implements GameEvent {
+  constructor(public groupToken: string) {}
+}
+
 export interface ClientInfo {
   clientID: ClientID;
   username: string;
@@ -948,6 +957,18 @@ export const ServerPrestartMessageSchema = z.object({
   gameMapSize: z.enum(GameMapSize),
 });
 
+// An opaque, server-minted, per-game token. It identifies "everyone in this
+// game" to something outside the game — the desktop shell publishes it as the
+// Steam player group — without handing that something the game id, which is a
+// private lobby's join secret. Random, never a function of the id, and never
+// accepted back: the server reads it from nowhere, so it grants nothing.
+//
+// Not part of GameStartInfoSchema on purpose. That object is archived into the
+// publicly downloadable game record and emitted to telemetry; a token sitting
+// next to the game id in a public record is exactly the derivation this exists
+// to prevent. It rides the two server->client messages instead.
+const GroupToken = z.string().min(1).max(64);
+
 export const ServerStartGameMessageSchema = z.object({
   type: z.literal("start"),
   // Turns the client missed if they are late to the game.
@@ -957,6 +978,11 @@ export const ServerStartGameMessageSchema = z.object({
   // The clientID assigned to this connection by the server.
   // Absent for replays where the viewer has no player identity.
   myClientID: ID.optional(),
+  // The same token the lobby_info broadcasts carried, repeated here because a
+  // late joiner connects after the lobby phase and never sees one. Optional
+  // because singleplayer and replays synthesize this message locally with no
+  // server game behind it, so they have no token and must send none.
+  groupToken: GroupToken.optional(),
 });
 
 export const ServerDesyncSchema = z.object({
@@ -987,6 +1013,13 @@ export const ServerLobbyInfoMessageSchema = z.object({
   lobby: GameInfoSchema,
   // The clientID assigned to this connection by the server
   myClientID: ID,
+  // See GroupToken below. Deliberately a sibling of `lobby` rather than a
+  // field of GameInfoSchema: gameInfo() is also the body of several HTTP
+  // routes (Worker's /api/game/:id, the admin-bot routes, the lobby
+  // preview), and a token anyone can GET by game id is a token derived from
+  // the game id. On this message it only ever reaches a connected
+  // participant of this game.
+  groupToken: GroupToken.optional(),
 });
 
 // Broadcast by a finished private game's server to every still-connected client

--- a/src/server/GameServer.ts
+++ b/src/server/GameServer.ts
@@ -1,4 +1,4 @@
-import { createHash } from "crypto";
+import { createHash, randomBytes } from "crypto";
 import ipAnonymize from "ip-anonymize";
 import { Logger } from "winston";
 import WebSocket from "ws";
@@ -129,6 +129,19 @@ export interface GameServerDeps {
   turnIntervalMs: () => number;
   telemetry: MatchTelemetryEmitter;
   telemetryBuildHash: string;
+  // This game's opaque grouping token (see mintGroupToken). Injectable only
+  // so a test can pin a value it can assert on; production always takes the
+  // random default.
+  mintGroupToken: () => string;
+}
+
+// 16 URL-safe characters of CSPRNG output — 12 bytes is exactly 16 base64url
+// characters, so there is no padding to strip and no truncation to reason
+// about. Deliberately NOT a hash or any other function of the game id: the id
+// is a private lobby's join secret, and anything derived from it hands a
+// holder of the token a head start on the id.
+function mintGroupToken(): string {
+  return randomBytes(12).toString("base64url");
 }
 
 export function defaultGameServerDeps(): GameServerDeps {
@@ -139,6 +152,7 @@ export function defaultGameServerDeps(): GameServerDeps {
     turnIntervalMs: () => ServerEnv.turnIntervalMs(),
     telemetry: noopMatchTelemetryEmitter,
     telemetryBuildHash: "DEV",
+    mintGroupToken,
   };
 }
 
@@ -229,6 +243,13 @@ export class GameServer {
   // counters, finished-once (see MatchTelemetryRecorder.ts).
   private readonly telemetry: MatchTelemetryRecorder;
 
+  // Opaque per-game grouping token, minted once here and sent to every
+  // participant (see mintGroupToken and the GroupToken comment in Schemas).
+  // Private, and it stays private: nothing reads it back off the wire, no
+  // route returns it, and it must never reach a log line or an error message
+  // — a token in a log is a token in whatever the log is shipped to.
+  private readonly groupToken: string;
+
   public readonly id: string;
   public readonly createdAt: number;
   public gameConfig: GameConfig;
@@ -252,6 +273,7 @@ export class GameServer {
     this.publicGameType = opts.publicGameType;
     this.matchmakingTeams = opts.matchmakingTeams;
     this.deps = { ...defaultGameServerDeps(), ...deps };
+    this.groupToken = this.deps.mintGroupToken();
     this.telemetry = new MatchTelemetryRecorder(
       this.deps.telemetry,
       opts.id,
@@ -923,6 +945,9 @@ export class GameServer {
             type: "lobby_info",
             lobby: shared ?? this.gameInfo(c.clientID),
             myClientID: c.clientID,
+            // Same value for every recipient, including spectators: the
+            // point of the token is that one game is one group.
+            groupToken: this.groupToken,
           } satisfies ServerLobbyInfoMessage,
           this.zbinCtx,
         );
@@ -1268,6 +1293,9 @@ export class GameServer {
             ),
             lobbyCreatedAt: this.createdAt,
             myClientID: client.clientID,
+            // Repeated here for the late joiner, who connects after the
+            // lobby broadcasts stopped and would otherwise never see it.
+            groupToken: this.groupToken,
           } satisfies ServerStartGameMessage,
           this.zbinCtx,
         ),

--- a/tests/client/GroupTokenPresence.test.ts
+++ b/tests/client/GroupTokenPresence.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { PresencePayload } from "../../src/client/DesktopPresence";
-import { groupTokenOf, withGroupToken } from "../../src/client/PresenceGroup";
-import type { ServerMessage } from "../../src/core/Schemas";
+import {
+  GroupTokenTracker,
+  groupTokenOf,
+  loggableStartMessage,
+  withGroupToken,
+} from "../../src/client/PresenceGroup";
+import { EventBus } from "../../src/core/EventBus";
+import {
+  GroupTokenEvent,
+  type ServerMessage,
+  type ServerStartGameMessage,
+} from "../../src/core/Schemas";
 import { testGameConfig } from "../util/Wire";
 
 // OPE-423, client half. Two rules, both of which Main and ClientGameRunner
@@ -104,5 +114,97 @@ describe("withGroupToken", () => {
 
   it("returns the payload untouched when there is no token", () => {
     expect(withGroupToken(game, undefined)).toBe(game);
+  });
+});
+
+describe("loggableStartMessage", () => {
+  const withToken = startGame(TOKEN) as ServerStartGameMessage;
+
+  // The console dump of the start message is what players paste into bug
+  // reports. Everything in it is already theirs to see except this.
+  it("drops the group token", () => {
+    const logged = loggableStartMessage(withToken);
+    expect("groupToken" in logged).toBe(false);
+    expect(JSON.stringify(logged)).not.toContain(TOKEN);
+  });
+
+  it("keeps every other field, so the dump stays useful", () => {
+    const logged = loggableStartMessage(withToken);
+    expect(logged).toEqual({
+      type: "start",
+      turns: [],
+      gameStartInfo: withToken.gameStartInfo,
+      lobbyCreatedAt: withToken.lobbyCreatedAt,
+      myClientID: CLIENT,
+    });
+  });
+
+  it("does not mutate the message the caller is still using", () => {
+    loggableStartMessage(withToken);
+    expect(withToken.groupToken).toBe(TOKEN);
+  });
+
+  it("is a no-op for a singleplayer start message, which has no token", () => {
+    const local = startGame() as ServerStartGameMessage;
+    expect(loggableStartMessage(local)).toEqual(local);
+  });
+});
+
+describe("GroupTokenTracker", () => {
+  it("accepts the first token", () => {
+    expect(new GroupTokenTracker().accept(TOKEN)).toBe(true);
+  });
+
+  it("rejects a repeat of the token it already holds", () => {
+    const tracker = new GroupTokenTracker();
+    tracker.accept(TOKEN);
+    expect(tracker.accept(TOKEN)).toBe(false);
+    expect(tracker.current()).toBe(TOKEN);
+  });
+
+  it("accepts a different token", () => {
+    const tracker = new GroupTokenTracker();
+    tracker.accept(TOKEN);
+    expect(tracker.accept("T3RmaXJzdGdhbWU0")).toBe(true);
+    expect(tracker.current()).toBe("T3RmaXJzdGdhbWU0");
+  });
+
+  it("holds nothing until a token arrives, and nothing after a clear", () => {
+    const tracker = new GroupTokenTracker();
+    expect(tracker.current()).toBeUndefined();
+    tracker.accept(TOKEN);
+    tracker.clear();
+    expect(tracker.current()).toBeUndefined();
+  });
+
+  // Rejoining the same game after a trip through the menu must re-publish
+  // the group, so a cleared tracker cannot treat the old token as a repeat.
+  it("accepts the same token again after a clear", () => {
+    const tracker = new GroupTokenTracker();
+    tracker.accept(TOKEN);
+    tracker.clear();
+    expect(tracker.accept(TOKEN)).toBe(true);
+  });
+
+  // Mirrors Main's subscription exactly: lobby_info carries the token once a
+  // second for the whole lobby phase, and each redundant emit is an IPC to
+  // the shell carrying the roster from BEFORE this frame's LobbyInfoEvent.
+  it("emits presence once across a second of identical lobby_info tokens", () => {
+    const eventBus = new EventBus();
+    const tracker = new GroupTokenTracker();
+    const emitPresence = vi.fn();
+    eventBus.on(GroupTokenEvent, (event) => {
+      if (tracker.accept(event.groupToken)) emitPresence();
+    });
+
+    for (let i = 0; i < 5; i++) {
+      eventBus.emit(new GroupTokenEvent(TOKEN));
+    }
+
+    expect(emitPresence).toHaveBeenCalledOnce();
+
+    // A real change still gets through.
+    eventBus.emit(new GroupTokenEvent("T3RmaXJzdGdhbWU0"));
+    expect(emitPresence).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/client/GroupTokenPresence.test.ts
+++ b/tests/client/GroupTokenPresence.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+import type { PresencePayload } from "../../src/client/DesktopPresence";
+import { groupTokenOf, withGroupToken } from "../../src/client/PresenceGroup";
+import type { ServerMessage } from "../../src/core/Schemas";
+import { testGameConfig } from "../util/Wire";
+
+// OPE-423, client half. Two rules, both of which Main and ClientGameRunner
+// depend on and neither of which can be reached through them in a test.
+
+const TOKEN = "Zm9vYmFyYmF6cXV4";
+const GAME = "abcd1234";
+const CLIENT = "cl001234";
+
+function lobbyInfo(groupToken?: string): ServerMessage {
+  return {
+    type: "lobby_info",
+    lobby: { gameID: GAME, serverTime: 1_700_000_000_000 },
+    myClientID: CLIENT,
+    ...(groupToken === undefined ? {} : { groupToken }),
+  };
+}
+
+// Shaped like what LocalServer synthesizes for a singleplayer game or a
+// replay: a real start message with no server behind it, and so no token.
+function startGame(groupToken?: string): ServerMessage {
+  return {
+    type: "start",
+    turns: [],
+    gameStartInfo: {
+      gameID: GAME,
+      lobbyCreatedAt: 1_700_000_000_000,
+      config: testGameConfig(),
+      players: [],
+    },
+    lobbyCreatedAt: 1_700_000_000_000,
+    myClientID: CLIENT,
+    ...(groupToken === undefined ? {} : { groupToken }),
+  };
+}
+
+describe("groupTokenOf", () => {
+  it("reads the token off a lobby_info", () => {
+    expect(groupTokenOf(lobbyInfo(TOKEN))).toBe(TOKEN);
+  });
+
+  // Both carriers, because a late joiner only ever sees the second one.
+  it("reads the token off a start message", () => {
+    expect(groupTokenOf(startGame(TOKEN))).toBe(TOKEN);
+  });
+
+  it("returns undefined for a singleplayer start message, which has none", () => {
+    expect(groupTokenOf(startGame())).toBeUndefined();
+  });
+
+  it("returns undefined for a lobby_info without one", () => {
+    expect(groupTokenOf(lobbyInfo())).toBeUndefined();
+  });
+
+  it("returns undefined for messages that never carry a token", () => {
+    expect(groupTokenOf({ type: "ping" })).toBeUndefined();
+    expect(groupTokenOf({ type: "new_lobby", gameID: GAME })).toBeUndefined();
+  });
+});
+
+describe("withGroupToken", () => {
+  const lobby: PresencePayload = {
+    state: "lobby",
+    gameType: "Private",
+    lobbyId: GAME,
+    playerCount: 3,
+  };
+  const game: PresencePayload = { ...lobby, state: "game" };
+  const spectating: PresencePayload = { ...lobby, state: "spectating" };
+
+  it("forwards the token in the lobby payload", () => {
+    expect(withGroupToken(lobby, TOKEN)).toEqual({
+      ...lobby,
+      groupToken: TOKEN,
+    });
+  });
+
+  it("forwards the token in the game payload", () => {
+    expect(withGroupToken(game, TOKEN)).toEqual({ ...game, groupToken: TOKEN });
+  });
+
+  // A spectator is in the same Steam group as the players; it is the shell,
+  // not the client, that decides what that does to the group's size.
+  it("forwards the token while spectating", () => {
+    expect(withGroupToken(spectating, TOKEN).groupToken).toBe(TOKEN);
+  });
+
+  it("changes nothing else about the payload", () => {
+    const rest: Record<string, unknown> = { ...withGroupToken(lobby, TOKEN) };
+    delete rest.groupToken;
+    expect(rest).toEqual(lobby);
+  });
+
+  // Omitting the key, not setting it to undefined: the shell diffs payloads.
+  it("omits the key entirely when there is no token (singleplayer)", () => {
+    const payload = withGroupToken(game, undefined);
+    expect("groupToken" in payload).toBe(false);
+    expect(payload).toEqual(game);
+  });
+
+  it("returns the payload untouched when there is no token", () => {
+    expect(withGroupToken(game, undefined)).toBe(game);
+  });
+});

--- a/tests/client/TransportFrameLogging.test.ts
+++ b/tests/client/TransportFrameLogging.test.ts
@@ -149,4 +149,16 @@ describe("Transport frame-handling errors", () => {
     expect(rendered).toMatch(/frame: \d+ bytes/);
     expect(rendered).toContain("downstream handler blew up");
   });
+
+  // console.* reads argument one as a format string (%s, %d, %o). Anything
+  // derived from the frame must therefore ride in a LATER argument, or a
+  // crafted frame could steer the formatting of the log line.
+  it("keeps frame-derived text out of the format-string argument", () => {
+    connectAndFailOn(lobbyInfoFrame());
+
+    for (const call of errorSpy.mock.calls) {
+      expect(typeof call[0]).toBe("string");
+      expect(call[0]).toBe("Error in onmessage handler:");
+    }
+  });
 });

--- a/tests/client/TransportFrameLogging.test.ts
+++ b/tests/client/TransportFrameLogging.test.ts
@@ -1,0 +1,152 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import type { ServerMessage } from "../../src/core/Schemas";
+import { encodeServerMessage } from "../../src/core/ZbinWire";
+
+// OPE-423. Transport's onmessage catch used to log the raw frame. That catch
+// wraps the downstream handler as well as the decode, so any exception thrown
+// while handling a message dumped the bytes that produced it — and a lobby_info
+// or start frame carries the game's group token in the clear. The desktop shell
+// persists console.error, so those bytes outlive the session.
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: {
+    workerPath: () => "w0",
+    serverWsBase: () => "ws://game.test",
+    gameWorkerPath: () => "w0",
+    gameWsBase: () => "ws://game.test",
+    gameHttpBase: () => "http://game.test",
+    gitCommit: () => "test-commit",
+  },
+}));
+vi.mock("../../src/client/Auth", () => ({
+  getPlayToken: async () => "8f1d2c3e-4b5a-4c6d-8e7f-90a1b2c3d4e5",
+}));
+vi.mock("../../src/client/LocalServer", () => ({ LocalServer: class {} }));
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameConfirm: async () => false,
+}));
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string) => key,
+  homeHref: () => "/",
+}));
+
+import type { LobbyConfig } from "../../src/client/ClientGameRunner";
+import { Transport } from "../../src/client/Transport";
+
+const TOKEN = "Zm9vYmFyYmF6cXV4";
+
+// Just enough socket for Transport to attach its handlers and be fed a frame.
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+  static last: FakeWebSocket | null = null;
+
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = "blob";
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: ArrayBuffer }) => void) | null = null;
+  onerror: ((err: unknown) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(public readonly url: string) {
+    FakeWebSocket.last = this;
+  }
+  send() {}
+  close() {
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+  serverOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+  serverSend(msg: ServerMessage) {
+    this.onmessage?.({ data: encodeServerMessage(msg, undefined).buffer });
+  }
+}
+
+function lobbyInfoFrame(): ServerMessage {
+  return {
+    type: "lobby_info",
+    lobby: { gameID: "abcd1234", serverTime: 1_700_000_000_000 },
+    myClientID: "cl001234",
+    groupToken: TOKEN,
+  };
+}
+
+describe("Transport frame-handling errors", () => {
+  let transport: Transport;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    FakeWebSocket.last = null;
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    transport = new Transport(
+      {
+        gameID: "abcd1234",
+        playerName: "tester",
+        spectator: false,
+      } as unknown as LobbyConfig,
+      new EventBus(),
+    );
+  });
+
+  afterEach(() => {
+    transport.leaveGame();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  // The downstream handler throwing is an ordinary application bug, not a
+  // corrupt frame — and it is the common way into this catch.
+  function connectAndFailOn(msg: ServerMessage) {
+    transport.connect(
+      () => {},
+      () => {
+        throw new Error("downstream handler blew up");
+      },
+    );
+    FakeWebSocket.last!.serverOpen();
+    FakeWebSocket.last!.serverSend(msg);
+  }
+
+  it("does not log the frame buffer", () => {
+    connectAndFailOn(lobbyInfoFrame());
+
+    expect(errorSpy).toHaveBeenCalled();
+    for (const call of errorSpy.mock.calls) {
+      for (const arg of call) {
+        expect(arg instanceof ArrayBuffer).toBe(false);
+        expect(ArrayBuffer.isView(arg)).toBe(false);
+      }
+    }
+  });
+
+  it("does not leak the group token the frame carried", () => {
+    connectAndFailOn(lobbyInfoFrame());
+
+    for (const call of errorSpy.mock.calls) {
+      // Covers the Error argument too, whose message and stack are strings.
+      const rendered = call
+        .map((a: unknown) =>
+          a instanceof Error ? `${a.message}${a.stack}` : String(a),
+        )
+        .join(" ");
+      expect(rendered).not.toContain(TOKEN);
+    }
+  });
+
+  // Something has to be diagnosable, or the fix is just deleting evidence.
+  it("still reports the error and the frame size", () => {
+    connectAndFailOn(lobbyInfoFrame());
+
+    const rendered = errorSpy.mock.calls.flat().map(String).join(" ");
+    expect(rendered).toContain("Error in onmessage handler");
+    expect(rendered).toMatch(/frame: \d+ bytes/);
+    expect(rendered).toContain("downstream handler blew up");
+  });
+});

--- a/tests/core/GroupTokenSchema.test.ts
+++ b/tests/core/GroupTokenSchema.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import {
+  ServerLobbyInfoMessageSchema,
+  ServerStartGameMessageSchema,
+  type ServerLobbyInfoMessage,
+  type ServerStartGameMessage,
+} from "../../src/core/Schemas";
+import {
+  decodeServerMessage,
+  encodeServerMessage,
+} from "../../src/core/ZbinWire";
+import { testGameConfig } from "../util/Wire";
+
+// OPE-423. The opaque per-game grouping token on the two server->client
+// messages that carry it. The interesting property is not that zod accepts a
+// string — it is that the field survives the binary wire in BOTH directions
+// (present and absent), because zbin is positional and an optional field that
+// only round-trips when set is an optional field that corrupts every frame
+// where it is not.
+
+const GAME = "abcd1234";
+const CLIENT = "cl001234";
+const TOKEN = "Zm9vYmFyYmF6cXV4";
+
+function lobbyInfo(
+  groupToken?: string,
+): ServerLobbyInfoMessage & { type: "lobby_info" } {
+  return {
+    type: "lobby_info",
+    lobby: { gameID: GAME, serverTime: 1_700_000_000_000 },
+    myClientID: CLIENT,
+    ...(groupToken === undefined ? {} : { groupToken }),
+  };
+}
+
+function startGame(groupToken?: string): ServerStartGameMessage {
+  return {
+    type: "start",
+    turns: [],
+    gameStartInfo: {
+      gameID: GAME,
+      lobbyCreatedAt: 1_700_000_000_000,
+      config: testGameConfig(),
+      players: [],
+    },
+    lobbyCreatedAt: 1_700_000_000_000,
+    myClientID: CLIENT,
+    ...(groupToken === undefined ? {} : { groupToken }),
+  };
+}
+
+describe("groupToken on the lobby_info message", () => {
+  it("accepts a token and round-trips it over the binary wire", () => {
+    const parsed = ServerLobbyInfoMessageSchema.parse(lobbyInfo(TOKEN));
+    expect(parsed.groupToken).toBe(TOKEN);
+
+    const decoded = decodeServerMessage(
+      encodeServerMessage(lobbyInfo(TOKEN), undefined),
+      undefined,
+    );
+    expect(decoded.type).toBe("lobby_info");
+    expect(decoded).toMatchObject({ groupToken: TOKEN });
+  });
+
+  it("accepts a message without one and omits the key entirely", () => {
+    const parsed = ServerLobbyInfoMessageSchema.parse(lobbyInfo());
+    expect("groupToken" in parsed).toBe(false);
+
+    const decoded = decodeServerMessage(
+      encodeServerMessage(lobbyInfo(), undefined),
+      undefined,
+    );
+    // The rest of the message must still decode correctly with the field
+    // absent: a mis-sized presence header shows up here first.
+    expect(decoded).toMatchObject({ type: "lobby_info", myClientID: CLIENT });
+    expect((decoded as { groupToken?: string }).groupToken).toBeUndefined();
+  });
+});
+
+describe("groupToken on the start message", () => {
+  it("accepts a token and round-trips it over the binary wire", () => {
+    const parsed = ServerStartGameMessageSchema.parse(startGame(TOKEN));
+    expect(parsed.groupToken).toBe(TOKEN);
+
+    const decoded = decodeServerMessage(
+      encodeServerMessage(startGame(TOKEN), undefined),
+      undefined,
+    );
+    expect(decoded).toMatchObject({ type: "start", groupToken: TOKEN });
+  });
+
+  it("accepts a message without one and omits the key entirely", () => {
+    const parsed = ServerStartGameMessageSchema.parse(startGame());
+    expect("groupToken" in parsed).toBe(false);
+
+    const decoded = decodeServerMessage(
+      encodeServerMessage(startGame(), undefined),
+      undefined,
+    );
+    expect(decoded).toMatchObject({ type: "start", myClientID: CLIENT });
+    expect((decoded as { groupToken?: string }).groupToken).toBeUndefined();
+  });
+});
+
+describe("groupToken bounds", () => {
+  // Both ends are load-bearing. An empty string is indistinguishable from
+  // "absent" to the shell but distinguishable to the schema, and an
+  // unbounded string is an unbounded allocation on every client that decodes
+  // a frame from a server it does not control.
+  it("rejects an empty token", () => {
+    expect(ServerLobbyInfoMessageSchema.safeParse(lobbyInfo("")).success).toBe(
+      false,
+    );
+  });
+
+  it("rejects a token longer than 64 characters", () => {
+    expect(
+      ServerLobbyInfoMessageSchema.safeParse(lobbyInfo("x".repeat(65))).success,
+    ).toBe(false);
+    expect(
+      ServerLobbyInfoMessageSchema.safeParse(lobbyInfo("x".repeat(64))).success,
+    ).toBe(true);
+  });
+});

--- a/tests/server/GameServerWire.test.ts
+++ b/tests/server/GameServerWire.test.ts
@@ -49,7 +49,10 @@ describe("GameServer wire transcript", () => {
       id: cid("golden"),
       creatorPersistentID: "host-pid",
       config: { gameType: GameType.Private, maxPlayers: 3 },
-      deps: { archive },
+      // Pinned so the transcript stays deterministic — and so the snapshot
+      // itself shows the same token reaching every client on both carriers.
+      // The real one is random (see GameServer.mintGroupToken).
+      deps: { archive, mintGroupToken: () => "GoldenGroupTok01" },
     });
     const host = makeClient({
       clientID: HOST,

--- a/tests/server/GroupToken.test.ts
+++ b/tests/server/GroupToken.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ServerMessage } from "../../src/core/Schemas";
+import { createGameWireContext } from "../../src/core/ZbinWire";
+import {
+  cid,
+  makeClient,
+  makeGame,
+  mockLogger,
+  mockWsOf,
+  startGame,
+} from "../util/GameServerHarness";
+
+// OPE-423. The per-game grouping token the desktop shell publishes as a Steam
+// player group: one value per game, the same for every participant, random
+// rather than derived from the game id (which is a private lobby's join
+// secret), and never written anywhere a human or a log sink can read it.
+
+const T0 = 1_700_000_000_000;
+
+// Collect the token off whatever frames a socket received, in order.
+function tokensSentTo(
+  ws: { sent: (ctx?: any) => ServerMessage[] },
+  ctx?: any,
+): { type: string; groupToken?: string }[] {
+  return ws
+    .sent(ctx)
+    .filter((m) => m.type === "lobby_info" || m.type === "start")
+    .map((m) => ({
+      type: m.type,
+      groupToken: (m as { groupToken?: string }).groupToken,
+    }));
+}
+
+describe("GameServer group token", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(T0);
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("is 16 URL-safe characters", () => {
+    const game = makeGame({ id: cid("shape") });
+    const client = makeClient({ clientID: cid("p1") });
+    game.joinClient(client);
+    vi.advanceTimersByTime(1000);
+
+    const [first] = tokensSentTo(mockWsOf(client));
+    expect(first.groupToken).toMatch(/^[A-Za-z0-9_-]{16}$/);
+  });
+
+  // The token exists precisely so that something outside the game can say
+  // "these players are together" without being handed the game id. If it were
+  // a hash (or any other function) of the id, two games sharing an id would
+  // share a token — and anyone holding a token would hold a head start on the
+  // id of a private lobby.
+  it("is not derived from the game id: same id, different tokens", () => {
+    const tokens = [cid("same"), cid("same")].map((id) => {
+      const game = makeGame({ id });
+      const client = makeClient();
+      game.joinClient(client);
+      vi.advanceTimersByTime(1000);
+      return tokensSentTo(mockWsOf(client))[0].groupToken;
+    });
+
+    expect(tokens[0]).toBeDefined();
+    expect(tokens[0]).not.toBe(tokens[1]);
+  });
+
+  it("gives every lobby participant, spectators included, the same token", () => {
+    const game = makeGame({ id: cid("lobby") });
+    const host = makeClient({
+      clientID: cid("host"),
+      persistentID: "host-pid",
+    });
+    const player = makeClient({ clientID: cid("p2") });
+    const spectator = makeClient({ clientID: cid("cast"), spectator: true });
+    [host, player, spectator].forEach((c) => game.joinClient(c));
+
+    vi.advanceTimersByTime(1000);
+
+    const seen = [host, player, spectator].map(
+      (c) => tokensSentTo(mockWsOf(c))[0],
+    );
+    expect(seen.map((s) => s.type)).toEqual([
+      "lobby_info",
+      "lobby_info",
+      "lobby_info",
+    ]);
+    expect(seen[0].groupToken).toBeDefined();
+    expect(new Set(seen.map((s) => s.groupToken)).size).toBe(1);
+  });
+
+  it("repeats the same token in the start message every client gets", () => {
+    const game = makeGame({ id: cid("start") });
+    const player = makeClient({ clientID: cid("p1") });
+    const spectator = makeClient({ clientID: cid("cast"), spectator: true });
+    [player, spectator].forEach((c) => game.joinClient(c));
+    vi.advanceTimersByTime(1000);
+
+    startGame(game);
+
+    const frames = [player, spectator].map((c) => tokensSentTo(mockWsOf(c)));
+    for (const perClient of frames) {
+      const start = perClient.filter((f) => f.type === "start");
+      expect(start).toHaveLength(1);
+      // The lobby broadcasts and the start message are the same group.
+      expect(start[0].groupToken).toBe(perClient[0].groupToken);
+    }
+    const lastOf = (f: { groupToken?: string }[]) => f[f.length - 1].groupToken;
+    expect(lastOf(frames[0])).toBe(lastOf(frames[1]));
+  });
+
+  // A late joiner never sees a lobby_info — the broadcast stopped before they
+  // connected — so the start message is their only chance at the token.
+  it("gives a late joiner the token in its catch-up start message", () => {
+    const game = makeGame({ id: cid("late") });
+    const player = makeClient({ clientID: cid("p1") });
+    game.joinClient(player);
+    vi.advanceTimersByTime(1000);
+    startGame(game);
+    const expected = tokensSentTo(mockWsOf(player))[0].groupToken;
+
+    const latecomer = makeClient({ clientID: cid("p2") });
+    game.joinClient(latecomer);
+
+    const ctx = createGameWireContext([{ clientID: cid("p1") }]);
+    const received = tokensSentTo(mockWsOf(latecomer), ctx);
+    expect(received.map((r) => r.type)).toContain("start");
+    expect(received.find((r) => r.type === "start")!.groupToken).toBe(expected);
+    expect(expected).toBeDefined();
+  });
+
+  // The whole point of an opaque token is that holding it means something.
+  // A log line is a copy of it in a file, a shipper, and a support ticket.
+  it("never writes the token to a log or the console", () => {
+    const log = mockLogger();
+    const consoleSpies = (
+      ["log", "info", "warn", "error", "debug"] as const
+    ).map((level) => vi.spyOn(console, level).mockImplementation(() => {}));
+
+    const game = makeGame({ id: cid("quiet"), log });
+    const player = makeClient({ clientID: cid("p1") });
+    const spectator = makeClient({ clientID: cid("cast"), spectator: true });
+    [player, spectator].forEach((c) => game.joinClient(c));
+    vi.advanceTimersByTime(3000);
+    startGame(game);
+    game.joinClient(makeClient({ clientID: cid("p2") }));
+
+    const token = tokensSentTo(mockWsOf(player))[0].groupToken!;
+    expect(token).toMatch(/^[A-Za-z0-9_-]{16}$/);
+
+    const written = [
+      ...log.info.mock.calls,
+      ...log.warn.mock.calls,
+      ...log.error.mock.calls,
+      ...log.debug.mock.calls,
+      ...consoleSpies.flatMap((s) => s.mock.calls),
+    ];
+    // Something must actually have been logged, or this asserts nothing.
+    expect(written.length).toBeGreaterThan(0);
+    for (const call of written) {
+      expect(JSON.stringify(call)).not.toContain(token);
+    }
+
+    consoleSpies.forEach((s) => s.mockRestore());
+  });
+});

--- a/tests/server/__snapshots__/GameServerWire.test.ts.snap
+++ b/tests/server/__snapshots__/GameServerWire.test.ts.snap
@@ -167,6 +167,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
   "frames": {
     "cast": [
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -220,6 +221,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
         "type": "lobby_info",
       },
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -327,6 +329,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
           ],
           "visibleAt": 1700000001000,
         },
+        "groupToken": "GoldenGroupTok01",
         "lobbyCreatedAt": 1700000000000,
         "myClientID": "cast0000",
         "turns": [],
@@ -521,6 +524,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
     ],
     "host": [
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -554,6 +558,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
         "type": "lobby_info",
       },
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -607,6 +612,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
         "type": "lobby_info",
       },
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -714,6 +720,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
           ],
           "visibleAt": 1700000001000,
         },
+        "groupToken": "GoldenGroupTok01",
         "lobbyCreatedAt": 1700000000000,
         "myClientID": "host0000",
         "turns": [],
@@ -914,6 +921,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
     ],
     "p2": [
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -967,6 +975,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
         "type": "lobby_info",
       },
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -1074,6 +1083,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
           ],
           "visibleAt": 1700000001000,
         },
+        "groupToken": "GoldenGroupTok01",
         "lobbyCreatedAt": 1700000000000,
         "myClientID": "p2000000",
         "turns": [],
@@ -1268,6 +1278,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
     ],
     "p3": [
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -1321,6 +1332,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
         "type": "lobby_info",
       },
       {
+        "groupToken": "GoldenGroupTok01",
         "lobby": {
           "clients": [
             {
@@ -1428,6 +1440,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
           ],
           "visibleAt": 1700000001000,
         },
+        "groupToken": "GoldenGroupTok01",
         "lobbyCreatedAt": 1700000000000,
         "myClientID": "p3000000",
         "turns": [],
@@ -1677,6 +1690,7 @@ exports[`GameServer wire transcript > matches the golden transcript for a script
           ],
           "visibleAt": 1700000001000,
         },
+        "groupToken": "GoldenGroupTok01",
         "lobbyCreatedAt": 1700000000000,
         "myClientID": "p3000000",
         "turns": [


### PR DESCRIPTION
## Why

The desktop shell wants to tell Steam "these players are in one game" so the overlay can group them for playing-together. The only per-game identifier the client has today is the lobby id — and for a private lobby that id **is** the join secret. Steam rich presence is readable by every friend of every group member, so publishing the lobby id there hands an invite to a wide, unbounded set of people who were never invited to the game.

This mints a separate opaque token for that job.

## What the server does

On construction, `GameServer` mints 12 CSPRNG bytes as base64url — exactly 16 URL-safe characters, no padding, no truncation. It is deliberately **not** a hash or any other function of the game id: anything derived from the id gives a token holder a head start on the id itself. Minting goes through a new `mintGroupToken` dep so tests can pin it; production always takes the random default.

The token is stored `private readonly`. Nothing reads it back — no join path, no HTTP route, no API. It is write-only, out to participants of one game.

## Message and field placement

`groupToken` is an optional top-level field (`z.string().min(1).max(64)`) on exactly two schemas in `src/core/Schemas.ts`:

- `ServerLobbyInfoMessageSchema` — a sibling of `lobby`, not a field of it
- `ServerStartGameMessageSchema` — a sibling of `gameStartInfo`, not a field of it

That placement is the point, not an accident of style:

- **Not on `GameInfoSchema`.** `gameInfo()` is also the JSON body of `/api/game/:id` (Worker), the admin-bot routes and the lobby preview route. A token any unauthenticated caller can `GET` by game id is a token derived from the game id, which defeats the entire exercise.
- **Not on `GameStartInfoSchema`.** That object is archived into the publicly downloadable game record and emitted to telemetry. A token sitting next to the game id in a public record is the same derivation by a slower route.

Neither schema is `.strict()`, and both directions validate; the round-trip is covered present **and** absent, because zbin is positional and an optional field that only round-trips when set corrupts every frame where it is not.

## Who receives it, and when

| Participant | Gets it from | When |
| --- | --- | --- |
| Player in the lobby | `lobby_info` | every broadcast, 1/s through the lobby phase |
| Spectator in the lobby | `lobby_info` | same — same value as the players |
| Everyone at game start | `start` | at start |
| Late joiner (connects after start) | `start` | on join; `joinClient` sends a catch-up start and no `lobby_info` ever arrives |
| Singleplayer / replay | — | nothing. `LocalServer` synthesizes both start messages with no server behind them, so there is no token to send |

One game is one group: every participant of a given game receives the identical value, spectators included. Anonymized lobbies build a per-viewer `lobby` object; the token is attached outside that, so it stays constant.

## Client forwarding

`PresencePayload` gains `groupToken?: string`. `ClientGameRunner` emits a new `GroupTokenEvent` from whichever carrier delivered it, and `Main` merges it into the lobby, game **and** spectating payloads (a spectator is in the same Steam group; it is the shell that decides what that does to the group's size). The key is omitted entirely rather than set to `undefined`, because the shell diffs payloads. The token is dropped when joining a different game and when returning to the menu, so no game inherits another's group.

Because `lobby_info` carries the token once a second but it never changes within a game, repeats are dropped (`GroupTokenTracker`). Without that, presence emitted twice a second — and since this handler runs before the `LobbyInfoEvent` from the same frame, the extra emit published the *previous* tick's roster.

The rules that `Main` and `ClientGameRunner` depend on live in `src/client/PresenceGroup.ts`, because neither of those modules is reachable from a test (one drags in WebGL, the other the whole boot sequence) and an untested rule here fails silently.

## Logging

The token must not reach a log line, an error message or any player-visible string. Two real leaks were found and closed:

- `ClientGameRunner` dumps the entire start message to the console, and players paste consoles into bug reports. It now logs `loggableStartMessage(message)`, which strips the token and keeps everything else.
- `Transport`'s `onmessage` catch logged the raw frame. That catch wraps the downstream handler as well as the decode, so it fires on ordinary application errors too, and the desktop shell persists `console.error` by default — meaning a `lobby_info` or `start` frame's token outlived the session in a log file. It now logs the frame's **size** (`frame: 78 bytes`), which is the part a decode failure actually needs.

## Wire cost

+17 bytes per message when present (measured: `lobby_info` 61 → 78, `start` 49 → 66). During the lobby phase that is 17 bytes per client per second; after start it is 17 bytes once. Nothing carries it in the steady-state game loop.

## Tests

`tests/core/GroupTokenSchema.test.ts`

- accepts a token and round-trips it over the binary wire (`lobby_info`, `start`)
- accepts a message without one and omits the key entirely (both), so the presence header stays correctly sized
- rejects an empty token; rejects one longer than 64 characters

`tests/server/GroupToken.test.ts`

- is 16 URL-safe characters
- is not derived from the game id: same id, different tokens
- gives every lobby participant, spectators included, the same token
- repeats the same token in the start message every client gets
- gives a late joiner the token in its catch-up start message
- never writes the token to a log or the console (logger + all five console levels, with a guard that something was in fact logged)

`tests/client/GroupTokenPresence.test.ts`

- `groupTokenOf`: both carriers; `undefined` for a singleplayer start, for a `lobby_info` without one, and for message types that never carry one
- `withGroupToken`: forwards in the lobby, game and spectating payloads; changes nothing else; omits the key entirely when there is no token
- `loggableStartMessage`: drops the token, keeps every other field, does not mutate the caller's message
- `GroupTokenTracker`: accepts the first, rejects a repeat, accepts a change, accepts the same token again after a clear, and emits presence once across a second of identical `lobby_info` tokens

`tests/client/TransportFrameLogging.test.ts`

- does not log the frame buffer; does not leak the token the frame carried; still reports the error and the frame size

`tests/server/GameServerWire.test.ts` — the golden transcript pins the token via deps, so the snapshot shows the same value reaching every client on both carriers, and shows the archived record still carrying none.

Eleven mutations were checked, each caught by a specific test: dropping the field from either message or either schema, deriving the token from the game id, logging it server-side, ignoring the start message on the client, setting the presence key unconditionally, keeping the token in the logged start message, restoring the raw-frame log, accepting every repeat, and a `clear()` that does not clear.

## Follow-up

The desktop shell currently derives its Steam player group from the lobby id. A follow-up PR in `openfront-desktop` switches it to this token; until that lands, this field is minted and delivered but unused, which is harmless.

Part of [OPE-423](https://linear.app/openfront/issue/OPE-423)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
