### PR TITLE
Clean-room reimplementation of 187 excised client blocks

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -1467,10 +1467,8 @@ export class ClientGameRunner {
     const canBuild = this.canBoatAttack(buildables);
     if (canBuild === false) return false;
 
-    // TODO: Global enable flag
-    // TODO: Global limit autoboat to nearby shore flag
-    // if (!enableAutoBoat) return false;
-    // if (!limitAutoBoatNear) return true;
+    // A global auto-boat on/off setting is not implemented yet.
+    // A global "only auto-boat to nearby shore" setting is not implemented yet.
     const distanceSquared = this.gameView.euclideanDistSquared(tile, canBuild);
     const limit = 100;
     const limitSquared = limit * limit;

--- a/src/client/HostLobbyModal.ts
+++ b/src/client/HostLobbyModal.ts
@@ -1330,7 +1330,6 @@ export class HostLobbyModal extends BaseModal {
     this.teamCount = value;
     this.putGameConfig();
   }
-
   private handleWhitelistToggle = (checked: boolean) => {
     this.whitelistEnabled = checked;
     this.putGameConfig();

--- a/src/client/InputHandler.ts
+++ b/src/client/InputHandler.ts
@@ -1226,6 +1226,7 @@ export class InputHandler {
   destroy() {
     if (this.moveInterval !== null) {
       clearInterval(this.moveInterval);
+      this.moveInterval = null;
     }
     globalThis.removeEventListener(
       `${USER_SETTINGS_CHANGED_EVENT}:${KEYBINDS_KEY}`,

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -381,22 +381,24 @@ export class LangSelector extends LitElement {
 }
 
 function flattenTranslations(
-  obj: Record<string, any>,
+  obj: Record<string, unknown>,
   parentKey = "",
   result: Record<string, string> = {},
 ): Record<string, string> {
-  for (const key in obj) {
+  for (const key of Object.keys(obj)) {
     const value = obj[key];
     const fullKey = parentKey ? `${parentKey}.${key}` : key;
-
     if (typeof value === "string") {
       result[fullKey] = value;
-    } else if (value && typeof value === "object" && !Array.isArray(value)) {
-      flattenTranslations(value, fullKey, result);
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
+      flattenTranslations(value as Record<string, unknown>, fullKey, result);
     } else {
       console.warn("Unknown type", typeof value, value);
     }
   }
-
   return result;
 }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -417,7 +417,6 @@ class Client {
     if (renderNavVersion() === 0) {
       console.warn("Game version element not found");
     }
-
     const langSelector = document.querySelector(
       "lang-selector",
     ) as LangSelector;
@@ -636,10 +635,8 @@ class Client {
       );
 
       if (userMeResponse !== false) {
-        // Authorized
         console.log(
-          `Your player ID is ${userMeResponse.player.publicId}\n` +
-            "Sharing this ID will allow others to view your game history and stats.",
+          `Your player ID is ${userMeResponse.player.publicId}\nSharing this ID will allow others to view your game history and stats.`,
         );
 
         // Resume a Steam-link flow that was interrupted by a login redirect
@@ -723,7 +720,6 @@ class Client {
         );
       }
     };
-
     // A profile request issued before a logout can still be in flight when the
     // session goes, and its 200 was fetched with a JWT that was valid at the
     // time. Applying it afterwards would put the expired account back in the
@@ -748,14 +744,12 @@ class Client {
     });
 
     if ((await userAuth()) === false) {
-      // Not logged in
-      onUserMe(false);
+      // Not signed in: nothing to fetch, apply the signed-out state directly.
+      void onUserMe(false);
     } else {
-      // JWT appears to be valid
-      // TODO: Add caching
+      // The stored JWT looks valid, so fetch the profile.
       getUserMe().then(applyUserMe(authGeneration));
     }
-
     // Re-run auth when the player signs into CrazyGames mid-session. Logout
     // reloads the page, so only login needs handling here.
     crazyGamesSDK.addAuthListener(() => {
@@ -816,7 +810,7 @@ class Client {
       this.joinModal.eventBus = this.eventBus;
     }
 
-    // Attempt to join lobby
+    // Join the lobby named by the URL once the document is ready.
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", () => this.handleUrl());
     } else {
@@ -853,7 +847,7 @@ class Client {
         return;
       }
 
-      // Reset the UI to its initial state
+      // Reset the lobby UI to its initial state.
       this.joinModal?.close();
 
       onJoinChanged();
@@ -903,7 +897,7 @@ class Client {
       this.handleUrl();
     };
 
-    // Handle browser navigation & manual hash edits
+    // Browser navigation (back/forward) and manual hash edits.
     window.addEventListener("popstate", onPopState);
     window.addEventListener("hashchange", onHashUpdate);
     window.addEventListener("join-changed", onJoinChanged);
@@ -1120,7 +1114,6 @@ class Client {
     history.replaceState(null, "", newUrl);
     return mode;
   }
-
   private desktopUpdateState: DesktopUpdateState | null = null;
 
   /**

--- a/src/client/NewsModal.ts
+++ b/src/client/NewsModal.ts
@@ -13,8 +13,7 @@ export class NewsModal extends BaseModal {
 
   @property({ type: String }) markdown = "Loading...";
 
-  private initialized: boolean = false;
-
+  private initialized = false;
   protected renderHeaderSlot() {
     return modalHeader({
       title: translateText("news.title"),

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -941,7 +941,6 @@ export class SinglePlayerModal extends BaseModal {
   private handleTeamCountSelection(value: TeamCountConfig) {
     this.teamCount = value;
   }
-
   /**
    * The name and cosmetics the dispatch needs, bounded so neither can outlive
    * the button waiting on them.
@@ -1122,9 +1121,9 @@ export class SinglePlayerModal extends BaseModal {
                 infiniteTroops: this.infiniteTroops,
                 instantBuild: this.instantBuild,
                 randomSpawn: this.randomSpawn,
-                disabledUnits: this.disabledUnits
-                  .map((u) => Object.values(UnitType).find((ut) => ut === u))
-                  .filter((ut): ut is UnitType => ut !== undefined),
+                disabledUnits: this.disabledUnits.filter((unit) =>
+                  Object.values(UnitType).includes(unit),
+                ),
                 nations: sliderToNationsConfig(
                   this.nations,
                   this.defaultNationCount,

--- a/src/client/TransformHandler.ts
+++ b/src/client/TransformHandler.ts
@@ -241,8 +241,9 @@ export class TransformHandler {
   private goTo() {
     const { screenX, screenY } = this.screenCenter();
 
-    if (this.target === null) throw new Error("null target");
-
+    if (this.target === null) {
+      throw new Error("null target");
+    }
     const positionClose =
       Math.abs(this.target.x - screenX) + Math.abs(this.target.y - screenY) < 2;
     const scaleClose =

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -270,8 +270,8 @@ export class Transport {
     // If gameRecord is not null, we are replaying an archived game.
     // For multiplayer games, GameConfig is not known until game starts.
     this.isLocal =
-      lobbyConfig.gameRecord !== undefined ||
-      lobbyConfig.gameStartInfo?.config.gameType === GameType.Singleplayer;
+      this.lobbyConfig.gameRecord !== undefined ||
+      this.lobbyConfig.gameStartInfo?.config.gameType === GameType.Singleplayer;
 
     this.eventBus.on(SendAllianceRequestIntentEvent, (e) =>
       this.onSendAllianceRequest(e),
@@ -484,7 +484,9 @@ export class Transport {
     };
     this.socket.onerror = (err) => {
       console.error("Socket encountered error: ", err, "Closing socket");
-      if (this.socket === null) return;
+      if (this.socket === null) {
+        return;
+      }
       this.socket.close();
     };
     this.socket.onclose = (event: CloseEvent) => {
@@ -657,7 +659,9 @@ export class Transport {
     this.connectionRefused = true;
     this.stopPing();
     this.cancelReconnect();
-    if (this.socket === null) return;
+    if (this.socket === null) {
+      return;
+    }
     if (this.socket.readyState === WebSocket.OPEN) {
       console.log("on stop: leaving game");
     } else {
@@ -934,16 +938,15 @@ export class Transport {
     }
   }
 
-  private sendMsg(msg: ClientMessage) {
+  private sendMsg(msg: ClientMessage): void {
     if (this.connectionRefused) {
       return;
     }
     if (this.isLocal) {
-      // Forward message to local server
+      // Local games never touch the network: hand it to the in-process server.
       this.localServer.onMessage(msg);
       return;
     } else if (this.socket === null) {
-      // Socket missing, do nothing
       return;
     }
 
@@ -963,7 +966,7 @@ export class Transport {
       // and keep them queued behind any previously buffered messages.
       this.buffer.push(msg);
     } else {
-      // Send the message directly
+      // Handshake complete and nothing queued ahead of it: send now.
       this.socket.send(encodeClientMessage(msg, this.zbinCtx ?? undefined));
     }
   }

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -417,12 +417,12 @@ export function createCanvas(): HTMLCanvasElement {
  */
 export function generateCryptoRandomUUID(): string {
   // Type guard to check if randomUUID is available
-  if (crypto !== undefined && "randomUUID" in crypto) {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
 
   // Fallback using crypto.getRandomValues
-  if (crypto !== undefined && "getRandomValues" in crypto) {
+  if (typeof crypto !== "undefined" && "getRandomValues" in crypto) {
     return (([1e7] as any) + -1e3 + -4e3 + -8e3 + -1e11).replace(
       /[018]/g,
       (c: number): string =>

--- a/src/client/hud/layers/EmojiTable.ts
+++ b/src/client/hud/layers/EmojiTable.ts
@@ -48,7 +48,7 @@ export class EmojiTable extends LitElement {
         this.hideTable();
       });
     });
-    eventBus.on(CloseViewEvent, (e) => {
+    eventBus.on(CloseViewEvent, () => {
       if (!this.hidden) {
         this.hideTable();
       }

--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -657,8 +657,8 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
         <div
           class="bg-gray-800/92 backdrop-blur-sm shadow-xs min-[1200px]:rounded-lg sm:rounded-b-lg shadow-lg text-white text-lg lg:text-base w-full sm:w-[500px] overflow-hidden ${containerClasses}"
         >
-          ${this.player !== null ? this.renderPlayerInfo(this.player) : ""}
-          ${this.unit !== null ? this.renderUnitInfo(this.unit) : ""}
+          ${this.player ? this.renderPlayerInfo(this.player) : ""}
+          ${this.unit ? this.renderUnitInfo(this.unit) : ""}
         </div>
       </div>
     `;

--- a/src/client/hud/layers/SpawnTimer.ts
+++ b/src/client/hud/layers/SpawnTimer.ts
@@ -18,7 +18,7 @@ export class SpawnTimer extends LitElement implements Controller {
   public eventBus: EventBus;
   public transformHandler: TransformHandler;
 
-  private ratios = [0];
+  private ratios: number[] = [0];
   private _barVisible = false;
   private teams: Team[] = [];
   private colors = [
@@ -180,7 +180,7 @@ export class SpawnTimer extends LitElement implements Controller {
   }
 }
 
-function sumIterator(values: MapIterator<number>) {
+function sumIterator(values: MapIterator<number>): number {
   let total = 0;
   for (const value of values) {
     total += value;

--- a/src/client/hud/layers/WinModal.ts
+++ b/src/client/hud/layers/WinModal.ts
@@ -310,7 +310,7 @@ export class WinModal extends LitElement implements Controller {
       this.show();
     }
     const updates = this.game.updatesSinceLastTick();
-    const winUpdates = updates !== null ? updates[GameUpdateType.Win] : [];
+    const winUpdates = updates?.[GameUpdateType.Win] ?? [];
     winUpdates.forEach((wu) => {
       if (wu.winner === undefined) {
         // Match cancelled (e.g. a ranked 2v2 that didn't fill or fully


### PR DESCRIPTION
## Description:

Clean-room reimplementation of the 187 `CLEANROOM-REWRITE` blocks (333 lines across 28 files under `src/client/`) excised in the 2026-09-11 clean-room bundle. Every block was reimplemented from the bundle's `cleanroom/SPECS.md` and the test suite only, under the bundle's rules: no git history, no other copy of the project, no recall.

The completed blocks were spliced onto the current tree at the marker sites. 14 of the 28 marked files came out byte-identical to the existing code, so this PR touches only the other 14 (44 insertions, 49 deletions). The bundle's own record (specs, manifest, provenance and the unified patch against the bundle) is kept out of this PR at the author's request.

Verification on the bundle tree and on this branch:

- `npx tsc --noEmit` clean
- `npm run lint` clean
- default Vitest project (excluding `MapConsistency.test.ts`, as the bundle instructs): all passing (447 files / 5469 tests on the bundle tree, 449 / 5488 on this branch)
- server Vitest project: 63 files / 655 tests passing

chat: https://claude.ai/code/session_01MrKBpQ1niToDJWzMBreaVd

## Please complete the following:

- [ ] I have added screenshots for all UI updates (no UI changes)
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file (no new strings; existing keys reused per the specs)
- [ ] I have added relevant tests to the test directory (the pinning tests already ship in the tree; no test files were modified, per the bundle's rules)

## Please put your Discord username so you can be contacted if a bug or regression is found:

(maintainer to fill in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MrKBpQ1niToDJWzMBreaVd

---
_Generated by [Claude Code](https://claude.ai/code/session_01MrKBpQ1niToDJWzMBreaVd)_