### PR TITLE
feat(settings): an Exit game control for the desktop build (OPE-402)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -2119,6 +2119,8 @@
     "performance_overlay_desc": "Toggle the performance overlay. When enabled, the performance overlay will be displayed. Press shift-D during game to toggle.",
     "performance_overlay_label": "Performance Overlay",
     "press_a_key": "Press a key",
+    "quit_desc": "Close OpenFront and return to your desktop.",
+    "quit_label": "Exit game",
     "render_debug_gui": "Render Debug GUI",
     "render_debug_gui_desc": "Toggle the renderer tuning panel",
     "request_alliance": "Request Alliance",

--- a/src/client/DesktopShell.ts
+++ b/src/client/DesktopShell.ts
@@ -369,3 +369,57 @@ export function desktopLinkGate(): DesktopLinkGateBridge | null {
     ? (desktop as DesktopLinkGateBridge)
     : null;
 }
+
+/**
+ * The shell's in-app exit (OPE-402).
+ *
+ * The desktop window opens borderless by default since OPE-173, which removes
+ * the title bar, and the menu bar is hidden — so the OS offers the player no
+ * visible way out. F11 back to windowed and Alt+F4 both still work, but
+ * neither is discoverable, and Steam players expect a Quit item in the game's
+ * own UI regardless.
+ *
+ * Null on the web, on CrazyGames and on any shell older than the one that
+ * introduced `quit()` (`shell.api` 4) — the same degrade-don't-break contract
+ * desktopUpdate() and desktopDisplay() keep, and for the same reason: the
+ * shell ships in the Steam depot on Steam's schedule while this client updates
+ * at runtime, so a client newer than its shell is ordinary.
+ *
+ * FEATURE DETECTION ON THE METHOD, not on `shell.api` — the rule
+ * desktopLinkGate() and desktopDisplay() already apply. A rename on the shell
+ * side then hides the control rather than wiring a button to nothing.
+ */
+export interface DesktopQuitBridge {
+  quit: () => Promise<void>;
+}
+
+export function desktopQuit(): DesktopQuitBridge | null {
+  if (typeof window === "undefined") return null;
+  const desktop = window.openfrontDesktop as { quit?: unknown } | undefined;
+  return typeof desktop?.quit === "function"
+    ? (desktop as DesktopQuitBridge)
+    : null;
+}
+
+/**
+ * Asks the shell to quit, and swallows everything.
+ *
+ * The invoke MAY NEVER SETTLE: the main process begins shutting down inside
+ * its handler, so this renderer is usually destroyed before a reply can come
+ * back. Awaiting it in a click handler would leave the caller hanging forever
+ * on the success path, and an unhandled rejection on the failure one.
+ *
+ * There is deliberately nothing to report back. A shell that refuses to quit
+ * leaves the player exactly where they were, with the window they can still
+ * close by every other means; a spinner or an error toast for it would be a
+ * UI for a state that has no remedy.
+ */
+export function requestDesktopQuit(): void {
+  const bridge = desktopQuit();
+  if (bridge === null) return;
+  try {
+    void bridge.quit().catch(() => {});
+  } catch {
+    // A bridge that throws synchronously rather than rejecting.
+  }
+}

--- a/src/client/UserSettingModal.ts
+++ b/src/client/UserSettingModal.ts
@@ -31,7 +31,11 @@ import {
   type DesktopDisplayPrefsPatch,
   type DesktopDisplaySnapshot,
 } from "./DesktopDisplay";
