### PR TITLE
Pipeline: upload an environment-only page and desktop descriptor per version, then flag it as latest (OPE-433)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,8 @@ tests/perf/output/
 # Locally built Go binary (gen-maps uses `go run .`)
 map-generator/map-generator
 map-generator/map-generator.exe
+
+# Staging dir tests/RenderDesktopDescriptor.test.ts creates in the repo root
+# (it needs the CLI copy at the same relative depth as the real one). Cleaned
+# up after each case; ignored so a crashed run cannot dirty the tree.
+.tmp-desktop-cli-*

--- a/deploy.sh
+++ b/deploy.sh
@@ -236,6 +236,11 @@ fi
 # when multiple deployments are happening at the same time.
 ENV_FILE="${REMOTE_UPDATE_PATH}/${SUBDOMAIN}-${RANDOM}.env"
 
+# CLUSTER_STATE_SOURCE is passed through unset (empty) until the API's server
+# registry is live. Setting it to "api" for a site says its clients get their
+# server list from the API rather than from the page, which is what makes
+# update.sh treat a failure to flag this version as `latest` as a failed deploy
+# rather than a warning — see flag_latest there and docs/MultiServer.md.
 print_header "EXECUTING UPDATE SCRIPT ON SERVER"
 
 ssh -i $SSH_KEY $REMOTE_USER@$SERVER_HOST "chmod +x $REMOTE_UPDATE_SCRIPT && \
@@ -250,6 +255,7 @@ ADMIN_BOT_API_KEY=$ADMIN_BOT_API_KEY
 DOMAIN=$DOMAIN
 SUBDOMAIN=$SUBDOMAIN
 SITE_HOST=$SITE_HOST
+CLUSTER_STATE_SOURCE=$CLUSTER_STATE_SOURCE
 CDN_BASE=$CDN_BASE
 CLUSTER_JSON=$CLUSTER_JSON
 TURNSTILE_SITE_KEY=$TURNSTILE_SITE_KEY

--- a/deploy.sh
+++ b/deploy.sh
@@ -236,11 +236,6 @@ fi
 # when multiple deployments are happening at the same time.
 ENV_FILE="${REMOTE_UPDATE_PATH}/${SUBDOMAIN}-${RANDOM}.env"
 
-# CLUSTER_STATE_SOURCE is passed through unset (empty) until the API's server
-# registry is live. Setting it to "api" for a site says its clients get their
-# server list from the API rather than from the page, which is what makes
-# update.sh treat a failure to flag this version as `latest` as a failed deploy
-# rather than a warning — see flag_latest there and docs/MultiServer.md.
 print_header "EXECUTING UPDATE SCRIPT ON SERVER"
 
 ssh -i $SSH_KEY $REMOTE_USER@$SERVER_HOST "chmod +x $REMOTE_UPDATE_SCRIPT && \
@@ -255,7 +250,6 @@ ADMIN_BOT_API_KEY=$ADMIN_BOT_API_KEY
 DOMAIN=$DOMAIN
 SUBDOMAIN=$SUBDOMAIN
 SITE_HOST=$SITE_HOST
-CLUSTER_STATE_SOURCE=$CLUSTER_STATE_SOURCE
 CDN_BASE=$CDN_BASE
 CLUSTER_JSON=$CLUSTER_JSON
 TURNSTILE_SITE_KEY=$TURNSTILE_SITE_KEY

--- a/docs/MultiServer.md
+++ b/docs/MultiServer.md
@@ -330,3 +330,63 @@ wait for games to end), then delete its cluster entries and its
   append-only forever, numWorkers immutable while a letter has live games,
   and membership ≠ liveness (a flapping health check must never shrink the
   map — removal stays drain-then-delete).
+
+## Publish pipeline (v2)
+
+Written while PR #5365 ("Server list v2") was still open; fold this into
+roadmap item 4 of that section once it merges.
+
+Every deploy already uploads the build's hashed assets to R2 and a
+fully-rendered `index-<short>.html` replay shell next to them. `update.sh`
+now also publishes, per **site** and per **version**, the three objects the
+static Worker will serve. The site is `SITE_HOST` when the deployment sits
+behind a load balancer, else `<subdomain>.<domain>`; the version is the
+7-character prefix of `static/commit.txt`. All four uploads go through
+`PUT $R2_ENDPOINT/game_assets/upload/<urlencoded key>`, which prefixes
+`game_assets/`:
+
+| Object                                        | Rendered by                                    |
+| --------------------------------------------- | ---------------------------------------------- |
+| `sites/<site>/v/<short>/index.html`           | `RenderStaticIndex.ts --environment-only`      |
+| `sites/<site>/v/<short>/desktop/release.json` | `RenderDesktopDescriptor.ts`                   |
+| `sites/<site>/v/<short>/desktop/version.json` | `RenderDesktopDescriptor.ts --version-pointer` |
+
+Both renderers run inside the freshly built image with the live container's
+env file, exactly as the replay shell already does, so what is published is
+what that build's server would itself have produced.
+
+**The page carries no server.** `renderHtmlContent(path, { perServer: false })`
+omits `cluster`, `instanceLetter`, `instanceId`, `serverHost` and `siteHost`;
+`index.html` guards those lines the way it already guarded `serverHost`, so a
+render that supplies them is byte-for-byte what it always was. That is what
+lets one page be cached and served to every player of a version — the client
+asks the API which server to use. The legacy `index-<short>.html` upload keeps
+the server values until OPE-431 lands, because today's client throws without a
+worker-count source.
+
+**The descriptors move earlier, not elsewhere.** `release.json` and
+`version.json` are the same objects `/desktop/*.json` serves today, from the
+same `buildDescriptor`; publishing them per version lets the Worker answer for
+a site with no game server reachable, and makes a rollback a pointer flip.
+`release.json`'s `template.html` is the raw EJS template by design: the Steam
+shell renders it itself.
+
+**Flagging `latest`.** After the new container is running, `update.sh` calls
+`POST $R2_ENDPOINT/cluster/latest` with `{ site, version }` (version is the
+full sha). The API refuses a version no server has checked in for, so a `409`
+right after `docker run` is expected and is retried every 5s for up to 90s —
+servers register within ~10s of boot. Outcomes:
+
+- `200` — logged, done.
+- `404` — the API predates the registry; warn and continue.
+- `409` (or an unreachable API) after the retries — warn and continue, because
+  the page and its servers still come from `BOOTSTRAP_CONFIG` and nothing a
+  player sees has changed. **Unless** `CLUSTER_STATE_SOURCE=api` is in the
+  site's env file, which says its clients take the server list from the API: an
+  unflagged version then means no server is `open` and nobody can start a game,
+  so the deploy fails rather than reporting a success it did not achieve.
+
+Until the Worker exists nothing reads any of this, so the uploads are additive
+and prod is unaffected. The decision table above is unit-tested in
+`tests/UpdateFlagLatest.test.ts`, which extracts the real function out of
+`update.sh` and drives it with a scripted `curl`.

--- a/docs/MultiServer.md
+++ b/docs/MultiServer.md
@@ -385,6 +385,8 @@ servers register within ~10s of boot. Outcomes:
   site's env file, which says its clients take the server list from the API: an
   unflagged version then means no server is `open` and nobody can start a game,
   so the deploy fails rather than reporting a success it did not achieve.
+  `deploy.sh` gains the passthrough for that variable separately (roadmap item
+  3); until it does, it is always absent, which is the lenient path above.
 
 Until the Worker exists nothing reads any of this, so the uploads are additive
 and prod is unaffected. The decision table above is unit-tested in

--- a/docs/MultiServer.md
+++ b/docs/MultiServer.md
@@ -377,8 +377,11 @@ full sha). The API refuses a version no server has checked in for, so a `409`
 right after `docker run` is expected and is retried every 5s for up to 90s —
 servers register within ~10s of boot. Outcomes:
 
-- `200` — logged, done.
+- `200` / `204` — logged, done.
 - `404` — the API predates the registry; warn and continue.
+- `400` / `401` / `403` — a bad key or a malformed request. No retry can fix
+  it, so it is decided at once on the same terms as the row below: warn and
+  continue, or fail under `CLUSTER_STATE_SOURCE=api`.
 - `409` (or an unreachable API) after the retries — warn and continue, because
   the page and its servers still come from `BOOTSTRAP_CONFIG` and nothing a
   player sees has changed. **Unless** `CLUSTER_STATE_SOURCE=api` is in the

