### PR TITLE
Add client tests locking in untested transport, game-runner, HUD and boot paths

### DIFF
--- a/tests/client/ClientGameRunnerActions.test.ts
+++ b/tests/client/ClientGameRunnerActions.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import { UnitType } from "../../src/core/game/Game";
+import { TileRef } from "../../src/core/game/GameMap";
+
+// ClientGameRunner's left-click handling: spawn intents during the spawn
+// phase, the lazy myPlayer lookup, attack intents, and the auto-boat
+// distance limit. Heavy renderer/audio/worker modules are mocked at import.
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: { gitCommit: () => "test-commit" },
+}));
+vi.mock("../../src/client/Auth", () => ({
+  getPlayToken: async () => "8f1d2c3e-4b5a-4c6d-8e7f-90a1b2c3d4e5",
+}));
+vi.mock("../../src/client/LocalServer", () => ({
+  LocalServer: class {},
+}));
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: vi.fn(async () => {}),
+  showInGameConfirm: vi.fn(async () => false),
+}));
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string) => key,
+  reloadForUpdate: vi.fn(),
+  createCanvas: () => document.createElement("canvas"),
+  homeHref: () => "/",
+}));
+vi.mock("../../src/core/game/TerrainMapLoader", () => ({
+  loadTerrainMap: vi.fn(async () => ({}) as never),
+}));
+vi.mock("../../src/client/TerrainMapFileLoader", () => ({
+  terrainMapFileLoader: {},
+}));
+vi.mock("../../src/client/hud/GameRenderer", () => ({
+  createRenderer: vi.fn(),
+}));
+vi.mock("../../src/client/hud/layers/lib/GoldRateTracker", () => ({
+  goldRateTracker: { resetAll: vi.fn() },
+}));
+vi.mock("../../src/client/theme/ThemeProvider", () => ({
+  themeProvider: { reset: vi.fn() },
+}));
+vi.mock("../../src/client/sound/SoundManager", () => ({
+  SoundManager: class {},
+}));
+vi.mock("../../src/client/render/gl", () => ({
+  GLUnavailableError: class extends Error {},
+  MapRenderer: class {},
+  applyGraphicsOverrides: vi.fn(),
+  createRenderSettings: vi.fn(() => ({})),
+  deepAssign: vi.fn(),
+  preloadAtlasData: vi.fn(async () => {}),
+  renderDpr: () => 1,
+  showGLGate: vi.fn(),
+  trackGLInit: vi.fn(),
+}));
+vi.mock("../../src/client/WebGLFrameBuilder", () => ({
+  WebGLFrameBuilder: class {},
+}));
+vi.mock("../../src/client/controllers/MapLayerController", () => ({
+  MapLayerController: class {},
+}));
+vi.mock("../../src/client/view", () => ({
+  GameView: class {},
+  PlayerView: class {},
+}));
+vi.mock("../../src/core/worker/WorkerClient", () => ({
+  WorkerClient: class {},
+}));
+
+import {
+  ClientGameRunner,
+  LobbyConfig,
+} from "../../src/client/ClientGameRunner";
+import { MouseUpEvent } from "../../src/client/InputHandler";
+import {
+  SendAttackIntentEvent,
+  SendBoatAttackIntentEvent,
+  SendSpawnIntentEvent,
+} from "../../src/client/Transport";
+
+const TILE = 77 as TileRef;
+const CLICK = { x: 10, y: 20 };
+
+// Runner around fully mocked collaborators; started so clicks are handled.
+function makeRunner(overrides: {
+  inSpawnPhase?: boolean;
+  hasOwner?: boolean;
+  playerByClientID?: () => unknown;
+  actions?: Record<string, unknown>;
+  boatDistSquared?: number;
+}) {
+  const eventBus = new EventBus();
+  const myPlayer = {
+    actions: vi.fn(async () => overrides.actions ?? {}),
+    troops: () => 100,
+  };
+  const gameView = {
+    config: () => ({ isRandomSpawn: () => false, isReplay: () => false }),
+    inSpawnPhase: () => overrides.inSpawnPhase ?? false,
+    myPlayer: () => null,
+    isValidCoord: () => true,
+    ref: () => TILE,
+    isLand: () => true,
+    hasOwner: () => overrides.hasOwner ?? false,
+    owner: () => ({ id: () => "enemy1" }),
+    playerByClientID: vi.fn(overrides.playerByClientID ?? (() => myPlayer)),
+    euclideanDistSquared: () => overrides.boatDistSquared ?? 0,
+  };
+  const runner = new ClientGameRunner(
+    { gameID: "game1234" } as LobbyConfig,
+    "c0000001",
+    eventBus,
+    {
+      initialize: vi.fn(),
+      tick: vi.fn(),
+      uiState: { attackRatio: 0.5, ghostStructure: null },
+      transformHandler: {
+        screenToWorldCoordinates: vi.fn(() => ({ x: 1, y: 2 })),
+      },
+    } as never,
+    { initialize: vi.fn() } as never,
+    {
+      updateCallback: vi.fn(),
+      rejoinGame: vi.fn(),
+      leaveGame: vi.fn(),
+      isLocal: true,
+    } as never,
+    { start: vi.fn(), sendTurn: vi.fn(), cleanup: vi.fn() } as never,
+    gameView as never,
+    { playBackgroundMusic: vi.fn(), dispose: vi.fn() } as never,
+    { goToPlayer: () => false } as never,
+  );
+  runner.start();
+  return { runner, eventBus, gameView, myPlayer };
+}
+
+const flushPromises = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("left click", () => {
+  it("emits a spawn intent when clicking unowned land during the spawn phase", () => {
+    const { eventBus } = makeRunner({ inSpawnPhase: true });
+    const spawns: SendSpawnIntentEvent[] = [];
+    eventBus.on(SendSpawnIntentEvent, (e) => spawns.push(e));
+
+    eventBus.emit(new MouseUpEvent(CLICK.x, CLICK.y));
+
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0].tile).toBe(TILE);
+  });
+
+  it("lazily resolves myPlayer by clientID and emits an attack intent", async () => {
+    const { eventBus, gameView } = makeRunner({
+      hasOwner: true,
+      actions: { canAttack: true, buildableUnits: [] },
+    });
+    const attacks: SendAttackIntentEvent[] = [];
+    eventBus.on(SendAttackIntentEvent, (e) => attacks.push(e));
+
+    eventBus.emit(new MouseUpEvent(CLICK.x, CLICK.y));
+    await flushPromises();
+
+    expect(gameView.playerByClientID).toHaveBeenCalledWith("c0000001");
+    expect(attacks).toHaveLength(1);
+    expect(attacks[0].targetID).toBe("enemy1");
+    expect(attacks[0].troops).toBe(50); // 100 troops * 0.5 attack ratio
+  });
+
+  it("does nothing when the player is not in the view yet", async () => {
+    const { eventBus, myPlayer } = makeRunner({
+      hasOwner: true,
+      playerByClientID: () => null,
+    });
+
+    eventBus.emit(new MouseUpEvent(CLICK.x, CLICK.y));
+    await flushPromises();
+
+    expect(myPlayer.actions).not.toHaveBeenCalled();
+  });
+});
+
+describe("auto boat", () => {
+  const boatActions = {
+    canAttack: false,
+    buildableUnits: [{ type: UnitType.TransportShip, canBuild: 5 as TileRef }],
+  };
+
+  it("boat-attacks land within the distance limit", async () => {
+    const { eventBus } = makeRunner({
+      hasOwner: true,
+      actions: boatActions,
+      boatDistSquared: 99 * 99,
+    });
+    const boats: SendBoatAttackIntentEvent[] = [];
+    eventBus.on(SendBoatAttackIntentEvent, (e) => boats.push(e));
+
+    eventBus.emit(new MouseUpEvent(CLICK.x, CLICK.y));
+    await flushPromises();
+
+    expect(boats).toHaveLength(1);
+    expect(boats[0].dst).toBe(TILE);
+    expect(boats[0].troops).toBe(50);
+  });
+
+  it("does not boat-attack past the distance limit", async () => {
+    const { eventBus } = makeRunner({
+      hasOwner: true,
+      actions: boatActions,
+      boatDistSquared: 100 * 100,
+    });
+    const boats: SendBoatAttackIntentEvent[] = [];
+    eventBus.on(SendBoatAttackIntentEvent, (e) => boats.push(e));
+
+    eventBus.emit(new MouseUpEvent(CLICK.x, CLICK.y));
+    await flushPromises();
+
+    expect(boats).toHaveLength(0);
+  });
+});

--- a/tests/client/ClientGameRunnerActions.test.ts
+++ b/tests/client/ClientGameRunnerActions.test.ts
@@ -176,15 +176,23 @@ describe("left click", () => {
   });
 
   it("does nothing when the player is not in the view yet", async () => {
-    const { eventBus, myPlayer } = makeRunner({
+    const { eventBus, gameView } = makeRunner({
       hasOwner: true,
       playerByClientID: () => null,
     });
+    const attacks: SendAttackIntentEvent[] = [];
+    eventBus.on(SendAttackIntentEvent, (e) => attacks.push(e));
+    const boats: SendBoatAttackIntentEvent[] = [];
+    eventBus.on(SendBoatAttackIntentEvent, (e) => boats.push(e));
 
     eventBus.emit(new MouseUpEvent(CLICK.x, CLICK.y));
     await flushPromises();
 
-    expect(myPlayer.actions).not.toHaveBeenCalled();
+    // The lazy-lookup branch was reached and returned early: no intent of
+    // either kind went out.
+    expect(gameView.playerByClientID).toHaveBeenCalledWith("c0000001");
+    expect(attacks).toHaveLength(0);
+    expect(boats).toHaveLength(0);
   });
 });
 

