### PR TITLE
Adopt clean-room reimplementations for a set of client code blocks

### DIFF
--- a/src/client/ClientGameRunner.ts
+++ b/src/client/ClientGameRunner.ts
@@ -1467,10 +1467,10 @@ export class ClientGameRunner {
     const canBuild = this.canBoatAttack(buildables);
     if (canBuild === false) return false;
 
-    // TODO: Global enable flag
-    // TODO: Global limit autoboat to nearby shore flag
-    // if (!enableAutoBoat) return false;
-    // if (!limitAutoBoatNear) return true;
+    // TODO: honor a global auto-boat enable flag once it exists.
+    // if (!this.userSettings.autoBoat()) return false;
+    // TODO: honor a global "limit auto-boat to nearby shore" flag once it exists.
+    // if (!this.userSettings.autoBoatNearbyOnly()) return true;
     const distanceSquared = this.gameView.euclideanDistSquared(tile, canBuild);
     const limit = 100;
     const limitSquared = limit * limit;

--- a/src/client/LangSelector.ts
+++ b/src/client/LangSelector.ts
@@ -385,18 +385,20 @@ function flattenTranslations(
   parentKey = "",
   result: Record<string, string> = {},
 ): Record<string, string> {
-  for (const key in obj) {
+  for (const key of Object.keys(obj)) {
     const value = obj[key];
     const fullKey = parentKey ? `${parentKey}.${key}` : key;
-
     if (typeof value === "string") {
       result[fullKey] = value;
-    } else if (value && typeof value === "object" && !Array.isArray(value)) {
+    } else if (
+      typeof value === "object" &&
+      value !== null &&
+      !Array.isArray(value)
+    ) {
       flattenTranslations(value, fullKey, result);
     } else {
       console.warn("Unknown type", typeof value, value);
     }
   }
-
   return result;
 }

--- a/src/client/Main.ts
+++ b/src/client/Main.ts
@@ -636,7 +636,6 @@ class Client {
       );
 
       if (userMeResponse !== false) {
-        // Authorized
         console.log(
           `Your player ID is ${userMeResponse.player.publicId}\n` +
             "Sharing this ID will allow others to view your game history and stats.",
@@ -748,11 +747,10 @@ class Client {
     });
 
     if ((await userAuth()) === false) {
-      // Not logged in
+      // Not logged in: apply the signed-out profile directly.
       onUserMe(false);
     } else {
-      // JWT appears to be valid
-      // TODO: Add caching
+      // JWT appears valid: fetch the profile and apply it if still current.
       getUserMe().then(applyUserMe(authGeneration));
     }
 
@@ -816,7 +814,7 @@ class Client {
       this.joinModal.eventBus = this.eventBus;
     }
 
-    // Attempt to join lobby
+    // Attempt to join lobby from the current URL once the document is ready.
     if (document.readyState === "loading") {
       document.addEventListener("DOMContentLoaded", () => this.handleUrl());
     } else {
@@ -853,7 +851,7 @@ class Client {
         return;
       }
 
-      // Reset the UI to its initial state
+      // Reset the UI to its initial state.
       this.joinModal?.close();
 
       onJoinChanged();
@@ -903,7 +901,7 @@ class Client {
       this.handleUrl();
     };
 
-    // Handle browser navigation & manual hash edits
+    // Handle browser navigation (back/forward) and manual hash edits.
     window.addEventListener("popstate", onPopState);
     window.addEventListener("hashchange", onHashUpdate);
     window.addEventListener("join-changed", onJoinChanged);

--- a/src/client/NewsModal.ts
+++ b/src/client/NewsModal.ts
@@ -13,7 +13,7 @@ export class NewsModal extends BaseModal {
 
   @property({ type: String }) markdown = "Loading...";
 
-  private initialized: boolean = false;
+  private initialized = false;
 
   protected renderHeaderSlot() {
     return modalHeader({

--- a/src/client/SinglePlayerModal.ts
+++ b/src/client/SinglePlayerModal.ts
@@ -1122,9 +1122,10 @@ export class SinglePlayerModal extends BaseModal {
                 infiniteTroops: this.infiniteTroops,
                 instantBuild: this.instantBuild,
                 randomSpawn: this.randomSpawn,
-                disabledUnits: this.disabledUnits
-                  .map((u) => Object.values(UnitType).find((ut) => ut === u))
-                  .filter((ut): ut is UnitType => ut !== undefined),
+                disabledUnits: this.disabledUnits.filter(
+                  (unit): unit is UnitType =>
+                    Object.values(UnitType).includes(unit),
+                ),
                 nations: sliderToNationsConfig(
                   this.nations,
                   this.defaultNationCount,

--- a/src/client/TransformHandler.ts
+++ b/src/client/TransformHandler.ts
@@ -241,8 +241,9 @@ export class TransformHandler {
   private goTo() {
     const { screenX, screenY } = this.screenCenter();
 
-    if (this.target === null) throw new Error("null target");
-
+    if (this.target === null) {
+      throw new Error("null target");
+    }
     const positionClose =
       Math.abs(this.target.x - screenX) + Math.abs(this.target.y - screenY) < 2;
     const scaleClose =

--- a/src/client/Transport.ts
+++ b/src/client/Transport.ts
@@ -270,8 +270,8 @@ export class Transport {
     // If gameRecord is not null, we are replaying an archived game.
     // For multiplayer games, GameConfig is not known until game starts.
     this.isLocal =
-      lobbyConfig.gameRecord !== undefined ||
-      lobbyConfig.gameStartInfo?.config.gameType === GameType.Singleplayer;
+      this.lobbyConfig.gameRecord !== undefined ||
+      this.lobbyConfig.gameStartInfo?.config.gameType === GameType.Singleplayer;
 
     this.eventBus.on(SendAllianceRequestIntentEvent, (e) =>
       this.onSendAllianceRequest(e),
@@ -484,7 +484,9 @@ export class Transport {
     };
     this.socket.onerror = (err) => {
       console.error("Socket encountered error: ", err, "Closing socket");
-      if (this.socket === null) return;
+      if (this.socket === null) {
+        return;
+      }
       this.socket.close();
     };
     this.socket.onclose = (event: CloseEvent) => {
@@ -657,7 +659,9 @@ export class Transport {
     this.connectionRefused = true;
     this.stopPing();
     this.cancelReconnect();
-    if (this.socket === null) return;
+    if (this.socket === null) {
+      return;
+    }
     if (this.socket.readyState === WebSocket.OPEN) {
       console.log("on stop: leaving game");
     } else {
@@ -934,16 +938,15 @@ export class Transport {
     }
   }
 
-  private sendMsg(msg: ClientMessage) {
+  private sendMsg(msg: ClientMessage): void {
     if (this.connectionRefused) {
       return;
     }
     if (this.isLocal) {
-      // Forward message to local server
+      // Route to the in-process server; nothing goes over the wire.
       this.localServer.onMessage(msg);
       return;
     } else if (this.socket === null) {
-      // Socket missing, do nothing
       return;
     }
 
@@ -963,7 +966,7 @@ export class Transport {
       // and keep them queued behind any previously buffered messages.
       this.buffer.push(msg);
     } else {
-      // Send the message directly
+      // Session is ready and nothing is queued ahead: send directly.
       this.socket.send(encodeClientMessage(msg, this.zbinCtx ?? undefined));
     }
   }

--- a/src/client/Utils.ts
+++ b/src/client/Utils.ts
@@ -417,12 +417,12 @@ export function createCanvas(): HTMLCanvasElement {
  */
 export function generateCryptoRandomUUID(): string {
   // Type guard to check if randomUUID is available
-  if (crypto !== undefined && "randomUUID" in crypto) {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
 
   // Fallback using crypto.getRandomValues
-  if (crypto !== undefined && "getRandomValues" in crypto) {
+  if (typeof crypto !== "undefined" && "getRandomValues" in crypto) {
     return (([1e7] as any) + -1e3 + -4e3 + -8e3 + -1e11).replace(
       /[018]/g,
       (c: number): string =>

--- a/src/client/hud/layers/BuildMenu.ts
+++ b/src/client/hud/layers/BuildMenu.ts
@@ -438,9 +438,9 @@ export class BuildMenu extends LitElement implements Controller {
                       width="40"
                       height="40"
                     />
-                    <span class="build-name"
-                      >${item.key && translateText(item.key)}</span
-                    >
+                    <span class="build-name">
+                      ${item.key && translateText(item.key)}
+                    </span>
                     <span class="build-description"
                       >${item.description &&
                       translateText(item.description)}</span

--- a/src/client/hud/layers/EmojiTable.ts
+++ b/src/client/hud/layers/EmojiTable.ts
@@ -48,7 +48,7 @@ export class EmojiTable extends LitElement {
         this.hideTable();
       });
     });
-    eventBus.on(CloseViewEvent, (e) => {
+    eventBus.on(CloseViewEvent, () => {
       if (!this.hidden) {
         this.hideTable();
       }

--- a/src/client/hud/layers/PlayerInfoOverlay.ts
+++ b/src/client/hud/layers/PlayerInfoOverlay.ts
@@ -657,8 +657,8 @@ export class PlayerInfoOverlay extends LitElement implements Controller {
         <div
           class="bg-gray-800/92 backdrop-blur-sm shadow-xs min-[1200px]:rounded-lg sm:rounded-b-lg shadow-lg text-white text-lg lg:text-base w-full sm:w-[500px] overflow-hidden ${containerClasses}"
         >
-          ${this.player !== null ? this.renderPlayerInfo(this.player) : ""}
-          ${this.unit !== null ? this.renderUnitInfo(this.unit) : ""}
+          ${this.player ? this.renderPlayerInfo(this.player) : ""}
+          ${this.unit ? this.renderUnitInfo(this.unit) : ""}
         </div>
       </div>
     `;

--- a/src/client/hud/layers/SpawnTimer.ts
+++ b/src/client/hud/layers/SpawnTimer.ts
@@ -18,7 +18,7 @@ export class SpawnTimer extends LitElement implements Controller {
   public eventBus: EventBus;
   public transformHandler: TransformHandler;
 
-  private ratios = [0];
+  private ratios: number[] = [0];
   private _barVisible = false;
   private teams: Team[] = [];
   private colors = [
@@ -180,7 +180,7 @@ export class SpawnTimer extends LitElement implements Controller {
   }
 }
 
-function sumIterator(values: MapIterator<number>) {
+function sumIterator(values: MapIterator<number>): number {
   let total = 0;
   for (const value of values) {
     total += value;

--- a/src/client/hud/layers/WinModal.ts
+++ b/src/client/hud/layers/WinModal.ts
@@ -310,7 +310,7 @@ export class WinModal extends LitElement implements Controller {
       this.show();
     }
     const updates = this.game.updatesSinceLastTick();
-    const winUpdates = updates !== null ? updates[GameUpdateType.Win] : [];
+    const winUpdates = updates?.[GameUpdateType.Win] ?? [];
     winUpdates.forEach((wu) => {
       if (wu.winner === undefined) {
         // Match cancelled (e.g. a ranked 2v2 that didn't fill or fully


### PR DESCRIPTION
## What

Applies the output of a sealed clean-room reimplementation of 333 lines (187 marked blocks across 28 files under `src/client/`). The clean-room session worked from a self-contained bundle in which those blocks had been removed and replaced with markers, and reimplemented every block using only functional specifications, the surrounding code, and the test suite — with no access to the original code, this repository, git history, or any network beyond `npm ci`.

Only 13 files change in this diff: the other 15 files' blocks were single-line imports and guards whose reimplementation came out byte-identical to what is already in the tree, so they produce no diff. Every change here is behavior-preserving (comment wording, formatting, type annotations, and equivalent constructs).

## Provenance chain

1. **Input bundle** — `openfront-cleanroom-bundle-2026-09-11.zip`, SHA-256 `c7b1e01d6fe6cc9e46711362f05c9e0336cf1c33257287ea4160495893366117`. Built mechanically from this repo at `07261002c` (main `1b0c0bc92` + the test-only PR #5363, which pins the behavior of every removed block); contains the excised tree, per-block specs, and the process rules. The bundle's `cleanroom/PROVENANCE.md` documents its construction.
2. **Clean-room session** — full transcript: https://claude.ai/share/5a0de2b6-1078-435d-8eac-f3a3894e2fc7. Deliverable was a patch against the bundle plus a handoff document; the session had no repository access and opened no PR.
3. **Clean-room patch** — `cleanroom-rewrite.patch`, SHA-256 `3448c36b7f9b739d5f984ac27da560c17327481c2da334f93ababa95ca23fd7b`.
4. **Maintainer-side audit** — the patch was verified to apply cleanly to a pristine copy of the bundle, to remove exactly the 187 marker lines, and to touch no test file and no unmarked file. Each divergence from the pre-existing code was reviewed for behavioral equivalence.

## Verification

On the completed bundle tree: `tsc --noEmit` clean; vitest 447 files / 5469 tests and server 63 files / 655 tests, all passing; oxlint + eslint clean; prettier clean.

On this branch (current main + this patch): `tsc --noEmit` clean; full `npm test` — 450 files / 5503 tests and server 63 files / 655 tests, all passing; `npm run lint` and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)