-import { isDesktopShell } from "./DesktopShell";
+import {
+  desktopQuit,
+  isDesktopShell,
+  requestDesktopQuit,
+} from "./DesktopShell";
 import { pushMapLayerState } from "./MapLayerSettings";
 import { Platform } from "./Platform";
 import {
@@ -913,9 +917,11 @@ export class UserSettingModal extends BaseModal {
         `;
 
     // Before the first snapshot arrives there is nothing truthful to select,
-    // so the controls are withheld rather than rendered empty. The hint is
-    // true either way.
-    if (snapshot === null) return html`${f11Hint}`;
+    // so the controls are withheld rather than rendered empty. The hint and
+    // the Quit button are true either way -- neither reads the snapshot, and
+    // withholding the way out while waiting on an unrelated IPC read would be
+    // exactly backwards.
+    if (snapshot === null) return html`${f11Hint}${this.renderQuitControl()}`;
 
     const displays = snapshot.displays;
     const selectedId = selectedDisplayId(snapshot);
@@ -973,8 +979,61 @@ export class UserSettingModal extends BaseModal {
             ></setting-select>
           `
         : null}
+      ${this.renderQuitControl()}
     `;
   }
+
+  /**
+   * The in-app way out (OPE-402).
+   *
+   * On the Display tab because that is where the window itself is controlled,
+   * and because the player this exists for is already here: borderless is the
+   * default, it removes the title bar, and switching back to Windowed is the
+   * other thing they came to this tab to do. Nothing else in the settings
+   * modal is about the window.
+   *
+   * DELIBERATELY NO CONFIRMATION. The action is identical to closing the
+   * window, which has never asked — and a confirm on one and not the other
+   * makes two spellings of the same thing behave differently. A single-player
+   * match is lost either way, and leaving a multiplayer game is already
+   * ordinary. What a confirm actually guards against is an accidental click,
+   * and there is no accidental path to a button three levels in (cog →
+   * settings → Display); the separator and the destructive colouring below do
+   * that job without putting a dialog between the player and the exit they
+   * went looking for.
+   *
+   * Renders nothing on the web, on CrazyGames and on a shell too old to
+   * expose quit() — desktopQuit() is already null in all three, which is the
+   * same feature-detection rule the Display tab applies to desktopDisplay().
+   * Checked here rather than folded into the tab's own gate on purpose: the
+   * two detect different bridge methods, and the shell currently in the depot
+   * has display.* without quit().
+   */
+  private renderQuitControl() {
+    if (desktopQuit() === null) return nothing;
+    return html`
+      <div class="mt-4 pt-4 border-t border-white/10">
+        <button
+          id="desktop-quit-button"
+          class="flex flex-row items-center justify-between w-full p-4 bg-red-500/10 border border-red-500/20 rounded-xl hover:bg-red-500/20 transition-all gap-4 text-left"
+          @click=${this.handleQuit}
+        >
+          <div class="flex flex-col flex-1 min-w-0">
+            <div class="text-red-200 font-bold text-base block mb-1">
+              ${translateText("user_setting.quit_label")}
+            </div>
+            <div class="text-white/50 text-sm leading-snug">
+              ${translateText("user_setting.quit_desc")}
+            </div>
+          </div>
+        </button>
+      </div>
+    `;
+  }
+
+  private handleQuit = () => {
+    requestDesktopQuit();
+  };
 
   private renderKeybindSettings() {
     return html`

--- a/tests/DesktopShell.test.ts
+++ b/tests/DesktopShell.test.ts
@@ -2,7 +2,9 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   composeVersionDisplay,
   desktopLinkGate,
+  desktopQuit,
   desktopVersion,
+  requestDesktopQuit,
 } from "../src/client/DesktopShell";
 
 describe("composeVersionDisplay", () => {
@@ -104,5 +106,83 @@ describe("desktopLinkGate", () => {
     expect(gate).not.toBeNull();
     await gate!.showLinkGate();
     expect(showLinkGate).toHaveBeenCalledTimes(1);
+  });
+});
+
+// The in-app exit (OPE-402). Same feature-detection rule as desktopLinkGate
+// above, and the same reason: the shell ships in the Steam depot on Steam's
+// schedule while this client updates at runtime, so a client that is newer
+// than its shell must hide the control rather than wire a button to nothing.
+describe("desktopQuit", () => {
+  afterEach(() => {
+    window.openfrontDesktop = undefined;
+  });
+
+  it("is null in the browser, with no bridge present", () => {
+    window.openfrontDesktop = undefined;
+    expect(desktopQuit()).toBeNull();
+  });
+
+  // A shell at api 3 -- display.* but no quit(). Not hypothetical: that shell
+  // is in the depot now, and a client carrying this change reaches it first.
+  it("is null on a shell older than quit()", () => {
+    window.openfrontDesktop = { shell: { api: 3 }, display: {} };
+    expect(desktopQuit()).toBeNull();
+  });
+
+  it("is null when quit exists but is not callable", () => {
+    window.openfrontDesktop = { quit: true };
+    expect(desktopQuit()).toBeNull();
+  });
+
+  it("returns the bridge when quit is callable", async () => {
+    const quit = vi.fn(async () => undefined);
+    window.openfrontDesktop = { quit };
+    const bridge = desktopQuit();
+    expect(bridge).not.toBeNull();
+    await bridge!.quit();
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("requestDesktopQuit", () => {
+  afterEach(() => {
+    window.openfrontDesktop = undefined;
+  });
+
+  it("does nothing at all with no bridge", () => {
+    window.openfrontDesktop = undefined;
+    expect(() => requestDesktopQuit()).not.toThrow();
+  });
+
+  it("calls the bridge's quit", () => {
+    const quit = vi.fn(async () => undefined);
+    window.openfrontDesktop = { quit };
+    requestDesktopQuit();
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+
+  // The whole reason this wrapper exists rather than callers invoking the
+  // bridge directly. The main process starts shutting down inside its handler,
+  // so the invoke commonly never settles and can reject when the renderer is
+  // torn down mid-call. An unhandled rejection from a click handler would
+  // surface as a renderer-wide error over an action that already succeeded.
+  it("swallows a rejected quit rather than leaving it unhandled", async () => {
+    window.openfrontDesktop = {
+      quit: () => Promise.reject(new Error("channel closed")),
+    };
+    expect(() => requestDesktopQuit()).not.toThrow();
+    // Let the rejection settle; an unhandled one fails the run.
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it("swallows a bridge that throws synchronously", () => {
+    window.openfrontDesktop = {
+      quit: () => {
+        throw new Error("boom");
+      },
+    };
+    expect(() => requestDesktopQuit()).not.toThrow();
   });
 });

--- a/tests/client/UserSettingModal.quit.test.ts
+++ b/tests/client/UserSettingModal.quit.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { DesktopDisplaySnapshot } from "../../src/client/DesktopDisplay";
+import { modalRouter } from "../../src/client/ModalRouter";
+import "../../src/client/UserSettingModal";
+import type { UserSettingModal } from "../../src/client/UserSettingModal";
+
+type TestModal = UserSettingModal & {
+  updateComplete: Promise<unknown>;
+  activeTab: string;
+  open(args?: Record<string, unknown>): void;
+};
+
+const SNAPSHOT: DesktopDisplaySnapshot = {
+  prefs: { mode: "borderless", displayId: null },
+  displays: [
+    {
+      id: 1,
+      label: "Dell U2718Q",
+      primary: true,
+      bounds: { x: 0, y: 0, width: 2560, height: 1440 },
+      scaleFactor: 1,
+    },
+  ],
+  activeDisplayId: 1,
+  preferredDisplayPresent: true,
+};
+
+/**
+ * A shell exposing both namespaces the Display tab needs. `quit` is separate
+ * from `display` on purpose: the tab and the button feature-detect on
+ * different methods, and the tests below turn one off without the other.
+ */
+function installShell(over: { quit?: unknown; display?: unknown } = {}): {
+  quit: ReturnType<typeof vi.fn>;
+} {
+  const quit = vi.fn(async () => undefined);
+  window.openfrontDesktop = {
+    shell: { api: 4 },
+    display: {
+      getPrefs: vi.fn(async () => SNAPSHOT),
+      setPrefs: vi.fn(async () => SNAPSHOT),
+      listDisplays: vi.fn(async () => SNAPSHOT.displays),
+      subscribe: vi.fn(() => () => {}),
+    },
+    quit,
+    ...over,
+  };
+  return { quit };
+}
+
+async function mountOnDisplay(): Promise<TestModal> {
+  const el = document.createElement("user-setting") as TestModal;
+  document.body.appendChild(el);
+  await el.updateComplete;
+  el.open({ tab: "display" });
+  await el.updateComplete;
+  // Let the tab's getPrefs() round trip and the resulting update land.
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+  await el.updateComplete;
+  return el;
+}
+
+function quitButton(el: TestModal): HTMLButtonElement | null {
+  return el.querySelector("#desktop-quit-button");
+}
+
+// See the note in UserSettingModal.display.test.ts: vitest tears down the
+// jsdom without removing elements first, so anything still connected never
+// gets disconnectedCallback and whatever it armed outlives the document.
+afterEach(async () => {
+  for (const el of [...document.body.children]) el.remove();
+  await Promise.resolve();
+  window.openfrontDesktop = undefined;
+  vi.useRealTimers();
+});
+
+function resetDom(): void {
+  document.body.innerHTML = "";
+  localStorage.clear();
+  location.hash = "";
+  modalRouter.register("settings", {
+    tag: "user-setting",
+    pageId: "page-settings",
+  });
+}
+
+describe("the Exit game control", () => {
+  beforeEach(resetDom);
+
+  it("renders on a desktop shell that exposes quit()", async () => {
+    installShell();
+    const el = await mountOnDisplay();
+    expect(el.activeTab).toBe("display");
+    expect(quitButton(el)).not.toBeNull();
+  });
+
+  // The regression that matters most: a Quit button on the web is a button
+  // that cannot work. The web build has no bridge at all, so it has no Display
+  // tab either -- asserted here from the rendered body rather than from the
+  // tab list, because that is the thing a player would see.
+  it("is absent with no desktop shell", async () => {
+    window.openfrontDesktop = undefined;
+    const el = document.createElement("user-setting") as TestModal;
+    document.body.appendChild(el);
+    await el.updateComplete;
+    el.open({ tab: "display" });
+    await el.updateComplete;
+    expect(quitButton(el)).toBeNull();
+  });
+
+  // CrazyGames is a web build: it sets no openfrontDesktop global, so it is
+  // covered by the case above. This is the one that is NOT covered by it --
+  // the shell currently in the Steam depot, which has display.* but no quit().
+  // The Display tab must still render; only the button goes.
+  it("is absent on a shell with display.* but no quit()", async () => {
+    installShell({ quit: undefined });
+    const el = await mountOnDisplay();
+    expect(el.activeTab).toBe("display");
+    // The tab itself is still there, so this is not passing for the trivial
+    // reason that nothing rendered.
+    expect(el.querySelector("#display-mode-select")).not.toBeNull();
+    expect(quitButton(el)).toBeNull();
+  });
+
+  it("asks the shell to quit when pressed", async () => {
+    const { quit } = installShell();
+    const el = await mountOnDisplay();
+    quitButton(el)!.click();
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+
+  // No confirmation dialog, by decision (see renderQuitControl). Quitting from
+  // here is the same action as closing the window, which has never asked. If
+  // someone adds a confirm later this fails, which is the point: it should be
+  // a deliberate change, not one that slips in with a component swap.
+  it("quits on the first press, with nothing in between", async () => {
+    const { quit } = installShell();
+    const el = await mountOnDisplay();
+    // The modal's own chrome has buttons of its own, so this is a before/after
+    // comparison rather than a count: what must not happen is a confirmation
+    // appearing between the press and the quit.
+    const before = el.querySelectorAll("button").length;
+    quitButton(el)!.click();
+    await el.updateComplete;
+    expect(quit).toHaveBeenCalledTimes(1);
+    expect(el.querySelectorAll("button").length).toBe(before);
+  });
+
+  // The tab withholds its selects until the shell's first snapshot arrives.
+  // The way out must not be withheld with them -- it reads nothing from that
+  // snapshot, and a player waiting on a wedged IPC read is exactly the player
+  // who wants it.
+  it("renders before the first display snapshot arrives", async () => {
+    const { quit } = installShell({
+      display: {
+        // Never settles, so no snapshot is ever adopted.
+        getPrefs: vi.fn(() => new Promise<DesktopDisplaySnapshot>(() => {})),
+        setPrefs: vi.fn(async () => SNAPSHOT),
+        subscribe: vi.fn(() => () => {}),
+      },
+    });
+    const el = await mountOnDisplay();
+    expect(el.querySelector("#display-mode-select")).toBeNull();
+    expect(quitButton(el)).not.toBeNull();
+    quitButton(el)!.click();
+    expect(quit).toHaveBeenCalledTimes(1);
+  });
+
+  // A shell whose quit() rejects (the renderer torn down mid-invoke is the
+  // ordinary case) must not produce an unhandled rejection out of a click
+  // handler. requestDesktopQuit owns that; this checks it through the button.
+  it("survives a quit() that rejects", async () => {
+    window.openfrontDesktop = {
+      shell: { api: 4 },
+      display: {
+        getPrefs: vi.fn(async () => SNAPSHOT),
+        setPrefs: vi.fn(async () => SNAPSHOT),
+        subscribe: vi.fn(() => () => {}),
+      },
+      quit: () => Promise.reject(new Error("channel closed")),
+    };
+    const el = await mountOnDisplay();
+    expect(() => quitButton(el)!.click()).not.toThrow();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+});


### PR DESCRIPTION
Part of OPE-402. **Land [openfront-desktop#57](https://github.com/openfrontio/openfront-desktop/pull/57) first** — it adds the `quit()` bridge method this calls. Merged in the other order this is simply inert: the control feature-detects on that method and renders nothing without it, so nothing breaks, but nothing appears either.

Web and CrazyGames are unaffected by this PR in every ordering.

## Why

OPE-173 shipped today: the desktop window opens **borderless by default**, which removes the title bar, and the menu bar was already hidden. I checked what that actually leaves a player rather than assuming the worst:

- Borderless is native fullscreen, not a frameless window, so **F11 → Windowed restores the title bar and its close button**, and **Alt+F4 still works on Windows**.
- So there is still a way out. It is just undiscoverable — nothing on screen says F11, and the hint that does say it lives on the very tab you have to find first.

Evan asked for a Quit item in the Playtest session regardless; borderless is what turns it from a nicety into something a player can fail to find.

## What this adds

`desktopQuit()` / `requestDesktopQuit()` in `DesktopShell.ts`, and an **Exit game** button at the foot of the settings modal's **Display** tab.

Display rather than a new tab or Gameplay: it is the tab that is about the window itself, and the player this exists for is already there — switching back to Windowed is the other thing that brings them to it. It is reachable mid-match too, since the in-game menu's Settings opens this same component.

**Gating** is the existing mechanism, not a new one: feature detection on the bridge method actually called, the rule `desktopLinkGate()` and `desktopDisplay()` already apply. It renders on no web build, no CrazyGames build, and no shell older than `shell.api` 4.

The button's detection is deliberately **separate from the Display tab's**. The shell in the depot right now has `display.*` without `quit()`, and against that shell the tab must stay and only the button go — there is a test for exactly that case. The button also renders *before* the tab's first display snapshot arrives: it reads nothing from that snapshot, and withholding the way out while waiting on an unrelated IPC read would be backwards.

`requestDesktopQuit()` fires and forgets. The main process begins shutting down inside its handler, so the invoke commonly never settles and can reject when the renderer is torn down mid-flight; awaiting it in a click handler would hang on the success path and leave an unhandled rejection on the failure one.

## No confirm on quit — decided, not skipped

Quitting mid-match does **not** prompt.

The action is identical to closing the window, which has never asked, and a confirm on one spelling of an action and not the other makes the same action behave two ways. A single-player match is lost either way; leaving a multiplayer game is already an ordinary thing to do. What a confirm actually guards against is an accidental press, and there is no accidental path to a button three levels in (cog → settings → Display) — a separator and destructive colouring do that job without putting a dialog between the player and the exit they went looking for.

`UserSettingModal.quit.test.ts` asserts the first press quits and that nothing new renders in between, so re-adding a confirm would have to be a deliberate change rather than something that arrives with a component swap.

## Strings

Two new keys in `resources/lang/en.json` only (`user_setting.quit_label`, `user_setting.quit_desc`), both through `translateText()`. No other translation file touched.

## Testing

- `tests/DesktopShell.test.ts` — `desktopQuit()` is null with no bridge, null on an `api: 3` shell, null when `quit` exists but is not callable; `requestDesktopQuit()` survives a rejected and a synchronously-throwing bridge without producing an unhandled rejection.
- `tests/client/UserSettingModal.quit.test.ts` — renders on a shell with `quit()`, absent with no shell, **absent on a shell with `display.*` but no `quit()` while the Display tab itself still renders** (so it is not passing because nothing rendered), calls the bridge on press, quits on the first press with no new buttons in between, renders before the first snapshot, and survives a rejecting `quit()`.

`npx vitest run` (423 files / 5403 tests), `vitest run tests/server` (63 / 655), `tsc --noEmit`, `npm run lint` and `prettier --check` are all green.

The quit path itself cannot be verified here — it ends in the shell. #57 covers it with a real-Electron e2e spec and a Windows orphan check, and adds a `MANUAL_TESTING.md` entry for quitting mid-match and for Steam registering the session as ended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WqYfRtgGASp1TGynBosToq