--- a/index.html
+++ b/index.html
@@ -113,18 +113,30 @@
     <meta property="og:image" content="<%- gameplayScreenshotUrl %>" />
     <meta property="og:type" content="game" />
 
-    <!-- Injected from Server env -->
+    <!--
+      Injected from Server env.
+
+      Every per-server value (cluster, instanceLetter, instanceId, serverHost,
+      siteHost) is emitted through a guard so the whole line — indentation and
+      trailing comma included — disappears when the renderer does not supply
+      it. That is what lets one page be rendered per VERSION rather than per
+      server and uploaded to the CDN (docs/MultiServer.md, "Publish pipeline
+      (v2)"); a game server supplies them all and gets exactly the page it
+      always served.
+
+      Never add a placeholder the Steam shell does not supply: openfront-desktop
+      renders this same template itself and a missing local is a ReferenceError,
+      i.e. a blank window. Guarding an existing one is safe — the shell supplies
+      a value and the line still emits.
+    -->
     <script>
       window.BOOTSTRAP_CONFIG = {
         gitCommit: <%- gitCommit %>,
         assetManifest: <%- assetManifest %>,
         cdnBase: <%- cdnBase %>,
-        gameEnv: <%- gameEnv %>,
-        cluster: <%- cluster %>,
-        instanceLetter: <%- instanceLetter %>,
+        gameEnv: <%- gameEnv %>,<%- typeof cluster !== "undefined" && cluster ? "\n        cluster: " + cluster + "," : "" %><%- typeof instanceLetter !== "undefined" && instanceLetter ? "\n        instanceLetter: " + instanceLetter + "," : "" %>
         turnstileSiteKey: <%- turnstileSiteKey %>,
-        jwtAudience: <%- jwtAudience %>,
-        instanceId: <%- instanceId %>,<%- typeof serverHost !== "undefined" && serverHost ? "\n        serverHost: " + serverHost + "," : "" %><%- typeof siteHost !== "undefined" && siteHost ? "\n        siteHost: " + siteHost + "," : "" %>
+        jwtAudience: <%- jwtAudience %>,<%- typeof instanceId !== "undefined" && instanceId ? "\n        instanceId: " + instanceId + "," : "" %><%- typeof serverHost !== "undefined" && serverHost ? "\n        serverHost: " + serverHost + "," : "" %><%- typeof siteHost !== "undefined" && siteHost ? "\n        siteHost: " + siteHost + "," : "" %>
       };
       document.documentElement.style.setProperty(
         "--background-image-url",

--- a/src/server/RenderDesktopDescriptor.ts
+++ b/src/server/RenderDesktopDescriptor.ts
@@ -1,0 +1,84 @@
+// Builds the desktop (Steam) release descriptor at DEPLOY time and writes it to
+// stdout, so update.sh can upload it alongside the version's page as
+// sites/<site>/v/<short>/desktop/release.json (and version.json with
+// --version-pointer).
+//
+// Today the game server builds this per request from its own static/ directory
+// (src/server/Master.ts, /desktop/*.json). Uploading it per version is what
+// lets the static Worker answer /desktop/*.json for a site without any game
+// server being reachable, and what makes a rollback a pointer flip rather than
+// a redeploy. Same buildDescriptor, same inputs, same env vars as the server —
+// this is the identical descriptor, computed one deploy earlier.
+//
+// Run inside the freshly built image with the live container's env file, the
+// same way RenderStaticIndex.ts is:
+//
+//   npx tsx src/server/RenderDesktopDescriptor.ts
+//   npx tsx src/server/RenderDesktopDescriptor.ts --version-pointer
+//
+// clientVersion is GIT_COMMIT (the full sha baked into the image) rather than
+// static/commit.txt, so it is the value the server would report for itself.
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const VERSION_POINTER = "--version-pointer";
+
+const args = process.argv.slice(2);
+const unknown = args.filter((a) => a !== VERSION_POINTER);
+if (unknown.length > 0) {
+  console.error(
+    `Unknown argument(s): ${unknown.join(" ")}. Usage: RenderDesktopDescriptor.ts [${VERSION_POINTER}]`,
+  );
+  process.exit(2);
+}
+const pointerOnly = args.includes(VERSION_POINTER);
+
+// stdout is this program's DATA channel: whatever lands there is uploaded
+// verbatim as release.json. Several things on the import path below write to
+// it as if it were a log — dotenv's "injected env" banner and Logger.ts's OTEL
+// line at module evaluation, and winston's Console transport (which defaults to
+// stdout for every level) if buildDescriptor warns about an empty cdnBase. Any
+// one of them prefixes the JSON with prose and publishes a descriptor no Steam
+// client can parse.
+//
+// So: send everything that thinks it is logging to stderr, and keep the real
+// stdout for the payload. This has to happen before DesktopRelease is loaded,
+// which is why that import is dynamic — a static one would be hoisted above
+// these statements, and prettier-plugin-organize-imports would reorder it
+// anyway.
+const writeOut = process.stdout.write.bind(process.stdout);
+process.stdout.write = process.stderr.write.bind(
+  process.stderr,
+) as typeof process.stdout.write;
+
+const [{ GameEnv }, { buildDescriptor }, { ServerEnv }] = await Promise.all([
+  import("../core/configuration/Config"),
+  import("./DesktopRelease"),
+  import("./ServerEnv"),
+]);
+
+try {
+  const descriptor = await buildDescriptor(
+    path.join(__dirname, "../../static"),
+    {
+      clientVersion: ServerEnv.gitCommit(),
+      cdnBase: ServerEnv.cdnBase(),
+      // Same rule as Master.ts's descriptorOpts: production must have a CDN, or
+      // the descriptor would send every Steam client to the app server for
+      // ~570MB of assets. Failing here fails the DEPLOY, which is the point.
+      requireCdnBase: ServerEnv.env() === GameEnv.Prod,
+    },
+  );
+  const out = pointerOnly
+    ? {
+        clientVersion: descriptor.clientVersion,
+        coreVersion: descriptor.coreVersion,
+      }
+    : descriptor;
+  writeOut(JSON.stringify(out));
+} catch (error) {
+  console.error("Failed to build desktop release descriptor:", error);
+  process.exit(1);
+}

--- a/src/server/RenderHtml.ts
+++ b/src/server/RenderHtml.ts
@@ -11,11 +11,68 @@ const APP_SHELL_CACHE_CONTROL =
 
 const appShellContentCache = new Map<string, Promise<string>>();
 
-export async function renderHtmlContent(htmlPath: string): Promise<string> {
+export interface RenderHtmlOptions {
+  /**
+   * Inject the values that only make sense for ONE running server: `cluster`,
+   * `instanceLetter`, `instanceId`, `serverHost`, `siteHost`.
+   *
+   * True (the default) is what a game server serves and what the legacy
+   * `index-<short>.html` replay shell is rendered with — byte-for-byte what
+   * this function has always produced.
+   *
+   * False produces an environment-only page: everything that depends on the
+   * BUILD and the ENVIRONMENT (gitCommit, assetManifest, cdnBase, gameEnv,
+   * turnstileSiteKey, jwtAudience) and nothing that depends on which server
+   * happens to render it. That page is uploaded once per version to
+   * `sites/<site>/v/<short>/index.html` and served by the static Worker to
+   * every player of that version, which is only sound if it names no server —
+   * the client asks the API for the server list instead (see
+   * docs/MultiServer.md, "Server list v2").
+   *
+   * Rendering with perServer false also avoids reading CLUSTER_JSON at all, so
+   * the page can be produced without a valid cluster entry for this host.
+   */
+  perServer?: boolean;
+}
+
+export async function renderHtmlContent(
+  htmlPath: string,
+  opts: RenderHtmlOptions = {},
+): Promise<string> {
+  const perServer = opts.perServer ?? true;
   const htmlContent = await fs.readFile(htmlPath, "utf-8");
   const assetManifest = await getRuntimeAssetManifest();
   const cdnBase = ServerEnv.cdnBase();
+  // Omitted entirely (not set to a falsy string) when perServer is false: the
+  // template guards each of these with `typeof x !== "undefined" && x`, so an
+  // absent local drops the whole line, indentation and trailing comma
+  // included.
+  const perServerLocals = perServer
+    ? {
+        // The fleet map plus which entry is this server. Replaces the old
+        // numWorkers scalar: the client derives its own-server worker count
+        // from cluster[instanceLetter], and (PR 5) routes foreign game ids by
+        // their leading letter.
+        cluster: JSON.stringify(ServerEnv.cluster()),
+        instanceLetter: JSON.stringify(ServerEnv.instanceLetter()),
+        instanceId: JSON.stringify(ServerEnv.instanceId()),
+        serverHost:
+          ServerEnv.publicHost() === undefined
+            ? undefined
+            : JSON.stringify(ServerEnv.publicHost()),
+        // The load-balancer apex, when this deployment sits behind one. The
+        // client uses it as the unknown-letter redirect target — the apex shell
+        // always carries the freshest cluster map. Absent for standalone
+        // deployments (beta, branch previews, dev), which have no apex to
+        // bounce to and fall through to their normal not-found flow.
+        siteHost:
+          ServerEnv.siteHost() === undefined
+            ? undefined
+            : JSON.stringify(ServerEnv.siteHost()),
+      }
+    : {};
   return ejs.render(htmlContent, {
+    ...perServerLocals,
     gitCommit: JSON.stringify(ServerEnv.gitCommit()),
     assetManifest: JSON.stringify(assetManifest),
     cdnBase: JSON.stringify(cdnBase),
@@ -25,28 +82,8 @@ export async function renderHtmlContent(htmlPath: string): Promise<string> {
     // refs to use this placeholder.
     cdnBaseRaw: cdnBase,
     gameEnv: JSON.stringify(ServerEnv.gameEnvName()),
-    // The fleet map plus which entry is this server. Replaces the old
-    // numWorkers scalar: the client derives its own-server worker count from
-    // cluster[instanceLetter], and (PR 5) routes foreign game ids by their
-    // leading letter.
-    cluster: JSON.stringify(ServerEnv.cluster()),
-    instanceLetter: JSON.stringify(ServerEnv.instanceLetter()),
     turnstileSiteKey: JSON.stringify(ServerEnv.turnstileSiteKey()),
     jwtAudience: JSON.stringify(ServerEnv.jwtAudience()),
-    instanceId: JSON.stringify(ServerEnv.instanceId()),
-    serverHost:
-      ServerEnv.publicHost() === undefined
-        ? undefined
-        : JSON.stringify(ServerEnv.publicHost()),
-    // The load-balancer apex, when this deployment sits behind one. The
-    // client uses it as the unknown-letter redirect target — the apex shell
-    // always carries the freshest cluster map. Absent for standalone
-    // deployments (beta, branch previews, dev), which have no apex to
-    // bounce to and fall through to their normal not-found flow.
-    siteHost:
-      ServerEnv.siteHost() === undefined
-        ? undefined
-        : JSON.stringify(ServerEnv.siteHost()),
     manifestHref: buildAssetUrl("manifest.json", assetManifest, cdnBase),
     faviconHref: buildAssetUrl("images/Favicon.svg", assetManifest, cdnBase),
     gameplayScreenshotUrl: buildAssetUrl(

--- a/src/server/RenderStaticIndex.ts
+++ b/src/server/RenderStaticIndex.ts
@@ -3,13 +3,38 @@
 // this inside the freshly built image at deploy time and uploads the result to
 // the CDN as index-<short-commit>.html, so games archived from this build stay
 // replayable after the deployment itself is gone (#4934).
+//
+// With --environment-only it renders the same template WITHOUT the per-server
+// locals (cluster, instanceLetter, instanceId, serverHost, siteHost). That
+// page describes a build and an environment, not a server, so one copy can be
+// uploaded per version as sites/<site>/v/<short>/index.html and served to
+// every player on that version by the static Worker; the client asks the API
+// for the server list instead (docs/MultiServer.md, "Server list v2").
+//
+// The default is deliberately unchanged: the legacy index-<short>.html replay
+// shell still needs the server values, because today's client throws without a
+// worker-count source (fixed by OPE-431, not before).
 import path from "path";
 import { fileURLToPath } from "url";
 import { renderHtmlContent } from "./RenderHtml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
-renderHtmlContent(path.join(__dirname, "../../static/index.html")).then(
+const ENVIRONMENT_ONLY = "--environment-only";
+
+const args = process.argv.slice(2);
+const unknown = args.filter((a) => a !== ENVIRONMENT_ONLY);
+if (unknown.length > 0) {
+  console.error(
+    `Unknown argument(s): ${unknown.join(" ")}. Usage: RenderStaticIndex.ts [${ENVIRONMENT_ONLY}]`,
+  );
+  process.exit(2);
+}
+const perServer = !args.includes(ENVIRONMENT_ONLY);
+
+renderHtmlContent(path.join(__dirname, "../../static/index.html"), {
+  perServer,
+}).then(
   (html) => process.stdout.write(html),
   (error: unknown) => {
     console.error("Failed to render static index:", error);

--- a/tests/RenderDesktopDescriptor.test.ts
+++ b/tests/RenderDesktopDescriptor.test.ts
@@ -1,0 +1,205 @@
+import { spawnSync } from "child_process";
+import { createHash } from "crypto";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Every case spawns tsx in a child process — under a second on its own, but
+// well past the 5s default once the whole suite is running in parallel.
+vi.setConfig({ testTimeout: 120_000 });
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "..");
+const CLI = path.join(REPO_ROOT, "src/server/RenderDesktopDescriptor.ts");
+
+const TEMPLATE = "<html><%- cdnBase %></html>";
+const TEMPLATE_SHA = createHash("sha256").update(TEMPLATE).digest("hex");
+
+// The CLI resolves its static directory from its own __dirname
+// (`../../static`), which is the whole point — it is meant to be run inside the
+// built image where that directory is the build output. To exercise the real
+// file rather than a paraphrase of it, stage a copy at the same depth inside a
+// throwaway directory in the repo, with fixture `static/` next to it, and
+// repoint its three imports back at the real sources. Anything the shipped
+// file does — argument handling, which BuildOpts it passes, what it writes to
+// stdout — is what runs here; only where it looks for `static/` changes.
+//
+// Inside the repo rather than os.tmpdir() so the rewritten relative imports and
+// node_modules resolution both still work.
+function stage(staticFiles: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(REPO_ROOT, ".tmp-desktop-cli-"));
+  const serverDir = path.join(root, "src", "server");
+  fs.mkdirSync(serverDir, { recursive: true });
+  fs.mkdirSync(path.join(root, "static"), { recursive: true });
+
+  const source = fs
+    .readFileSync(CLI, "utf8")
+    // Rewrites both the static `from "./X"` form and the dynamic
+    // `import("./X")` form; `"../../static"` is deliberately left alone, since
+    // pointing the CLI at the fixture build output is the whole trick.
+    .replace(/"\.\/(\w+)"/g, '"../../../src/server/$1"')
+    .replace(/"\.\.\/core\//g, '"../../../src/core/');
+  fs.writeFileSync(path.join(serverDir, "RenderDesktopDescriptor.ts"), source);
+
+  for (const [name, content] of Object.entries(staticFiles)) {
+    fs.writeFileSync(path.join(root, "static", name), content);
+  }
+  return root;
+}
+
+const VALID_STATIC: Record<string, string> = {
+  "index.html": TEMPLATE,
+  "core-version.txt": "core-9\n",
+  "asset-manifest.json": JSON.stringify({
+    "images/a.png": "/_assets/images/a.deadbeef.png",
+  }),
+  "asset-hashes.json": JSON.stringify({
+    "_assets/images/a.deadbeef.png": { sha256: "f".repeat(64), bytes: 12 },
+    "assets/index-xyz.js": { sha256: "e".repeat(64), bytes: 34 },
+  }),
+};
+
+let staged: string | null = null;
+
+afterEach(() => {
+  if (staged) {
+    fs.rmSync(staged, { recursive: true, force: true });
+    staged = null;
+  }
+});
+
+interface RunResult {
+  status: number;
+  stdout: string;
+  stderr: string;
+}
+
+function run(
+  args: string[],
+  env: Record<string, string>,
+  staticFiles: Record<string, string> = VALID_STATIC,
+): RunResult {
+  staged = stage(staticFiles);
+  const entry = path.join(staged, "src/server/RenderDesktopDescriptor.ts");
+  const result = spawnSync(
+    process.execPath,
+    [path.join(REPO_ROOT, "node_modules/tsx/dist/cli.mjs"), entry, ...args],
+    {
+      cwd: REPO_ROOT,
+      encoding: "utf8",
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  if (result.error) throw result.error;
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+const STAGING_ENV = {
+  GAME_ENV: "staging",
+  GIT_COMMIT: "a".repeat(40),
+  CDN_BASE: "https://cdn.example",
+  DOMAIN: "openfront.dev",
+};
+
+describe("RenderDesktopDescriptor CLI", () => {
+  it("writes the release descriptor the server would serve", () => {
+    const result = run([], STAGING_ENV);
+
+    expect(result.status).toBe(0);
+    const d = JSON.parse(result.stdout);
+    expect(d.schemaVersion).toBe(1);
+    // clientVersion is GIT_COMMIT, not static/commit.txt: it has to be the
+    // value the running server reports for itself, because that is what the
+    // API's registry matches a flagged `latest` against.
+    expect(d.clientVersion).toBe("a".repeat(40));
+    expect(d.coreVersion).toBe("core-9");
+    expect(d.cdnBase).toBe("https://cdn.example");
+    // The raw EJS template, by design — the Steam shell renders it itself.
+    expect(d.template.html).toBe(TEMPLATE);
+    expect(d.template.sha256).toBe(TEMPLATE_SHA);
+    expect(d.assets["_assets/images/a.deadbeef.png"]).toEqual({
+      url: "/_assets/images/a.deadbeef.png",
+      sha256: "f".repeat(64),
+      bytes: 12,
+    });
+  });
+
+  // version.json is polled once a minute by every running desktop client, so
+  // it must stay the two fields and nothing else.
+  it("writes only the pointer with --version-pointer", () => {
+    const result = run(["--version-pointer"], STAGING_ENV);
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout)).toEqual({
+      clientVersion: "a".repeat(40),
+      coreVersion: "core-9",
+    });
+  });
+
+  // stdout is the data channel and several things on the import path write to
+  // it as if it were a log: dotenv's "injected env" banner, Logger.ts's OTEL
+  // line, and winston's Console transport (stdout for every level, including
+  // buildDescriptor's empty-cdnBase warning). Any of them would publish a
+  // release.json no Steam client can parse, so the CLI redirects the lot to
+  // stderr. This asserts both halves: stdout is only JSON, and the noise is
+  // still there to be read.
+  it("keeps log noise off stdout, on stderr", () => {
+    const result = run([], { ...STAGING_ENV, CDN_BASE: "" });
+
+    expect(result.stdout.startsWith("{")).toBe(true);
+    expect(result.stdout.trimEnd().endsWith("}")).toBe(true);
+    expect(() => JSON.parse(result.stdout)).not.toThrow();
+    expect(result.stderr).toContain("remote logging disabled");
+    // The winston warning buildDescriptor emits for an empty cdnBase.
+    expect(result.stderr).toContain("CDN_BASE is unset");
+  });
+
+  // Same rule as Master.ts's descriptorOpts. Failing here fails the deploy,
+  // which is the entire reason to build the descriptor before publishing it
+  // rather than after.
+  it("refuses to build a production descriptor with no CDN", () => {
+    const result = run([], {
+      ...STAGING_ENV,
+      GAME_ENV: "prod",
+      CDN_BASE: "",
+      DOMAIN: "openfront.io",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("CDN_BASE is unset");
+  });
+
+  it("allows an empty CDN outside production", () => {
+    const result = run([], { ...STAGING_ENV, CDN_BASE: "" });
+
+    expect(result.status).toBe(0);
+    expect(JSON.parse(result.stdout).cdnBase).toBe("");
+  });
+
+  // A broken build must stop the deploy rather than publish a descriptor the
+  // shell will reject on every Steam client.
+  it("exits non-zero when the build output is unusable", () => {
+    const result = run([], STAGING_ENV, {
+      ...VALID_STATIC,
+      "asset-hashes.json": JSON.stringify({}),
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Failed to build desktop release");
+  });
+
+  it("rejects an unrecognised argument instead of silently full-rendering", () => {
+    const result = run(["--pointer"], STAGING_ENV);
+
+    expect(result.status).toBe(2);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("--pointer");
+  });
+});

--- a/tests/UpdateFlagLatest.test.ts
+++ b/tests/UpdateFlagLatest.test.ts
@@ -49,6 +49,14 @@ interface Result {
  * Run the real flag_latest against a fake curl that hands back `codes` in
  * order, repeating the last one forever once they run out (which is how a
  * genuinely-stuck API behaves, and what the retry deadline has to end).
+ *
+ * Two entries model a curl that never got a status, and both EXIT NON-ZERO the
+ * way the real one does — a stub that always exits 0 cannot see how the caller
+ * fills in a fallback code, which is where the interesting bug lives:
+ *
+ *   "000"      — reached nothing (DNS, TLS, connect timeout). curl still
+ *                prints 000 via -w, then exits 6/7/28.
+ *   "nostatus" — died before writing anything at all.
  */
 function runFlagLatest(
   codes: string[],
@@ -82,8 +90,20 @@ while [ $# -gt 0 ]; do
   esac
 done
 echo "\${URL} \${DATA}" >> '${logFile}'
-printf 'scripted body for %s' "\${CODES[$idx]}" > "$OUT"
-printf '%s' "\${CODES[$idx]}"
+CODE="\${CODES[$idx]}"
+case "$CODE" in
+  nostatus)
+    # curl died before it could write a status or a body.
+    exit 7
+    ;;
+  000)
+    # curl reached nothing: -w still prints 000, and the exit is non-zero.
+    printf '000'
+    exit 7
+    ;;
+esac
+printf 'scripted body for %s' "$CODE" > "$OUT"
+printf '%s' "$CODE"
 `;
   const curlPath = path.join(binDir, "curl");
   fs.writeFileSync(curlPath, fakeCurl);
@@ -142,15 +162,38 @@ describe("update.sh flag_latest", () => {
     expect(result.output).toContain("Flagged abc123 as latest");
   });
 
-  it.each([["000"], ["500"], ["502"], ["503"]])(
-    "retries an unreachable or broken API (%s)",
-    (code) => {
-      const result = runFlagLatest([code, "200"]);
+  it.each([["500"], ["502"], ["503"]])("retries a broken API (%s)", (code) => {
+    const result = runFlagLatest([code, "200"]);
+
+    expect(result.status).toBe(0);
+    expect(result.requests).toHaveLength(2);
+  });
+
+  // The case the retry loop most needs to survive, and the one a stub that
+  // always exits 0 cannot reach. curl prints its own 000 AND exits non-zero,
+  // so a fallback that appends (`|| echo 000`) produces "000000" — not a code
+  // the loop recognises, which drops it into the decide-now arm and abandons
+  // the deploy after a single attempt.
+  it.each([["000"], ["nostatus"]])(
+    "retries when curl itself fails (%s) instead of deciding on one attempt",
+    (failure) => {
+      const result = runFlagLatest([failure, failure, "200"]);
 
       expect(result.status).toBe(0);
-      expect(result.requests).toHaveLength(2);
+      expect(result.requests).toHaveLength(3);
+      expect(result.output).toContain("Flagged abc123 as latest");
+      expect(result.output).not.toContain("000000");
     },
   );
+
+  // And it must still give up eventually rather than loop forever.
+  it("stops retrying an unreachable API once the deadline passes", () => {
+    const result = runFlagLatest(["000"], { timeout: 0 });
+
+    expect(result.status).toBe(0);
+    expect(result.requests).toHaveLength(1);
+    expect(result.output).toContain("HTTP 000");
+  });
 
   // Every deploy hits this until the registry ships, so it must be quiet and
   // must not retry: there is no route to come back.

--- a/tests/UpdateFlagLatest.test.ts
+++ b/tests/UpdateFlagLatest.test.ts
@@ -1,0 +1,228 @@
+import { execFileSync } from "child_process";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { fileURLToPath } from "url";
+import { afterEach, describe, expect, it } from "vitest";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SCRIPT = path.resolve(__dirname, "../update.sh");
+
+const BEGIN = "# --- BEGIN flag latest (tested) ---";
+const END = "# --- END flag latest (tested) ---";
+
+// Same arrangement as tests/UpdateRestartPolicy.test.ts: update.sh as a whole
+// drives docker and ssh, but the decision this block makes is reachable — it
+// talks to exactly one thing, curl, and that can be replaced. Lift the real
+// function out of the shipped file rather than restating it, so an edit to
+// update.sh that changes the outcome fails here instead of on a deploy.
+function extractFlagLatestBlock(): string {
+  const source = fs.readFileSync(SCRIPT, "utf8");
+  const start = source.indexOf(BEGIN);
+  const end = source.indexOf(END);
+  if (start === -1 || end === -1 || end < start) {
+    throw new Error(
+      `Could not find the flag-latest markers in ${SCRIPT}. If the block ` +
+        `moved or was renamed, update the markers here and there together.`,
+    );
+  }
+  return source.slice(start + BEGIN.length, end);
+}
+
+let tempDir: string | null = null;
+
+afterEach(() => {
+  if (tempDir) {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  }
+});
+
+interface Result {
+  status: number;
+  output: string;
+  /** One line per request the function actually made. */
+  requests: string[];
+}
+
+/**
+ * Run the real flag_latest against a fake curl that hands back `codes` in
+ * order, repeating the last one forever once they run out (which is how a
+ * genuinely-stuck API behaves, and what the retry deadline has to end).
+ */
+function runFlagLatest(
+  codes: string[],
+  opts: { clusterStateSource?: string; timeout?: number } = {},
+): Result {
+  tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "flag-latest-"));
+  const binDir = path.join(tempDir, "bin");
+  fs.mkdirSync(binDir);
+  const countFile = path.join(tempDir, "count");
+  const logFile = path.join(tempDir, "requests");
+  fs.writeFileSync(countFile, "0");
+  fs.writeFileSync(logFile, "");
+
+  // Writes the response body where -o points, logs the URL and payload, and
+  // prints the scripted status code on stdout the way -w "%{http_code}" does.
+  const fakeCurl = `#!/bin/bash
+CODES=(${codes.map((c) => `'${c}'`).join(" ")})
+n="$(cat '${countFile}')"
+idx="$n"
+if [ "$idx" -ge "\${#CODES[@]}" ]; then idx=$(( \${#CODES[@]} - 1 )); fi
+echo $(( n + 1 )) > '${countFile}'
+OUT=/dev/null
+URL=""
+DATA=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -o) OUT="$2"; shift 2 ;;
+    -d) DATA="$2"; shift 2 ;;
+    http*) URL="$1"; shift ;;
+    *) shift ;;
+  esac
+done
+echo "\${URL} \${DATA}" >> '${logFile}'
+printf 'scripted body for %s' "\${CODES[$idx]}" > "$OUT"
+printf '%s' "\${CODES[$idx]}"
+`;
+  const curlPath = path.join(binDir, "curl");
+  fs.writeFileSync(curlPath, fakeCurl);
+  fs.chmodSync(curlPath, 0o755);
+
+  const script = [
+    `export PATH='${binDir}':"$PATH"`,
+    `FLAG_LATEST_TIMEOUT=${opts.timeout ?? 5}`,
+    "FLAG_LATEST_RETRY_DELAY=0",
+    extractFlagLatestBlock(),
+    `flag_latest 'openfront.io' 'abc123' 'https://api.openfront.io' 'k3y' '${opts.clusterStateSource ?? ""}'`,
+    'echo "exit=$?"',
+  ].join("\n");
+
+  const output = execFileSync("bash", ["-c", script], {
+    encoding: "utf8",
+    // A run that hangs is a bug in the loop, not a slow machine: every sleep
+    // is zero here.
+    timeout: 30_000,
+  });
+  const statusMatch = /exit=(\d+)/.exec(output);
+  if (statusMatch === null) {
+    throw new Error(`flag_latest produced no exit line:\n${output}`);
+  }
+  return {
+    status: Number(statusMatch[1]),
+    output,
+    requests: fs
+      .readFileSync(logFile, "utf8")
+      .split("\n")
+      .filter((l) => l.trim() !== ""),
+  };
+}
+
+describe("update.sh flag_latest", () => {
+  it("posts the site and the full version to /cluster/latest", () => {
+    const result = runFlagLatest(["200"]);
+
+    expect(result.status).toBe(0);
+    expect(result.requests).toHaveLength(1);
+    expect(result.requests[0]).toContain(
+      "https://api.openfront.io/cluster/latest",
+    );
+    expect(result.requests[0]).toContain('"site": "openfront.io"');
+    expect(result.requests[0]).toContain('"version": "abc123"');
+  });
+
+  // The whole reason the call is last in update.sh: the API refuses a version
+  // nothing has registered for, and the container takes ~10s to register. A
+  // single 409 must not end the deploy.
+  it("retries a 409 until a server has registered for this version", () => {
+    const result = runFlagLatest(["409", "409", "200"]);
+
+    expect(result.status).toBe(0);
+    expect(result.requests).toHaveLength(3);
+    expect(result.output).toContain("Flagged abc123 as latest");
+  });
+
+  it.each([["000"], ["500"], ["502"], ["503"]])(
+    "retries an unreachable or broken API (%s)",
+    (code) => {
+      const result = runFlagLatest([code, "200"]);
+
+      expect(result.status).toBe(0);
+      expect(result.requests).toHaveLength(2);
+    },
+  );
+
+  // Every deploy hits this until the registry ships, so it must be quiet and
+  // must not retry: there is no route to come back.
+  it("accepts a 404 immediately — the API predates the registry", () => {
+    const result = runFlagLatest(["404"]);
+
+    expect(result.status).toBe(0);
+    expect(result.requests).toHaveLength(1);
+    expect(result.output).toContain("not deployed yet");
+  });
+
+  // While clients still boot from BOOTSTRAP_CONFIG, an unflagged version
+  // changes nothing a player can see. Failing here would fail every deploy for
+  // a warning.
+  it("warns but succeeds when 409 outlasts the retries and the site still boots from the page", () => {
+    const result = runFlagLatest(["409"], { timeout: 0 });
+
+    expect(result.status).toBe(0);
+    expect(result.output).toContain("Failed to flag abc123 as latest");
+    expect(result.output).toContain("Continuing");
+  });
+
+  // ...but once the site's clients ask the API for their server list, an
+  // unflagged version means no server is open: nobody can start a game. A
+  // deploy that ends there has not succeeded.
+  it("fails the deploy when 409 outlasts the retries and CLUSTER_STATE_SOURCE=api", () => {
+    const result = runFlagLatest(["409"], {
+      timeout: 0,
+      clusterStateSource: "api",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.output).toContain("CLUSTER_STATE_SOURCE=api");
+  });
+
+  it("still tolerates a 404 when CLUSTER_STATE_SOURCE=api", () => {
+    const result = runFlagLatest(["404"], { clusterStateSource: "api" });
+
+    expect(result.status).toBe(0);
+  });
+
+  // A bad key or a malformed body is not a race with a booting container, so
+  // spending 90 seconds on it only delays the report.
+  it.each([["400"], ["401"], ["403"]])(
+    "does not retry a client error (%s)",
+    (code) => {
+      const result = runFlagLatest([code]);
+
+      expect(result.status).toBe(0);
+      expect(result.requests).toHaveLength(1);
+      expect(result.output).toContain(`HTTP ${code}`);
+    },
+  );
+
+  it("fails the deploy on a client error when CLUSTER_STATE_SOURCE=api", () => {
+    const result = runFlagLatest(["401"], { clusterStateSource: "api" });
+
+    expect(result.status).toBe(1);
+  });
+
+  // Anything other than the literal "api" is not the switch. An env file
+  // carrying CLUSTER_STATE_SOURCE=page (or a typo) must keep the lenient
+  // behaviour rather than start failing deploys.
+  it.each([["page"], ["API"], ["api-preview"], [""]])(
+    "treats CLUSTER_STATE_SOURCE=%s as not-the-API",
+    (value) => {
+      const result = runFlagLatest(["409"], {
+        timeout: 0,
+        clusterStateSource: value,
+      });
+
+      expect(result.status).toBe(0);
+    },
+  );
+});

--- a/tests/server/RenderHtml.test.ts
+++ b/tests/server/RenderHtml.test.ts
@@ -1,12 +1,18 @@
 import fs from "fs/promises";
 import os from "os";
 import path from "path";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { fileURLToPath } from "url";
+import { afterEach, beforeEach, describe, expect, it, test, vi } from "vitest";
+import vm from "vm";
 import {
   clearAppShellContentCache,
   getAppShellContent,
+  renderHtmlContent,
   setAppShellCacheHeaders,
 } from "../../src/server/RenderHtml";
+import { ServerEnv } from "../../src/server/ServerEnv";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Covers both hosts the tests below boot as: the pinned blue deployment and
 // the bare-domain dev box.
@@ -172,5 +178,134 @@ describe("RenderHtml siteHost injection", () => {
   test("omits siteHost for a standalone deployment", async () => {
     vi.stubEnv("SITE_HOST", "");
     expect(await render()).toBe("");
+  });
+});
+
+// The real template, not a fixture. Everything above renders a one-line stub,
+// which is the right scope for those tests but cannot catch the thing this
+// file most needs to catch: that the guarded BOOTSTRAP_CONFIG block in
+// index.html still produces the page the client (and the Steam shell, which
+// renders the same file) boots from.
+const REAL_TEMPLATE = path.resolve(__dirname, "../../index.html");
+
+function bootstrapConfig(html: string): Record<string, unknown> {
+  const match = /window\.BOOTSTRAP_CONFIG = (\{[\s\S]*?\n\s*\});/.exec(html);
+  if (match === null) {
+    throw new Error("rendered page has no window.BOOTSTRAP_CONFIG assignment");
+  }
+  return vm.runInNewContext(`(${match[1]})`) as Record<string, unknown>;
+}
+
+describe("RenderHtml environment-only render", () => {
+  beforeEach(() => {
+    vi.stubEnv("CLUSTER_JSON", TEST_CLUSTER);
+    vi.stubEnv("TURNSTILE_SITE_KEY", "test-key");
+    vi.stubEnv("DOMAIN", "openfront.io");
+    vi.stubEnv("SUBDOMAIN", "blue");
+    vi.stubEnv("SITE_HOST", "openfront.io");
+    vi.stubEnv("INSTANCE_ID", "i-1");
+    vi.stubEnv("GIT_COMMIT", "abc");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    clearAppShellContentCache();
+  });
+
+  // The point of the mode. This page is uploaded once per version and served
+  // to every player on it, so naming one server in it would pin the whole
+  // version to that server.
+  it.each([
+    ["cluster"],
+    ["instanceLetter"],
+    ["instanceId"],
+    ["serverHost"],
+    ["siteHost"],
+  ])("omits the per-server value %s entirely", async (field) => {
+    const html = await renderHtmlContent(REAL_TEMPLATE, { perServer: false });
+
+    // Double-escaped on purpose: this is a template literal, so a single \s
+    // would reach RegExp as a literal "s" and the assertion could never fail.
+    const line = new RegExp(`^\\s*${field}:`, "m");
+    // Prove the pattern can match at all before asserting it does not.
+    expect(await renderHtmlContent(REAL_TEMPLATE)).toMatch(line);
+    expect(html).not.toMatch(line);
+    expect(bootstrapConfig(html)).not.toHaveProperty(field);
+  });
+
+  it.each([
+    ["gitCommit"],
+    ["gameEnv"],
+    ["turnstileSiteKey"],
+    ["jwtAudience"],
+    ["cdnBase"],
+    ["assetManifest"],
+  ])("keeps the build/environment value %s", async (field) => {
+    const config = bootstrapConfig(
+      await renderHtmlContent(REAL_TEMPLATE, { perServer: false }),
+    );
+
+    expect(config[field], field).toBeDefined();
+  });
+
+  // Rendering without the per-server locals must not go anywhere near
+  // CLUSTER_JSON: the pipeline builds this page from an image, and requiring a
+  // valid cluster entry for the rendering host would be a deploy-time failure
+  // for no reason.
+  it("renders without a cluster map at all", async () => {
+    vi.stubEnv("CLUSTER_JSON", "");
+    vi.stubEnv("SUBDOMAIN", "nobody");
+
+    const html = await renderHtmlContent(REAL_TEMPLATE, { perServer: false });
+
+    expect(html).toContain("BOOTSTRAP_CONFIG");
+    expect(bootstrapConfig(html).gitCommit).toBe("abc");
+  });
+
+  // A full render is what the game server serves and what the legacy
+  // index-<short>.html replay shell is built from, so guarding those lines had
+  // to leave it byte-for-byte identical — same order, same eight-space
+  // indentation, same trailing commas.
+  it("still emits every guarded line, in place, when the locals are supplied", async () => {
+    const html = await renderHtmlContent(REAL_TEMPLATE);
+
+    expect(html).toContain(
+      [
+        "      window.BOOTSTRAP_CONFIG = {",
+        '        gitCommit: "abc",',
+        "        assetManifest: {},",
+        '        cdnBase: "",',
+        `        gameEnv: ${JSON.stringify(ServerEnv.gameEnvName())},`,
+        `        cluster: ${JSON.stringify(ServerEnv.cluster())},`,
+        '        instanceLetter: "a",',
+        '        turnstileSiteKey: "test-key",',
+        '        jwtAudience: "openfront.io",',
+        '        instanceId: "i-1",',
+        '        serverHost: "blue.openfront.io",',
+        '        siteHost: "openfront.io",',
+        "      };",
+      ].join("\n"),
+    );
+  });
+
+  // INSTANCE_ID is unset on every deployment that does not set it, and
+  // ServerEnv.instanceId() answers "" rather than undefined. The guard tests
+  // the rendered LOCAL (the JSON string `""`, which is truthy), not the value,
+  // so the line survives — as it must, since ClientEnv treats a missing
+  // instanceId as a missing BOOTSTRAP_CONFIG.
+  it("keeps instanceId in a full render even when it is empty", async () => {
+    vi.stubEnv("INSTANCE_ID", "");
+
+    const html = await renderHtmlContent(REAL_TEMPLATE);
+
+    expect(html).toContain('\n        instanceId: "",');
+    expect(bootstrapConfig(html).instanceId).toBe("");
+  });
+
+  it("defaults to the full render when no options are passed", async () => {
+    const config = bootstrapConfig(await renderHtmlContent(REAL_TEMPLATE));
+
+    expect(config.instanceLetter).toBe("a");
+    expect(config.serverHost).toBe("blue.openfront.io");
   });
 });

--- a/update.sh
+++ b/update.sh
@@ -65,6 +65,11 @@ echo "Extracted to $STATIC_DIR; top-level contents:"
 ls -la "$STATIC_DIR/" || true
 
 R2_ENDPOINT="https://api.${DOMAIN}"
+# The hostname players load the page from, which is what the server list and
+# the static Worker are keyed by (docs/MultiServer.md, "Server list v2"). Behind
+# a load balancer that is the apex (SITE_HOST); a standalone deployment — beta,
+# a branch preview — is its own site.
+SITE="${SITE_HOST:-${SUBDOMAIN}.${DOMAIN}}"
 MANIFEST="$STATIC_DIR/asset-manifest.json"
 if [ ! -f "$MANIFEST" ]; then
     echo "❌ Manifest not found at $MANIFEST"
@@ -182,6 +187,106 @@ else
         exit 1
     fi
     echo "✅ Uploaded $INDEX_KEY."
+
+    # --- Per-version publish (multi-server v2) -------------------------------
+    #
+    # Three more objects, keyed by SITE and the short commit rather than by this
+    # container. Together they are everything a player of this version needs
+    # that is not already a hashed asset: the page, and the desktop shell's
+    # release descriptor plus its cheap poll pointer.
+    #
+    #   game_assets/sites/<site>/v/<short>/index.html
+    #   game_assets/sites/<site>/v/<short>/desktop/release.json
+    #   game_assets/sites/<site>/v/<short>/desktop/version.json
+    #
+    # (The upload endpoint prefixes game_assets/ itself.) Nothing serves these
+    # until the static Worker exists, so this is additive and harmless today —
+    # see docs/MultiServer.md, "Publish pipeline (v2)".
+    #
+    # The page is rendered --environment-only: no cluster, instanceLetter,
+    # instanceId, serverHost or siteHost. One page per VERSION, not per server,
+    # is the whole point; the client asks the API for the server list. The
+    # legacy index-<short>.html above deliberately keeps the server values
+    # until OPE-431 lands, because today's client throws without a worker-count
+    # source.
+    SHORT="${FULL_COMMIT:0:7}"
+    VERSION_PREFIX="sites/${SITE}/v/${SHORT}"
+    echo "Publishing ${VERSION_PREFIX}/ for ${SITE}..."
+
+    # Same single-segment URL encoding the asset loop uses: the whole key goes
+    # through jq's @uri, so "/" arrives as %2F and the endpoint stores it at
+    # game_assets/<key>.
+    upload_versioned() {
+        local key="$1" file="$2" content_type="$3" enc
+        enc="$(jq -rn --arg k "$key" '$k|@uri')"
+        if ! curl -fsS \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            --connect-timeout 10 --max-time 120 \
+            -X PUT \
+            "$R2_ENDPOINT/game_assets/upload/$enc" \
+            -H "X-API-Key: $API_KEY" \
+            -H "Content-Type: $content_type" \
+            --data-binary "@$file" > /dev/null; then
+            echo "❌ Failed to upload $key"
+            return 1
+        fi
+        echo "✅ Uploaded $key."
+    }
+
+    ENV_INDEX="$EXTRACT_DIR/environment-index.html"
+    if ! docker run --rm --env-file "$ENV_FILE" --entrypoint npx \
+        "${GHCR_IMAGE}" tsx src/server/RenderStaticIndex.ts --environment-only \
+        > "$ENV_INDEX"; then
+        echo "❌ Failed to render the environment-only page"
+        exit 1
+    fi
+    # Same sanity check as the replay shell: a renderer that crashed downstream
+    # of the redirect would otherwise publish an empty page for the version.
+    if ! grep -q "BOOTSTRAP_CONFIG" "$ENV_INDEX"; then
+        echo "❌ The environment-only page looks wrong (no BOOTSTRAP_CONFIG)"
+        exit 1
+    fi
+    # A per-server value in a page served to every player of this version would
+    # pin them all to one server — exactly what v2 removes. Cheap to assert
+    # here, invisible until it hurts otherwise.
+    for FIELD in cluster instanceLetter instanceId serverHost siteHost; do
+        if grep -q "^ *${FIELD}:" "$ENV_INDEX"; then
+            echo "❌ The environment-only page still carries ${FIELD}"
+            exit 1
+        fi
+    done
+
+    DESKTOP_RELEASE="$EXTRACT_DIR/desktop-release.json"
+    DESKTOP_VERSION="$EXTRACT_DIR/desktop-version.json"
+    if ! docker run --rm --env-file "$ENV_FILE" --entrypoint npx \
+        "${GHCR_IMAGE}" tsx src/server/RenderDesktopDescriptor.ts \
+        > "$DESKTOP_RELEASE"; then
+        echo "❌ Failed to build the desktop release descriptor"
+        exit 1
+    fi
+    if ! docker run --rm --env-file "$ENV_FILE" --entrypoint npx \
+        "${GHCR_IMAGE}" tsx src/server/RenderDesktopDescriptor.ts --version-pointer \
+        > "$DESKTOP_VERSION"; then
+        echo "❌ Failed to build the desktop version pointer"
+        exit 1
+    fi
+    # The shell refuses a descriptor it cannot parse, so publishing a truncated
+    # one strands every Steam client on this version.
+    if ! jq -e '.schemaVersion and .clientVersion and .template.sha256' \
+        "$DESKTOP_RELEASE" > /dev/null; then
+        echo "❌ The desktop release descriptor is missing required fields"
+        exit 1
+    fi
+    if ! jq -e '.clientVersion and .coreVersion' "$DESKTOP_VERSION" > /dev/null; then
+        echo "❌ The desktop version pointer is missing required fields"
+        exit 1
+    fi
+
+    upload_versioned "${VERSION_PREFIX}/index.html" "$ENV_INDEX" "text/html" || exit 1
+    upload_versioned "${VERSION_PREFIX}/desktop/release.json" \
+        "$DESKTOP_RELEASE" "application/json" || exit 1
+    upload_versioned "${VERSION_PREFIX}/desktop/version.json" \
+        "$DESKTOP_VERSION" "application/json" || exit 1
 fi
 
 echo "Checking for existing container..."
@@ -281,6 +386,117 @@ if [ $? -eq 0 ]; then
 else
     echo "Failed to start container"
     exit 1
+fi
+
+# Tell the API which commit new players of this site should get. This is the
+# single switch of multi-server v2 (docs/MultiServer.md): servers running
+# `latest` are `open` and take new games, everything else drains, and the
+# static Worker serves `latest`'s page at <site>/ and its /desktop/*.json.
+#
+# It runs LAST, after the new container is up, because the API refuses to flag
+# a version no server has checked in for — that refusal (409) is the interlock
+# that stops a deploy from pointing every player at a build that cannot serve
+# them. The container registers within ~10s of boot, so a 409 immediately after
+# `docker run` is expected and is retried, not an error. There is no separate
+# health wait in this script; this retry loop is the closest thing to one, and
+# CI's own "Wait for deployment to start" step polls /commit.txt afterwards.
+#
+# The markers below delimit the block that tests/UpdateFlagLatest.test.ts
+# extracts and runs against a fake curl — the rest of this script talks to
+# docker and ssh and cannot be executed in a test, but this decision can. Keep
+# them in place.
+# --- BEGIN flag latest (tested) ---
+# Overridable so the test can drive the same loop without waiting 90 seconds.
+: "${FLAG_LATEST_TIMEOUT:=90}"
+: "${FLAG_LATEST_RETRY_DELAY:=5}"
+
+# flag_latest <site> <version> <endpoint> <api_key> <cluster_state_source>
+#
+# Returns 0 when the deploy may report success, 1 when it must not.
+#
+# The asymmetry is deliberate. While the page and the servers still come from
+# BOOTSTRAP_CONFIG, a missing `latest` changes nothing a player can see, so a
+# warning is the honest outcome and failing the deploy would be noise. Once
+# CLUSTER_STATE_SOURCE=api is in the env file the site's clients get their
+# server list from the API, and a version that was never flagged means no
+# server is `open`: nobody can start a game. A deploy that ends there has not
+# succeeded and must not say it has.
+flag_latest() {
+    local site="$1" version="$2" endpoint="$3" api_key="$4" state_source="$5"
+    local strict=no
+    if [ "$state_source" = "api" ]; then
+        strict=yes
+    fi
+
+    local deadline=$((SECONDS + FLAG_LATEST_TIMEOUT))
+    local body code reason
+    body="$(mktemp)"
+
+    while :; do
+        # No -f: the status code IS the answer here, so it must be read rather
+        # than collapsed into a non-zero exit. A curl that cannot run at all
+        # (DNS, TLS) yields 000 and is treated as a retryable outage.
+        code="$(curl -sS --connect-timeout 10 --max-time 30 \
+            -o "$body" -w "%{http_code}" \
+            -X POST "${endpoint}/cluster/latest" \
+            -H "X-API-Key: ${api_key}" \
+            -H "Content-Type: application/json" \
+            -d "{\"site\": \"${site}\", \"version\": \"${version}\"}" || echo "000")"
+
+        case "$code" in
+            200 | 204)
+                echo "✅ Flagged ${version} as latest for ${site}."
+                rm -f "$body"
+                return 0
+                ;;
+            404)
+                # The API predates the registry. Never strict: there is nothing
+                # to flag and nothing reading it, so this is the expected
+                # answer everywhere until the API ships.
+                echo "⚠️ ${endpoint}/cluster/latest is not deployed yet (HTTP 404); skipping the latest flag."
+                rm -f "$body"
+                return 0
+                ;;
+            409 | 000 | 5??)
+                # 409: no server has checked in for this version yet — the
+                # normal state for the first few seconds after docker run.
+                # 000/5xx: the API is unreachable or broken; same treatment,
+                # because the deploy is equally unfinished either way.
+                if [ "$SECONDS" -ge "$deadline" ]; then
+                    reason="HTTP ${code} after ${FLAG_LATEST_TIMEOUT}s of retries"
+                    break
+                fi
+                echo "… ${endpoint}/cluster/latest returned HTTP ${code}; retrying in ${FLAG_LATEST_RETRY_DELAY}s"
+                sleep "$FLAG_LATEST_RETRY_DELAY"
+                ;;
+            *)
+                # 400/401/403 and friends: a bad key or a malformed request.
+                # Retrying cannot fix it, so decide now.
+                reason="HTTP ${code}"
+                break
+                ;;
+        esac
+    done
+
+    echo "⚠️ Failed to flag ${version} as latest for ${site}: ${reason}"
+    cat "$body" || true
+    rm -f "$body"
+    if [ "$strict" = "yes" ]; then
+        echo "❌ CLUSTER_STATE_SOURCE=api: clients take their server list from the API, so an unflagged version means no server is open. Failing the deploy."
+        return 1
+    fi
+    echo "   Continuing: this site still boots from the page's own values."
+    return 0
+}
+# --- END flag latest (tested) ---
+
+if [[ "$FULL_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+    if ! flag_latest "$SITE" "$FULL_COMMIT" "$R2_ENDPOINT" "$API_KEY" \
+        "${CLUSTER_STATE_SOURCE:-}"; then
+        exit 1
+    fi
+else
+    echo "⚠️ Skipping the latest flag: commit.txt is not a full SHA ('$FULL_COMMIT')"
 fi
 
 echo "======================================================"

--- a/update.sh
+++ b/update.sh
@@ -434,14 +434,20 @@ flag_latest() {
 
     while :; do
         # No -f: the status code IS the answer here, so it must be read rather
-        # than collapsed into a non-zero exit. A curl that cannot run at all
-        # (DNS, TLS) yields 000 and is treated as a retryable outage.
-        code="$(curl -sS --connect-timeout 10 --max-time 30 \
+        # than collapsed into a non-zero exit. A curl that cannot reach the API
+        # at all (DNS, TLS, connect timeout) exits non-zero AND prints 000, so
+        # the fallback must only fill in for a curl that printed nothing —
+        # `|| echo 000` would append to curl's own 000 and yield "000000",
+        # which falls through to the decide-now arm and kills the retry loop
+        # on the one failure it exists to survive.
+        if ! code="$(curl -sS --connect-timeout 10 --max-time 30 \
             -o "$body" -w "%{http_code}" \
             -X POST "${endpoint}/cluster/latest" \
             -H "X-API-Key: ${api_key}" \
             -H "Content-Type: application/json" \
-            -d "{\"site\": \"${site}\", \"version\": \"${version}\"}" || echo "000")"
+            -d "{\"site\": \"${site}\", \"version\": \"${version}\"}")"; then
+            code="${code:-000}"
+        fi
 
         case "$code" in
             200 | 204)


### PR DESCRIPTION
Roadmap item 4 of **Server list v2** (`docs/MultiServer.md`, designed in #5365): the deploy pipeline starts producing the objects the static Worker will serve, and tells the API which commit new players of a site should get.

Nothing reads any of this yet — the Worker does not exist and the API has no registry — so the uploads are additive and prod is unaffected. This lands before the cut because it touches CI.

## What a deploy now publishes

Per **site** and per **version**, alongside the hashed assets and the existing `index-<short>.html`:

```
game_assets/sites/<site>/v/<short>/index.html
game_assets/sites/<site>/v/<short>/desktop/release.json
game_assets/sites/<site>/v/<short>/desktop/version.json
```

Site is `SITE_HOST` when the deployment sits behind a load balancer, else `<subdomain>.<domain>`; version is the 7-char prefix of `static/commit.txt`. All three go through the existing `PUT $R2_ENDPOINT/game_assets/upload/<urlencoded key>`, which prefixes `game_assets/` itself — the key layout settled with the infra registry PR.

Both renderers run inside the freshly built image with the live container's env file, exactly as the replay shell already does, so what is published is what that build's server would itself have produced.

## The page carries no server

`renderHtmlContent(path, { perServer: false })` omits `cluster`, `instanceLetter`, `instanceId`, `serverHost` and `siteHost`. A page served to every player of a version must not name one server — the client asks the API for the server list instead.

`index.html`'s three unconditional lines are now guarded exactly like `serverHost` and `siteHost` already were, so **a render that supplies the locals is byte-for-byte what it always produced**. I verified that directly: a throwaway test rendered `origin/main`'s template and this one side by side under identical env and compared, for both a set and an empty `INSTANCE_ID`. The committed test asserts the exact rendered block instead — order, eight-space indentation, trailing commas.

No new placeholder was added. openfront-desktop renders this same template itself and a missing local is a `ReferenceError`, i.e. a blank window; guarding an existing one is safe, because the shell supplies a value and the line still emits. `vendorTemplate.test.ts` over there keeps passing.

The legacy `index-<short>.html` upload deliberately **keeps** the server values, until OPE-431 lands — today's client throws without a worker-count source.

## The descriptors move earlier, not elsewhere

`src/server/RenderDesktopDescriptor.ts` builds the descriptor the game server already serves at `/desktop/*.json`, from the same `buildDescriptor` with the same env-derived opts (`clientVersion` = `GIT_COMMIT`, `requireCdnBase` iff prod), one deploy earlier. Publishing it per version lets the Worker answer for a site with no game server reachable, and makes a rollback a pointer flip rather than a redeploy. `release.json`'s `template.html` stays the raw EJS template by design — the Steam shell renders it itself.

**Worth a look:** the CLI redirects stdout-bound logging to stderr before loading `DesktopRelease`. `DesktopRelease` imports `Logger`, and dotenv's "injected env" banner, `Logger.ts`'s OTEL line and winston's `Console` transport (stdout for *every* level, including `buildDescriptor`'s empty-`cdnBase` warning) all write to stdout. Any one of them would have prefixed `release.json` with prose that no Steam client can parse. That is why the module imports are dynamic — a static import is hoisted above the rebind, and `prettier-plugin-organize-imports` would reorder it anyway. There is a test asserting stdout is pure JSON while the noise is still readable on stderr.

## Flagging `latest`

`update.sh` ends by POSTing `{ site, version }` to `${R2_ENDPOINT}/cluster/latest`. It runs **last, after the new container is up**, because the API refuses a version no server has checked in for — and that refusal is the interlock that stops a deploy pointing every player at a build that cannot serve them. There is no separate health wait in `update.sh`; this retry loop is the closest thing to one, and CI's own "Wait for deployment to start" polls `/commit.txt` afterwards.

| Response | Outcome |
| --- | --- |
| `200` / `204` | Logged, done. |
| `404` | The API predates the registry. Warn and continue, never retried, never strict — the expected answer everywhere today. |
| `409`, `000`, `5xx` | Retried every 5s for up to 90s; servers register within ~10s of boot. |
| `4xx` | A bad key or malformed request. Decided immediately — retrying cannot fix it. |

Past the retries it warns and continues, because the page and its servers still come from `BOOTSTRAP_CONFIG` and nothing a player sees has changed — **unless** `CLUSTER_STATE_SOURCE=api` is in the site's env file, which says its clients take the server list from the API. An unflagged version then means no server is `open` and nobody can start a game, so the deploy fails rather than reporting a success it did not achieve. The passthrough for that variable comes from #5366, so it is absent on every site today and the lenient path is what runs.

Two deliberate extensions to the spec: an unreachable or 500-ing API is treated like a 409 (the deploy is equally unfinished either way), and in strict mode any non-200/404 fails, not only 409. Silently succeeding on a 500 when clients read the API is the same failure 409-strict exists to prevent.

## Tests

- `tests/server/RenderHtml.test.ts` — the environment-only and full renders of the **real** `index.html`. There was no test rendering it before; every existing case used a one-line stub. Also pins that `instanceId` survives a full render when it is empty (the guard keys off the rendered local, the JSON string `""`, which is truthy).
- `tests/RenderDesktopDescriptor.test.ts` — the CLI's output shape, the `--version-pointer` form, the production CDN requirement, and stdout purity. It stages the shipped file at the same relative depth against a fixture build rather than paraphrasing it, so the real argument handling and the real `BuildOpts` are what run.
- `tests/UpdateFlagLatest.test.ts` — `flag_latest`'s decision table, extracted from `update.sh` between markers and driven by a scripted `curl` on `PATH`, the way `tests/UpdateRestartPolicy.test.ts` tests the restart policy.

`npx tsc --noEmit`, `npm run lint`, `prettier --check` and `bash -n update.sh deploy.sh` all clean; full `npx vitest run` green (451 files, 5539 tests).

Closes OPE-433.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PTKyUrxqfwKvf2QxAovR6Z
