### PR TITLE
Delete direct dollar purchases of cosmetics and flares

### DIFF
--- a/src/client/Api.ts
+++ b/src/client/Api.ts
@@ -1376,42 +1376,6 @@ export async function claimAllRewards(): Promise<
   }
 }
 
-export async function createCheckoutSession(
-  priceId: string,
-  colorPaletteName?: string,
-): Promise<string | false> {
-  try {
-    const response = await fetch(
-      `${getApiBase()}/stripe/create-checkout-session`,
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: await getAuthHeader(),
-        },
-        body: JSON.stringify({
-          priceId: priceId,
-          hostname: window.location.origin,
-          colorPaletteName: colorPaletteName,
-        }),
-      },
-    );
-    if (!response.ok) {
-      console.error(
-        "createCheckoutSession: request failed",
-        response.status,
-        response.statusText,
-      );
-      return false;
-    }
-    const json = await response.json();
-    return json.url;
-  } catch (e) {
-    console.error("createCheckoutSession: request failed", e);
-    return false;
-  }
-}
-
 export async function createCustomCurrencyCheckout(
   hardAmount: number,
 ): Promise<string | false> {
@@ -1562,7 +1526,8 @@ function readRetryAfterSeconds(response: Response): number | null {
 // hand the player over to it. Replaces both legacy Stripe endpoints for packs,
 // custom currency and subscription tiers.
 //
-// Unlike createCheckoutSession below, failures are NOT collapsed to `false`:
+// Unlike the legacy checkout helpers it replaced, failures are NOT collapsed
+// to `false`:
 // callers have to tell "the rail is off" from "you already have a pending
 // Steam purchase" from "try again later", and each of those is a different
 // thing to say to the player.

--- a/src/client/Cosmetics.ts
+++ b/src/client/Cosmetics.ts
@@ -24,7 +24,6 @@ import {
 } from "../core/Schemas";
 import {
   changeSubscriptionTier,
-  createCheckoutSession,
   getApiBase,
   getUserMe,
   invalidateUserMe,
@@ -420,19 +419,11 @@ export async function purchaseCosmetic(
       return;
     }
 
-    // Legacy Stripe-only path, deliberately not ported: dollar-priced
-    // cosmetics and flares, which genuinely still need a priceId.
-    const product = "product" in c ? c.product : null;
-    if (!product) {
-      await showInGameAlert(translateText("store.checkout_failed"));
-      return;
-    }
-    const url = await createCheckoutSession(product.priceId, colorPaletteName);
-    if (url === false) {
-      await showInGameAlert(translateText("store.checkout_failed"));
-      return;
-    }
-    window.location.href = url;
+    // Real money only buys plutonium (packs above) or a subscription;
+    // dollar-priced cosmetics/flares and their legacy create-checkout-session
+    // endpoint are gone. Only a stale cached cosmetics.json that still
+    // carries a product block can land here.
+    await showInGameAlert(translateText("store.checkout_failed"));
     return;
   }
 

--- a/tests/client/CosmeticsPaymentsMigration.test.ts
+++ b/tests/client/CosmeticsPaymentsMigration.test.ts
@@ -2,7 +2,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/client/Api", () => ({
   changeSubscriptionTier: vi.fn(),
-  createCheckoutSession: vi.fn(),
   getApiBase: vi.fn(() => "https://api.test"),
   getUserMe: vi.fn(async () => false),
   invalidateUserMe: vi.fn(),
@@ -36,7 +35,6 @@ vi.mock("../../src/client/SubscriptionPolicy", () => ({
 
 import {
   changeSubscriptionTier,
-  createCheckoutSession,
   getUserMe,
   invalidateUserMe,
 } from "../../src/client/Api";
@@ -50,8 +48,6 @@ import { startPurchase } from "../../src/client/Payments";
 import type { Cosmetics, Pack, Pattern } from "../../src/core/CosmeticSchemas";
 
 const startPurchaseMock = startPurchase as unknown as ReturnType<typeof vi.fn>;
-const createCheckoutSessionMock =
-  createCheckoutSession as unknown as ReturnType<typeof vi.fn>;
 const alertMock = showInGameAlert as unknown as ReturnType<typeof vi.fn>;
 const getUserMeMock = getUserMe as unknown as ReturnType<typeof vi.fn>;
 const confirmMock = showInGameConfirm as unknown as ReturnType<typeof vi.fn>;
@@ -138,7 +134,6 @@ describe("purchaseCosmetic dollar path", () => {
       packName: "starter_pack",
     });
     expect(alertMock).not.toHaveBeenCalled();
-    expect(createCheckoutSessionMock).not.toHaveBeenCalled();
   });
 
   it("buys a subscription tier by name", async () => {
@@ -272,10 +267,11 @@ describe("purchaseCosmetic dollar path", () => {
     });
   });
 
-  // The cosmetic/flare branch of the legacy Stripe endpoint was deliberately
-  // never ported, and it genuinely still needs a priceId.
-  it("keeps the legacy Stripe path for dollar-priced cosmetics", async () => {
-    createCheckoutSessionMock.mockResolvedValue("https://stripe.test/session");
+  // Direct dollar purchases of cosmetics/flares are deleted: real money only
+  // buys plutonium (or a subscription), everything else is currency-priced.
+  // Only a stale cached cosmetics.json still carrying a product block can
+  // route "dollar" here — it must fail, never start a checkout.
+  it("refuses a dollar purchase for a cosmetic even when it carries a product", async () => {
     const pattern = {
       name: "camo",
       product: { productId: "prod_p", priceId: "price_p", price: "$1.99" },
@@ -292,11 +288,11 @@ describe("purchaseCosmetic dollar path", () => {
       "dollar",
     );
 
-    expect(createCheckoutSessionMock).toHaveBeenCalledWith("price_p", "blue");
+    expect(alertMock).toHaveBeenCalledWith("store.checkout_failed");
     expect(startPurchaseMock).not.toHaveBeenCalled();
   });
 
-  it("still reports a failure for a dollar-priced cosmetic with no Stripe price", async () => {
+  it("refuses a dollar purchase for a cosmetic with no Stripe price", async () => {
     await purchaseCosmetic(
       resolved({
         type: "pattern",

--- a/tests/client/PurchaseReturn.test.ts
+++ b/tests/client/PurchaseReturn.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../../src/client/Api", () => ({
   changeSubscriptionTier: vi.fn(),
-  createCheckoutSession: vi.fn(),
   getApiBase: vi.fn(() => "https://api.test"),
   getUserMe: vi.fn(async () => false),
   invalidateUserMe: vi.fn(),


### PR DESCRIPTION
Real money only ever buys plutonium (currency packs / custom amount via `/payments/checkout`) or a subscription — everything else is currency-priced. This deletes the legacy direct-dollar path for cosmetics/flares:

- `purchaseCosmetic`'s `"dollar"` method now refuses (`store.checkout_failed`) for anything that isn't a pack or subscription. The path was already unreachable from the UI — `Store.ts` forces `product` to null for cosmetics — so only a stale cached `cosmetics.json` still carrying a `product` block could route here, and it must fail rather than start a checkout.
- `createCheckoutSession` (`POST /stripe/create-checkout-session`) is removed from `Api.ts` along with its last import.
- Tests updated: the "keeps the legacy Stripe path" test is inverted into "refuses a dollar purchase even when the cosmetic carries a product".

Not in this diff, flagged for follow-up:
- The API's `/stripe/create-checkout-session` endpoint should keep serving already-deployed bundles for a while; retire it API-side once this has been live.
- `createCustomCurrencyCheckout` in `Api.ts` is the same kind of leftover (zero callers since the `/payments/checkout` migration) — left untouched to keep this diff scoped to the direct-purchase deletion.

Full suite passes (63 files / 655 tests), lint + prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)