### PR TITLE
Add tests locking in kick-player, replay-speed and events-display paths

### DIFF
--- a/tests/client/HostLobbyModalKickPlayer.test.ts
+++ b/tests/client/HostLobbyModalKickPlayer.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it, vi } from "vitest";
+
+// The desktop bridge is absent in jsdom; mock it like HostLobbyModal.test.ts.
+vi.mock("../../src/client/DesktopPresence", () => ({
+  desktopPresence: {
+    isAvailable: vi.fn(() => false),
+    openInviteDialog: vi.fn(async () => true),
+    set: vi.fn(),
+    consumePendingInvite: vi.fn(async () => null),
+    subscribeInvites: vi.fn(() => () => undefined),
+  },
+}));
+
+import { HostLobbyModal } from "../../src/client/HostLobbyModal";
+
+describe("HostLobbyModal kick player", () => {
+  it("dispatches a bubbling kick-player event carrying the target", () => {
+    const modal = new HostLobbyModal() as any;
+    const seen: CustomEvent[] = [];
+    modal.addEventListener("kick-player", (e: Event) =>
+      seen.push(e as CustomEvent),
+    );
+
+    modal.kickPlayer("cAbc1234");
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0].detail).toEqual({ target: "cAbc1234" });
+    // Main listens on document, so the event must escape the component.
+    expect(seen[0].bubbles).toBe(true);
+    expect(seen[0].composed).toBe(true);
+  });
+});

--- a/tests/client/LocalServerReplaySpeed.test.ts
+++ b/tests/client/LocalServerReplaySpeed.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EventBus } from "../../src/core/EventBus";
+import type { GameStartInfo, ServerMessage } from "../../src/core/Schemas";
+
+vi.mock("../../src/client/Auth", () => ({
+  getAuthHeader: vi.fn(async () => "Bearer test-jwt"),
+  getPersistentID: vi.fn(() => "123e4567-e89b-12d3-a456-426614174000"),
+}));
+
+vi.mock("../../src/client/Api", () => ({
+  getApiBase: vi.fn(() => "https://api.test"),
+}));
+
+vi.mock("src/client/ClientEnv", () => ({
+  ClientEnv: {
+    turnIntervalMs: vi.fn(() => 100),
+    gitCommit: vi.fn(() => "DEV"),
+  },
+}));
+
+import { ReplaySpeedChangeEvent } from "../../src/client/InputHandler";
+import { LocalServer } from "../../src/client/LocalServer";
+import { ReplaySpeedMultiplier } from "../../src/client/utilities/ReplaySpeedMultiplier";
+
+const CLIENT_ID = "abCD1234";
+
+function makeGameStartInfo(): GameStartInfo {
+  return {
+    gameID: "gameID12",
+    lobbyCreatedAt: 1000,
+    config: {
+      gameMap: "Africa",
+      difficulty: "Medium",
+      donateGold: false,
+      donateTroops: false,
+      gameType: "Singleplayer",
+      gameMode: "Free For All",
+      gameMapSize: "Normal",
+      nations: "default",
+      bots: 400,
+      infiniteGold: false,
+      infiniteTroops: false,
+      instantBuild: false,
+      randomSpawn: false,
+    },
+    players: [
+      {
+        clientID: CLIENT_ID,
+        username: "TestUser",
+        clanTag: null,
+      },
+    ],
+  } as GameStartInfo;
+}
+
+describe("LocalServer replay speed", () => {
+  let server: LocalServer;
+
+  afterEach(() => {
+    clearInterval((server as any).turnCheckInterval);
+    vi.useRealTimers();
+  });
+
+  it("emitting ReplaySpeedChangeEvent stretches the turn interval", () => {
+    vi.useFakeTimers();
+    const bus = new EventBus();
+    server = new LocalServer(
+      {
+        gameID: "gameID12",
+        playerName: "TestUser",
+        playerClanTag: null,
+        gameStartInfo: makeGameStartInfo(),
+      } as any,
+      false,
+      bus,
+    );
+    let turns = 0;
+    server.updateCallback(
+      () => {},
+      (msg: ServerMessage) => {
+        if (msg.type === "turn") {
+          turns++;
+          // Ack immediately so the backlog gate never throttles pacing.
+          server.turnComplete();
+        }
+      },
+    );
+    server.start();
+
+    vi.advanceTimersByTime(1000);
+    const atNormalSpeed = turns;
+    // 100ms interval at the default 1x multiplier: ~10 turns a second.
+    expect(atNormalSpeed).toBeGreaterThanOrEqual(4);
+
+    bus.emit(new ReplaySpeedChangeEvent(ReplaySpeedMultiplier.slow));
+    turns = 0;
+    vi.advanceTimersByTime(1000);
+
+    // The 2x interval multiplier must roughly halve the cadence.
+    expect(turns).toBeGreaterThan(0);
+    expect(turns).toBeLessThan(atNormalSpeed);
+  });
+});