--- a/tests/client/ClientGameRunnerMessages.test.ts
+++ b/tests/client/ClientGameRunnerMessages.test.ts
@@ -1,0 +1,307 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import { GameUpdateType } from "../../src/core/game/GameUpdates";
+
+// ClientGameRunner's server-message handling, driven through captured
+// callbacks: the lobby-phase onmessage joinLobby installs on the transport,
+// the in-game onmessage ClientGameRunner.start installs, and the worker
+// update callback. Heavy renderer/audio/worker modules are mocked at import.
+
+const captured = vi.hoisted(() => ({
+  lobbyOnConnect: undefined as (() => void) | undefined,
+  lobbyOnMessage: undefined as ((msg: unknown) => void) | undefined,
+}));
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: {
+    gitCommit: () => "test-commit",
+    resolveGame: () => ({ kind: "own" }),
+  },
+}));
+vi.mock("../../src/client/Auth", () => ({
+  getPlayToken: async () => "8f1d2c3e-4b5a-4c6d-8e7f-90a1b2c3d4e5",
+}));
+vi.mock("../../src/client/LocalServer", () => ({
+  LocalServer: class {},
+}));
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameAlert: vi.fn(async () => {}),
+  showInGameConfirm: vi.fn(async () => false),
+}));
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string) => key,
+  reloadForUpdate: vi.fn(),
+  createCanvas: () => document.createElement("canvas"),
+  homeHref: () => "/",
+}));
+vi.mock("../../src/core/game/TerrainMapLoader", () => ({
+  loadTerrainMap: vi.fn(async () => ({}) as never),
+}));
+vi.mock("../../src/client/TerrainMapFileLoader", () => ({
+  terrainMapFileLoader: {},
+}));
+vi.mock("../../src/client/hud/GameRenderer", () => ({
+  createRenderer: vi.fn(),
+}));
+vi.mock("../../src/client/hud/layers/lib/GoldRateTracker", () => ({
+  goldRateTracker: { resetAll: vi.fn() },
+}));
+vi.mock("../../src/client/theme/ThemeProvider", () => ({
+  themeProvider: { reset: vi.fn() },
+}));
+vi.mock("../../src/client/sound/SoundManager", () => ({
+  SoundManager: class {},
+}));
+vi.mock("../../src/client/render/gl", () => ({
+  GLUnavailableError: class extends Error {},
+  MapRenderer: class {},
+  applyGraphicsOverrides: vi.fn(),
+  createRenderSettings: vi.fn(() => ({})),
+  deepAssign: vi.fn(),
+  preloadAtlasData: vi.fn(async () => {}),
+  renderDpr: () => 1,
+  showGLGate: vi.fn(),
+  trackGLInit: vi.fn(),
+}));
+vi.mock("../../src/client/WebGLFrameBuilder", () => ({
+  WebGLFrameBuilder: class {},
+}));
+vi.mock("../../src/client/controllers/MapLayerController", () => ({
+  MapLayerController: class {},
+}));
+vi.mock("../../src/client/view", () => ({
+  GameView: class {},
+  PlayerView: class {},
+}));
+vi.mock("../../src/core/worker/WorkerClient", () => ({
+  WorkerClient: class {},
+}));
+vi.mock("../../src/client/Transport", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../src/client/Transport")>();
+  class MockTransport {
+    constructor(..._args: unknown[]) {}
+    connect(onconnect: () => void, onmessage: (msg: unknown) => void) {
+      captured.lobbyOnConnect = onconnect;
+      captured.lobbyOnMessage = onmessage;
+    }
+    joinGame() {}
+    leaveGame() {}
+  }
+  return { ...actual, Transport: MockTransport };
+});
+
+import {
+  ClientGameRunner,
+  joinLobby,
+  LobbyConfig,
+} from "../../src/client/ClientGameRunner";
+import { SendHashEvent } from "../../src/client/Transport";
+import { loadTerrainMap } from "../../src/core/game/TerrainMapLoader";
+
+function makeLobbyConfig(withStartInfo: boolean): LobbyConfig {
+  return {
+    gameID: "game1234",
+    playerName: "tester",
+    playerClanTag: null,
+    playerRole: null,
+    turnstileToken: null,
+    cosmetics: {},
+    ...(withStartInfo
+      ? { gameStartInfo: { gameID: "game1234", config: {} } }
+      : {}),
+  } as unknown as LobbyConfig;
+}
+
+// Builds a runner around fully mocked collaborators, starts it, and returns
+// the callbacks start() handed to the transport and the worker.
+function makeStartedRunner(withStartInfo: boolean) {
+  const eventBus = new EventBus();
+  const emitSpy = vi.spyOn(eventBus, "emit");
+  const worker = { start: vi.fn(), sendTurn: vi.fn(), cleanup: vi.fn() };
+  const transport = {
+    updateCallback: vi.fn(),
+    rejoinGame: vi.fn(),
+    turnComplete: vi.fn(),
+    leaveGame: vi.fn(),
+    isLocal: true,
+  };
+  const renderer = {
+    initialize: vi.fn(),
+    tick: vi.fn(),
+    uiState: { attackRatio: 0.5, ghostStructure: null },
+    transformHandler: { screenToWorldCoordinates: vi.fn() },
+  };
+  const gameView = {
+    config: () => ({ isRandomSpawn: () => false, isReplay: () => false }),
+    inSpawnPhase: () => false,
+    myPlayer: () => null,
+    update: vi.fn(),
+  };
+  const soundManager = { playBackgroundMusic: vi.fn(), dispose: vi.fn() };
+  const userSettings = { goToPlayer: () => false };
+
+  const runner = new ClientGameRunner(
+    makeLobbyConfig(withStartInfo),
+    "c0000001",
+    eventBus,
+    renderer as never,
+    { initialize: vi.fn() } as never,
+    transport as never,
+    worker as never,
+    gameView as never,
+    soundManager as never,
+    userSettings as never,
+  );
+  runner.start();
+
+  const workerCallback = worker.start.mock.calls[0][0] as (gu: unknown) => void;
+  const onmessage = transport.updateCallback.mock.calls[0][1] as (
+    msg: unknown,
+  ) => void;
+  return {
+    runner,
+    worker,
+    transport,
+    gameView,
+    emitSpy,
+    workerCallback,
+    onmessage,
+  };
+}
+
+const errorModalText = () =>
+  document.querySelector("#error-modal pre")?.textContent ?? "";
+
+beforeEach(() => {
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  captured.lobbyOnConnect = undefined;
+  captured.lobbyOnMessage = undefined;
+});
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+  vi.clearAllMocks();
+});
+
+describe("joinLobby lobby-phase messages", () => {
+  it("preloads the terrain and resolves prestart on a prestart message", async () => {
+    const result = joinLobby(new EventBus(), makeLobbyConfig(false));
+
+    captured.lobbyOnMessage!({
+      type: "prestart",
+      gameMap: "world",
+      gameMapSize: "medium",
+    });
+
+    await expect(result.prestart).resolves.toBeUndefined();
+    expect(loadTerrainMap).toHaveBeenCalledWith(
+      "world",
+      "medium",
+      expect.anything(),
+      false,
+    );
+  });
+
+  it("shows the connection-error modal when start carries no gameStartInfo", async () => {
+    const result = joinLobby(new EventBus(), makeLobbyConfig(false));
+
+    captured.lobbyOnMessage!({
+      type: "start",
+      myClientID: "c0000001",
+      turns: [],
+      gameStartInfo: undefined,
+    });
+
+    await expect(result.join).resolves.toBeUndefined();
+    await vi.waitFor(() =>
+      expect(document.querySelector("#error-modal")).not.toBeNull(),
+    );
+    expect(errorModalText()).toContain("error_modal.connection_error");
+    expect(errorModalText()).toContain("game id: game1234");
+    expect(errorModalText()).toContain("Error: missing gameStartInfo");
+  });
+});
+
+describe("ClientGameRunner in-game messages", () => {
+  it("forwards buffered turns to the worker on a start message", () => {
+    const { worker, onmessage } = makeStartedRunner(true);
+    const turns = [
+      { turnNumber: 0, intents: [] },
+      { turnNumber: 1, intents: [] },
+    ];
+
+    onmessage({ type: "start", turns });
+
+    expect(worker.sendTurn).toHaveBeenCalledTimes(2);
+    expect(worker.sendTurn).toHaveBeenNthCalledWith(1, turns[0]);
+    expect(worker.sendTurn).toHaveBeenNthCalledWith(2, turns[1]);
+  });
+
+  it("shows the desync modal on a desync message", () => {
+    const { onmessage } = makeStartedRunner(true);
+
+    onmessage({ type: "desync" });
+
+    expect(errorModalText()).toContain("error_modal.desync_notice");
+    expect(errorModalText()).toContain("game id: game1234");
+    expect(errorModalText()).toContain("client id: c0000001");
+  });
+
+  it("throws on a desync message when gameStartInfo is missing", () => {
+    const { onmessage } = makeStartedRunner(false);
+
+    expect(() => onmessage({ type: "desync" })).toThrow(
+      "missing gameStartInfo",
+    );
+  });
+
+  it("forwards a matching turn and rejects a wrong turn number", () => {
+    const { worker, onmessage } = makeStartedRunner(true);
+    const turn = { turnNumber: 0, intents: [] };
+
+    onmessage({ type: "turn", turn });
+    expect(worker.sendTurn).toHaveBeenCalledWith(turn);
+
+    onmessage({ type: "turn", turn: { turnNumber: 5, intents: [] } });
+    expect(worker.sendTurn).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith(
+      "got wrong turn have turns 1, received turn 5",
+    );
+  });
+
+  it("processes a worker game update: turnComplete, hash events, render tick", () => {
+    const { worker, transport, gameView, emitSpy, workerCallback } =
+      makeStartedRunner(true);
+    void worker;
+
+    workerCallback({
+      updates: { [GameUpdateType.Hash]: [{ tick: 3, hash: 42 }] },
+      tickExecutionDuration: 1,
+    });
+
+    expect(transport.turnComplete).toHaveBeenCalled();
+    expect(emitSpy).toHaveBeenCalledWith(new SendHashEvent(3, 42));
+    expect(gameView.update).toHaveBeenCalled();
+  });
+
+  it("shows the crash modal and stops on a worker error update", () => {
+    const { worker, transport, workerCallback } = makeStartedRunner(true);
+
+    workerCallback({ errMsg: "boom", stack: "trace" });
+
+    expect(errorModalText()).toContain("Error: boom");
+    expect(worker.cleanup).toHaveBeenCalled();
+    expect(transport.leaveGame).toHaveBeenCalled();
+  });
+
+  it("throws on a worker update when gameStartInfo is missing", () => {
+    const { workerCallback } = makeStartedRunner(false);
+
+    expect(() => workerCallback({ errMsg: "boom" })).toThrow(
+      "missing gameStartInfo",
+    );
+  });
+});

--- a/tests/client/HostLobbyModalTeamCount.test.ts
+++ b/tests/client/HostLobbyModalTeamCount.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The desktop bridge is absent in jsdom; mock it like HostLobbyModal.test.ts.
+vi.mock("../../src/client/DesktopPresence", () => ({
+  desktopPresence: {
+    isAvailable: vi.fn(() => false),
+    openInviteDialog: vi.fn(async () => true),
+    set: vi.fn(),
+    consumePendingInvite: vi.fn(async () => null),
+    subscribeInvites: vi.fn(() => () => undefined),
+  },
+}));
+
+import { HostLobbyModal } from "../../src/client/HostLobbyModal";
+
+describe("HostLobbyModal team count selection", () => {
+  it("updates the lobby's team count and pushes the new config", () => {
+    const modal = new HostLobbyModal() as any;
+    const putGameConfig = vi.fn(); // network push stubbed out
+    modal.putGameConfig = putGameConfig;
+
+    modal.handleConfigTeamCountSelected(
+      new CustomEvent("team-count-selected", { detail: { count: 5 } }),
+    );
+
+    expect(modal.teamCount).toBe(5);
+    expect(putGameConfig).toHaveBeenCalledOnce();
+  });
+});

--- a/tests/client/LangSelectorTranslate.test.ts
+++ b/tests/client/LangSelectorTranslate.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LangSelector } from "../../src/client/LangSelector";
+
+// applyTranslation/changeLanguage are private; drive them through a cast, the
+// same way GameInfoView.test.ts does. Constructing without attaching skips
+// connectedCallback's full language bootstrap.
+function makeSelector(translations: Record<string, string>): LangSelector {
+  const selector = new LangSelector();
+  selector.translations = translations;
+  selector.defaultTranslations = translations;
+  return selector;
+}
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("LangSelector applyTranslation", () => {
+  it("writes resolved data-i18n keys and skips unresolvable ones", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    document.body.innerHTML = `
+      <span data-i18n="test.hello"></span>
+      <span data-i18n="test.bogus">untouched</span>
+    `;
+    const selector = makeSelector({
+      "main.title": "OpenFront",
+      "test.hello": "Hello",
+      // Malformed map value: translateText hands it back as null, which the
+      // loop must skip with a warning instead of blanking the node.
+      "test.bogus": null as unknown as string,
+    });
+
+    (selector as unknown as { applyTranslation(): void }).applyTranslation();
+
+    expect(
+      document.querySelector('[data-i18n="test.hello"]')!.textContent,
+    ).toBe("Hello");
+    expect(
+      document.querySelector('[data-i18n="test.bogus"]')!.textContent,
+    ).toBe("untouched");
+    expect(warn).toHaveBeenCalledWith("Translation key not found: test.bogus");
+    expect(document.title).toBe("OpenFront");
+  });
+});
+
+describe("LangSelector translateText", () => {
+  it("warns and returns the key itself when it is not found", () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const selector = makeSelector({});
+
+    expect(selector.translateText("missing.key")).toBe("missing.key");
+    expect(warn).toHaveBeenCalledWith("Translation key not found: missing.key");
+  });
+
+  it("substitutes {placeholders} from params", () => {
+    const selector = makeSelector({
+      "test.greeting": "Hello {name}, {count} new messages",
+    });
+
+    expect(
+      selector.translateText("test.greeting", { name: "Sam", count: 3 }),
+    ).toBe("Hello Sam, 3 new messages");
+  });
+});
+
+describe("LangSelector language loading", () => {
+  it("flattens fetched translations, warning on non-string non-object values", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          main: { title: "Titre" },
+          bogus: [1, 2],
+        }),
+      })),
+    );
+    const selector = makeSelector({});
+
+    await (
+      selector as unknown as { changeLanguage(lang: string): Promise<void> }
+    ).changeLanguage("fr");
+
+    expect(selector.currentLang).toBe("fr");
+    expect(selector.translations).toEqual({ "main.title": "Titre" });
+    // The array value is dropped, not flattened.
+    expect(warn).toHaveBeenCalledWith("Unknown type", "object", [1, 2]);
+  });
+});

--- a/tests/client/LocalServerEdge.test.ts
+++ b/tests/client/LocalServerEdge.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import type { GameStartInfo, ServerMessage } from "../../src/core/Schemas";
+
+vi.mock("../../src/client/Auth", () => ({
+  getAuthHeader: vi.fn(async () => "Bearer test-jwt"),
+  getPersistentID: vi.fn(() => "123e4567-e89b-12d3-a456-426614174000"),
+}));
+
+vi.mock("../../src/client/Api", () => ({
+  getApiBase: vi.fn(() => "https://api.test"),
+}));
+
+vi.mock("src/client/ClientEnv", () => ({
+  ClientEnv: {
+    turnIntervalMs: vi.fn(() => 100),
+    gitCommit: vi.fn(() => "DEV"),
+  },
+}));
+
+import { LocalServer } from "../../src/client/LocalServer";
+
+const CLIENT_ID = "abCD1234";
+
+function makeGameStartInfo(): GameStartInfo {
+  return {
+    gameID: "gameID12",
+    lobbyCreatedAt: 1000,
+    config: {
+      gameMap: "Africa",
+      difficulty: "Medium",
+      donateGold: false,
+      donateTroops: false,
+      gameType: "Singleplayer",
+      gameMode: "Free For All",
+      gameMapSize: "Normal",
+      nations: "default",
+      bots: 400,
+      infiniteGold: false,
+      infiniteTroops: false,
+      instantBuild: false,
+      randomSpawn: false,
+    },
+    players: [
+      {
+        clientID: CLIENT_ID,
+        username: "TestUser",
+        clanTag: null,
+      },
+    ],
+  } as GameStartInfo;
+}
+
+describe("LocalServer edge cases", () => {
+  it("refuses to start or archive a lobby without gameStartInfo", () => {
+    const server = new LocalServer(
+      { playerName: "TestUser", playerClanTag: null } as any,
+      false,
+      new EventBus(),
+    );
+    server.updateCallback(
+      () => {},
+      () => {},
+    );
+
+    expect(() => server.start()).toThrow("missing gameStartInfo");
+    // endGame -> archiveGameRecord hits the same guard (and stops the
+    // turn-check interval start() had already begun).
+    expect(() => server.endGame()).toThrow("missing gameStartInfo");
+  });
+
+  it("reports a desync when a replay hash disagrees with the archived one", () => {
+    const messages: ServerMessage[] = [];
+    const gameRecord = {
+      turns: [{ turnNumber: 0, intents: [], hash: 1111 }],
+      info: { num_turns: 1 },
+    };
+    const server = new LocalServer(
+      {
+        gameStartInfo: makeGameStartInfo(),
+        gameRecord,
+        playerName: "TestUser",
+        playerClanTag: null,
+      } as any,
+      true,
+      new EventBus(),
+    );
+    server.updateCallback(
+      () => {},
+      (message) => messages.push(message),
+    );
+    server.start();
+    server.endGame(); // stop the turn loop; replays never archive
+
+    server.onMessage({ type: "hash", turnNumber: 0, hash: 2222 });
+
+    expect(messages.filter((m) => m.type === "desync")).toEqual([
+      {
+        type: "desync",
+        turn: 0,
+        correctHash: 1111,
+        clientsWithCorrectHash: 0,
+        totalActiveClients: 1,
+        yourHash: 2222,
+      },
+    ]);
+
+    // A matching hash verifies silently.
+    server.onMessage({ type: "hash", turnNumber: 0, hash: 1111 });
+    expect(messages.filter((m) => m.type === "desync")).toHaveLength(1);
+  });
+});

