### PR TITLE
fix(client): display calculated troop count in mobile attack ratio control

### DIFF
--- a/src/client/hud/layers/ControlPanel.ts
+++ b/src/client/hud/layers/ControlPanel.ts
@@ -627,21 +627,29 @@ export class ControlPanel extends LitElement implements Controller {
         >
           ${this.renderMobileTroopBar()}
         </div>
-        <!-- Sword + % label -->
+        <!-- Sword + % and troop count label -->
         <div
-          class="flex flex-col items-center shrink-0 gap-0.5 w-8"
+          class="flex flex-col items-center justify-center shrink-0"
           translate="no"
         >
-          <img
-            src=${swordIcon}
-            alt=""
-            aria-hidden="true"
-            width="10"
-            height="10"
-            style="filter: brightness(0) invert(1);"
-          />
-          <span class="text-white text-xs font-bold tabular-nums"
-            >${(this.attackRatio * 100).toFixed(0)}%</span
+          <div class="flex items-center gap-0.5">
+            <img
+              src=${swordIcon}
+              alt=""
+              aria-hidden="true"
+              width="10"
+              height="10"
+              style="filter: brightness(0) invert(1);"
+            />
+            <span class="text-white text-xs font-bold tabular-nums"
+              >${(this.attackRatio * 100).toFixed(0)}%</span
+            >
+          </div>
+          <span
+            class="text-white/80 text-[10px] font-bold tabular-nums leading-none"
+            >(${renderTroops(
+              (this.game?.myPlayer()?.troops() ?? 0) * this.attackRatio,
+            )})</span
           >
         </div>
         <!-- Attack ratio slider -->

--- a/tests/client/ControlPanelAttackRatio.test.ts
+++ b/tests/client/ControlPanelAttackRatio.test.ts
@@ -53,4 +53,18 @@ describe("control-panel attack ratio", () => {
 
     expect(uiState.attackRatio).toBeCloseTo(0.2);
   });
+
+  it("renders the calculated troop count alongside percentage in mobile view", async () => {
+    panel.game = {
+      inSpawnPhase: () => false,
+      myPlayer: () => ({ isAlive: () => true, troops: () => 100_000 }),
+    } as unknown as GameView;
+
+    panel.setVisibile(true);
+    await (panel as any).updateComplete;
+
+    const mobileContainer = panel.querySelector(".lg\\:hidden");
+    expect(mobileContainer?.textContent).toContain("20%");
+    expect(mobileContainer?.textContent).toContain("(2.00K)");
+  });
 });


### PR DESCRIPTION
## Description:

On desktop, the control panel displays both the attack ratio percentage and the exact calculated troop count (e.g. `20% (100k)`). On mobile, only the percentage was displayed, leaving mobile players without an immediate indicator of the exact troop number being dispatched.

This change updates the mobile attack ratio label to display the calculated troop count alongside the percentage in a compact vertical layout, preserving slider target area on touch devices while matching desktop information parity.

## Please complete the following:

- [x] I have added screenshots for all UI updates
- [x] I process any text displayed to the user through translateText() and I've added it to the en.json file
- [x] I have added relevant tests to the test directory

## Please put your Discord username so you can be contacted if a bug or regression is found:

ayushthepiro_22739