--- a/tests/client/MainInitialize.test.ts
+++ b/tests/client/MainInitialize.test.ts
@@ -9,6 +9,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import { beforeAll, describe, expect, it, vi } from "vitest";
+import { SendKickPlayerIntentEvent } from "../../src/client/Transport";
+import { EventBus } from "../../src/core/EventBus";
 
 const mocks = vi.hoisted(() => ({
   userAuth: vi.fn(async (): Promise<unknown> => false),
@@ -260,6 +262,23 @@ describe("Client.initialize() booted from Main.ts module scope", () => {
       expect.stringContaining("joining lobby"),
     );
     expect(mocks.joinLobby).not.toHaveBeenCalled();
+  });
+
+  it("forwards a kick-player DOM event to the game event bus", () => {
+    const emitSpy = vi.spyOn(EventBus.prototype, "emit");
+    document.dispatchEvent(
+      new CustomEvent("kick-player", {
+        detail: { target: "c0000002" },
+        bubbles: true,
+      }),
+    );
+    expect(
+      emitSpy.mock.calls.some(
+        ([e]) =>
+          e instanceof SendKickPlayerIntentEvent && e.target === "c0000002",
+      ),
+    ).toBe(true);
+    emitSpy.mockRestore();
   });
 
   it("logs the player id when a retry lands a signed-in userMe", async () => {

--- a/tests/client/TransportSendPaths.test.ts
+++ b/tests/client/TransportSendPaths.test.ts
@@ -53,6 +53,7 @@ import {
   SendAttackIntentEvent,
   SendDonateGoldIntentEvent,
   SendHashEvent,
+  SendKickPlayerIntentEvent,
   SendSpawnIntentEvent,
   SendWinnerEvent,
   Transport,
@@ -197,6 +198,16 @@ describe("Transport send paths", () => {
           intent: { type: "cancel_attack", attackID: "atk-1" },
         },
       ]);
+    });
+
+    it("turns a kick-player event into a kick_player intent frame", () => {
+      const { eventBus, ws } = connected();
+      eventBus.emit(new SendKickPlayerIntentEvent("player01"));
+
+      expect(decodeFrames(ws)).toContainEqual({
+        type: "intent",
+        intent: { type: "kick_player", targetClientID: "player01" },
+      });
     });
 
     it("does nothing when an intent arrives before any socket exists", () => {

--- a/tests/client/graphics/layers/EventsDisplayHandlers.test.ts
+++ b/tests/client/graphics/layers/EventsDisplayHandlers.test.ts
@@ -128,6 +128,56 @@ describe("EventsDisplay handlers", () => {
       ed.tick();
       expect(events()).toHaveLength(0);
     });
+
+    it("shows the panel after spawn and hides it when the player dies", () => {
+      ed.tick();
+      expect((ed as unknown as { _isVisible: boolean })._isVisible).toBe(true);
+
+      game.myPlayer = () => ({ ...myPlayer, isAlive: () => false });
+      ed.tick();
+      expect((ed as unknown as { _isVisible: boolean })._isVisible).toBe(false);
+      // render() must short-circuit to an empty template while hidden.
+      const rendered = (
+        ed as unknown as { render: () => { values: unknown[] } }
+      ).render();
+      expect(rendered.values).toHaveLength(0);
+    });
+  });
+
+  describe("renderButton", () => {
+    const renderButton = (options: Record<string, unknown>) =>
+      (
+        ed as unknown as {
+          renderButton: (o: unknown) => {
+            strings: string[];
+            values: unknown[];
+          };
+        }
+      ).renderButton(options);
+
+    it("renders a button wired to the given click handler", () => {
+      const onClick = vi.fn();
+      const button = renderButton({
+        content: "jump to player",
+        onClick,
+        className: "text-left",
+        disabled: true,
+      });
+
+      expect(button.strings.join("")).toContain("<button");
+      expect(button.values).toContain("jump to player");
+      expect(button.values).toContain("text-left");
+      const handler = button.values.find((v) => typeof v === "function") as
+        | (() => void)
+        | undefined;
+      expect(handler).toBe(onClick);
+    });
+
+    it("renders nothing when hidden", () => {
+      const button = renderButton({ content: "invisible", hidden: true });
+      expect(button.values).toHaveLength(0);
+      expect(button.strings.join("")).toBe("");
+    });
   });
 
   describe("onAllianceRequestReplyEvent", () => {

--- a/tests/client/graphics/layers/ReplayPanel.test.ts
+++ b/tests/client/graphics/layers/ReplayPanel.test.ts
@@ -1,0 +1,87 @@
+/**
+ * ReplayPanel: the speed buttons' change handler must update the selection
+ * and broadcast a ReplaySpeedChangeEvent on the bus, and render() must gate
+ * on visibility.
+ */
+
+vi.mock("lit", () => ({
+  html: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+  }),
+  LitElement: class extends EventTarget {
+    requestUpdate() {}
+  },
+}));
+
+vi.mock("lit/decorators.js", () => ({
+  customElement: () => (clazz: unknown) => clazz,
+  state: () => () => {},
+  property: () => () => {},
+}));
+
+vi.mock("../../../../src/client/Utils", () => ({
+  translateText: vi.fn((key: string) => key),
+}));
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReplaySpeedChangeEvent } from "../../../../src/client/InputHandler";
+import { ReplayPanel } from "../../../../src/client/hud/layers/ReplayPanel";
+import { ReplaySpeedMultiplier } from "../../../../src/client/utilities/ReplaySpeedMultiplier";
+
+describe("ReplayPanel", () => {
+  let panel: ReplayPanel;
+  let emit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    panel = new ReplayPanel();
+    emit = vi.fn();
+    panel.eventBus = { emit, on: vi.fn() } as any;
+  });
+
+  it("onReplaySpeedChange selects the speed and emits the change event", () => {
+    panel.onReplaySpeedChange(ReplaySpeedMultiplier.fast);
+
+    expect((panel as any)._replaySpeedMultiplier).toBe(
+      ReplaySpeedMultiplier.fast,
+    );
+    expect(emit).toHaveBeenCalledTimes(1);
+    const event = emit.mock.calls[0][0];
+    expect(event).toBeInstanceOf(ReplaySpeedChangeEvent);
+    expect(event.replaySpeedMultiplier).toBe(ReplaySpeedMultiplier.fast);
+  });
+
+  it("renders nothing while hidden and the speed grid once visible", () => {
+    const hidden = panel.render() as unknown as { values: unknown[] };
+    expect(hidden.values).toHaveLength(0);
+
+    panel.visible = true;
+    const rendered = panel.render() as unknown as { values: unknown[] };
+    // Without a game (or with a non-replay one) the label is "game speed".
+    expect(JSON.stringify(rendered)).toContain("replay_panel.game_speed");
+    // One button per ReplaySpeedMultiplier member.
+    expect(JSON.stringify(rendered).match(/<button/g)).toHaveLength(4);
+  });
+
+  it("clicking a speed button routes through onReplaySpeedChange", () => {
+    panel.visible = true;
+    const rendered = panel.render() as unknown as { values: unknown[] };
+
+    // The mocked html tag stores each button's @click arrow in its template
+    // values; collect them in document order and fire the slow (first) one.
+    const clicks: (() => void)[] = [];
+    const walk = (node: unknown) => {
+      if (typeof node === "function") clicks.push(node as () => void);
+      else if (node && typeof node === "object")
+        for (const v of Object.values(node)) walk(v);
+    };
+    rendered.values.forEach(walk);
+    // One contextmenu handler on the container plus four button clicks.
+    expect(clicks.length).toBe(5);
+    clicks[1]();
+
+    const event = emit.mock.calls[0][0];
+    expect(event).toBeInstanceOf(ReplaySpeedChangeEvent);
+    expect(event.replaySpeedMultiplier).toBe(ReplaySpeedMultiplier.slow);
+  });
+});