--- a/tests/client/MainInitialize.test.ts
+++ b/tests/client/MainInitialize.test.ts
@@ -200,9 +200,9 @@ describe("Client.initialize() booted from Main.ts module scope", () => {
       path.resolve(__dirname, "../../index.html"),
       "utf8",
     );
-    const bodyInner = html
-      .match(/<body[^>]*>([\s\S]*)<\/body>/)![1]
-      .replace(/<script[\s\S]*?<\/script>/g, "");
+    const parsed = new DOMParser().parseFromString(html, "text/html");
+    parsed.querySelectorAll("script").forEach((s) => s.remove());
+    const bodyInner = parsed.body.innerHTML;
     // A guaranteed-first <username-input> so Client.initialize() captures an
     // element we can stub canPlay() on (play-page renders its own copy async,
     // maybe, later — document order keeps ours the querySelector result).

--- a/tests/client/MainInitialize.test.ts
+++ b/tests/client/MainInitialize.test.ts
@@ -1,0 +1,278 @@
+/**
+ * First harness that imports src/client/Main.ts for real. Main bootstraps at
+ * module scope (`new Client().initialize()`), so the DOM (built from the real
+ * index.html body) and every global it dereferences must exist BEFORE the
+ * dynamic import in beforeAll. All tests share that one boot: custom elements
+ * cannot be re-defined in the file's single jsdom, so a second import of Main
+ * (after vi.resetModules) would throw on the first `customElements.define`.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  userAuth: vi.fn(async (): Promise<unknown> => false),
+  retrySteamSignIn: vi.fn(async (): Promise<unknown> => false),
+  reauthAfterCrazyGamesChange: vi.fn(async (): Promise<unknown> => false),
+  getDesktopSessionState: vi.fn(() => ({ status: "unknown" })),
+  getUserMe: vi.fn(async (): Promise<unknown> => false),
+  invalidateUserMe: vi.fn(),
+  joinLobby: vi.fn(),
+}));
+
+// Auth is imported by half the component tree; keep the real module and only
+// take over the four functions Main's auth flow calls.
+vi.mock("../../src/client/Auth", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    userAuth: mocks.userAuth,
+    retrySteamSignIn: mocks.retrySteamSignIn,
+    reauthAfterCrazyGamesChange: mocks.reauthAfterCrazyGamesChange,
+    getDesktopSessionState: mocks.getDesktopSessionState,
+  };
+});
+
+// Same story for Api: <username-input> calls getUserMe from
+// connectedCallback, which runs while Main's import is still executing.
+vi.mock("../../src/client/Api", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return {
+    ...actual,
+    getUserMe: mocks.getUserMe,
+    invalidateUserMe: mocks.invalidateUserMe,
+  };
+});
+
+// Deterministic "version element not found" (Main.ts line 411) regardless of
+// whether the Lit nav bars have rendered their version spans yet.
+vi.mock("../../src/client/GameVersion", async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, renderNavVersion: () => 0 };
+});
+
+// Main is the only importer. Stubbing it keeps onUserMe's boot-interrupt tail
+// deterministic (no confirm dialogs, no reward popups).
+vi.mock("../../src/client/BootInterrupts", () => ({
+  bootInterruptsAllowed: () => false,
+  CLAIM_PROMPT_KEY: "claim-prompt-store",
+  claimPromptDue: () => false,
+  claimPromptStringsReady: () => false,
+  joinOwnsInFlightFlag: () => true,
+  lapseShownAfterDispatch: (
+    _resp: unknown,
+    _marker: unknown,
+    dispatch: () => void,
+  ) => {
+    dispatch();
+    return false;
+  },
+  nextBootInterrupt: () => null,
+  parseClaimPromptStore: () => ({}),
+  runBootInterrupt: async () => {},
+}));
+
+// Injects a third-party script and polls; nothing under test needs it.
+vi.mock("../../src/client/Admiral", () => ({
+  loadAdmiral: vi.fn(),
+  onAdmiralMeasured: vi.fn(),
+}));
+
+// adGatekeeper.start() would install a poll interval and DOM bait.
+// HomepagePromos (also in Main's graph) reads canShowAds and nothing else.
+vi.mock("../../src/client/AdGatekeeper", () => ({
+  adGatekeeper: {
+    seed: vi.fn(),
+    start: vi.fn(),
+    stop: vi.fn(),
+    canShowAds: false,
+    whenClear: () => () => {},
+  },
+}));
+
+// Cuts the whole Pixi/WebGL/worker/audio in-game graph out of the import.
+// Transport/LocalServer only take the LobbyConfig *type* from this module,
+// so a value-only stub is safe.
+vi.mock("../../src/client/ClientGameRunner", () => ({
+  joinLobby: mocks.joinLobby,
+}));
+
+function userMeFixture(): unknown {
+  return {
+    user: { email: "player@example.com" },
+    player: {
+      publicId: "public-id-1",
+      usernameStatus: "claimed",
+      usernameBase: "RyanTheGreat",
+      username: "RyanTheGreat",
+      usernameClaimExpiresAt: null,
+      nextUsernameChangeAt: null,
+      rewards: [],
+      // SinglePlayerModal's userMeResponse listener dereferences this.
+      achievements: { singleplayerMap: [] },
+    },
+  };
+}
+
+describe("Client.initialize() booted from Main.ts module scope", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeAll(async () => {
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "info").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // ClientEnv.get() throws without this (initialize reads instanceId()
+    // before the Turnstile prefetch).
+    (window as any).BOOTSTRAP_CONFIG = {
+      gameEnv: "dev",
+      numWorkers: 2,
+      turnstileSiteKey: "test-site-key",
+      jwtAudience: "localhost",
+      instanceId: "dev-instance",
+      gitCommit: "DEV",
+    };
+
+    // Without this the Turnstile prefetch polls for 10s and then rejects a
+    // stored promise nothing catches.
+    (window as any).turnstile = {
+      render: () => "widget-1",
+      execute: (
+        _widgetId: string,
+        opts: { callback: (token: string) => void },
+      ) => opts.callback("turnstile-test-token"),
+      remove: () => {},
+    };
+
+    // jsdom has neither FontFace nor document.fonts.
+    vi.stubGlobal(
+      "FontFace",
+      class {
+        load() {
+          return Promise.resolve(this);
+        }
+      },
+    );
+    Object.defineProperty(document, "fonts", {
+      value: { add: () => {} },
+      configurable: true,
+    });
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+      },
+    );
+    vi.stubGlobal(
+      "IntersectionObserver",
+      class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+        takeRecords() {
+          return [];
+        }
+      },
+    );
+    // Components in Main's graph fire fetches from connectedCallback; answer
+    // them all with a failure they already handle instead of real sockets.
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({
+        ok: false,
+        status: 500,
+        statusText: "Server Error",
+        headers: new Map<string, string>(),
+        json: async () => ({}),
+        text: async () => "",
+        arrayBuffer: async () => new ArrayBuffer(0),
+      })),
+    );
+
+    // Real markup, so every unguarded getElementById/querySelector in
+    // initialize() (store modal, help modal, turnstile container, ...) finds
+    // the element it dereferences. Scripts hold EJS placeholders — drop them.
+    const html = fs.readFileSync(
+      path.resolve(__dirname, "../../index.html"),
+      "utf8",
+    );
+    const bodyInner = html
+      .match(/<body[^>]*>([\s\S]*)<\/body>/)![1]
+      .replace(/<script[\s\S]*?<\/script>/g, "");
+    // A guaranteed-first <username-input> so Client.initialize() captures an
+    // element we can stub canPlay() on (play-page renders its own copy async,
+    // maybe, later — document order keeps ours the querySelector result).
+    document.body.innerHTML = `<username-input></username-input>${bodyInner}`;
+
+    // The import runs bootstrap: component registration, element upgrades,
+    // then `new Client().initialize()`.
+    await import("../../src/client/Main");
+
+    if (document.readyState === "loading") {
+      document.dispatchEvent(new Event("DOMContentLoaded", { bubbles: true }));
+    }
+
+    // After `await userAuth()` resolves, the remainder of initialize() is
+    // synchronous — one flush after the call is observed means the hashchange
+    // listener, join-lobby listener and slider wiring are all in place.
+    await vi.waitFor(() => expect(mocks.userAuth).toHaveBeenCalled());
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }, 20_000);
+
+  it("runs the signed-out boot: onUserMe(false) and the missing-version warn", () => {
+    // renderNavVersion() === 0 branch (line 411).
+    expect(warnSpy).toHaveBeenCalledWith("Game version element not found");
+    // userAuth() === false → onUserMe(false) (line 735), which flips the ad
+    // entitlement on for a signed-out web player.
+    expect(window.adsEnabled).toBe(true);
+  });
+
+  it("routes a hashchange through onHashUpdate", async () => {
+    const joinModal = document.querySelector("join-lobby-modal") as unknown as {
+      close: () => void;
+    };
+    const closeSpy = vi.spyOn(joinModal, "close").mockImplementation(() => {});
+    window.dispatchEvent(new Event("hashchange"));
+    await vi.waitFor(() => expect(closeSpy).toHaveBeenCalled());
+    closeSpy.mockRestore();
+  });
+
+  it("reads the join-lobby detail and stops at the username gate", async () => {
+    const input = document.querySelector("username-input") as unknown as {
+      canPlay: () => boolean;
+    };
+    const canPlay = vi.fn(() => false);
+    input.canPlay = canPlay;
+    logSpy.mockClear();
+    document.dispatchEvent(
+      new CustomEvent("join-lobby", {
+        detail: { gameID: "AbCd1234" },
+        bubbles: true,
+      }),
+    );
+    await vi.waitFor(() => expect(canPlay).toHaveBeenCalled());
+    // Early return before the "joining lobby" log — nothing joined.
+    expect(logSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("joining lobby"),
+    );
+    expect(mocks.joinLobby).not.toHaveBeenCalled();
+  });
+
+  it("logs the player id when a retry lands a signed-in userMe", async () => {
+    mocks.retrySteamSignIn.mockResolvedValueOnce({
+      jwt: "jwt",
+      claims: {},
+    });
+    mocks.getUserMe.mockResolvedValueOnce(userMeFixture());
+    document.dispatchEvent(new CustomEvent("desktop-session-retry"));
+    await vi.waitFor(() =>
+      expect(logSpy).toHaveBeenCalledWith(
+        expect.stringContaining("Your player ID is public-id-1"),
+      ),
+    );
+  });
+});

--- a/tests/client/NewsModal.test.ts
+++ b/tests/client/NewsModal.test.ts
@@ -19,7 +19,7 @@ describe("NewsModal", () => {
   });
 
   it("fetches the changelog on first open only", async () => {
-    const fetchMock = vi.fn(async () => ({
+    const fetchMock = vi.fn(async (_input: unknown) => ({
       ok: true,
       text: async () => "changelog body text",
     }));

--- a/tests/client/NewsModal.test.ts
+++ b/tests/client/NewsModal.test.ts
@@ -1,0 +1,51 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// Side-effect import registers <news-modal>; a type-only import would be
+// elided and leave the element inert.
+import "../../src/client/NewsModal";
+import { NewsModal } from "../../src/client/NewsModal";
+
+beforeEach(() => {
+  document.body.innerHTML = "";
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("NewsModal", () => {
+  it("starts on the loading placeholder", () => {
+    const modal = new NewsModal();
+    expect(modal.markdown).toBe("Loading...");
+  });
+
+  it("fetches the changelog on first open only", async () => {
+    const fetchMock = vi.fn(async () => ({
+      ok: true,
+      text: async () => "changelog body text",
+    }));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const modal = new NewsModal();
+    modal.open();
+
+    await vi.waitFor(() => expect(modal.markdown).toContain("changelog body"));
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(String(fetchMock.mock.calls[0][0])).toContain("changelog.md");
+
+    // Already initialized: re-opening must not refetch.
+    modal.open();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows a failure message on a non-ok response", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => ({ ok: false })),
+    );
+
+    const modal = new NewsModal();
+    modal.open();
+
+    await vi.waitFor(() => expect(modal.markdown).toBe("Failed to load"));
+  });
+});

--- a/tests/client/SinglePlayerModalStart.test.ts
+++ b/tests/client/SinglePlayerModalStart.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from "vitest";
+import { UnitType } from "../../src/core/game/Game";
+
+vi.mock("../../src/client/Cosmetics", () => ({
+  getPlayerCosmetics: vi.fn(async () => ({})),
+}));
+
+vi.mock("../../src/client/CrazyGamesSDK", () => ({
+  crazyGamesSDK: {
+    isOnCrazyGames: vi.fn(() => false),
+    requestMidgameAd: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock("../../src/client/TerrainMapFileLoader", () => ({
+  terrainMapFileLoader: { getMapData: vi.fn() },
+}));
+
+// Side-effect import so the custom element registers (a type-only import
+// would be elided and createElement would return an inert element).
+import "../../src/client/SinglePlayerModal";
+
+function createModal(): any {
+  return document.createElement("single-player-modal") as any;
+}
+
+describe("SinglePlayerModal start", () => {
+  it("carries the selected team count and validated disabled units into the join-lobby config", async () => {
+    const modal = createModal();
+    const events: any[] = [];
+    modal.addEventListener("join-lobby", (e: Event) =>
+      events.push((e as CustomEvent).detail),
+    );
+
+    // Selection arrives via the game-config-settings child event.
+    modal.handleConfigTeamCountSelected(
+      new CustomEvent("team-count-selected", { detail: { count: 4 } }),
+    );
+    // One real unit and one junk entry: the start path must keep only
+    // values that are actual UnitTypes.
+    modal.disabledUnits = [UnitType.Warship, "Bogus"];
+
+    await modal.startGame();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].source).toBe("singleplayer");
+    const config = events[0].gameStartInfo.config;
+    expect(config.playerTeams).toBe(4);
+    expect(config.disabledUnits).toEqual([UnitType.Warship]);
+  });
+});

--- a/tests/client/TransformHandler.test.ts
+++ b/tests/client/TransformHandler.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  GOTO_INTERVAL_MS,
+  GoToPositionEvent,
+  TransformHandler,
+} from "../../src/client/TransformHandler";
+import type { GameView } from "../../src/client/view";
+import { EventBus } from "../../src/core/EventBus";
+
+function makeHandler() {
+  const game = {
+    width: () => 400,
+    height: () => 400,
+    myPlayer: () => null,
+  } as unknown as GameView;
+  const eventBus = new EventBus();
+  const handler = new TransformHandler(
+    game,
+    eventBus,
+    document.createElement("canvas"),
+  );
+  return { handler, eventBus };
+}
+
+describe("TransformHandler", () => {
+  it("starts with the default camera and no pending changes", () => {
+    const { handler } = makeHandler();
+    expect(handler.scale).toBe(1.8);
+    expect(handler.hasChanged()).toBe(false);
+  });
+
+  it("treats a goTo tick after the target was cleared as a programming error", () => {
+    const { handler } = makeHandler();
+    handler.override(); // clears any target
+    expect(() => (handler as any).goTo()).toThrow("null target");
+  });
+
+  describe("go-to animation", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("pans toward the target each tick until manual control clears it", () => {
+      const { handler, eventBus } = makeHandler();
+      const startX = handler.offsetX;
+
+      eventBus.emit(new GoToPositionEvent(500, 500));
+      vi.advanceTimersByTime(GOTO_INTERVAL_MS);
+      expect(handler.offsetX).not.toBe(startX);
+      expect(handler.hasChanged()).toBe(true);
+
+      // Taking manual control stops the pending go-to interval.
+      handler.override(10, 20, 1);
+      const [x, y] = [handler.offsetX, handler.offsetY];
+      vi.advanceTimersByTime(GOTO_INTERVAL_MS * 5);
+      expect(handler.offsetX).toBe(x);
+      expect(handler.offsetY).toBe(y);
+    });
+  });
+});

--- a/tests/client/TransportSendPaths.test.ts
+++ b/tests/client/TransportSendPaths.test.ts
@@ -120,7 +120,7 @@ function handshake(transport: Transport): FakeWebSocket {
     () => {},
     () => {},
   );
-  const ws = FakeWebSocket.instances.at(-1)!;
+  const ws = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
   ws.serverOpen();
   ws.serverSend({
     type: "start",

--- a/tests/client/TransportSendPaths.test.ts
+++ b/tests/client/TransportSendPaths.test.ts
@@ -294,11 +294,13 @@ describe("Transport send paths", () => {
       ws.onmessage?.({ data: new Uint8Array([255, 255, 255]).buffer });
 
       expect(onmessage).not.toHaveBeenCalled();
-      expect(console.error).toHaveBeenCalledWith(
-        "Error in onmessage handler:",
-        expect.anything(),
-        expect.anything(),
-      );
+      // The log's trailing args are incidental detail; only the branch
+      // itself is under test.
+      expect(
+        vi
+          .mocked(console.error)
+          .mock.calls.some((call) => call[0] === "Error in onmessage handler:"),
+      ).toBe(true);
     });
   });
 });

--- a/tests/client/TransportSendPaths.test.ts
+++ b/tests/client/TransportSendPaths.test.ts
@@ -1,0 +1,304 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import { ServerMessage } from "../../src/core/Schemas";
+import {
+  createGameWireContext,
+  decodeClientMessage,
+  encodeServerMessage,
+} from "../../src/core/ZbinWire";
+import { testGameConfig } from "../util/Wire";
+
+// Transport's send paths: intent events on the bus leave the socket as
+// decodable frames (or reach the local server in singleplayer), and the
+// guards around a torn-down socket stay quiet instead of throwing.
+
+vi.mock("../../src/client/ClientEnv", () => ({
+  ClientEnv: {
+    workerPath: () => "w0",
+    serverWsBase: () => "ws://game.test",
+    gameWorkerPath: () => "w0",
+    gameWsBase: () => "ws://game.test",
+    gameHttpBase: () => "http://game.test",
+    gitCommit: () => "test-commit",
+  },
+}));
+vi.mock("../../src/client/Auth", () => ({
+  getPlayToken: async () => "8f1d2c3e-4b5a-4c6d-8e7f-90a1b2c3d4e5",
+}));
+const localServer = vi.hoisted(() => ({
+  onMessage: vi.fn(),
+  start: vi.fn(),
+  updateCallback: vi.fn(),
+  endGame: vi.fn(),
+}));
+vi.mock("../../src/client/LocalServer", () => ({
+  LocalServer: class {
+    onMessage = localServer.onMessage;
+    start = localServer.start;
+    updateCallback = localServer.updateCallback;
+    endGame = localServer.endGame;
+  },
+}));
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameConfirm: async () => false,
+}));
+vi.mock("../../src/client/Utils", () => ({
+  translateText: (key: string) => key,
+  homeHref: () => "/",
+}));
+
+import type { LobbyConfig } from "../../src/client/ClientGameRunner";
+import {
+  CancelAttackIntentEvent,
+  SendAttackIntentEvent,
+  SendDonateGoldIntentEvent,
+  SendHashEvent,
+  SendSpawnIntentEvent,
+  SendWinnerEvent,
+  Transport,
+} from "../../src/client/Transport";
+import type { PlayerView } from "../../src/client/view";
+
+// Just enough of the browser socket for Transport: readyState constants,
+// handler properties, captured outgoing frames.
+class FakeWebSocket {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+  static readonly CLOSING = 2;
+  static readonly CLOSED = 3;
+
+  static instances: FakeWebSocket[] = [];
+
+  readyState = FakeWebSocket.CONNECTING;
+  binaryType = "blob";
+  sent: Uint8Array[] = [];
+  clientClosed = false;
+
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: ArrayBuffer }) => void) | null = null;
+  onerror: ((err: unknown) => void) | null = null;
+  onclose: ((event: { code: number; reason: string }) => void) | null = null;
+
+  constructor(readonly url: string) {
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: Uint8Array) {
+    this.sent.push(data);
+  }
+
+  close() {
+    this.clientClosed = true;
+    this.readyState = FakeWebSocket.CLOSED;
+  }
+
+  serverOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  serverSend(msg: ServerMessage) {
+    this.onmessage?.({ data: encodeServerMessage(msg, undefined).buffer });
+  }
+}
+
+function makeTransport(extra: Partial<LobbyConfig> = {}) {
+  const lobbyConfig = {
+    gameID: "game1234",
+    playerName: "tester",
+    spectator: false,
+    ...extra,
+  } as unknown as LobbyConfig;
+  const eventBus = new EventBus();
+  return { transport: new Transport(lobbyConfig, eventBus), eventBus };
+}
+
+// Connect, open the socket, and complete the join handshake; gameplay
+// messages are buffered until the server's start frame proves admission.
+function handshake(transport: Transport): FakeWebSocket {
+  transport.connect(
+    () => {},
+    () => {},
+  );
+  const ws = FakeWebSocket.instances.at(-1)!;
+  ws.serverOpen();
+  ws.serverSend({
+    type: "start",
+    turns: [],
+    lobbyCreatedAt: 1_700_000_000_000,
+    myClientID: "c0000001",
+    gameStartInfo: {
+      gameID: "game1234",
+      lobbyCreatedAt: 1_700_000_000_000,
+      config: testGameConfig(),
+      players: [],
+      tribes: [],
+    },
+  });
+  return ws;
+}
+
+// Decode with the same (empty-roster) dictionary the transport seeded from
+// the start message.
+function decodeFrames(ws: FakeWebSocket) {
+  return ws.sent.map((f) => decodeClientMessage(f, createGameWireContext([])));
+}
+
+describe("Transport send paths", () => {
+  let transports: Transport[];
+
+  beforeEach(() => {
+    FakeWebSocket.instances = [];
+    vi.stubGlobal("WebSocket", FakeWebSocket);
+    localServer.onMessage.mockClear();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    transports = [];
+  });
+
+  afterEach(() => {
+    for (const t of transports) t.leaveGame();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  function connected() {
+    const made = makeTransport();
+    transports.push(made.transport);
+    return { ...made, ws: handshake(made.transport) };
+  }
+
+  describe("intents", () => {
+    it("turns bus intent events into intent frames the server can decode", () => {
+      const { eventBus, ws } = connected();
+      eventBus.emit(new SendSpawnIntentEvent(123));
+      eventBus.emit(new SendAttackIntentEvent("player01", 50));
+      eventBus.emit(
+        new SendDonateGoldIntentEvent(
+          { id: () => "player02" } as unknown as PlayerView,
+          25n,
+        ),
+      );
+      eventBus.emit(new CancelAttackIntentEvent("atk-1"));
+
+      expect(decodeFrames(ws)).toEqual([
+        { type: "intent", intent: { type: "spawn", tile: 123 } },
+        {
+          type: "intent",
+          intent: { type: "attack", targetID: "player01", troops: 50 },
+        },
+        {
+          type: "intent",
+          intent: { type: "donate_gold", recipient: "player02", gold: 25 },
+        },
+        {
+          type: "intent",
+          intent: { type: "cancel_attack", attackID: "atk-1" },
+        },
+      ]);
+    });
+
+    it("does nothing when an intent arrives before any socket exists", () => {
+      const { transport, eventBus } = makeTransport();
+      transports.push(transport);
+
+      expect(() => eventBus.emit(new SendSpawnIntentEvent(123))).not.toThrow();
+      expect(FakeWebSocket.instances).toHaveLength(0);
+    });
+  });
+
+  describe("winner and hash", () => {
+    it("sends the winner over an open socket", () => {
+      const { eventBus, ws } = connected();
+      eventBus.emit(new SendWinnerEvent(["player", "player01"], {}));
+
+      expect(decodeFrames(ws)).toContainEqual({
+        type: "winner",
+        winner: ["player", "player01"],
+        allPlayersStats: {},
+      });
+    });
+
+    it("sends the hash over an open socket", () => {
+      const { eventBus, ws } = connected();
+      eventBus.emit(new SendHashEvent(10, 42));
+
+      expect(decodeFrames(ws)).toContainEqual({
+        type: "hash",
+        turnNumber: 10,
+        hash: 42,
+      });
+    });
+
+    it("forwards the winner to the local server in singleplayer", () => {
+      const { transport, eventBus } = makeTransport({
+        gameRecord: {} as LobbyConfig["gameRecord"],
+      });
+      transports.push(transport);
+      transport.connect(
+        () => {},
+        () => {},
+      );
+      eventBus.emit(new SendWinnerEvent(["player", "player01"], {}));
+
+      expect(FakeWebSocket.instances).toHaveLength(0);
+      expect(localServer.onMessage).toHaveBeenCalledWith({
+        type: "winner",
+        winner: ["player", "player01"],
+        allPlayersStats: {},
+      });
+    });
+  });
+
+  describe("torn-down socket guards", () => {
+    // The browser can fire a queued handler after killExistingSocket nulled
+    // the transport's reference; each guard must bail without acting.
+
+    it("ignores onopen when the socket was torn down before it fired", () => {
+      const onconnect = vi.fn();
+      const { transport } = makeTransport();
+      transports.push(transport);
+      transport.connect(onconnect, () => {});
+      const ws = FakeWebSocket.instances[0];
+
+      (transport as any).socket = null;
+      ws.serverOpen();
+
+      expect(onconnect).not.toHaveBeenCalled();
+    });
+
+    it("ignores onerror when the socket was torn down before it fired", () => {
+      const { transport } = makeTransport();
+      transports.push(transport);
+      transport.connect(
+        () => {},
+        () => {},
+      );
+      const ws = FakeWebSocket.instances[0];
+
+      (transport as any).socket = null;
+      ws.onerror?.(new Error("boom"));
+
+      expect(ws.clientClosed).toBe(false);
+    });
+
+    it("drops a frame that fails to decode without reaching the game", () => {
+      const onmessage = vi.fn();
+      const { transport } = makeTransport();
+      transports.push(transport);
+      transport.connect(() => {}, onmessage);
+      const ws = FakeWebSocket.instances[0];
+      ws.serverOpen();
+
+      ws.onmessage?.({ data: new Uint8Array([255, 255, 255]).buffer });
+
+      expect(onmessage).not.toHaveBeenCalled();
+      expect(console.error).toHaveBeenCalledWith(
+        "Error in onmessage handler:",
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+  });
+});

--- a/tests/client/UserSettingModalValues.test.ts
+++ b/tests/client/UserSettingModalValues.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { modalRouter } from "../../src/client/ModalRouter";
+import "../../src/client/UserSettingModal";
+import type { UserSettingModal } from "../../src/client/UserSettingModal";
+
+type TestModal = UserSettingModal & { updateComplete: Promise<unknown> };
+
+// The easter-egg controls only render on Gameplay after the konami-style
+// unlock; flip the flag directly instead of replaying the key sequence.
+async function mountGameplayWithEasterEggs(): Promise<TestModal> {
+  const el = document.createElement("user-setting") as TestModal;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  el.open({ tab: "gameplay" });
+  (el as any).showEasterEggSettings = true;
+  await el.updateComplete;
+  return el;
+}
+
+describe("user-setting easter-egg value handlers", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    localStorage.clear();
+    location.hash = "";
+    // Main.ts registers this at boot; the URL sync is a no-op without it.
+    modalRouter.register("settings", {
+      tag: "user-setting",
+      pageId: "page-settings",
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs the writing-speed slider value when the event carries one", async () => {
+    const el = await mountGameplayWithEasterEggs();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const slider = el.querySelector("setting-slider[easter]");
+    expect(slider).not.toBeNull();
+    slider!.dispatchEvent(new CustomEvent("change", { detail: { value: 55 } }));
+
+    expect(log).toHaveBeenCalledWith("Changed:", 55);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("logs the bug-count value when the event carries one", async () => {
+    const el = await mountGameplayWithEasterEggs();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const number = el.querySelector("setting-number[easter]");
+    expect(number).not.toBeNull();
+    number!.dispatchEvent(
+      new CustomEvent("change", { detail: { value: 250 } }),
+    );
+
+    expect(log).toHaveBeenCalledWith("Changed:", 250);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/tests/client/UsernameInputValidation.test.ts
+++ b/tests/client/UsernameInputValidation.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Same boundary stubs as tests/UsernameInput.test.ts: the identity bar pulls
+// in the whole client bootstrap, so keep the test on the component itself.
+vi.mock("../../src/client/Api", () => ({
+  getUserMe: vi.fn(async () => false),
+  invalidateUserMe: vi.fn(),
+}));
+vi.mock("../../src/client/ClanApi", () => ({
+  checkClanTagOwnership: vi.fn(async (tag: string) => ({ tag, error: null })),
+}));
+vi.mock("../../src/client/CrazyGamesSDK", () => ({
+  crazyGamesSDK: {
+    isOnCrazyGames: () => false,
+    getUsername: async () => null,
+    addAuthListener: () => {},
+  },
+}));
+vi.mock("../../src/client/SteamSDK", () => ({
+  steamSDK: { isOnSteam: () => false, getUser: async () => null },
+}));
+vi.mock("../../src/client/InGameModal", () => ({
+  showInGameConfirm: vi.fn(async () => false),
+  showInGameAlert: vi.fn(async () => true),
+}));
+// Echo keys (plus interpolations) so assertions read as i18n keys.
+vi.mock("../../src/client/Utils", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/client/Utils")>()),
+  translateText: (key: string, vars?: Record<string, unknown>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+}));
+
+// Side-effect import registers <username-input>; vi.mock is hoisted above it.
+import "../../src/client/UsernameInput";
+import type { UsernameInput as UsernameInputEl } from "../../src/client/UsernameInput";
+
+async function mount(): Promise<UsernameInputEl> {
+  const el = document.createElement("username-input") as UsernameInputEl;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  return el;
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  document.body.innerHTML = "";
+});
+
+describe("UsernameInput validation error", () => {
+  it("surfaces the validator's error and blocks play on an invalid name", async () => {
+    const el = await mount();
+    const input = el.querySelector<HTMLInputElement>(
+      'input[aria-label="username.enter_username"]',
+    )!;
+
+    // Below MIN_USERNAME_LENGTH, so validateUsername rejects it.
+    input.value = "ab";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+
+    expect(el.canPlay()).toBe(false);
+    expect(el.validationError).toContain("username.too_short");
+
+    // Typing a valid name clears the error again.
+    input.value = "ValidName";
+    input.dispatchEvent(new Event("input"));
+    await el.updateComplete;
+
+    expect(el.canPlay()).toBe(true);
+    expect(el.validationError).toBe("");
+  });
+});

--- a/tests/client/UtilsUuid.test.ts
+++ b/tests/client/UtilsUuid.test.ts
@@ -1,0 +1,33 @@
+import { randomFillSync } from "node:crypto";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { generateCryptoRandomUUID } from "../../src/client/Utils";
+
+const UUID_V4 =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+describe("generateCryptoRandomUUID", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("uses crypto.randomUUID when available", () => {
+    vi.stubGlobal("crypto", {
+      randomUUID: () => "11111111-1111-4111-8111-111111111111",
+    });
+    expect(generateCryptoRandomUUID()).toBe(
+      "11111111-1111-4111-8111-111111111111",
+    );
+  });
+
+  it("builds a v4 uuid from getRandomValues when randomUUID is missing", () => {
+    vi.stubGlobal("crypto", {
+      getRandomValues: (array: Uint8Array) => randomFillSync(array),
+    });
+    expect(generateCryptoRandomUUID()).toMatch(UUID_V4);
+  });
+
+  it("falls back to Math.random when crypto offers neither", () => {
+    vi.stubGlobal("crypto", {});
+    expect(generateCryptoRandomUUID()).toMatch(UUID_V4);
+  });
+});

--- a/tests/client/graphics/GameRendererCreate.test.ts
+++ b/tests/client/graphics/GameRendererCreate.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+// GameRenderer only uses GameStartingModal as a type, so importing it there
+// never registers the custom element; register it here.
+import "../../../src/client/GameStartingModal";
+import {
+  createRenderer,
+  GameRenderer,
+} from "../../../src/client/hud/GameRenderer";
+import type { EmojiTable } from "../../../src/client/hud/layers/EmojiTable";
+import type { WinModal } from "../../../src/client/hud/layers/WinModal";
+import { ShowEmojiMenuEvent } from "../../../src/client/InputHandler";
+import type { MapRenderer } from "../../../src/client/render/gl";
+import type { GameView } from "../../../src/client/view";
+import { EventBus } from "../../../src/core/EventBus";
+
+// Every custom element createRenderer looks up with document.querySelector.
+const HUD_TAGS = [
+  "game-starting-modal",
+  "emoji-table",
+  "build-menu",
+  "game-left-sidebar",
+  "control-panel",
+  "events-display",
+  "actionable-events",
+  "attacks-display",
+  "chat-display",
+  "player-info-overlay",
+  "win-modal",
+  "new-lobby-prompt",
+  "replay-panel",
+  "game-right-sidebar",
+  "settings-modal",
+  "graphics-settings-modal",
+  "unit-display",
+  "player-panel",
+  "chat-modal",
+  "multi-tab-modal",
+  "heads-up-message",
+  "performance-overlay",
+  "alert-frame",
+  "spawn-timer",
+  "immunity-timer",
+  "in-game-promo",
+  "tutorial-panel",
+] as const;
+
+describe("createRenderer", () => {
+  // Serve detached elements from the spy so createRenderer finds each HUD
+  // component without connecting (and rendering) 27 components in jsdom.
+  const elements = new Map<string, HTMLElement>();
+
+  beforeEach(() => {
+    elements.clear();
+    for (const tag of HUD_TAGS) {
+      elements.set(tag, document.createElement(tag));
+    }
+    const original = document.querySelector.bind(document);
+    vi.spyOn(document, "querySelector").mockImplementation(
+      (selector: string) => elements.get(selector) ?? original(selector),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("wires the HUD components and returns a renderer", () => {
+    const eventBus = new EventBus();
+    const game = {
+      layers: () => [],
+      width: () => 100,
+      height: () => 100,
+      isValidCoord: () => false,
+      config: () => ({
+        gameConfig: () => ({}),
+        isReplay: () => false,
+      }),
+    } as unknown as GameView;
+    const view = {} as MapRenderer;
+    const inputEl = document.createElement("div");
+
+    const renderer = createRenderer(inputEl, game, eventBus, null, view);
+
+    expect(renderer).toBeInstanceOf(GameRenderer);
+    expect(renderer.transformHandler).toBeDefined();
+
+    // Win modal wiring (fed by the shared bus and game view).
+    const winModal = elements.get("win-modal") as WinModal;
+    expect(winModal.eventBus).toBe(eventBus);
+    expect(winModal.game).toBe(game);
+
+    // Emoji table got its own initEventBus: opening the menu reaches it.
+    const emojiTable = elements.get("emoji-table") as EmojiTable;
+    expect(emojiTable.game).toBe(game);
+    eventBus.emit(new ShowEmojiMenuEvent(1, 1));
+    expect(emojiTable.isVisible).toBe(true);
+  });
+});

--- a/tests/client/graphics/RadialMenuSpawn.test.ts
+++ b/tests/client/graphics/RadialMenuSpawn.test.ts
@@ -1,0 +1,41 @@
+import { vi } from "vitest";
+
+// Mock BuildMenu to avoid importing lit and other ESM-heavy deps in this unit test
+vi.mock("../../../src/client/hud/layers/BuildMenu", () => ({
+  BuildMenu: class {},
+  flattenedBuildTable: [],
+}));
+
+// Mock Utils to avoid touching DOM (document) during tests
+vi.mock("../../../src/client/Utils", () => ({
+  translateText: (key: string) => key,
+  renderNumber: (num: number) => num.toString(),
+}));
+
+import {
+  centerButtonElement,
+  MenuElementParams,
+} from "../../../src/client/hud/layers/RadialMenuElements";
+import { TileRef } from "../../../src/core/game/GameMap";
+
+describe("RadialMenu center button - spawn phase", () => {
+  it("clicking the center button during the spawn phase spawns on the tile", () => {
+    const tile = 42 as TileRef;
+    const handleSpawn = vi.fn();
+    const handleAttack = vi.fn();
+    const closeMenu = vi.fn();
+
+    const params = {
+      tile,
+      game: { inSpawnPhase: () => true },
+      playerActionHandler: { handleSpawn, handleAttack },
+      closeMenu,
+    } as unknown as MenuElementParams;
+
+    centerButtonElement.action(params);
+
+    expect(handleSpawn).toHaveBeenCalledExactlyOnceWith(tile);
+    expect(handleAttack).not.toHaveBeenCalled();
+    expect(closeMenu).toHaveBeenCalled();
+  });
+});

--- a/tests/client/graphics/SpriteLoaderError.test.ts
+++ b/tests/client/graphics/SpriteLoaderError.test.ts
@@ -1,0 +1,31 @@
+import { colord } from "colord";
+import { describe, expect, it } from "vitest";
+import { getColoredSprite } from "../../../src/client/hud/SpriteLoader";
+import type { Theme } from "../../../src/client/theme/ThemeProvider";
+import type { UnitView } from "../../../src/client/view";
+import { UnitType } from "../../../src/core/game/Game";
+
+function makeUnit(): UnitView {
+  return {
+    type: () => UnitType.Warship,
+    trainType: () => undefined,
+    isLoaded: () => false,
+    owner: () => ({
+      id: () => "player1",
+      territoryColor: () => colord("#ff0000"),
+      borderColor: () => colord("#00ff00"),
+    }),
+  } as unknown as UnitView;
+}
+
+const theme = {
+  spawnHighlightColor: () => colord("#ffffff"),
+} as unknown as Theme;
+
+describe("getColoredSprite", () => {
+  it("throws, naming the unit type, when its sprite was never loaded", () => {
+    expect(() => getColoredSprite(makeUnit(), theme)).toThrow(
+      `Failed to load sprite for ${UnitType.Warship}`,
+    );
+  });
+});

--- a/tests/client/graphics/layers/BuildMenuCost.test.ts
+++ b/tests/client/graphics/layers/BuildMenuCost.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+// Side-effect import: the @customElement decorator registers <build-menu>
+// when the module is evaluated, and a type-only reference would not evaluate it.
+import "../../../../src/client/hud/layers/BuildMenu";
+import type { BuildMenu } from "../../../../src/client/hud/layers/BuildMenu";
+import { BuildableUnit, UnitType } from "../../../../src/core/game/Game";
+
+function makeMenu(): BuildMenu {
+  return document.createElement("build-menu") as BuildMenu;
+}
+
+const item = (unitType: UnitType) => ({ unitType, icon: "" }) as any;
+
+describe("BuildMenu.cost", () => {
+  it("returns the buildable's cost for a matching unit type", () => {
+    const menu = makeMenu();
+    menu.playerBuildables = [
+      { type: UnitType.City, canBuild: true, canUpgrade: false, cost: 125n },
+      { type: UnitType.Port, canBuild: false, canUpgrade: false, cost: 5n },
+    ] as unknown as BuildableUnit[];
+
+    // Skips non-matching entries before finding the match.
+    expect(menu.cost(item(UnitType.Port))).toBe(5n);
+    expect(menu.cost(item(UnitType.City))).toBe(125n);
+  });
+
+  it("falls back to 0 when the unit type is not buildable here", () => {
+    const menu = makeMenu();
+    menu.playerBuildables = [
+      { type: UnitType.City, canBuild: true, canUpgrade: false, cost: 125n },
+    ] as unknown as BuildableUnit[];
+
+    expect(menu.cost(item(UnitType.Factory))).toBe(0n);
+  });
+
+  it("falls back to 0 before the buildables have arrived", () => {
+    const menu = makeMenu();
+    menu.playerBuildables = null;
+
+    expect(menu.cost(item(UnitType.City))).toBe(0n);
+  });
+});

--- a/tests/client/graphics/layers/ChatDisplay.test.ts
+++ b/tests/client/graphics/layers/ChatDisplay.test.ts
@@ -1,0 +1,108 @@
+/**
+ * ChatDisplay must only surface CHAT messages that are broadcast or addressed
+ * to the local player, and tick() must tolerate ticks with no updates.
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("lit/directive.js", () => ({}));
+vi.mock("lit/directives/unsafe-html.js", () => ({
+  unsafeHTML: (s: string) => s,
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ChatDisplay } from "../../../../src/client/hud/layers/ChatDisplay";
+import { MessageType } from "../../../../src/core/game/Game";
+import { GameUpdateType } from "../../../../src/core/game/GameUpdates";
+
+interface Cd {
+  chatEvents: { description: string }[];
+  game: unknown;
+}
+
+const chatMsg = (message: string, playerID: number | null) => ({
+  type: GameUpdateType.DisplayEvent,
+  message,
+  messageType: MessageType.CHAT,
+  playerID,
+});
+
+describe("ChatDisplay", () => {
+  let cd: ChatDisplay;
+  const myPlayer = { smallID: () => 1 };
+  const chatEvents = () => (cd as unknown as Cd).chatEvents;
+
+  const setGame = (updates: unknown) => {
+    (cd as unknown as Cd).game = {
+      myPlayer: () => myPlayer,
+      ticks: () => 0,
+      updatesSinceLastTick: () => updates,
+    };
+  };
+
+  beforeEach(() => {
+    cd = new ChatDisplay();
+  });
+
+  describe("tick", () => {
+    it("does nothing when there are no updates", () => {
+      setGame(null);
+      cd.tick();
+      expect(chatEvents()).toHaveLength(0);
+    });
+
+    it("collects chat messages addressed to me or broadcast", () => {
+      setGame({
+        [GameUpdateType.DisplayEvent]: [
+          chatMsg("to me", 1),
+          chatMsg("broadcast", null),
+          chatMsg("to someone else", 2),
+          { ...chatMsg("not chat", 1), messageType: MessageType.ATTACK_FAILED },
+        ],
+      });
+      cd.tick();
+      expect(chatEvents().map((e) => e.description)).toEqual([
+        "to me",
+        "broadcast",
+      ]);
+    });
+  });
+
+  describe("onDisplayMessageEvent", () => {
+    it("adds a chat message addressed to me", () => {
+      setGame(null);
+      cd.onDisplayMessageEvent(chatMsg("hi there", 1) as never);
+      expect(chatEvents().map((e) => e.description)).toEqual(["hi there"]);
+    });
+
+    it("ignores chat addressed to another player", () => {
+      setGame(null);
+      cd.onDisplayMessageEvent(chatMsg("private", 2) as never);
+      expect(chatEvents()).toHaveLength(0);
+    });
+
+    it("ignores non-chat messages", () => {
+      setGame(null);
+      cd.onDisplayMessageEvent({
+        ...chatMsg("attack", 1),
+        messageType: MessageType.ATTACK_FAILED,
+      } as never);
+      expect(chatEvents()).toHaveLength(0);
+    });
+  });
+});

--- a/tests/client/graphics/layers/ControlPanelTick.test.ts
+++ b/tests/client/graphics/layers/ControlPanelTick.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+// Side-effect import: the @customElement decorator registers <control-panel>
+// when the module is evaluated, and a type-only reference would not evaluate it.
+import "../../../../src/client/hud/layers/ControlPanel";
+import type { ControlPanel } from "../../../../src/client/hud/layers/ControlPanel";
+import { AttackRatioEvent } from "../../../../src/client/InputHandler";
+import type { UIState } from "../../../../src/client/UIState";
+import type { GameView } from "../../../../src/client/view";
+import { EventBus } from "../../../../src/core/EventBus";
+import { UserSettings } from "../../../../src/core/game/UserSettings";
+
+describe("control-panel keybind attack ratio and tick visibility", () => {
+  let panel: ControlPanel;
+  let uiState: UIState;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    localStorage.clear();
+    // UserSettings' cache is static and survives localStorage.clear().
+    new UserSettings().setAttackRatio(0.2);
+
+    panel = document.createElement("control-panel") as ControlPanel;
+    uiState = { attackRatio: 0 } as UIState;
+    panel.uiState = uiState;
+    panel.eventBus = new EventBus();
+    panel.game = {
+      inSpawnPhase: () => false,
+      myPlayer: () => null,
+    } as unknown as GameView;
+    document.body.appendChild(panel);
+    panel.init();
+  });
+
+  afterEach(() => {
+    panel.remove();
+  });
+
+  it("stepping up from the 1% floor snaps to 10% instead of 11%", () => {
+    // Big decrement clamps to the 1% floor.
+    panel.eventBus.emit(new AttackRatioEvent(-100));
+    expect(uiState.attackRatio).toBe(0.01);
+
+    // +10 from 1% would land on 11%; it snaps to 10% for consistency.
+    panel.eventBus.emit(new AttackRatioEvent(10));
+    expect(uiState.attackRatio).toBe(0.1);
+  });
+
+  it("normal keybind steps are not snapped", () => {
+    panel.eventBus.emit(new AttackRatioEvent(10));
+    expect(uiState.attackRatio).toBeCloseTo(0.3);
+  });
+
+  it("tick() hides the panel when there is no local player", () => {
+    panel.tick();
+    expect((panel as any)._isVisible).toBe(false);
+  });
+
+  it("tick() hides the panel once the local player is dead", () => {
+    panel.game = {
+      inSpawnPhase: () => false,
+      myPlayer: () => ({ isAlive: () => false, troops: () => 0 }),
+    } as unknown as GameView;
+    panel.setVisibile(true);
+
+    panel.tick();
+
+    expect((panel as any)._isVisible).toBe(false);
+  });
+});

--- a/tests/client/graphics/layers/EmojiTable.test.ts
+++ b/tests/client/graphics/layers/EmojiTable.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "../../../../src/client/hud/layers/EmojiTable";
+import type { EmojiTable } from "../../../../src/client/hud/layers/EmojiTable";
+import {
+  CloseViewEvent,
+  ShowEmojiMenuEvent,
+} from "../../../../src/client/InputHandler";
+import type { TransformHandler } from "../../../../src/client/TransformHandler";
+import { SendEmojiIntentEvent } from "../../../../src/client/Transport";
+import type { GameView } from "../../../../src/client/view";
+import { EventBus } from "../../../../src/core/EventBus";
+import { AllPlayers } from "../../../../src/core/game/Game";
+import { flattenedEmojiTable } from "../../../../src/core/Util";
+
+describe("EmojiTable event bus wiring", () => {
+  let table: EmojiTable;
+  let eventBus: EventBus;
+  let emojiIntents: SendEmojiIntentEvent[];
+  const myPlayer = { name: "me" };
+  const otherPlayer = { name: "other" };
+  let tileOwner: object;
+
+  beforeEach(() => {
+    table = document.createElement("emoji-table") as EmojiTable;
+    table.transformHandler = {
+      screenToWorldCoordinates: (x: number, y: number) => ({ x, y }),
+    } as unknown as TransformHandler;
+    table.game = {
+      isValidCoord: () => true,
+      ref: (x: number, y: number) => x + y,
+      hasOwner: () => true,
+      owner: () => tileOwner,
+      myPlayer: () => myPlayer,
+    } as unknown as GameView;
+    document.body.appendChild(table);
+
+    eventBus = new EventBus();
+    emojiIntents = [];
+    eventBus.on(SendEmojiIntentEvent, (e) => emojiIntents.push(e));
+    table.initEventBus(eventBus);
+  });
+
+  afterEach(() => {
+    table.remove();
+  });
+
+  async function pickEmoji(index: number) {
+    await table.updateComplete;
+    const buttons = table.querySelectorAll<HTMLButtonElement>(".grid button");
+    expect(buttons.length).toBe(flattenedEmojiTable.length);
+    buttons[index].click();
+  }
+
+  it("sends the picked emoji to AllPlayers when the target is myself", async () => {
+    tileOwner = myPlayer;
+    eventBus.emit(new ShowEmojiMenuEvent(3, 4));
+    expect(table.isVisible).toBe(true);
+
+    await pickEmoji(2);
+
+    expect(emojiIntents).toHaveLength(1);
+    expect(emojiIntents[0].recipient).toBe(AllPlayers);
+    expect(emojiIntents[0].emoji).toBe(2);
+    expect(table.isVisible).toBe(false);
+  });
+
+  it("sends the picked emoji to the tile owner when targeting someone else", async () => {
+    tileOwner = otherPlayer;
+    eventBus.emit(new ShowEmojiMenuEvent(3, 4));
+
+    await pickEmoji(0);
+
+    expect(emojiIntents).toHaveLength(1);
+    expect(emojiIntents[0].recipient).toBe(otherPlayer);
+    expect(emojiIntents[0].emoji).toBe(0);
+  });
+
+  it("closes on CloseViewEvent", () => {
+    tileOwner = myPlayer;
+    eventBus.emit(new ShowEmojiMenuEvent(3, 4));
+    expect(table.isVisible).toBe(true);
+
+    eventBus.emit(new CloseViewEvent());
+
+    expect(table.isVisible).toBe(false);
+  });
+});

--- a/tests/client/graphics/layers/EventsDisplayHandlers.test.ts
+++ b/tests/client/graphics/layers/EventsDisplayHandlers.test.ts
@@ -73,7 +73,7 @@ describe("EventsDisplay handlers", () => {
   const byID: Record<number, unknown> = { 1: myPlayer, 2: friend, 3: stranger };
 
   const events = () => (ed as unknown as Ed).events;
-  let game: { updatesSinceLastTick: () => unknown };
+  let game: Record<string, unknown>;
 
   beforeEach(() => {
     ed = new EventsDisplay();

--- a/tests/client/graphics/layers/EventsDisplayHandlers.test.ts
+++ b/tests/client/graphics/layers/EventsDisplayHandlers.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Coverage for the EventsDisplay update handlers: the tick() dispatch loop
+ * over updateMap, and the alliance/target/unit handlers' myPlayer guards.
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("lit/directive.js", () => ({}));
+vi.mock("lit/directives/unsafe-html.js", () => ({
+  unsafeHTML: (s: string) => s,
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  // Include params in the output so descriptions are assertable.
+  translateText: vi.fn((key: string, params?: Record<string, unknown>) =>
+    params ? `${key} ${JSON.stringify(params)}` : key,
+  ),
+  renderNumber: vi.fn(),
+  renderTroops: vi.fn(),
+  getMessageTypeClasses: vi.fn(() => ""),
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { EventsDisplay } from "../../../../src/client/hud/layers/EventsDisplay";
+import { PlaySoundEffectEvent } from "../../../../src/client/sound/Sounds";
+import { MessageType } from "../../../../src/core/game/Game";
+import { GameUpdateType } from "../../../../src/core/game/GameUpdates";
+
+interface Ed {
+  events: { description: string; type: MessageType; focusID?: number }[];
+  game: unknown;
+  eventBus: unknown;
+}
+
+describe("EventsDisplay handlers", () => {
+  let ed: EventsDisplay;
+  let emit: ReturnType<typeof vi.fn>;
+  const myPlayer = {
+    smallID: () => 1,
+    displayName: () => "Me",
+    isAlive: () => true,
+    isFriendly: (p: { smallID: () => number }) => p.smallID() === 2,
+  };
+  const friend = {
+    smallID: () => 2,
+    displayName: () => "Friend",
+    isAlive: () => true,
+    isDisconnected: () => false,
+    isTraitor: () => false,
+  };
+  const stranger = {
+    smallID: () => 3,
+    displayName: () => "Stranger",
+    isAlive: () => true,
+    isDisconnected: () => false,
+    isTraitor: () => false,
+  };
+  const byID: Record<number, unknown> = { 1: myPlayer, 2: friend, 3: stranger };
+
+  const events = () => (ed as unknown as Ed).events;
+  let game: { updatesSinceLastTick: () => unknown };
+
+  beforeEach(() => {
+    ed = new EventsDisplay();
+    emit = vi.fn();
+    (ed as unknown as Ed).eventBus = { emit };
+    game = {
+      myPlayer: () => myPlayer,
+      playerBySmallID: (id: number) => byID[id],
+      unit: (id: number) => ({ id, isActive: () => true }),
+      ticks: () => 0,
+      inSpawnPhase: () => false,
+      config: () => ({
+        traitorDefenseDebuff: () => 0.5,
+        traitorDuration: () => 25, // ticks -> floor(2.5) = 2 seconds
+      }),
+      updatesSinceLastTick: () => null,
+    };
+    (ed as unknown as Ed).game = game;
+  });
+
+  describe("tick", () => {
+    it("dispatches queued updates through updateMap", () => {
+      game.updatesSinceLastTick = () => ({
+        [GameUpdateType.DisplayEvent]: [
+          {
+            type: GameUpdateType.DisplayEvent,
+            message: "hello world",
+            messageType: MessageType.ATTACK_FAILED,
+            playerID: 1,
+          },
+        ],
+        [GameUpdateType.UnitIncoming]: [
+          {
+            type: GameUpdateType.UnitIncoming,
+            unitID: 7,
+            message: "incoming!",
+            messageType: MessageType.NUKE_INBOUND,
+            playerID: 1,
+          },
+        ],
+      });
+
+      ed.tick();
+
+      expect(events().map((e) => e.description)).toEqual([
+        "hello world",
+        "incoming!",
+      ]);
+    });
+
+    it("adds nothing when there are no updates", () => {
+      ed.tick();
+      expect(events()).toHaveLength(0);
+    });
+  });
+
+  describe("onAllianceRequestReplyEvent", () => {
+    const reply = (requestorID: number, accepted: boolean) => ({
+      type: GameUpdateType.AllianceRequestReply,
+      request: { requestorID, recipientID: 2, createdAt: 0 },
+      accepted,
+    });
+
+    it("shows the reply to my own request", () => {
+      ed.onAllianceRequestReplyEvent(reply(1, true) as never);
+      expect(events()).toHaveLength(1);
+      expect(events()[0].type).toBe(MessageType.ALLIANCE_ACCEPTED);
+      expect(events()[0].focusID).toBe(2);
+      expect(events()[0].description).toContain("Friend");
+    });
+
+    it("ignores replies to other players' requests", () => {
+      ed.onAllianceRequestReplyEvent(reply(3, true) as never);
+      expect(events()).toHaveLength(0);
+    });
+  });
+
+  describe("onBrokeAllianceEvent", () => {
+    it("shows the betrayal malus and duration when I am the traitor", () => {
+      ed.onBrokeAllianceEvent({
+        type: GameUpdateType.BrokeAlliance,
+        traitorID: 1,
+        betrayedID: 2,
+        allianceID: 0,
+      } as never);
+
+      expect(events()).toHaveLength(1);
+      expect(events()[0].type).toBe(MessageType.ALLIANCE_BROKEN);
+      // malus = (1 - 0.5) * 100; duration = floor(25 * 0.1) = 2 -> plural text
+      expect(events()[0].description).toContain('"malusPercent":50');
+      expect(events()[0].description).toContain(
+        "events_display.duration_seconds_plural",
+      );
+      expect(events()[0].description).toContain(String.raw`\"seconds\":2`);
+      expect(emit).toHaveBeenCalledWith(expect.any(PlaySoundEffectEvent));
+    });
+
+    it("shows nothing for a betrayal between other players", () => {
+      ed.onBrokeAllianceEvent({
+        type: GameUpdateType.BrokeAlliance,
+        traitorID: 3,
+        betrayedID: 2,
+        allianceID: 0,
+      } as never);
+      expect(events()).toHaveLength(0);
+    });
+  });
+
+  describe("onAllianceExpiredEvent", () => {
+    it("shows the expiry when I am one of the parties", () => {
+      ed.onAllianceExpiredEvent({
+        type: GameUpdateType.AllianceExpired,
+        player1ID: 1,
+        player2ID: 2,
+      } as never);
+
+      expect(events()).toHaveLength(1);
+      expect(events()[0].type).toBe(MessageType.ALLIANCE_EXPIRED);
+      expect(events()[0].focusID).toBe(2);
+      expect(events()[0].description).toContain("Friend");
+    });
+
+    it("ignores expiries between other players", () => {
+      ed.onAllianceExpiredEvent({
+        type: GameUpdateType.AllianceExpired,
+        player1ID: 2,
+        player2ID: 3,
+      } as never);
+      expect(events()).toHaveLength(0);
+    });
+  });
+
+  describe("onTargetPlayerEvent", () => {
+    it("shows an ally's attack request", () => {
+      ed.onTargetPlayerEvent({
+        type: GameUpdateType.TargetPlayer,
+        playerID: 2,
+        targetID: 3,
+      } as never);
+
+      expect(events()).toHaveLength(1);
+      expect(events()[0].type).toBe(MessageType.ATTACK_REQUEST);
+      expect(events()[0].focusID).toBe(3);
+      expect(events()[0].description).toContain("Friend");
+      expect(events()[0].description).toContain("Stranger");
+    });
+
+    it("ignores requests from non-friendly players", () => {
+      ed.onTargetPlayerEvent({
+        type: GameUpdateType.TargetPlayer,
+        playerID: 3,
+        targetID: 2,
+      } as never);
+      expect(events()).toHaveLength(0);
+    });
+  });
+
+  describe("onUnitIncomingEvent", () => {
+    const incoming = (playerID: number) => ({
+      type: GameUpdateType.UnitIncoming,
+      unitID: 7,
+      message: "nuke inbound",
+      messageType: MessageType.NUKE_INBOUND,
+      playerID,
+    });
+
+    it("shows incoming-unit warnings addressed to me", () => {
+      ed.onUnitIncomingEvent(incoming(1) as never);
+      expect(events()).toHaveLength(1);
+      expect(events()[0].description).toBe("nuke inbound");
+      expect(events()[0].type).toBe(MessageType.NUKE_INBOUND);
+    });
+
+    it("ignores warnings addressed to other players", () => {
+      ed.onUnitIncomingEvent(incoming(2) as never);
+      expect(events()).toHaveLength(0);
+    });
+  });
+});

--- a/tests/client/graphics/layers/PlayerActionHandler.test.ts
+++ b/tests/client/graphics/layers/PlayerActionHandler.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+
+import { PlayerActionHandler } from "../../../../src/client/hud/layers/PlayerActionHandler";
+import { SendSpawnIntentEvent } from "../../../../src/client/Transport";
+import type { UIState } from "../../../../src/client/UIState";
+import { EventBus } from "../../../../src/core/EventBus";
+import type { TileRef } from "../../../../src/core/game/GameMap";
+
+describe("PlayerActionHandler.handleSpawn", () => {
+  it("emits a SendSpawnIntentEvent for the clicked tile", () => {
+    const eventBus = new EventBus();
+    const events: SendSpawnIntentEvent[] = [];
+    eventBus.on(SendSpawnIntentEvent, (e) => events.push(e));
+
+    const handler = new PlayerActionHandler(eventBus, {
+      attackRatio: 0.5,
+    } as UIState);
+    const tile = 1234 as TileRef;
+
+    handler.handleSpawn(tile);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toBeInstanceOf(SendSpawnIntentEvent);
+    expect(events[0].tile).toBe(tile);
+  });
+});

--- a/tests/client/graphics/layers/PlayerInfoOverlay.test.ts
+++ b/tests/client/graphics/layers/PlayerInfoOverlay.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Hovering an owned tile must show the owner's info card, and the name color
+ * must reflect the local player's relation to them (friendly = green).
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+  nothing: "",
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  renderDuration: vi.fn(() => ""),
+  renderNumber: vi.fn(() => "0"),
+  renderTroops: vi.fn(() => "0"),
+  getTranslatedPlayerTeamLabel: vi.fn(() => ""),
+  getSvgAspectRatio: vi.fn(() => 1),
+}));
+
+vi.mock("../../../../src/client/hud/PlayerIcons", () => ({
+  EMOJI_ICON_KIND: "emoji",
+  IMAGE_ICON_KIND: "image",
+  getFirstPlacePlayer: vi.fn(() => null),
+  getPlayerIcons: vi.fn(() => []),
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PlayerInfoOverlay } from "../../../../src/client/hud/layers/PlayerInfoOverlay";
+import { PlayerType } from "../../../../src/core/game/Game";
+
+// Flattens the mocked-html template tree into one string for assertions.
+function flatten(node: unknown): string {
+  if (node === null || node === undefined) return "";
+  if (Array.isArray(node)) return node.map(flatten).join("");
+  if (typeof node === "object" && "strings" in (node as object)) {
+    const { strings, values } = node as {
+      strings: readonly string[];
+      values: unknown[];
+    };
+    return strings.map((s, i) => s + flatten(values[i])).join("");
+  }
+  if (typeof node === "object") return "";
+  return String(node);
+}
+
+describe("PlayerInfoOverlay", () => {
+  let overlay: PlayerInfoOverlay;
+
+  const hovered = {
+    isPlayer: () => true,
+    profile: () => Promise.resolve(null),
+    getTraitorRemainingTicks: () => 0,
+    outgoingAttacks: () => [],
+    troops: () => 100,
+    gold: () => 0n,
+    type: () => PlayerType.Human,
+    team: () => null,
+    displayName: () => "Bob",
+    cosmetics: {},
+    id: () => "bob",
+    smallID: () => 2,
+  };
+
+  const makeGame = (myPlayer: unknown) => ({
+    isValidCoord: () => true,
+    ref: () => 42,
+    owner: () => hovered,
+    myPlayer: () => myPlayer,
+    config: () => ({
+      isUnitDisabled: () => true,
+      maxTroops: () => 1000,
+    }),
+    teamClanTag: () => undefined,
+  });
+
+  beforeEach(() => {
+    overlay = new PlayerInfoOverlay();
+    overlay.eventBus = { on: vi.fn() } as never;
+    overlay.transform = {
+      screenToWorldCoordinates: () => ({ x: 5, y: 5 }),
+    } as never;
+    overlay.init();
+  });
+
+  it("shows the hovered player's card with a green name for a friend", () => {
+    overlay.game = makeGame({
+      isFriendly: () => true,
+      isAlliedWith: () => false,
+      smallID: () => 1,
+    }) as never;
+
+    overlay.maybeShow(10, 10);
+    const out = flatten(overlay.render());
+
+    expect(out).toContain("opacity-100 visible");
+    expect(out).toContain("Bob");
+    expect(out).toContain("text-green-500");
+  });
+
+  it("shows a white name when there is no local player", () => {
+    overlay.game = makeGame(null) as never;
+
+    overlay.maybeShow(10, 10);
+    const out = flatten(overlay.render());
+
+    expect(out).toContain("Bob");
+    expect(out).toContain("text-white");
+    expect(out).not.toContain("text-green-500");
+  });
+});

--- a/tests/client/graphics/layers/PlayerPanelActions.test.ts
+++ b/tests/client/graphics/layers/PlayerPanelActions.test.ts
@@ -1,0 +1,259 @@
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+  query: () => () => {},
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  renderDuration: vi.fn(),
+  renderNumber: vi.fn(),
+  renderTroops: vi.fn(),
+  showToast: vi.fn(),
+}));
+
+vi.mock("../../../../src/client/components/ui/ActionButton", () => ({
+  actionButton: vi.fn((props: unknown) => props),
+}));
+
+vi.mock("../../../../src/client/InGameModal", () => ({
+  showInGameConfirm: vi.fn(),
+  showInGameAlert: vi.fn(),
+}));
+
+import { actionButton } from "../../../../src/client/components/ui/ActionButton";
+import { PlayerPanel } from "../../../../src/client/hud/layers/PlayerPanel";
+import {
+  SendEmbargoIntentEvent,
+  SendEmojiIntentEvent,
+} from "../../../../src/client/Transport";
+import { PlayerView } from "../../../../src/client/view";
+import { EventBus } from "../../../../src/core/EventBus";
+import {
+  AllPlayers,
+  GameType,
+  PlayerType,
+} from "../../../../src/core/game/Game";
+import { flattenedEmojiTable } from "../../../../src/core/Util";
+
+const mockActionButton = actionButton as unknown as ReturnType<typeof vi.fn>;
+
+// Labels of the buttons the last render produced, in order.
+const renderedLabels = () =>
+  mockActionButton.mock.calls.map((c) => (c[0] as { label: string }).label);
+
+const my = {
+  id: () => 1,
+  displayName: () => "Me",
+  type: () => PlayerType.Human,
+  clientID: () => "client-1",
+  isLobbyCreator: () => false,
+} as unknown as PlayerView;
+
+const other = {
+  id: () => 2,
+  name: () => "Other",
+  displayName: () => "[TAG] Other",
+  type: () => PlayerType.Human,
+  clientID: () => "client-2",
+  isLobbyCreator: () => false,
+} as unknown as PlayerView;
+
+function makeGame() {
+  return {
+    myPlayer: () => my,
+    config: () => ({
+      gameConfig: () => ({ gameType: GameType.Public }),
+      isReplay: () => false,
+    }),
+    gameOver: () => false,
+  };
+}
+
+describe("PlayerPanel - embargo intents", () => {
+  let panel: PlayerPanel;
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    panel = new PlayerPanel();
+    (panel as any).requestUpdate = vi.fn();
+    (panel as any).isVisible = true;
+    (panel as any).g = makeGame();
+    eventBus = new EventBus();
+    panel.eventBus = eventBus;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("start-embargo button emits a start SendEmbargoIntentEvent and closes the panel", () => {
+    const events: SendEmbargoIntentEvent[] = [];
+    eventBus.on(SendEmbargoIntentEvent, (e) => events.push(e));
+
+    (panel as any).handleEmbargoClick({ stopPropagation: vi.fn() }, my, other);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].target).toBe(other);
+    expect(events[0].action).toBe("start");
+    expect(panel.isVisible).toBe(false);
+  });
+
+  test("stop-embargo button emits a stop SendEmbargoIntentEvent and closes the panel", () => {
+    const events: SendEmbargoIntentEvent[] = [];
+    eventBus.on(SendEmbargoIntentEvent, (e) => events.push(e));
+
+    (panel as any).handleStopEmbargoClick(
+      { stopPropagation: vi.fn() },
+      my,
+      other,
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0].target).toBe(other);
+    expect(events[0].action).toBe("stop");
+    expect(panel.isVisible).toBe(false);
+  });
+});
+
+describe("PlayerPanel - emoji intents", () => {
+  let panel: PlayerPanel;
+  let eventBus: EventBus;
+  let events: SendEmojiIntentEvent[];
+  // The panel hands EmojiTable a callback; capture it to simulate a pick.
+  let pickEmoji: (emoji: string) => void;
+
+  beforeEach(() => {
+    panel = new PlayerPanel();
+    (panel as any).requestUpdate = vi.fn();
+    (panel as any).isVisible = true;
+    (panel as any).g = makeGame();
+    eventBus = new EventBus();
+    panel.eventBus = eventBus;
+    events = [];
+    eventBus.on(SendEmojiIntentEvent, (e) => events.push(e));
+    panel.emojiTable = {
+      showTable: vi.fn((cb: (emoji: string) => void) => {
+        pickEmoji = cb;
+      }),
+      hideTable: vi.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("emoji on your own panel is broadcast to all players", () => {
+    (panel as any).handleEmojiClick({ stopPropagation: vi.fn() }, my, my);
+    pickEmoji(flattenedEmojiTable[4]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].recipient).toBe(AllPlayers);
+    expect(events[0].emoji).toBe(4);
+    expect(panel.emojiTable.hideTable).toHaveBeenCalled();
+    expect(panel.isVisible).toBe(false);
+  });
+
+  test("emoji on another player's panel is sent to that player", () => {
+    (panel as any).handleEmojiClick({ stopPropagation: vi.fn() }, my, other);
+    pickEmoji(flattenedEmojiTable[0]);
+
+    expect(events).toHaveLength(1);
+    expect(events[0].recipient).toBe(other);
+    expect(events[0].emoji).toBe(0);
+    expect(panel.isVisible).toBe(false);
+  });
+});
+
+describe("PlayerPanel - action buttons follow PlayerActions capability flags", () => {
+  let panel: PlayerPanel;
+
+  beforeEach(() => {
+    panel = new PlayerPanel();
+    (panel as any).requestUpdate = vi.fn();
+    (panel as any).isVisible = true;
+    (panel as any).g = makeGame();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("all capability flags enabled renders every action for another player", () => {
+    (panel as any).actions = {
+      canSendEmojiAllPlayers: false,
+      canEmbargoAll: true,
+      interaction: {
+        canSendEmoji: true,
+        canTarget: true,
+        canEmbargo: true,
+        canBreakAlliance: true,
+        canSendAllianceRequest: true,
+        canDonateGold: true,
+        canDonateTroops: true,
+      },
+    };
+
+    (panel as any).renderActions(my, other);
+
+    const labels = renderedLabels();
+    expect(labels).toContain("player_panel.emotes");
+    expect(labels).toContain("player_panel.target");
+    expect(labels).toContain("player_panel.troops");
+    expect(labels).toContain("player_panel.gold");
+    // canEmbargo picks the stop-trade button (start-trade otherwise).
+    expect(labels).toContain("player_panel.stop_trade");
+    expect(labels).not.toContain("player_panel.start_trade");
+    expect(labels).toContain("player_panel.break_alliance");
+    expect(labels).toContain("player_panel.send_alliance");
+  });
+
+  test("no capability flags renders only chat and the start-trade toggle", () => {
+    (panel as any).actions = { interaction: {} };
+
+    (panel as any).renderActions(my, other);
+
+    const labels = renderedLabels();
+    expect(labels).toContain("player_panel.chat");
+    expect(labels).toContain("player_panel.start_trade");
+    expect(labels).not.toContain("player_panel.emotes");
+    expect(labels).not.toContain("player_panel.target");
+    expect(labels).not.toContain("player_panel.break_alliance");
+    expect(labels).not.toContain("player_panel.send_alliance");
+  });
+
+  test("own panel uses canSendEmojiAllPlayers instead of the interaction flag", () => {
+    (panel as any).actions = {
+      canSendEmojiAllPlayers: true,
+      canEmbargoAll: true,
+      interaction: { canSendEmoji: false },
+    };
+
+    (panel as any).renderActions(my, my);
+
+    expect(renderedLabels()).toContain("player_panel.emotes");
+
+    mockActionButton.mockClear();
+    (panel as any).actions = {
+      canSendEmojiAllPlayers: false,
+      canEmbargoAll: true,
+      interaction: { canSendEmoji: true },
+    };
+
+    (panel as any).renderActions(my, my);
+
+    expect(renderedLabels()).not.toContain("player_panel.emotes");
+  });
+});

--- a/tests/client/graphics/layers/SpawnTimer.test.ts
+++ b/tests/client/graphics/layers/SpawnTimer.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import "../../../../src/client/hud/layers/SpawnTimer";
+import type { SpawnTimer } from "../../../../src/client/hud/layers/SpawnTimer";
+import { SpawnBarVisibleEvent } from "../../../../src/client/hud/layers/SpawnTimer";
+import type { GameView } from "../../../../src/client/view";
+import { EventBus } from "../../../../src/core/EventBus";
+import { GameMode, GameType } from "../../../../src/core/game/Game";
+
+function makePlayer(team: string | null, tiles: number) {
+  return { team: () => team, numTilesOwned: () => tiles };
+}
+
+describe("SpawnTimer team ratios", () => {
+  let timer: SpawnTimer;
+  let eventBus: EventBus;
+  let visibility: SpawnBarVisibleEvent[];
+
+  beforeEach(() => {
+    timer = document.createElement("spawn-timer") as SpawnTimer;
+    eventBus = new EventBus();
+    visibility = [];
+    eventBus.on(SpawnBarVisibleEvent, (e) => visibility.push(e));
+    timer.eventBus = eventBus;
+    document.body.appendChild(timer);
+  });
+
+  afterEach(() => {
+    timer.remove();
+  });
+
+  it("splits the bar by team tile ownership after the spawn phase", async () => {
+    timer.game = {
+      config: () => ({
+        gameConfig: () => ({
+          gameType: GameType.Public,
+          gameMode: GameMode.Team,
+        }),
+      }),
+      inSpawnPhase: () => false,
+      players: () => [
+        makePlayer("Red", 30),
+        makePlayer("Blue", 10),
+        makePlayer(null, 999), // teamless players are ignored
+      ],
+    } as unknown as GameView;
+
+    timer.init();
+    timer.tick();
+    await timer.updateComplete;
+
+    const segments = timer.querySelectorAll<HTMLElement>(
+      'div[style*="--width"]',
+    );
+    expect(segments).toHaveLength(2);
+    expect(segments[0].style.getPropertyValue("--width")).toBe("75%");
+    expect(segments[1].style.getPropertyValue("--width")).toBe("25%");
+    expect(visibility.map((v) => v.visible)).toEqual([true]);
+  });
+
+  it("renders nothing when no team owns tiles yet", async () => {
+    timer.game = {
+      config: () => ({
+        gameConfig: () => ({
+          gameType: GameType.Public,
+          gameMode: GameMode.Team,
+        }),
+      }),
+      inSpawnPhase: () => false,
+      players: () => [makePlayer("Red", 0), makePlayer("Blue", 0)],
+    } as unknown as GameView;
+
+    timer.init();
+    timer.tick();
+    await timer.updateComplete;
+
+    expect(timer.querySelectorAll('div[style*="--width"]')).toHaveLength(0);
+    expect(visibility).toHaveLength(0);
+  });
+});

--- a/tests/client/graphics/layers/WinModalTick.test.ts
+++ b/tests/client/graphics/layers/WinModalTick.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import "../../../../src/client/hud/layers/WinModal";
+import type { WinModal } from "../../../../src/client/hud/layers/WinModal";
+import { SendWinnerEvent } from "../../../../src/client/Transport";
+import type { GameView } from "../../../../src/client/view";
+import { EventBus } from "../../../../src/core/EventBus";
+import { GameUpdateType } from "../../../../src/core/game/GameUpdates";
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+  getGamesPlayed: vi.fn(() => 10),
+  isInIframe: vi.fn(() => false),
+  homeHref: vi.fn(() => "/"),
+  TUTORIAL_VIDEO_URL: "https://example.com/tutorial",
+}));
+
+vi.mock("../../../../src/client/Api", () => ({
+  getUserMe: vi.fn(async () => null),
+}));
+
+vi.mock("../../../../src/client/Cosmetics", async (importOriginal) => ({
+  ...(await importOriginal<
+    typeof import("../../../../src/client/Cosmetics")
+  >()),
+  fetchCosmetics: vi.fn(async () => null),
+  resolveCosmetics: vi.fn(() => []),
+}));
+
+vi.mock("../../../../src/client/CrazyGamesSDK", () => ({
+  crazyGamesSDK: {
+    happytime: vi.fn(),
+    requestAd: vi.fn(),
+    gameplayStop: vi.fn(),
+  },
+}));
+
+import { crazyGamesSDK } from "../../../../src/client/CrazyGamesSDK";
+
+type Winner = ["team", string] | ["player", string] | undefined;
+
+function makeGame(opts: {
+  winner: Winner;
+  myTeam?: string;
+  myClientID?: string;
+  winnerPlayer?: {
+    isPlayer: () => boolean;
+    clientID: () => string | null;
+    displayName: () => string;
+  };
+}): GameView {
+  const winUpdate = { winner: opts.winner, allPlayersStats: {} };
+  return {
+    myPlayer: () => ({
+      isAlive: () => true,
+      hasSpawned: () => true,
+      team: () => opts.myTeam ?? null,
+      clientID: () => opts.myClientID ?? null,
+    }),
+    inSpawnPhase: () => false,
+    updatesSinceLastTick: () => ({ [GameUpdateType.Win]: [winUpdate] }),
+    playerByClientID: () => opts.winnerPlayer,
+    config: () => ({ gameConfig: () => ({ rankedType: undefined }) }),
+  } as unknown as GameView;
+}
+
+describe("WinModal tick win handling", () => {
+  let modal: WinModal | undefined;
+
+  function setup(game: GameView) {
+    const eventBus = new EventBus();
+    const winnerEvents: SendWinnerEvent[] = [];
+    eventBus.on(SendWinnerEvent, (e) => winnerEvents.push(e));
+    modal = document.createElement("win-modal") as WinModal;
+    modal.game = game;
+    modal.eventBus = eventBus;
+    return winnerEvents;
+  }
+
+  afterEach(() => {
+    modal?.remove();
+    modal = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("emits the winner and celebrates when my team wins", async () => {
+    const events = setup(
+      makeGame({ winner: ["team", "Blue"], myTeam: "Blue" }),
+    );
+    modal!.tick();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].winner).toEqual(["team", "Blue"]);
+    expect(crazyGamesSDK.happytime).toHaveBeenCalled();
+    await vi.waitFor(() => expect(modal!.isVisible).toBe(true));
+  });
+
+  it("emits the winner without celebrating when another team wins", async () => {
+    const events = setup(makeGame({ winner: ["team", "Red"], myTeam: "Blue" }));
+    modal!.tick();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].winner).toEqual(["team", "Red"]);
+    expect(crazyGamesSDK.happytime).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(modal!.isVisible).toBe(true));
+  });
+
+  it("emits a player winner resolved through playerByClientID", async () => {
+    const events = setup(
+      makeGame({
+        winner: ["player", "winner-client"],
+        myClientID: "my-client",
+        winnerPlayer: {
+          isPlayer: () => true,
+          clientID: () => "winner-client",
+          displayName: () => "Bob",
+        },
+      }),
+    );
+    modal!.tick();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].winner).toEqual(["player", "winner-client"]);
+    expect(crazyGamesSDK.happytime).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(modal!.isVisible).toBe(true));
+  });
+
+  it("celebrates when the winning client is me", async () => {
+    setup(
+      makeGame({
+        winner: ["player", "my-client"],
+        myClientID: "my-client",
+        winnerPlayer: {
+          isPlayer: () => true,
+          clientID: () => "my-client",
+          displayName: () => "Me",
+        },
+      }),
+    );
+    modal!.tick();
+
+    expect(crazyGamesSDK.happytime).toHaveBeenCalled();
+    await vi.waitFor(() => expect(modal!.isVisible).toBe(true));
+  });
+
+  it("emits a winnerless result when the match is cancelled", async () => {
+    const events = setup(makeGame({ winner: undefined }));
+    modal!.tick();
+
+    expect(events).toHaveLength(1);
+    expect(events[0].winner).toBeUndefined();
+    await vi.waitFor(() => expect(modal!.isVisible).toBe(true));
+  });
+
+  it("ignores a player win whose winner is not a known player", () => {
+    const events = setup(
+      makeGame({ winner: ["player", "gone"], winnerPlayer: undefined }),
+    );
+    modal!.tick();
+
+    expect(events).toHaveLength(0);
+    expect(modal!.isVisible).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

26 new test files (~120 tests) exercising client code paths that had no coverage. **Tests only — no production code changes.**

- **Transport**: intent/winner/hash send paths asserted by decoding the actual frames the (fake) socket received, socket-teardown guards, local-server forwarding, null-socket buffering.
- **ClientGameRunner**: lobby-phase `prestart`/`start` handling, in-game `start`/`desync`/`turn` (including the wrong-turn-number path), spawn/attack/auto-boat click actions (pinning the auto-boat distance limit at strictly < 100), and the error-modal content for connection errors, desyncs, and worker crashes.
- **Main.ts**: first harness that boots the real module in jsdom — signed-out and signed-in auth flows, hash routing, and the join-lobby username gate. The test file documents the landmines (bootstrap config, turnstile stub, one-boot-per-file) for future Main tests.
- **GameRenderer**: `createRenderer()` runs end to end and the test asserts the HUD wiring it produces (win modal, emoji table event bus).
- **HUD layers**: EventsDisplay handlers (alliance expiry/reply, broken-alliance traitor penalty, target requests, incoming-unit warnings), WinModal win-update handling (team/player/undefined winners), PlayerPanel actions (embargo, emoji recipients, capability flags), ControlPanel attack-ratio snap + dead-player tick, BuildMenu cost fallbacks, EmojiTable menu flow, SpawnTimer team ratios, ChatDisplay filtering, PlayerInfoOverlay, radial spawn action, PlayerActionHandler, SpriteLoader missing-sprite error.
- **Misc client**: LocalServer edge paths (missing gameStartInfo, replay hash desync), SinglePlayerModal/HostLobbyModal team-count + start config (including disabled-units sanitization), TransformHandler target/interval lifecycle, LangSelector translation fallbacks + param substitution, NewsModal changelog fetch, UsernameInput validation, UUID generation fallbacks, UserSettingModal change handlers.

## Why

Locks in the current behavior of these paths so upcoming refactors in the client can be verified against pinned behavior instead of relying on manual testing.

## Testing

- Full suite: **437 files / 5372 tests pass** (was 411 / 5277)
- `npm run lint` and Prettier clean
- Verified via lcov that every previously-uncovered target line in the touched areas is now executed

🤖 Generated with [Claude Code](https://claude.com/claude-code)