### PR TITLE
test: global per-test DOM teardown so leaked Lit updates cannot outlive their jsdom (OPE-422)

### DIFF
--- a/tests/client/GameRightSidebar.fullscreen.test.ts
+++ b/tests/client/GameRightSidebar.fullscreen.test.ts
@@ -101,25 +101,10 @@ function clickFullscreen(el: TestSidebar): void {
   );
 }
 
-// Vitest tears down this file's jsdom when the file ends, but it does NOT
-// remove elements from document.body first -- so a component still connected
-// at that point never gets disconnectedCallback, and anything it has armed
-// outlives the document.
-//
-// That is not hypothetical here: three of the tests below deliberately leave a
-// write in flight, which leaves the 2s settle ceiling armed. When it fired
-// after teardown it set a @state field, Lit scheduled an update, and
-// modalConfig() -> translateText() -> getCachedLangSelector() reached for a
-// `document` that no longer existed. Vitest reports that as an unhandled
-// rejection against whichever FILE happened to be running at the time, which
-// is why it read as an unrelated flake.
-//
-// Removing every element here runs disconnectedCallback, which clears the
-// timer and the subscription.
-afterEach(async () => {
-  for (const el of [...document.body.children]) el.remove();
-  // Let any update already scheduled run while the document still exists.
-  await Promise.resolve();
+// Elements mounted by a test are removed by the global DOM teardown in
+// tests/domTeardown.ts, which runs after this file's own hooks. Only the
+// globals this file installs need undoing here.
+afterEach(() => {
   window.openfrontDesktop = undefined;
   vi.useRealTimers();
 });

--- a/tests/client/InGameSettingsMenu.test.ts
+++ b/tests/client/InGameSettingsMenu.test.ts
@@ -59,15 +59,10 @@ describe("in-game menu opens the shared settings modal", () => {
     await settle();
   });
 
-  afterEach(async () => {
+  // Both elements are removed by the global DOM teardown in
+  // tests/domTeardown.ts, which runs after this hook.
+  afterEach(() => {
     vi.restoreAllMocks();
-    // A Lit element left connected when the file ends can schedule an update
-    // after jsdom is gone, which surfaces as an unhandled "document is not
-    // defined" and fails the run even though every test passed.
-    menu.remove();
-    settings.remove();
-    await menu.updateComplete;
-    await settings.updateComplete;
   });
 
   /** Open the menu the way GameRightSidebar does in a single-player game. */

--- a/tests/client/UserSettingModal.display.test.ts
+++ b/tests/client/UserSettingModal.display.test.ts
@@ -140,25 +140,10 @@ function choose(select: HTMLSelectElement, value: string): void {
   select.dispatchEvent(new Event("change", { bubbles: true }));
 }
 
-// Vitest tears down this file's jsdom when the file ends, but it does NOT
-// remove elements from document.body first -- so a component still connected
-// at that point never gets disconnectedCallback, and anything it has armed
-// outlives the document.
-//
-// That is not hypothetical here: three of the tests below deliberately leave a
-// write in flight, which leaves the 2s settle ceiling armed. When it fired
-// after teardown it set a @state field, Lit scheduled an update, and
-// modalConfig() -> translateText() -> getCachedLangSelector() reached for a
-// `document` that no longer existed. Vitest reports that as an unhandled
-// rejection against whichever FILE happened to be running at the time, which
-// is why it read as an unrelated flake.
-//
-// Removing every element here runs disconnectedCallback, which clears the
-// timer and the subscription.
-afterEach(async () => {
-  for (const el of [...document.body.children]) el.remove();
-  // Let any update already scheduled run while the document still exists.
-  await Promise.resolve();
+// Elements mounted by a test are removed by the global DOM teardown in
+// tests/domTeardown.ts, which runs after this file's own hooks. Only the
+// globals this file installs need undoing here.
+afterEach(() => {
   window.openfrontDesktop = undefined;
   vi.useRealTimers();
 });

--- a/tests/client/UserSettingModal.graphics.test.ts
+++ b/tests/client/UserSettingModal.graphics.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 
 import "../../src/client/UserSettingModal";
 import type { UserSettingModal } from "../../src/client/UserSettingModal";
@@ -13,21 +13,6 @@ type TestModal = UserSettingModal & {
   updateComplete: Promise<unknown>;
   activeTab: string;
 };
-
-/**
- * Everything mounted this test. A Lit element left connected when the file
- * ends can schedule an update after jsdom is gone, which surfaces as an
- * unhandled "document is not defined" and fails the run even though every
- * test passed.
- */
-const mounted: TestModal[] = [];
-
-async function unmountAll() {
-  for (const el of mounted.splice(0)) {
-    el.remove();
-    await el.updateComplete;
-  }
-}
 
 const LAYERS: MapLayer[] = [
   { id: "forest", placement: "land", nukeable: true, alpha: 0.8 },
@@ -56,7 +41,6 @@ async function mountGraphics(
     el.onLayerAlphaChange = wire.onLayerAlphaChange;
   }
   document.body.appendChild(el);
-  mounted.push(el);
   el.open({ tab: "graphics" });
   await el.updateComplete;
   if (wire?.advanced !== false) {
@@ -113,7 +97,6 @@ function resetGraphicsSettings() {
 
 describe("Graphics tab: advanced options folded in from the in-game modal", () => {
   beforeEach(resetGraphicsSettings);
-  afterEach(unmountAll);
 
   it("renders every folded control", async () => {
     const el = await mountGraphics();
@@ -280,7 +263,6 @@ describe("Graphics tab: advanced options folded in from the in-game modal", () =
 
 describe("Graphics tab: preset tools sit outside the Advanced fold", () => {
   beforeEach(resetGraphicsSettings);
-  afterEach(unmountAll);
 
   function typeInto(el: TestModal, id: string, value: string) {
     const field = el.querySelector<HTMLInputElement | HTMLTextAreaElement>(
@@ -362,7 +344,6 @@ describe("Graphics tab: preset tools sit outside the Advanced fold", () => {
 
 describe("Graphics tab: live apply from the in-game instance", () => {
   beforeEach(resetGraphicsSettings);
-  afterEach(unmountAll);
 
   it("fires the settings.graphics change event a running game listens for", async () => {
     // ClientGameRunner re-resolves the render settings and rebuilds the
@@ -493,7 +474,6 @@ describe("Graphics tab: live apply from the in-game instance", () => {
 
 describe("Graphics tab: layer state reaches the renderer with Advanced collapsed", () => {
   beforeEach(resetGraphicsSettings);
-  afterEach(unmountAll);
 
   /** Everything the renderer was told, in order. */
   function wire() {
@@ -599,7 +579,6 @@ describe("Graphics tab: layer state reaches the renderer with Advanced collapsed
 
 describe("Graphics tab: the page instance has no game", () => {
   beforeEach(resetGraphicsSettings);
-  afterEach(unmountAll);
 
   it("hides the map-layer section, because the rows come from the running map", async () => {
     const el = await mountGraphics();

--- a/tests/client/_teardown/GlobalDomTeardown.test.ts
+++ b/tests/client/_teardown/GlobalDomTeardown.test.ts
@@ -1,7 +1,7 @@
 import { setTimeout as nodeDelay } from "node:timers/promises";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
-import { removeAndSettle } from "../../domTeardown";
+import { drainFakeTimers, removeAndSettle } from "../../domTeardown";
 import {
   disconnects,
   lateUpdates,
@@ -83,6 +83,27 @@ describe("global DOM teardown", () => {
     expect(vi.isFakeTimers()).toBe(false);
     // Would hang if fake timers were still installed.
     await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+
+  // The drain is deliberately not error-swallowing: a pending callback that
+  // throws is the test's own code failing, and afterEach runs per test, so
+  // letting it propagate fails the test that armed it. Catching it would turn
+  // that failure into a pass. Asserted against the helper rather than the hook,
+  // because a hook that throws fails its test by design -- there is no vantage
+  // point inside a passing test from which to watch it happen.
+  it("surfaces an error thrown by a drained timer, real timers restored", () => {
+    vi.useFakeTimers();
+    setTimeout(() => {
+      throw new Error("armed and dangerous");
+    }, 1_000);
+
+    expect(() => drainFakeTimers()).toThrow("armed and dangerous");
+    expect(vi.isFakeTimers()).toBe(false);
+  });
+
+  it("is a no-op when the test already restored real timers", () => {
+    expect(vi.isFakeTimers()).toBe(false);
+    expect(() => drainFakeTimers()).not.toThrow();
   });
 });
 

--- a/tests/client/_teardown/GlobalDomTeardown.test.ts
+++ b/tests/client/_teardown/GlobalDomTeardown.test.ts
@@ -1,9 +1,11 @@
 import { setTimeout as nodeDelay } from "node:timers/promises";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 
+import { removeAndSettle } from "../../domTeardown";
 import {
-  LEAK_DELAY_MS,
+  disconnects,
   lateUpdates,
+  LEAK_DELAY_MS,
   type TeardownLeaker,
 } from "./LeakyElement";
 
@@ -13,24 +15,19 @@ import {
  * cleaned up after it. Disable the afterEach in tests/domTeardown.ts and this
  * file fails.
  *
- * WHAT A LEAK ACTUALLY COSTS, MEASURED
+ * A leaked timer really can outlive the environment: `globalThis.setTimeout` is
+ * Node's, not jsdom's, so `dom.window.close()` does not cancel it, and the
+ * worker keeps running timers for a while after the teardown has deleted
+ * `document`. The mechanism, and how it was measured, is written up in
+ * tests/domTeardown.ts.
  *
- * The escape route these leaks are usually described as taking -- work landing
- * after the file's jsdom is gone -- could not be reproduced on Vitest 4.1.5.
- * Two things close it: the jsdom teardown calls `dom.window.close()`, and jsdom
- * stops every timer it owns, so a leaked setTimeout is cancelled outright; and
- * with the default forks pool each file gets its own child process, which exits
- * at the end of the file, so a promise settled by Node cannot reach it either.
- * Removing #5357's guard and running the whole suite with this hook disabled
- * produced no unhandled rejection at all.
- *
- * What is reproducible, and what these tests pin, is the leak WITHIN the file:
- * the element outlives the test that mounted it, so the next test starts with
- * someone else's DOM and someone else's timer armed against it. That is a real
- * cost -- removing the ad-hoc cleanup from
- * tests/client/UserSettingModal.graphics.test.ts fails 18 of its tests without
- * this hook -- and it is the same disconnectedCallback that never runs in
- * either story, so fixing it closes both.
+ * That window is ~10 ms here and only wide enough to catch a timer that happens
+ * to land inside it, which is why the CI failure was intermittent and why these
+ * tests do not try to reproduce it directly. They pin the deterministic half:
+ * the element and its timer are gone as soon as the test that mounted them
+ * ends. Disable the afterEach in tests/domTeardown.ts and this file fails --
+ * and so do 18 tests in tests/client/UserSettingModal.graphics.test.ts, which
+ * had grown its own copy of this cleanup.
  */
 
 let leaked: TeardownLeaker | null = null;
@@ -86,5 +83,44 @@ describe("global DOM teardown", () => {
     expect(vi.isFakeTimers()).toBe(false);
     // Would hang if fake timers were still installed.
     await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});
+
+/**
+ * The afterAll sweep is what gives a beforeAll fixture its disconnectedCallback.
+ * It cannot be asserted from inside a test file -- running last is the point, so
+ * nothing here runs after it to look -- so the two halves are covered
+ * separately: that the per-test hook SPARES such a fixture, which is observable,
+ * and that removeAndSettle (all the sweep does) disconnects it, which is
+ * testable directly.
+ */
+describe("what the afterAll sweep is left holding", () => {
+  let fixture: TeardownLeaker;
+
+  beforeAll(() => {
+    fixture = document.createElement("teardown-leaker") as TeardownLeaker;
+    document.body.appendChild(fixture);
+  });
+
+  it("mounts a transient element alongside the fixture", async () => {
+    const transient = document.createElement("teardown-leaker");
+    document.body.appendChild(transient);
+    await (transient as TeardownLeaker).updateComplete;
+
+    expect(document.body.children.length).toBe(2);
+  });
+
+  it("took the transient element and spared the fixture", () => {
+    expect([...document.body.children]).toEqual([fixture]);
+  });
+
+  it("removeAndSettle disconnects what is left", async () => {
+    const before = disconnects.count;
+
+    await removeAndSettle([...document.body.children]);
+
+    expect(disconnects.count).toBe(before + 1);
+    expect(fixture.isConnected).toBe(false);
+    expect(document.body.children.length).toBe(0);
   });
 });

--- a/tests/client/_teardown/GlobalDomTeardown.test.ts
+++ b/tests/client/_teardown/GlobalDomTeardown.test.ts
@@ -1,0 +1,90 @@
+import { setTimeout as nodeDelay } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LEAK_DELAY_MS,
+  lateUpdates,
+  type TeardownLeaker,
+} from "./LeakyElement";
+
+/**
+ * The control for tests/domTeardown.ts. The first test here deliberately leaves
+ * a component mounted with a late update armed; the rest assert the global hook
+ * cleaned up after it. Disable the afterEach in tests/domTeardown.ts and this
+ * file fails.
+ *
+ * WHAT A LEAK ACTUALLY COSTS, MEASURED
+ *
+ * The escape route these leaks are usually described as taking -- work landing
+ * after the file's jsdom is gone -- could not be reproduced on Vitest 4.1.5.
+ * Two things close it: the jsdom teardown calls `dom.window.close()`, and jsdom
+ * stops every timer it owns, so a leaked setTimeout is cancelled outright; and
+ * with the default forks pool each file gets its own child process, which exits
+ * at the end of the file, so a promise settled by Node cannot reach it either.
+ * Removing #5357's guard and running the whole suite with this hook disabled
+ * produced no unhandled rejection at all.
+ *
+ * What is reproducible, and what these tests pin, is the leak WITHIN the file:
+ * the element outlives the test that mounted it, so the next test starts with
+ * someone else's DOM and someone else's timer armed against it. That is a real
+ * cost -- removing the ad-hoc cleanup from
+ * tests/client/UserSettingModal.graphics.test.ts fails 18 of its tests without
+ * this hook -- and it is the same disconnectedCallback that never runs in
+ * either story, so fixing it closes both.
+ */
+
+let leaked: TeardownLeaker | null = null;
+const order: string[] = [];
+const drained: string[] = [];
+
+// Registered at import time, so Vitest registers it AFTER the setup file's
+// hooks. afterEach is LIFO within a file, so this one runs FIRST and still sees
+// what the test mounted. If that order ever inverts, the second test catches it.
+afterEach(() => {
+  if (!leaked) return;
+  order.push(
+    document.body.contains(leaked) ? "file-hook-first" : "global-hook-first",
+  );
+});
+
+describe("global DOM teardown", () => {
+  it("leaves a component mounted with a late update armed", async () => {
+    leaked = document.createElement("teardown-leaker") as TeardownLeaker;
+    document.body.appendChild(leaked);
+    await leaked.updateComplete;
+
+    expect(document.body.contains(leaked)).toBe(true);
+    expect(lateUpdates.count).toBe(0);
+    // Deliberately no cleanup: this is the leak the global hook exists for.
+  });
+
+  it("removed it once the test ended, without pre-empting this file's hooks", () => {
+    expect(order).toEqual(["file-hook-first"]);
+    expect(document.body.children.length).toBe(0);
+    expect(leaked!.isConnected).toBe(false);
+  });
+
+  it("disarmed what it had armed", async () => {
+    // Well past the point the leaked update was scheduled for.
+    // disconnectedCallback cleared the timer, so it never fires; leave the
+    // element mounted and this is 1, in a test that never asked for it.
+    await nodeDelay(LEAK_DELAY_MS * 4);
+    expect(lateUpdates.count).toBe(0);
+  });
+
+  it("leaves a pending fake timer behind", () => {
+    vi.useFakeTimers();
+    setTimeout(() => drained.push("armed-under-fake-timers"), 5_000);
+
+    expect(drained).toEqual([]);
+    // Deliberately neither advanced nor restored: vi.useRealTimers() discards
+    // the fake clock, so without the hook's drain this callback never runs.
+  });
+
+  it("drained it and handed control back to real timers", async () => {
+    expect(drained).toEqual(["armed-under-fake-timers"]);
+    expect(vi.isFakeTimers()).toBe(false);
+    // Would hang if fake timers were still installed.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  });
+});

--- a/tests/client/_teardown/LeakyElement.ts
+++ b/tests/client/_teardown/LeakyElement.ts
@@ -1,0 +1,56 @@
+import { html, LitElement } from "lit";
+import { customElement, state } from "lit/decorators.js";
+
+/**
+ * A deliberately leaky component, used only to prove that the global DOM
+ * teardown in tests/domTeardown.ts catches the pattern: a component arms work
+ * on connect, a test leaves it mounted, and the work lands later and writes
+ * reactive state, which makes Lit render.
+ *
+ * The shape is DesktopDisplay's settle ceiling, which is what was left armed by
+ * the tests that made main red on 11 Sept.
+ */
+
+/**
+ * Short on purpose, so the control test can wait the timer out inside the file
+ * and assert it never fired. What matters is that it outlives the TEST, not
+ * that it outlives the run.
+ */
+export const LEAK_DELAY_MS = 25;
+
+/** How many late updates actually reached the component, across the file. */
+export const lateUpdates = { count: 0 };
+
+@customElement("teardown-leaker")
+export class TeardownLeaker extends LitElement {
+  @state() private ticks = 0;
+  private timer: ReturnType<typeof setTimeout> | undefined;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    this.timer = setTimeout(() => {
+      lateUpdates.count++;
+      // Writing @state is what schedules the render below.
+      this.ticks++;
+    }, LEAK_DELAY_MS);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    clearTimeout(this.timer);
+    this.timer = undefined;
+  }
+
+  render() {
+    // Reads a global Vitest deletes when it tears the file's jsdom down. In
+    // production code the same read is indirect --
+    // translateText() -> getCachedLangSelector() -> document.querySelector.
+    return html`<span>${document.body.childElementCount}/${this.ticks}</span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "teardown-leaker": TeardownLeaker;
+  }
+}

--- a/tests/client/_teardown/LeakyElement.ts
+++ b/tests/client/_teardown/LeakyElement.ts
@@ -21,6 +21,9 @@ export const LEAK_DELAY_MS = 25;
 /** How many late updates actually reached the component, across the file. */
 export const lateUpdates = { count: 0 };
 
+/** How many times disconnectedCallback has run, across the file. */
+export const disconnects = { count: 0 };
+
 @customElement("teardown-leaker")
 export class TeardownLeaker extends LitElement {
   @state() private ticks = 0;
@@ -37,6 +40,7 @@ export class TeardownLeaker extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    disconnects.count++;
     clearTimeout(this.timer);
     this.timer = undefined;
   }

--- a/tests/domTeardown.ts
+++ b/tests/domTeardown.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, vi } from "vitest";
+import { afterAll, afterEach, beforeEach, vi } from "vitest";
 
 /**
  * Per-test DOM teardown for the jsdom environment. Imported for its side
@@ -7,50 +7,91 @@ import { afterEach, beforeEach, vi } from "vitest";
  * WHY THIS EXISTS
  *
  * Nothing removes an element from document.body when a test ends, so a
- * component a test mounted is still connected for every test after it -- and
- * still holds whatever it armed on connect: a timer, a subscription, a pending
- * Lit update. The next test starts with someone else's DOM, and that timer
- * fires into it.
+ * component a test mounted stays connected for every test after it, and keeps
+ * whatever it armed on connect: a timer, a subscription, a pending Lit update.
+ * disconnectedCallback -- where components clear exactly those things -- never
+ * runs. Removing the element while the document still exists is what runs it.
  *
- * The same missing disconnectedCallback is behind the CI failures on 11 Sept
- * (#5357, #5360), where a Lit update landed after the file's environment was
- * gone and threw "ReferenceError: document is not defined" / "window is not
- * defined" from translateText and Platform. Those were fixed by guarding the
- * two call sites; both PRs said the pattern itself was still there. This is
- * that fix.
+ * The expensive version of that is the CI failure on 11 Sept (#5357, #5360): a
+ * leaked timer fires, writes @state, Lit schedules an update, and the update
+ * lands after the file's environment is gone --
  *
- * Removing the element while the document still exists runs
- * disconnectedCallback, which is where components clear their timers and
- * unsubscribe. Doing it here means no test file has to remember.
+ *   ReferenceError: document is not defined
+ *    at getCachedLangSelector src/client/Utils.ts
+ *    at UserSettingModal.willUpdate / performUpdate  (lit reactive-element)
+ *    at processTicksAndRejections
  *
- * Scope note, measured rather than assumed: on Vitest 4.1.5 the post-teardown
- * escape is narrow. The jsdom teardown calls `dom.window.close()`, which stops
- * every timer jsdom owns, and the default forks pool gives each file its own
- * child process that exits at the end of the file. Reverting #5357's guard and
- * running the whole suite with this hook disabled produced no unhandled
- * rejection. The within-file leak is the part that reproduces on demand, and
- * it is the part worth being strict about.
+ * -- which fails the run on an unhandled rejection with every test passing.
+ * Both PRs guarded their call site and said the pattern itself was still there.
+ * This is the pattern.
+ *
+ * HOW THE UPDATE GETS PAST THE ENVIRONMENT TEARDOWN
+ *
+ * Worth spelling out, because two plausible-sounding reasons it "cannot happen"
+ * are both wrong, and were checked against the installed Vitest (4.1.5) rather
+ * than assumed.
+ *
+ * 1. The leaked timer is a NODE timer, not a jsdom one, so `dom.window.close()`
+ *    does not cancel it. Vitest's `populateGlobal` only copies a window
+ *    property onto the global if the name is absent from Node's global or
+ *    appears in its own KEYS list (`getWindowKeys` in
+ *    node_modules/vitest/dist/chunks/index.DC7d2Pf8.js). `setTimeout` is on
+ *    Node's global and is not in KEYS, so `globalThis.setTimeout` stays Node's.
+ *    Measured: `globalThis.setTimeout === require("timers").setTimeout` is
+ *    true inside a jsdom test.
+ * 2. The worker does not die with the file. After the last test the environment
+ *    teardown deletes `document` and the other window keys from the global, and
+ *    the process then stays alive and keeps servicing Node timers until the
+ *    main process kills it (`cli-api.Cjt90eJu.js`). Measured with a 1 ms
+ *    interval logging `typeof document` under `--coverage`: `object` up to
+ *    +37 ms, then `undefined` at +41 ms and +47 ms, still running. That
+ *    document-less window is ~10 ms on this machine and longer on a loaded CI
+ *    runner with coverage on, which is why the failure reads as intermittent
+ *    and CI-only.
+ *
+ * So the settle ceiling at src/client/UserSettingModal.ts:781 -- 2 s, armed on
+ * every display write -- genuinely can land in that window. Disconnecting the
+ * element clears it before it ever gets there.
+ *
+ * #5357's guard in src/client/Utils.ts stays. This closes the door; that guard
+ * is defence in depth for anything that finds another way through.
  *
  * WHAT IT REMOVES
  *
- * Only elements added to document.body DURING the test. Anything already there
- * when the test started -- a fixture mounted in beforeAll, page scaffolding a
- * file sets up once -- is left alone, so files that mount once and reuse the
- * element across tests keep working.
+ * After each test: every element added to document.body DURING that test.
+ * Anything already there when the test started -- a beforeAll fixture, page
+ * scaffolding a file sets up once -- is left alone, so files that mount once
+ * and reuse the element across tests keep working.
  *
- * HOOK ORDER (verified empirically, see below)
+ * After the file: everything still in document.body, which is how those
+ * beforeAll fixtures get their disconnectedCallback (ten client files mount
+ * that way, e.g. tests/client/GameStatsModal.test.ts).
  *
- * Vitest runs afterEach hooks LIFO within a file. Setup-file hooks are
- * registered before any hook a test file registers, so this afterEach runs
- * LAST: a test file's own afterEach still sees everything it mounted, can
- * assert on it, and can do its own cleanup first. beforeEach is the mirror
- * image -- FIFO, so the snapshot below is taken before a file's own beforeEach
- * mounts anything, which is why elements mounted in a file's beforeEach count
- * as "added during the test".
+ * HOOK ORDER (verified empirically)
  *
- * tests/client/_teardown/GlobalDomTeardown.test.ts pins that ordering: it
- * records, from a file-level afterEach, whether the element it mounted is
- * still in the document, and fails if this hook ever runs first.
+ * Vitest runs afterEach and afterAll LIFO within a file. Setup-file hooks are
+ * registered before any hook a test file registers, so these run LAST: a test
+ * file's own hooks still see everything they mounted, can assert on it, and can
+ * clean up first. beforeEach is the mirror image -- FIFO, so the snapshot below
+ * is taken before a file's own beforeEach mounts anything, which is why
+ * elements mounted in a file's beforeEach count as "added during the test".
+ *
+ * tests/client/_teardown/GlobalDomTeardown.test.ts pins the afterEach half of
+ * that ordering. The afterAll half is deliberately NOT asserted from a test
+ * file: being last is the whole point, so nothing inside the file runs after it
+ * to observe it. `removeAndSettle` is exported and tested directly instead.
+ *
+ * KNOWN LIMITS
+ *
+ * - Only direct children of document.body are tracked. An element appended
+ *   into a container that already existed, or into document.head, is not
+ *   removed by the afterEach -- though the afterAll sweep does take the
+ *   container itself, and with it everything inside.
+ * - Files running under the node environment (`@vitest-environment node`) have
+ *   no document, so they skip all of this, including the fake-timer drain.
+ * - Nothing here unsubscribes a component that only cleans up on an explicit
+ *   close()/dispose() rather than on disconnect. Those still need their own
+ *   afterEach.
  */
 
 /** An element that may be mid-update, e.g. any LitElement. */
@@ -63,9 +104,19 @@ function hasDom(): boolean {
 }
 
 /**
- * Let any update already scheduled on the removed elements run while the
- * document still exists. disconnectedCallback itself can schedule one.
+ * Remove each element and let any update already scheduled on it run while the
+ * document still exists -- disconnectedCallback itself can schedule one.
+ *
+ * Exported so the behaviour can be asserted directly; see the hook-order note
+ * above for why the afterAll sweep cannot be observed from inside a test file.
  */
+export async function removeAndSettle(
+  elements: readonly Element[],
+): Promise<void> {
+  for (const element of elements) element.remove();
+  await settle(elements);
+}
+
 async function settle(elements: readonly Element[]): Promise<void> {
   for (const element of elements) {
     const pending = (element as MaybeUpdating).updateComplete;
@@ -86,8 +137,7 @@ afterEach(async () => {
   );
   preexisting = new Set();
 
-  for (const element of added) element.remove();
-  await settle(added);
+  await removeAndSettle(added);
 
   // Fake timers are only touched when they are STILL installed -- a test that
   // already called vi.useRealTimers() is left exactly as it left things.
@@ -110,4 +160,12 @@ afterEach(async () => {
     // The drain can have scheduled one more update on a disconnected element.
     await settle(added);
   }
+});
+
+// The afterEach deliberately spares anything mounted before the test started,
+// so a beforeAll fixture survives to here. This is its disconnectedCallback --
+// the last moment at which there is still a document to run it against.
+afterAll(async () => {
+  if (!hasDom()) return;
+  await removeAndSettle([...document.body.children]);
 });

--- a/tests/domTeardown.ts
+++ b/tests/domTeardown.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, vi } from "vitest";
+
+/**
+ * Per-test DOM teardown for the jsdom environment. Imported for its side
+ * effects by tests/setup.ts, so it applies to every test file.
+ *
+ * WHY THIS EXISTS
+ *
+ * Nothing removes an element from document.body when a test ends, so a
+ * component a test mounted is still connected for every test after it -- and
+ * still holds whatever it armed on connect: a timer, a subscription, a pending
+ * Lit update. The next test starts with someone else's DOM, and that timer
+ * fires into it.
+ *
+ * The same missing disconnectedCallback is behind the CI failures on 11 Sept
+ * (#5357, #5360), where a Lit update landed after the file's environment was
+ * gone and threw "ReferenceError: document is not defined" / "window is not
+ * defined" from translateText and Platform. Those were fixed by guarding the
+ * two call sites; both PRs said the pattern itself was still there. This is
+ * that fix.
+ *
+ * Removing the element while the document still exists runs
+ * disconnectedCallback, which is where components clear their timers and
+ * unsubscribe. Doing it here means no test file has to remember.
+ *
+ * Scope note, measured rather than assumed: on Vitest 4.1.5 the post-teardown
+ * escape is narrow. The jsdom teardown calls `dom.window.close()`, which stops
+ * every timer jsdom owns, and the default forks pool gives each file its own
+ * child process that exits at the end of the file. Reverting #5357's guard and
+ * running the whole suite with this hook disabled produced no unhandled
+ * rejection. The within-file leak is the part that reproduces on demand, and
+ * it is the part worth being strict about.
+ *
+ * WHAT IT REMOVES
+ *
+ * Only elements added to document.body DURING the test. Anything already there
+ * when the test started -- a fixture mounted in beforeAll, page scaffolding a
+ * file sets up once -- is left alone, so files that mount once and reuse the
+ * element across tests keep working.
+ *
+ * HOOK ORDER (verified empirically, see below)
+ *
+ * Vitest runs afterEach hooks LIFO within a file. Setup-file hooks are
+ * registered before any hook a test file registers, so this afterEach runs
+ * LAST: a test file's own afterEach still sees everything it mounted, can
+ * assert on it, and can do its own cleanup first. beforeEach is the mirror
+ * image -- FIFO, so the snapshot below is taken before a file's own beforeEach
+ * mounts anything, which is why elements mounted in a file's beforeEach count
+ * as "added during the test".
+ *
+ * tests/client/_teardown/GlobalDomTeardown.test.ts pins that ordering: it
+ * records, from a file-level afterEach, whether the element it mounted is
+ * still in the document, and fails if this hook ever runs first.
+ */
+
+/** An element that may be mid-update, e.g. any LitElement. */
+type MaybeUpdating = Element & { updateComplete?: unknown };
+
+let preexisting = new Set<Element>();
+
+function hasDom(): boolean {
+  return typeof document !== "undefined" && document.body !== null;
+}
+
+/**
+ * Let any update already scheduled on the removed elements run while the
+ * document still exists. disconnectedCallback itself can schedule one.
+ */
+async function settle(elements: readonly Element[]): Promise<void> {
+  for (const element of elements) {
+    const pending = (element as MaybeUpdating).updateComplete;
+    if (pending instanceof Promise) await pending;
+  }
+}
+
+beforeEach(() => {
+  if (!hasDom()) return;
+  preexisting = new Set(document.body.children);
+});
+
+afterEach(async () => {
+  if (!hasDom()) return;
+
+  const added = [...document.body.children].filter(
+    (element) => !preexisting.has(element),
+  );
+  preexisting = new Set();
+
+  for (const element of added) element.remove();
+  await settle(added);
+
+  // Fake timers are only touched when they are STILL installed -- a test that
+  // already called vi.useRealTimers() is left exactly as it left things.
+  //
+  // Draining first matters: vi.useRealTimers() discards the fake clock, so a
+  // timer the test armed and never ran would vanish without ever running. The
+  // elements are already disconnected at this point, so anything they armed
+  // has been cleared and what is left belongs to the test itself. Running it
+  // here keeps that work inside the test's own document.
+  if (vi.isFakeTimers()) {
+    try {
+      vi.runOnlyPendingTimers();
+    } catch {
+      // A pending callback that throws belongs to the test that armed it.
+      // Rethrowing from a global afterEach would pin it on whichever test
+      // happened to run last -- the exact misattribution this file exists to
+      // remove. Draining is the goal here, not asserting.
+    }
+    vi.useRealTimers();
+    // The drain can have scheduled one more update on a disconnected element.
+    await settle(added);
+  }
+});

--- a/tests/domTeardown.ts
+++ b/tests/domTeardown.ts
@@ -117,6 +117,33 @@ export async function removeAndSettle(
   await settle(elements);
 }
 
+/**
+ * Run whatever the test armed on the fake clock and hand control back to real
+ * timers. A no-op unless fake timers are STILL installed -- a test that already
+ * called vi.useRealTimers() is left exactly as it left things.
+ *
+ * Draining matters because vi.useRealTimers() discards the fake clock: a timer
+ * the test armed and never ran would otherwise vanish without ever running. By
+ * this point the elements are disconnected, so anything THEY armed has been
+ * cleared and what is left belongs to the test.
+ *
+ * A callback that throws propagates, after real timers are restored. It is the
+ * test's own code failing, and afterEach runs per test, so it fails the test
+ * that armed it rather than leaking into the next one -- swallowing it here
+ * would turn a genuine failure into a pass.
+ *
+ * Exported so that can be asserted directly: a hook that throws fails its test
+ * by design, which is not something a passing test can observe from the inside.
+ */
+export function drainFakeTimers(): void {
+  if (!vi.isFakeTimers()) return;
+  try {
+    vi.runOnlyPendingTimers();
+  } finally {
+    vi.useRealTimers();
+  }
+}
+
 async function settle(elements: readonly Element[]): Promise<void> {
   for (const element of elements) {
     const pending = (element as MaybeUpdating).updateComplete;
@@ -139,27 +166,17 @@ afterEach(async () => {
 
   await removeAndSettle(added);
 
-  // Fake timers are only touched when they are STILL installed -- a test that
-  // already called vi.useRealTimers() is left exactly as it left things.
-  //
-  // Draining first matters: vi.useRealTimers() discards the fake clock, so a
-  // timer the test armed and never ran would vanish without ever running. The
-  // elements are already disconnected at this point, so anything they armed
-  // has been cleared and what is left belongs to the test itself. Running it
-  // here keeps that work inside the test's own document.
-  if (vi.isFakeTimers()) {
-    try {
-      vi.runOnlyPendingTimers();
-    } catch {
-      // A pending callback that throws belongs to the test that armed it.
-      // Rethrowing from a global afterEach would pin it on whichever test
-      // happened to run last -- the exact misattribution this file exists to
-      // remove. Draining is the goal here, not asserting.
-    }
-    vi.useRealTimers();
-    // The drain can have scheduled one more update on a disconnected element.
-    await settle(added);
+  let drainFailure: { error: unknown } | null = null;
+  try {
+    drainFakeTimers();
+  } catch (error) {
+    drainFailure = { error };
   }
+  // The drain can have scheduled one more update on a disconnected element.
+  await settle(added);
+  // Held until the cleanup above has finished, then surfaced. afterEach runs
+  // per test, so this lands on the test that armed the timer.
+  if (drainFailure) throw drainFailure.error;
 });
 
 // The afterEach deliberately spares anything mounted before the test started,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,5 +1,9 @@
 // Add global mocks or configuration here if needed
 import "vitest-canvas-mock";
+// Registers the per-test DOM teardown. Imported here, and not from individual
+// test files, so its hooks are registered before any test file's own -- see the
+// hook-order note in that file.
+import "./domTeardown";
 
 // ServerEnv.gitCommit() throws when unset; the dev server sets GIT_COMMIT=DEV,
 // so tests exercising server code (e.g. the lobby feed) mirror that.


### PR DESCRIPTION
## Description:

Nothing removed an element from `document.body` when a test ended, so a component a test mounted stayed connected for every test after it, still holding whatever it armed on connect — and `disconnectedCallback`, where components clear exactly those things, never ran. That is the shape behind the CI failures on 11 Sept: a leaked settle timer fires, writes `@state`, lit schedules an update, and the update lands after the file's environment has been torn down, throwing `ReferenceError: document is not defined` from `getCachedLangSelector` (#5357) and `window is not defined` from `Platform` (#5360) — failing the run on an unhandled rejection with every test passing. Both of those guarded a call site and said the pattern itself was still there; this is the pattern.

### How the update gets past the environment teardown

Worth spelling out, because two plausible reasons it "cannot happen" are both wrong. Checked against the installed Vitest (4.1.5), not assumed:

1. **The leaked timer is a Node timer, not a jsdom one**, so `dom.window.close()` does not cancel it. Vitest's `populateGlobal` only copies a window property onto the global when the name is absent from Node's global or appears in its own `KEYS` list (`getWindowKeys`, `vitest/dist/chunks/index.DC7d2Pf8.js`). `setTimeout` is on Node's global and is not in `KEYS`. Measured inside a jsdom test: `globalThis.setTimeout === require("timers").setTimeout` is `true`.
2. **The worker does not die with the file.** After the last test the environment teardown deletes `document` and the other window keys, and the process then stays alive servicing Node timers until the main process kills it. Measured with a 1 ms interval logging `typeof document` under `--coverage`: `object` up to +37 ms, then `undefined` at +41 ms and +47 ms, still running.

That document-less window is ~10 ms on this machine and wider on a loaded CI runner with coverage on — which is why the failure read as intermittent and CI-only. The 2 s settle ceiling armed on every display write (`UserSettingModal.ts:781`) genuinely can land in it.

### What the hook does

`tests/domTeardown.ts`, imported by `tests/setup.ts`:

- **`beforeEach`** snapshots `document.body.children`.
- **`afterEach`** removes every element added *during* the test, awaits `updateComplete` on each, and — only if `vi.isFakeTimers()` is still true — drains pending timers and restores real ones. A test that already called `vi.useRealTimers()` is left exactly as it left things.
- **`afterAll`** sweeps whatever is left, which is how a `beforeAll` fixture gets its `disconnectedCallback` (ten client files mount that way).

Registering it from the setup file is load-bearing: Vitest runs `afterEach`/`afterAll` LIFO within a file and setup-file hooks register first, so these run **last** and a file's own hooks still see everything they mounted. `beforeEach` is the mirror image — FIFO — which is why elements mounted in a file's `beforeEach` count as added during the test.

**Limits, documented in the file:** only direct children of `document.body` are tracked, so an element appended into a pre-existing container or into `document.head` is not removed by the `afterEach` (the `afterAll` sweep does take the container, and with it everything inside); node-environment files have no document and skip all of it, including the fake-timer drain; and a component that only cleans up on an explicit `close()`/`dispose()` still needs its own `afterEach`.

### Proof it catches the pattern

`tests/client/_teardown/` holds a deliberately leaky component and the control for the hook.

- With the hook: 8/8 pass.
- With the `afterEach` disabled: 3 of those fail — the element is still in `document.body` for the next test, its timer fires into a test that never asked for it, and the fake timer is never drained — **and 18 of 21 tests in `UserSettingModal.graphics.test.ts` fail**, since that file's own copy of this cleanup was removed in favour of the global one.

The tests deliberately do not try to reproduce the post-teardown rejection itself: the window is ~10 ms wide and only catches a timer that happens to land inside it, which is exactly why it was a flake rather than a reliable failure. They pin the deterministic half instead. The `afterAll` sweep cannot be observed from inside a test file — running last is the point — so `removeAndSettle` is exported and asserted directly, alongside a test that the per-test hook *spares* a `beforeAll` fixture.

### Ad-hoc teardown removed

Now redundant, one file at a time: `UserSettingModal.display.test.ts`, `UserSettingModal.graphics.test.ts` (the whole `mounted`/`unmountAll` helper), `GameRightSidebar.fullscreen.test.ts`, `InGameSettingsMenu.test.ts`. Each keeps the part that undoes its own globals and mocks — that is not hygiene, that is the test. No file needed fixing to mount per test.

### Keep #5357's guard

It stays, and this does not make it dead code: it is defence in depth for anything that finds another way into that window. It can be revisited separately once this has been on `main` for a while.

### Verification

- `npm run test:coverage` (CI's command): 5482 passed, **no unhandled errors**. Three files flaked on 5 s/20 s timeouts — `InventoryModal`, `MainInitialize` and `MapConsistency`, the last of which does file I/O and touches no DOM. All three pass when run alone, and `InventoryModal` fails identically with this hook disabled; this box was running other work.
- Runtime, back-to-back on `tests/client`: 134.2 s with the hook, 152.2 s without. No measurable cost.
- `npx tsc --noEmit`, `npm run lint`, `npx prettier --check` — clean.
- No production code changed.

Resolves OPE-422 — https://linear.app/openfront/issue/OPE-422

## Please complete the following:

- [x] I have added screenshots for all UI updates — n/a, no UI change
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file — n/a, no user-facing text
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

jish

🤖 Generated with [Claude Code](https://claude.com/claude-code)