### PR DESCRIPTION
## What

Adds test coverage for client paths that previously had no executing test:

- **Host kick flow**, end to end across its three hops: `HostLobbyModal.kickPlayer` dispatches a bubbling/composed `kick-player` CustomEvent; Main's document listener forwards it to the game EventBus as a `SendKickPlayerIntentEvent`; Transport turns that event into a decodable `kick_player` intent frame.
- **Replay speed control**: emitting `ReplaySpeedChangeEvent` on the bus measurably stretches LocalServer's turn cadence (asserted behaviorally with fake timers and `turnComplete()` acks); ReplayPanel's speed buttons update the selection and broadcast the change event (the test drives the actual `@click` handler captured from the template).
- **EventsDisplay**: the `renderButton` helper (including its `hidden` short-circuit), the render visibility guard, and the hide-when-the-player-dies tick branch.

Two new focused harnesses (`LocalServerReplaySpeed`, `ReplayPanel`, plus a small `HostLobbyModalKickPlayer` file); the rest extends the existing TransportSendPaths, MainInitialize and EventsDisplayHandlers harnesses.

## Verification

- Full suite green: 454 files / 5520 tests, server 63 / 655.
- `tsc --noEmit`, lint, prettier all clean.
- lcov confirms every previously zero-hit line in these paths now executes under test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)